### PR TITLE
Fix issue #196 - helm template indentation

### DIFF
--- a/deployment/k8s/helm/victoria-metrics/templates/vminsert-ingress.yaml
+++ b/deployment/k8s/helm/victoria-metrics/templates/vminsert-ingress.yaml
@@ -8,7 +8,9 @@ metadata:
 {{- end }}
   labels:
   {{- include "victoria-metrics.vminsert.labels" . | nindent 4 }}
+  {{ if .Values.vminsert.ingress.extraLabels }}
   {{ toYaml .Values.vminsert.ingress.extraLabels | indent 4 }}
+  {{ end }}
   name: {{ template "victoria-metrics.vminsert.fullname" . }}
 spec:
   rules:
@@ -23,7 +25,7 @@ spec:
             servicePort: http
   {{- end -}}
 {{- if .Values.vminsert.ingress.tls }}
-tls:
+  tls:
 {{ toYaml .Values.vminsert.ingress.tls | indent 4 }}
 {{- end -}}
 {{- end -}}

--- a/deployment/k8s/helm/victoria-metrics/templates/vminsert-ingress.yaml
+++ b/deployment/k8s/helm/victoria-metrics/templates/vminsert-ingress.yaml
@@ -8,7 +8,7 @@ metadata:
 {{- end }}
   labels:
   {{- include "victoria-metrics.vminsert.labels" . | nindent 4 }}
-{{ toYaml .Values.vminsert.ingress.extraLabels | indent 4 }}
+  {{ toYaml .Values.vminsert.ingress.extraLabels | indent 4 }}
   name: {{ template "victoria-metrics.vminsert.fullname" . }}
 spec:
   rules:

--- a/deployment/k8s/helm/victoria-metrics/templates/vmselect-ingress.yaml
+++ b/deployment/k8s/helm/victoria-metrics/templates/vmselect-ingress.yaml
@@ -8,7 +8,9 @@ metadata:
 {{- end }}
   labels:
   {{- include "victoria-metrics.vmselect.labels" . | nindent 4 }}
+  {{ if .Values.vmselect.ingress.extraLabels }}
   {{ toYaml .Values.vmselect.ingress.extraLabels | indent 4 }}
+  {{ end }}
   name: {{ template "victoria-metrics.vmselect.fullname" . }}
 spec:
   rules:
@@ -23,7 +25,7 @@ spec:
             servicePort: http
     {{- end -}}
 {{- if .Values.vmselect.ingress.tls }}
-tls:
+  tls:
 {{ toYaml .Values.vmselect.ingress.tls | indent 4 }}
 {{- end -}}
 {{- end -}}

--- a/deployment/k8s/helm/victoria-metrics/templates/vmselect-ingress.yaml
+++ b/deployment/k8s/helm/victoria-metrics/templates/vmselect-ingress.yaml
@@ -8,7 +8,7 @@ metadata:
 {{- end }}
   labels:
   {{- include "victoria-metrics.vmselect.labels" . | nindent 4 }}
-{{ toYaml .Values.vmselect.ingress.extraLabels | indent 4 }}
+  {{ toYaml .Values.vmselect.ingress.extraLabels | indent 4 }}
   name: {{ template "victoria-metrics.vmselect.fullname" . }}
 spec:
   rules:
@@ -22,8 +22,8 @@ spec:
             serviceName: {{ $serviceName }}
             servicePort: http
     {{- end -}}
-  {{- if .Values.vmselect.ingress.tls }}
+{{- if .Values.vmselect.ingress.tls }}
 tls:
-  {{ toYaml .Values.vmselect.ingress.tls | indent 4 }}
-  {{- end -}}
+{{ toYaml .Values.vmselect.ingress.tls | indent 4 }}
+{{- end -}}
 {{- end -}}


### PR DESCRIPTION
This fixes issue #196 . Helm lint now passes:

```
$ helm lint victoria-metrics/
==> Linting victoria-metrics/
[INFO] Chart.yaml: icon is recommended

1 chart(s) linted, no failures
```

Deployment with helm v3 also works (as should v2):

```
helm3 upgrade --install vm victoria-metrics/
Release "vm" does not exist. Installing it now.
NAME: vm
LAST DEPLOYED: 2019-10-02 13:30:51.9474376 +0200 CEST m=+1.756634101
NAMESPACE: default
STATUS: deployed
NOTES:
Write API:

The Victoria Metrics write api can be accessed via port 8480 on the following DNS name from within your cluster:
vm-victoria-metrics-vminsert.default.svc.cluster.local

Get the Victoria Metrics insert service URL by running these commands in the same shell:
  export POD_NAME=$(kubectl get pods --namespace default -l "app=vminsert" -o jsonpath="{.items[0].metadata.name}")
  kubectl --namespace default port-forward $POD_NAME 8480

You need to update your prometheus configuration file and add next lines into it:

prometheus.yml
remote_write:
  - url: "http://<insert-service>/insert/0/prometheus/"


for e.g. inside the kubernetes cluster:
remote_write:
  - url: "http://vm-victoria-metrics-vminsert.default.svc.cluster.local:8480/insert/0/prometheus/"

Read API:

The Victoria Metrics read api can be accessed via port 8481 on the following DNS name from within your cluster:
vm-victoria-metrics-vmselect.default.svc.cluster.local

Get the Victoria Metrics select service URL by running these commands in the same shell:
  export POD_NAME=$(kubectl get pods --namespace default -l "app=vmselect" -o jsonpath="{.items[0].metadata.name}")
  kubectl --namespace default port-forward $POD_NAME 8481

You need to update specify select service URL in your Grafana:
 NOTE: you need to use Prometheus Data Source

Input for URL field in Grafana

http://<select-service>/select/0/prometheus/

for e.g. inside the kubernetes cluster:
http://vm-victoria-metrics-vmselect.default.svc.cluster.local:8481/select/0/prometheus/"
```