### PR TITLE
Small bug in cluster Helm Chart

### DIFF
--- a/deployment/k8s/helm/victoria-metrics/templates/_helpers.tpl
+++ b/deployment/k8s/helm/victoria-metrics/templates/_helpers.tpl
@@ -66,7 +66,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- else -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- if contains $name .Release.Name -}}
-{{- printf "%s-%s" .Release.Name .Values.server.name | trunc 63 | trimSuffix "-" -}}
+{{- printf "%s-%s" .Release.Name .Values.vmstorage.name | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
 {{- printf "%s-%s-%s" .Release.Name $name .Values.vmstorage.name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}


### PR DESCRIPTION
There seems to be a small bug in the definition of `victoria-metrics.vmstorage.fullname` in the `_helpers.tpl` of the cluster Helm chart. This PR should fix that.