### PR TITLE
Fix docker-compose cluster

### DIFF
--- a/deployment/docker/docker-compose.yml
+++ b/deployment/docker/docker-compose.yml
@@ -33,7 +33,6 @@ services:
     volumes:
       - grafanadata:/var/lib/grafana
       - ./provisioning/:/etc/grafana/provisioning/
-      - ./provisioning/dashboards/:/var/lib/grafana/dashboards
       - ./../../dashboards/victoriametrics.json:/var/lib/grafana/vm.json
 
   vmstorage:


### PR DESCRIPTION
The `provisioning/dashboards` folder should be already mounted on the previous line.

This should fix the `/bin/sh: can't create dashboards/vm.json: Permission denied` error on `docker-compose up`

@hagen1778 , could you look into this?