### PR TITLE
Fix graphite minus one timestamp

### DIFF
--- a/lib/protoparser/graphite/parser_test.go
+++ b/lib/protoparser/graphite/parser_test.go
@@ -165,7 +165,7 @@ func TestRowsUnmarshalSuccess(t *testing.T) {
 }
 
 func Test_streamContext_Read(t *testing.T) {
-	f := func(s string, rowsExpected *Rows){
+	f := func(s string, rowsExpected *Rows) {
 		t.Helper()
 		ctx := &streamContext{}
 		ctx.Read(strings.NewReader(s))
@@ -181,9 +181,9 @@ func Test_streamContext_Read(t *testing.T) {
 	currentTimestamp := int64(fasttime.UnixTimestamp())
 	f("aaa 1123", &Rows{
 		Rows: []Row{{
-			Metric: "aaa",
-			Value:  1123,
-			Timestamp: currentTimestamp*1000,
+			Metric:    "aaa",
+			Value:     1123,
+			Timestamp: currentTimestamp * 1000,
 		}},
 	})
 }

--- a/lib/protoparser/graphite/parser_test.go
+++ b/lib/protoparser/graphite/parser_test.go
@@ -1,7 +1,9 @@
 package graphite
 
 import (
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/fasttime"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -159,5 +161,29 @@ func TestRowsUnmarshalSuccess(t *testing.T) {
 				Timestamp: 43,
 			},
 		},
+	})
+}
+
+func Test_streamContext_Read(t *testing.T) {
+	f := func(s string, rowsExpected *Rows){
+		t.Helper()
+		ctx := &streamContext{}
+		ctx.Read(strings.NewReader(s))
+		if len(ctx.Rows.Rows) != len(rowsExpected.Rows) {
+			t.Fatalf("different len of expected rows;\ngot\n%+v;\nwant\n%+v", ctx.Rows, rowsExpected.Rows)
+		}
+		if !reflect.DeepEqual(ctx.Rows.Rows, rowsExpected.Rows) {
+			t.Fatalf("unexpected rows;\ngot\n%+v;\nwant\n%+v", ctx.Rows.Rows, rowsExpected.Rows)
+		}
+	}
+
+	// -1 timestamp
+	currentTimestamp := int64(fasttime.UnixTimestamp())
+	f("aaa 1123", &Rows{
+		Rows: []Row{{
+			Metric: "aaa",
+			Value:  1123,
+			Timestamp: currentTimestamp*1000,
+		}},
 	})
 }

--- a/lib/protoparser/graphite/streamparser.go
+++ b/lib/protoparser/graphite/streamparser.go
@@ -75,7 +75,7 @@ func (ctx *streamContext) Read(r io.Reader) bool {
 	currentTimestamp := int64(fasttime.UnixTimestamp())
 	for i := range rows {
 		r := &rows[i]
-		if r.Timestamp == 0 {
+		if r.Timestamp == 0 || r.Timestamp == -1 {
 			r.Timestamp = currentTimestamp
 		}
 	}


### PR DESCRIPTION
Graphite format support "-1" as valid timestamp, which equals to empty timestamp. 

>Carbon-cache will use the time of arrival if the timestamp is set to -1
https://graphite.readthedocs.io/en/latest/feeding-carbon.html

Also, added tests for the Test_streamContext_Read, while timestamp parsing is a part of the Read function. 