### PR TITLE
vmalert: check if remoteRead object was initied before calling Restore

### DIFF
--- a/app/vmalert/manager.go
+++ b/app/vmalert/manager.go
@@ -57,7 +57,7 @@ func (m *manager) close() {
 }
 
 func (m *manager) startGroup(ctx context.Context, group Group, restore bool) {
-	if restore {
+	if restore && m.rr != nil {
 		err := group.Restore(ctx, m.rr, *remoteReadLookBack)
 		if err != nil {
 			logger.Errorf("error while restoring state for group %q: %s", group.Name, err)

--- a/app/vmalert/rule.go
+++ b/app/vmalert/rule.go
@@ -295,6 +295,10 @@ func newTimeSeries(value float64, labels map[string]string, timestamp time.Time)
 // Restore restores only Start field. Field State will be always Pending and supposed
 // to be updated on next Eval, as well as Value field.
 func (r *Rule) Restore(ctx context.Context, q datasource.Querier, lookback time.Duration) error {
+	if q == nil {
+		return fmt.Errorf("querier is nil")
+	}
+
 	// Get the last datapoint in range via MetricsQL `last_over_time`.
 	// We don't use plain PromQL since Prometheus doesn't support
 	// remote write protocol which is used for state persistence in vmalert.


### PR DESCRIPTION
The check for non-nil remoteRead was mistakenly dropped
during refactoring which caused panics when `vmalert`
wasn't configured with `remoteRead` flag.

#473
