### PR TITLE
vmalert config reload, vmagent changed reload api response code

### DIFF
--- a/app/vmagent/main.go
+++ b/app/vmagent/main.go
@@ -160,7 +160,7 @@ func requestHandler(w http.ResponseWriter, r *http.Request) bool {
 	case "/-/reload":
 		promscrapeConfigReloadRequests.Inc()
 		procutil.SelfSIGHUP()
-		w.WriteHeader(http.StatusNoContent)
+		w.WriteHeader(http.StatusOK)
 		return true
 	}
 	return false

--- a/app/vmalert/main.go
+++ b/app/vmalert/main.go
@@ -151,7 +151,7 @@ var (
 
 	configReloadTotal      = metrics.NewCounter(`vmalert_config_reload_total`)
 	configReloadOkTotal    = metrics.NewCounter(`vmalert_config_reload_ok_total`)
-	ConfigReloadErrorTotal = metrics.NewCounter(`vmalert_config_reload_error_total`)
+	configReloadErrorTotal = metrics.NewCounter(`vmalert_config_reload_error_total`)
 )
 
 func (w *watchdog) run(ctx context.Context, group Group, evaluationInterval time.Duration, groupUpdate chan Group) {

--- a/app/vmalert/rule.go
+++ b/app/vmalert/rule.go
@@ -36,14 +36,13 @@ func (g *Group) Restore(ctx context.Context, q datasource.Querier, lookback time
 	return nil
 }
 
-
 // Update group
-func (g *Group)Update(newGroup Group)*Group{
+func (g *Group) Update(newGroup Group) *Group {
 	//check if old rule exists at new rules
-	for _, newRule := range newGroup.Rules{
-		for _, oldRule := range g.Rules{
-			if newRule.Name == oldRule.Name{
-	            //is lock nessesary?
+	for _, newRule := range newGroup.Rules {
+		for _, oldRule := range g.Rules {
+			if newRule.Name == oldRule.Name {
+				//is lock nessesary?
 				oldRule.mu.Lock()
 				//we copy only rules related values
 				//it`s safe to add additional fields to rule

--- a/app/vmalert/rule.go
+++ b/app/vmalert/rule.go
@@ -36,6 +36,31 @@ func (g *Group) Restore(ctx context.Context, q datasource.Querier, lookback time
 	return nil
 }
 
+
+// Update group
+func (g *Group)Update(newGroup Group)*Group{
+	//check if old rule exists at new rules
+	for _, newRule := range newGroup.Rules{
+		for _, oldRule := range g.Rules{
+			if newRule.Name == oldRule.Name{
+	            //is lock nessesary?
+				oldRule.mu.Lock()
+				//we copy only rules related values
+				//it`s safe to add additional fields to rule
+				//struct
+				oldRule.Annotations = newRule.Annotations
+				oldRule.Labels = newRule.Labels
+				oldRule.For = newRule.For
+				newRule = oldRule
+				oldRule.mu.Unlock()
+			}
+		}
+	}
+	//swap rules
+	g.Rules = newGroup.Rules
+	return g
+}
+
 // Rule is basic alert entity
 type Rule struct {
 	Name        string            `yaml:"alert"`

--- a/app/vmalert/rule.go
+++ b/app/vmalert/rule.go
@@ -50,6 +50,8 @@ func (g *Group) Update(newGroup Group) *Group {
 				oldRule.Annotations = newRule.Annotations
 				oldRule.Labels = newRule.Labels
 				oldRule.For = newRule.For
+				oldRule.Expr = newRule.Expr
+				oldRule.group = newRule.group
 				newRule = oldRule
 				oldRule.mu.Unlock()
 			}

--- a/app/vmalert/rule_test.go
+++ b/app/vmalert/rule_test.go
@@ -550,36 +550,36 @@ func TestGroup_Update(t *testing.T) {
 		want   *Group
 	}{
 		{
-			name:"update group with replace one value",
-			args:args{newGroup:Group{Name:"base-group",Rules:[]*Rule{
-				{Annotations:map[string]string{"different":"annotation"},For: time.Second*30},
+			name: "update group with replace one value",
+			args: args{newGroup: Group{Name: "base-group", Rules: []*Rule{
+				{Annotations: map[string]string{"different": "annotation"}, For: time.Second * 30},
 			}}},
-			fields:fields{
+			fields: fields{
 				Name:  "base-group",
-				Rules: []*Rule{{Annotations:map[string]string{"one":"annotations"}}},
+				Rules: []*Rule{{Annotations: map[string]string{"one": "annotations"}}},
 			},
-			want:&Group{
-				Name:  "base-group",
+			want: &Group{
+				Name: "base-group",
 				Rules: []*Rule{
-					{Annotations:map[string]string{"different":"annotation"},For: time.Second*30},
+					{Annotations: map[string]string{"different": "annotation"}, For: time.Second * 30},
 				},
 			},
 		},
 		{
-			name:"update group with change one value for rule",
-			args:args{newGroup:Group{Name:"base-group-2",Rules:[]*Rule{
-				{Annotations:map[string]string{"different":"annotation","replace-value":"new-one"},For: time.Second*30},
+			name: "update group with change one value for rule",
+			args: args{newGroup: Group{Name: "base-group-2", Rules: []*Rule{
+				{Annotations: map[string]string{"different": "annotation", "replace-value": "new-one"}, For: time.Second * 30},
 			}}},
-			fields:fields{
-				Name:  "base-group-2",
+			fields: fields{
+				Name: "base-group-2",
 				Rules: []*Rule{
-					{Annotations:map[string]string{"different":"annotation","replace-value":"old-one"},For: time.Second*50},
+					{Annotations: map[string]string{"different": "annotation", "replace-value": "old-one"}, For: time.Second * 50},
 				},
 			},
-			want:&Group{
-				Name:  "base-group-2",
+			want: &Group{
+				Name: "base-group-2",
 				Rules: []*Rule{
-					{Annotations:map[string]string{"different":"annotation","replace-value":"new-one"},For: time.Second*30},
+					{Annotations: map[string]string{"different": "annotation", "replace-value": "new-one"}, For: time.Second * 30},
 				},
 			},
 		},

--- a/app/vmalert/rule_test.go
+++ b/app/vmalert/rule_test.go
@@ -552,11 +552,18 @@ func TestGroup_Update(t *testing.T) {
 		{
 			name: "update group with replace one value",
 			args: args{newGroup: Group{Name: "base-group", Rules: []*Rule{
-				{Annotations: map[string]string{"different": "annotation"}, For: time.Second * 30},
+				{
+					Annotations: map[string]string{"different": "annotation"},
+					For:         time.Second * 30,
+				},
 			}}},
 			fields: fields{
-				Name:  "base-group",
-				Rules: []*Rule{{Annotations: map[string]string{"one": "annotations"}}},
+				Name: "base-group",
+				Rules: []*Rule{
+					{
+						Annotations: map[string]string{"one": "annotations"},
+					},
+				},
 			},
 			want: &Group{
 				Name: "base-group",
@@ -568,18 +575,32 @@ func TestGroup_Update(t *testing.T) {
 		{
 			name: "update group with change one value for rule",
 			args: args{newGroup: Group{Name: "base-group-2", Rules: []*Rule{
-				{Annotations: map[string]string{"different": "annotation", "replace-value": "new-one"}, For: time.Second * 30},
+				{
+					Annotations: map[string]string{"different": "annotation", "replace-value": "new-one"},
+					For:         time.Second * 30,
+					Labels:      map[string]string{"label-1": "value-1"},
+					Expr:        "rate(vm) > 1",
+				},
 			}}},
 			fields: fields{
 				Name: "base-group-2",
 				Rules: []*Rule{
-					{Annotations: map[string]string{"different": "annotation", "replace-value": "old-one"}, For: time.Second * 50},
+					{
+						Annotations: map[string]string{"different": "annotation", "replace-value": "old-one"},
+						For:         time.Second * 50,
+						Expr:        "rate(vm) > 5",
+					},
 				},
 			},
 			want: &Group{
 				Name: "base-group-2",
 				Rules: []*Rule{
-					{Annotations: map[string]string{"different": "annotation", "replace-value": "new-one"}, For: time.Second * 30},
+					{
+						Annotations: map[string]string{"different": "annotation", "replace-value": "new-one"},
+						For:         time.Second * 30,
+						Labels:      map[string]string{"label-1": "value-1"},
+						Expr:        "rate(vm) > 1",
+					},
 				},
 			},
 		},

--- a/app/vmalert/web.go
+++ b/app/vmalert/web.go
@@ -1,14 +1,17 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/logger"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/procutil"
 	"net/http"
+	"os"
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/httpserver"
@@ -29,6 +32,74 @@ type APIAlert struct {
 
 type requestHandler struct {
 	groups []Group
+	mu     sync.RWMutex
+}
+
+func (rh *requestHandler) runConfigUpdater(ctx context.Context, reloadChan <-chan os.Signal, groupUpdateStorage map[string]chan Group, w *watchdog, wg *sync.WaitGroup) {
+	logger.Infof("starting config updater")
+	defer wg.Done()
+	for {
+		select {
+		case <-reloadChan:
+			logger.Infof("get sighup signal, updating config")
+			configReloadTotal.Inc()
+			newRules, err := readRules()
+			if err != nil {
+				logger.Errorf("sighup, cannot read new rules: %v", err)
+				ConfigReloadErrorTotal.Inc()
+				continue
+			}
+
+			rh.mu.Lock()
+			configReloadOkTotal.Inc()
+			//send new group to running watchers
+			for _, group := range newRules {
+				//update or start new group
+				if updateChan, ok := groupUpdateStorage[group.Name]; ok {
+					updateChan <- group
+				} else {
+					//its new group, we need to start it
+					updateChan := make(chan Group, 1)
+					groupUpdateStorage[group.Name] = updateChan
+					wg.Add(1)
+					go func(grp Group) {
+						w.run(ctx, grp, *evaluationInterval, updateChan)
+						wg.Done()
+					}(group)
+					//add new group to route handler
+					rh.groups = append(rh.groups, group)
+				}
+			}
+			//we have to check, if group is missing and remove it
+			for groupName, updateChan := range groupUpdateStorage {
+				var exist bool
+				for _, newGroup := range newRules {
+					if groupName == newGroup.Name {
+						exist = true
+					}
+				}
+				if !exist {
+					logger.Infof("group not exists in new rules, remove it, group: %s", groupName)
+					delete(groupUpdateStorage, groupName)
+					updateChan <- Group{Rules: []*Rule{}}
+					for i, group := range rh.groups {
+						if group.Name == groupName {
+							rh.groups[i] = rh.groups[len(rh.groups)-1]
+							rh.groups[len(rh.groups)-1] = Group{}
+							rh.groups = rh.groups[:len(rh.groups)-1]
+						}
+					}
+				}
+			}
+			rh.mu.Unlock()
+			logger.Infof("finished sync")
+
+		case <-ctx.Done():
+			logger.Infof("exiting config updater")
+			return
+
+		}
+	}
 }
 
 var pathList = [][]string{
@@ -74,6 +145,8 @@ type listAlertsResponse struct {
 }
 
 func (rh *requestHandler) list() ([]byte, error) {
+	rh.mu.RLock()
+	defer rh.mu.RUnlock()
 	lr := listAlertsResponse{Status: "success"}
 	for _, g := range rh.groups {
 		for _, r := range g.Rules {
@@ -97,6 +170,8 @@ func (rh *requestHandler) list() ([]byte, error) {
 }
 
 func (rh *requestHandler) alert(path string) ([]byte, error) {
+	rh.mu.RLock()
+	defer rh.mu.RUnlock()
 	parts := strings.SplitN(strings.TrimPrefix(path, "/api/v1/"), "/", 3)
 	if len(parts) != 3 {
 		return nil, &httpserver.ErrorWithStatusCode{

--- a/app/vmalert/web.go
+++ b/app/vmalert/web.go
@@ -46,7 +46,7 @@ func (rh *requestHandler) runConfigUpdater(ctx context.Context, reloadChan <-cha
 			newRules, err := readRules()
 			if err != nil {
 				logger.Errorf("sighup, cannot read new rules: %v", err)
-				ConfigReloadErrorTotal.Inc()
+				configReloadErrorTotal.Inc()
 				continue
 			}
 

--- a/app/vmalert/web.go
+++ b/app/vmalert/web.go
@@ -3,6 +3,8 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/logger"
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/procutil"
 	"net/http"
 	"sort"
 	"strconv"
@@ -48,6 +50,12 @@ func (rh *requestHandler) handler(w http.ResponseWriter, r *http.Request) bool {
 	case "/api/v1/alerts":
 		resph.handle(rh.list())
 		return true
+	case "/-/reload":
+		logger.Infof("api config reload was called, sending sighup")
+		procutil.SelfSIGHUP()
+		w.WriteHeader(http.StatusOK)
+		return true
+
 	default:
 		// /api/v1/<groupName>/<alertID>/status
 		if strings.HasSuffix(r.URL.Path, "/status") {

--- a/app/vmalert/web_test.go
+++ b/app/vmalert/web_test.go
@@ -1,13 +1,17 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
+	"github.com/VictoriaMetrics/VictoriaMetrics/app/vmalert/notifier"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"reflect"
+	"sync"
+	"syscall"
 	"testing"
-
-	"github.com/VictoriaMetrics/VictoriaMetrics/app/vmalert/notifier"
+	"time"
 )
 
 func TestHandler(t *testing.T) {
@@ -22,6 +26,7 @@ func TestHandler(t *testing.T) {
 			Name:  "group",
 			Rules: []*Rule{rule},
 		}},
+		mu: sync.RWMutex{},
 	}
 	getResp := func(url string, to interface{}, code int) {
 		t.Helper()
@@ -69,4 +74,97 @@ func TestHandler(t *testing.T) {
 	t.Run("/", func(t *testing.T) {
 		getResp(ts.URL, nil, 200)
 	})
+}
+
+func Test_requestHandler_runConfigUpdater(t *testing.T) {
+	type fields struct {
+		groups []Group
+	}
+	type args struct {
+		updateChan     chan os.Signal
+		w              *watchdog
+		wg             *sync.WaitGroup
+		initRulePath   []string
+		updateRulePath string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   []Group
+	}{
+		{
+			name: "update good rules",
+			args: args{
+				w:              &watchdog{},
+				wg:             &sync.WaitGroup{},
+				updateChan:     make(chan os.Signal),
+				initRulePath:   []string{"testdata/rules0-good.rules"},
+				updateRulePath: "testdata/dir/rules1-good.rules",
+			},
+			fields: fields{
+				groups: []Group{},
+			},
+			want: []Group{{Name: "duplicatedGroupDiffFiles", Rules: []*Rule{newTestRule("VMRows", time.Second*10)}}},
+		},
+		{
+			name: "update with one bad rule file",
+			args: args{
+				w:              &watchdog{},
+				wg:             &sync.WaitGroup{},
+				updateChan:     make(chan os.Signal),
+				initRulePath:   []string{"testdata/rules0-good.rules"},
+				updateRulePath: "testdata/dir/rules2-bad.rules",
+			},
+			fields: fields{
+				groups: []Group{},
+			},
+			want: []Group{
+				{
+					Name: "duplicatedGroupDiffFiles", Rules: []*Rule{
+					newTestRule("VMRows", time.Second*10),
+				}},
+				{
+					Name: "TestGroup", Rules: []*Rule{
+					newTestRule("Conns", time.Duration(0)),
+					newTestRule("ExampleAlertAlwaysFiring", time.Duration(0)),
+				}},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.TODO())
+			grp, err := Parse(tt.args.initRulePath, *validateTemplates)
+			if err != nil {
+				t.Errorf("cannot setup test: %v", err)
+				cancel()
+				return
+			}
+			groupUpdateStorage := startInitGroups(ctx, tt.args.w, nil, grp, tt.args.wg)
+			rh := &requestHandler{
+				groups: grp,
+				mu:     sync.RWMutex{},
+			}
+			tt.args.wg.Add(1)
+			go func() {
+				//possible side effect with global var modification
+				err = rulePath.Set(tt.args.updateRulePath)
+				if err != nil {
+					t.Errorf("cannot update rule")
+					panic(err)
+				}
+				//need some delay
+				time.Sleep(time.Millisecond * 300)
+				tt.args.updateChan <- syscall.SIGHUP
+				cancel()
+
+			}()
+			rh.runConfigUpdater(ctx, tt.args.updateChan, groupUpdateStorage, tt.args.w, tt.args.wg)
+			tt.args.wg.Wait()
+			if len(tt.want) != len(rh.groups) {
+				t.Errorf("want: %v,\ngot :%v ", tt.want, rh.groups)
+			}
+		})
+	}
 }

--- a/app/vmalert/web_test.go
+++ b/app/vmalert/web_test.go
@@ -122,13 +122,13 @@ func Test_requestHandler_runConfigUpdater(t *testing.T) {
 			want: []Group{
 				{
 					Name: "duplicatedGroupDiffFiles", Rules: []*Rule{
-					newTestRule("VMRows", time.Second*10),
-				}},
+						newTestRule("VMRows", time.Second*10),
+					}},
 				{
 					Name: "TestGroup", Rules: []*Rule{
-					newTestRule("Conns", time.Duration(0)),
-					newTestRule("ExampleAlertAlwaysFiring", time.Duration(0)),
-				}},
+						newTestRule("Conns", time.Duration(0)),
+						newTestRule("ExampleAlertAlwaysFiring", time.Duration(0)),
+					}},
 			},
 		},
 	}


### PR DESCRIPTION
added config reload with sighup and api call.

https://github.com/VictoriaMetrics/VictoriaMetrics/issues/431

1) rules will be always updated after config reread, maybe it`s better to apply changes only for rules with diff? But in another hand, it`s easier to deal with missing rules.

2) Breaking changes for response code at vmagent config reload api. I need it for future operator integration, it easy to change correct response code at basic prometheus config reload.
 But for operator different image is used without such option (https://github.com/thanos-io/thanos/blob/master/pkg/reloader/reloader.go).
 