### PR TITLE
Fix a typo in README (selfScrapeInterval)

### DIFF
--- a/README.md
+++ b/README.md
@@ -808,7 +808,7 @@ mkfs.ext4 ... -O 64bit,huge_file,extent -T huge
 VictoriaMetrics exports internal metrics in Prometheus format at `/metrics` page.
 These metrics may be collected either via Prometheus by adding the corresponding scrape config to it.
 Alternatively they can be self-scraped by setting `-selfScrapeInterval` command-line flag to duration greater than 0.
-For example, `-scrapeInterval=10s` would enable self-scraping of `/metrics` page with 10 seconds interval.
+For example, `-selfScrapeInterval=10s` would enable self-scraping of `/metrics` page with 10 seconds interval.
 
 There are officials Grafana dashboards for [single-node VictoriaMetrics](https://grafana.com/dashboards/10229) and [clustered VictoriaMetrics](https://grafana.com/grafana/dashboards/11176).
 


### PR DESCRIPTION
`-scrapeInterval` option does not exist. It seems to be a typo of `-selfScrapeInterval`.