### PR TITLE
allow to use values lower than 10 with the flag -memory.allowedPercent

### DIFF
--- a/lib/memory/memory.go
+++ b/lib/memory/memory.go
@@ -24,8 +24,8 @@ func initOnce() {
 		// Do not use logger.Panicf here, since logger may be uninitialized yet.
 		panic(fmt.Errorf("BUG: memory.Allowed must be called only after flag.Parse call"))
 	}
-	if *allowedMemPercent < 10 || *allowedMemPercent > 200 {
-		logger.Panicf("FATAL: -memory.allowedPercent must be in the range [10...200]; got %f", *allowedMemPercent)
+	if *allowedMemPercent < 1 || *allowedMemPercent > 200 {
+		logger.Panicf("FATAL: -memory.allowedPercent must be in the range [1...200]; got %f", *allowedMemPercent)
 	}
 	percent := *allowedMemPercent / 100
 


### PR DESCRIPTION
Currently the flag -memory.allowedPercent allows values between 10 and 200. In cases when victoriametrics runs on server that have large amount of memory(500GB for example) it consumes at least 50GB(10%) of memory. At the same time, if we have just 2M of active timeseries, even 1% of memory consumed by caches would be decent and a lot of memory wouldn't wasted.