### PR TITLE
add the method to get targets number in vmagent

### DIFF
--- a/app/vmagent/main.go
+++ b/app/vmagent/main.go
@@ -167,7 +167,7 @@ func requestHandler(w http.ResponseWriter, r *http.Request) bool {
 			return true
 		}
 		for key, val := range queryContent {
-			if val == nil || len(val) == 0 {
+			if len(val) == 0 {
 				break
 			}
 			switch key {

--- a/app/vmagent/main.go
+++ b/app/vmagent/main.go
@@ -156,11 +156,14 @@ func requestHandler(w http.ResponseWriter, r *http.Request) bool {
 		influxQueryRequests.Inc()
 		fmt.Fprintf(w, `{"results":[{"series":[{"values":[]}]}]}`)
 		return true
-	case "/api/v1/query":
-		//this is used to realize promethuse /api/v1/query api
-		//get the number of target in vmagent with this method
-		promscrapeQueryTargetsrRequests.Inc()
-		//get the query content
+	case "/targets":
+		promscrapeTargetsRequests.Inc()
+		w.Header().Set("Content-Type", "text/plain")
+		promscrape.WriteHumanReadableTargetsStatus(w)
+		return true
+	case "/targets/more":
+		//return the info of target
+		promscrapeTargetsMoreRequests.Inc()
 		queryContent, err := url.ParseQuery(r.URL.RawQuery)
 		if err != nil {
 			fmt.Fprintf(w, `error occur when ParseQuery,err is:%s`, err)
@@ -181,11 +184,7 @@ func requestHandler(w http.ResponseWriter, r *http.Request) bool {
 		}
 		fmt.Fprintf(w, `{"results":[{"series":[{"values":[]}]}]}`)
 		return true
-	case "/targets":
-		promscrapeTargetsRequests.Inc()
-		w.Header().Set("Content-Type", "text/plain")
-		promscrape.WriteHumanReadableTargetsStatus(w)
-		return true
+
 	case "/-/reload":
 		promscrapeConfigReloadRequests.Inc()
 		procutil.SelfSIGHUP()
@@ -212,6 +211,6 @@ var (
 
 	promscrapeTargetsRequests = metrics.NewCounter(`vmagent_http_requests_total{path="/targets"}`)
 
-	promscrapeConfigReloadRequests  = metrics.NewCounter(`vmagent_http_requests_total{path="/-/reload"}`)
-	promscrapeQueryTargetsrRequests = metrics.NewCounter(`vmagent_http_requests_total{path="/query/targets"}`)
+	promscrapeConfigReloadRequests = metrics.NewCounter(`vmagent_http_requests_total{path="/-/reload"}`)
+	promscrapeTargetsMoreRequests  = metrics.NewCounter(`vmagent_http_requests_total{path="/targets/more"}`)
 )

--- a/lib/promscrape/targetstatus.go
+++ b/lib/promscrape/targetstatus.go
@@ -15,6 +15,11 @@ func WriteHumanReadableTargetsStatus(w io.Writer) {
 	tsmGlobal.WriteHumanReadable(w)
 }
 
+//return the number of target
+func GetTargetNumber() int {
+	return len(tsmGlobal.m)
+}
+
 type targetStatusMap struct {
 	mu sync.Mutex
 	m  map[uint64]targetStatus

--- a/lib/promscrape/targetstatus.go
+++ b/lib/promscrape/targetstatus.go
@@ -17,6 +17,8 @@ func WriteHumanReadableTargetsStatus(w io.Writer) {
 
 //return the number of target
 func GetTargetNumber() int {
+	tsmGlobal.mu.Lock()
+	defer tsmGlobal.mu.Unlock()
 	return len(tsmGlobal.m)
 }
 


### PR DESCRIPTION
When we use cluster deployment, we hope that we can obtain the number of targets in vmagent, so that we can achieve a balanced selection on each vmagent.   
At the same time, because we have promethues in our cluster, we hope to be consistent with the promethuse API.