### PR TITLE
Change default value of the influxMeasurementFieldSeparator flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ Do not forget substituting `<victoriametrics-addr>` with the real address where 
 
 VictoriaMetrics maps Influx data using the following rules:
 * [`db` query arg](https://docs.influxdata.com/influxdb/v1.7/tools/api/#write-http-endpoint) is mapped into `db` label value.
-* Field names are mapped to time series names prefixed with `{measurement}{separator}` value. `{separator}` equals to `.` by default, but can be changed with `-influxMeasurementFieldSeparator` command-line flag.
+* Field names are mapped to time series names prefixed with `{measurement}{separator}` value. `{separator}` equals to `_` by default, but can be changed with `-influxMeasurementFieldSeparator` command-line flag.
 * Field values are mapped to time series values.
 * Tags are mapped to Prometheus labels as-is.
 

--- a/app/victoria-metrics/main.go
+++ b/app/victoria-metrics/main.go
@@ -3,6 +3,8 @@ package main
 import (
 	"flag"
 	"net/http"
+	"os"
+	"regexp"
 	"time"
 
 	"github.com/VictoriaMetrics/VictoriaMetrics/app/vminsert"
@@ -18,6 +20,15 @@ var httpListenAddr = flag.String("httpListenAddr", ":8428", "TCP address to list
 
 func main() {
 	flag.Parse()
+	reSep := regexp.MustCompile(`[a-zA-Z0-9_:]*`)
+	flag.VisitAll(func(f *flag.Flag) {
+		// Validate influxMeasurementFieldSeparator flag
+		if f.Name == "influxMeasurementFieldSeparator" && !reSep.MatchString(f.Value.String()) {
+			logger.Errorf("The influxMeasurementFieldSeparator flag has invalid value of '%s'. It can only be ASCII letter, digit, underscore or colon.", f.Value.String())
+			flag.PrintDefaults()
+			os.Exit(1)
+		}
+	})
 	buildinfo.Init()
 	logger.Init()
 	logger.Infof("starting VictoraMetrics at %q...", *httpListenAddr)

--- a/app/vminsert/influx/request_handler.go
+++ b/app/vminsert/influx/request_handler.go
@@ -18,7 +18,7 @@ import (
 )
 
 var (
-	measurementFieldSeparator = flag.String("influxMeasurementFieldSeparator", ".", "Separator for `{measurement}{separator}{field_name}` metric name when inserted via Influx line protocol")
+	measurementFieldSeparator = flag.String("influxMeasurementFieldSeparator", "_", "Separator for `{measurement}{separator}{field_name}` metric name when inserted via Influx line protocol")
 	skipSingleField           = flag.Bool("influxSkipSingleField", false, "Uses `{measurement}` instead of `{measurement}{separator}{field_name}` for metic name if Influx line contains only a single field")
 )
 


### PR DESCRIPTION
According to the [Prometheus documentation](https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels), the metric name can only contain:

> ... ASCII letters and digits, as well as underscores and colons.

This means that the field separator cannot be `.` as it's for `influxMeasurementFieldSeparator` by default now.

This PR is changing the default value of `influxMeasurementFieldSeparator` to `_`. This is the default separator used by Telegraf when using `prometheus_client` output plugin. That makes it compliant with the documentation and prevent any possible incompatibility of other products using PromQL like experienced for example [here](https://github.com/jacksontj/promxy/issues/183).