### PR TITLE
lib/flagutil: specify additional description for all Array type flags

### DIFF
--- a/lib/flagutil/array.go
+++ b/lib/flagutil/array.go
@@ -10,6 +10,8 @@ import (
 // NewArray returns new Array with the given name and description.
 func NewArray(name, description string) *Array {
 	var a Array
+	description += "\nSupports `array` of values separated by comma" +
+		" or specified via multiple flags."
 	flag.Var(&a, name, description)
 	return &a
 }


### PR DESCRIPTION
Array type flag is currently defined as `value` type in flag description when printed.
This change adds additional description to every Array type flag so it would be
clear what exact type is used:
```
  -remoteWrite.urlRelabelConfig array
        Optional path to relabel config for the corresponding -remoteWrite.url
        Supports array of values separated by comma or specified via multiple flags.
```