### PR TITLE
Cluster - prometheus metrics fix

### DIFF
--- a/app/vmselect/main.go
+++ b/app/vmselect/main.go
@@ -303,7 +303,7 @@ var (
 	queryRequests = metrics.NewCounter(`vm_http_requests_total{path="/select/{}/prometheus/api/v1/query"}`)
 	queryErrors   = metrics.NewCounter(`vm_http_request_errors_total{path="/select/{}/prometheus/api/v1/query"}`)
 
-	queryRangeRequests = metrics.NewCounter(`vm_http_requests_total{path="/select/prometheus/api/v1/query_range"}`)
+	queryRangeRequests = metrics.NewCounter(`vm_http_requests_total{path="/select/{}/prometheus/api/v1/query_range"}`)
 	queryRangeErrors   = metrics.NewCounter(`vm_http_request_errors_total{path="/select/{}/prometheus/api/v1/query_range"}`)
 
 	seriesRequests = metrics.NewCounter(`vm_http_requests_total{path="/select/{}/prometheus/api/v1/series"}`)

--- a/app/vmselect/main.go
+++ b/app/vmselect/main.go
@@ -298,7 +298,7 @@ func sendPrometheusError(w http.ResponseWriter, r *http.Request, err error) {
 
 var (
 	labelValuesRequests = metrics.NewCounter(`vm_http_requests_total{path="/select/{}/prometheus/api/v1/label/{}/values"}`)
-	labelValuesErrors   = metrics.NewCounter(`vm_http_request_errors_total{path="select/{}/prometheus/api/v1/label/{}/values"}`)
+	labelValuesErrors   = metrics.NewCounter(`vm_http_request_errors_total{path="/select/{}/prometheus/api/v1/label/{}/values"}`)
 
 	queryRequests = metrics.NewCounter(`vm_http_requests_total{path="/select/{}/prometheus/api/v1/query"}`)
 	queryErrors   = metrics.NewCounter(`vm_http_request_errors_total{path="/select/{}/prometheus/api/v1/query"}`)


### PR DESCRIPTION
Hello,

I was wandering thru VM cluster metrics and I think I found a small typo.
![image](https://user-images.githubusercontent.com/3418467/74051811-f88d6100-49d8-11ea-8716-7e1674f4eb54.png)

`query_range` path for the `vm_http_requests_total` metric is missing the `{}` tenant placeholder.

While fixing it, I found an even smaller typo: all paths have a leading `/` in the `path` tag, all but `vm_http_request_errors_total`. While this could be intended, it seems very unlikely as it counterpart `vm_http_requests_total` does have it.

TL;DR: check the diff, it will make more sense