### PR TITLE
lib/storage: metaindexRow use memroy more efficiently

### DIFF
--- a/lib/storage/metaindex_row.go
+++ b/lib/storage/metaindex_row.go
@@ -16,10 +16,6 @@ type metaindexRow struct {
 	// TSID is the first TSID in the corresponding index block.
 	TSID TSID
 
-	// BlockHeadersCount is the number of block headers
-	// in the given index block.
-	BlockHeadersCount uint32
-
 	// MinTimestamp is the minimum timestamp in the given index block.
 	MinTimestamp int64
 
@@ -28,6 +24,10 @@ type metaindexRow struct {
 
 	// IndexBlockOffset is the offset of index block.
 	IndexBlockOffset uint64
+
+	// BlockHeadersCount is the number of block headers
+	// in the given index block.
+	BlockHeadersCount uint32
 
 	// IndexBlockSize is the size of compressed index block.
 	IndexBlockSize uint32


### PR DESCRIPTION
due to memory align the metaindexRow structure use 64-byte pre object.
```
Meta Index Row: 64 byte
  TSID:              24 byte
  BlockHeadersCount: 4  byte
  blank padding:     4  byte
  MinTimestamp:      8  byte
  MaxTimestamp:      8  byte
  IndexBlcokOffset:  8  byte
  IndexBlcokSize:    4  byte
  blank padding:     4  byte
```

this PR removes the blank padding by changing the field order.

```
Meta Index Row: 56 byte
  TSID:              24 byte
  MinTimestamp:      8  byte
  MaxTimestamp:      8  byte
  IndexBlcokOffset:  8  byte
  BlockHeadersCount: 4  byte
  IndexBlcokSize:    4  byte
```