### PR TITLE
Ignore /health endpoint when checking auth

### DIFF
--- a/lib/httpserver/httpserver.go
+++ b/lib/httpserver/httpserver.go
@@ -203,6 +203,9 @@ func handlerWrapper(w http.ResponseWriter, r *http.Request, rh RequestHandler) {
 
 func checkAuth(w http.ResponseWriter, r *http.Request) bool {
 	path := r.URL.Path
+	if path == "/health" {
+		return true
+	}
 	if path == "/metrics" && len(*metricsAuthKey) > 0 {
 		authKey := r.FormValue("authKey")
 		if *metricsAuthKey == authKey {


### PR DESCRIPTION
We are trying to deploy Victoria Metrics to Kubernetes with Basic Auth enabled.  

This causes the readiness probe to fail because it is unable to authenticate using the [victoria-metrics-single Helm chart](https://github.com/VictoriaMetrics/helm-charts/tree/master/charts/victoria-metrics-single).  We have added a Basic Auth header to the readiness probe, but that exposes the encoded credentials in the statefulset manifest.

Given the `/health` endpoint only returns `OK` without any logic/side-effects, it seems reasonable to white-list the endpoint and allow anonymous users.