### PR TITLE
feat(vmselect): add tmp block dir size metrics `vm_tmp_blocks_files_size_total`

### DIFF
--- a/app/vmselect/netstorage/tmp_blocks_file.go
+++ b/app/vmselect/netstorage/tmp_blocks_file.go
@@ -87,7 +87,7 @@ func (addr tmpBlockAddr) String() string {
 
 var (
 	tmpBlocksFilesCreated = metrics.NewCounter(`vm_tmp_blocks_files_created_total`)
-	_ = metrics.NewGauge(`vm_tmp_blocks_files_directory_free_space`, func() float64 {
+	_ = metrics.NewGauge(`vm_tmp_blocks_files_directory_free_bytes`, func() float64 {
 		return float64(fs.MustGetFreeSpace(tmpBlocksDir))
 	})
 )

--- a/app/vmselect/netstorage/tmp_blocks_file.go
+++ b/app/vmselect/netstorage/tmp_blocks_file.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path/filepath"
 	"sync"
 
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/bytesutil"
@@ -30,23 +29,6 @@ func InitTmpBlocksDir(tmpDirPath string) {
 }
 
 var tmpBlocksDir string
-func tmpBlockDirSize() int64 {
-	var size int64
-	err := filepath.Walk(tmpBlocksDir, func(_ string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
-		if !info.IsDir() {
-			size += info.Size()
-		}
-		return err
-	})
-	if err != nil {
-		logger.Errorf("failed to get tmp block file size, error: %s", err)
-		return 0
-	}
-	return size
-}
 
 func maxInmemoryTmpBlocksFile() int {
 	mem := memory.Allowed()
@@ -105,8 +87,8 @@ func (addr tmpBlockAddr) String() string {
 
 var (
 	tmpBlocksFilesCreated = metrics.NewCounter(`vm_tmp_blocks_files_created_total`)
-	_ = metrics.NewGauge(`vm_tmp_blocks_files_size_total`, func() float64 {
-		return float64(tmpBlockDirSize())
+	_ = metrics.NewGauge(`vm_tmp_blocks_files_directory_free_space`, func() float64 {
+		return float64(fs.MustGetFreeSpace(tmpBlocksDir))
 	})
 )
 


### PR DESCRIPTION
since `vmselect` stores any fetched data from `storage` to tmp file if the content size is bigger than `vm_tmp_blocks_max_inmemory_file_size_bytes`, we want to find a way to watch the tmp file size.
If there a bunch of "big query"(a bunch of query from grafana with a long time range), it may have cause high IO usage and exhaust the disk space.