### PR TITLE
Add option to build 32b ARM Debian package (armhf)

### DIFF
--- a/package/package_deb.sh
+++ b/package/package_deb.sh
@@ -13,6 +13,9 @@ if [[ "$ARCH" == "amd64" ]]; then
 elif [[ "$ARCH" == "arm64" ]]; then
     DEB_ARCH=arm64
     EXENAME_SRC="victoria-metrics-arm64-prod"
+elif [[ "$ARCH" == "arm" ]]; then
+    DEB_ARCH=armhf
+    EXENAME_SRC="victoria-metrics-arm-prod"
 else
     echo "*** Unknown arch $ARCH"
     exit 1


### PR DESCRIPTION
Trivial patch to allow building Debian package for `armhf` architecture as well.