### PR TITLE
Removed link to misleading information about Thanos

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,6 @@ Adhering `KISS` principle simplifies the resulting code and architecture, so it 
 
 Due to `KISS` cluster version of VictoriaMetrics has no the following "features" popular in distributed computing world:
 
-- Fragile [gossip protocols](https://github.com/improbable-eng/thanos/blob/master/docs/proposals/approved/201809_gossip-removal.md).
 - Hard-to-understand-and-implement-properly [Paxos protocols](https://www.quora.com/In-distributed-systems-what-is-a-simple-explanation-of-the-Paxos-algorithm).
 - Complex replication schemes, which may go nuts in unforesseen edge cases. The replication is offloaded to the underlying durable replicated storage
   such as [persistent disks in Google Compute Engine](https://cloud.google.com/compute/docs/disks/#pdspecs).


### PR DESCRIPTION
Hi :wave: 

While this item was true for like first 4 months of Thanos existence (until ~Feb 2018 when we added other means for discovery), currently Thanos project totally removed gossip protocol in last release and disabled couple months ago, so that information is no longer true. (:

Cheers! 