### PR TITLE
Do not fill max lines on cluster dashboard

### DIFF
--- a/dashboards/victoriametrics.json
+++ b/dashboards/victoriametrics.json
@@ -2509,6 +2509,7 @@
             {
               "alias": "max allowed",
               "color": "#C4162A",
+              "fill": 0,
               "stack": false
             }
           ],
@@ -3466,7 +3467,8 @@
           "seriesOverrides": [
             {
               "alias": "max",
-              "color": "#C4162A"
+              "color": "#C4162A",
+              "fill": 0
             }
           ],
           "spaceLength": 10,
@@ -3685,7 +3687,8 @@
           "seriesOverrides": [
             {
               "alias": "max",
-              "color": "#C4162A"
+              "color": "#C4162A",
+              "fill": 0
             }
           ],
           "spaceLength": 10,
@@ -4011,7 +4014,8 @@
           "seriesOverrides": [
             {
               "alias": "max",
-              "color": "#C4162A"
+              "color": "#C4162A",
+              "fill": 0
             }
           ],
           "spaceLength": 10,


### PR DESCRIPTION
Hello,

I would like to suggest a small visual change on the cluster dashboard: 4 graphs have a "max" line to visually indicate the upper limit of the graph values. While this is most helpful, having this line drawn in the same way as the other could be misleading.

You already put a static red color which is nice but you could get further by not filling the space between 0 and this line: it helps visually understand that this is not a regular value as the others but is instead the upper limit.

For example:
![image](https://user-images.githubusercontent.com/3418467/73655118-91487780-468d-11ea-9bd0-bbdde965d9b7.png)
vs
![image](https://user-images.githubusercontent.com/3418467/73654722-bab4d380-468c-11ea-9fb3-5b030a1233d2.png)
(my others values are unfortunatly too low to show their are indeed filled as regular series in Grafana, but you can see the "max" serie is not filled but instead is just a visual upper limit while not "coloring" the entire graph)

4 graphs are affected by this change:
* Caches > Cache size
* storage > Concurrent inserts
* vmselect > Concurrent selects
* vminsert > Concurrent inserts