### PR TITLE
vmalert reload rule too slow(blocked by rule executing)

### DIFF
--- a/app/vmalert/README.md
+++ b/app/vmalert/README.md
@@ -316,7 +316,8 @@ Pass `-help` to `vmalert` in order to see the full list of supported
 command-line flags with their descriptions.
 
 To reload configuration without `vmalert` restart send SIGHUP signal
-or send GET request to `/-/reload` endpoint.
+or send GET request to `/-/reload` endpoint. The reloading is running 
+asynchronously by groups.
 
 ### Contributing
 

--- a/app/vmalert/group.go
+++ b/app/vmalert/group.go
@@ -165,8 +165,7 @@ var (
 	alertsSent           = metrics.NewCounter(`vmalert_alerts_sent_total`)
 	alertsSendErrors     = metrics.NewCounter(`vmalert_alerts_send_errors_total`)
 	groupReloadRequested = metrics.NewCounter(`vmalert_group_reload_requested_total`)
-	groupReloadSucceeded = metrics.NewCounter(`vmalert_group_reload_succeeded_total`)
-	groupReloadFailed    = metrics.NewCounter(`vmalert_group_reload_failed_total`)
+	groupReloadErrors    = metrics.NewCounter(`vmalert_group_reload_errors_total`)
 )
 
 func (g *Group) close() {
@@ -201,7 +200,7 @@ func (g *Group) start(ctx context.Context, querier datasource.Querier, nts []not
 			g.mu.Lock()
 			err := g.updateWith(ng)
 			if err != nil {
-				groupReloadFailed.Inc()
+				groupReloadErrors.Inc()
 				logger.Errorf("group %q: failed to update: %s", g.Name, err)
 				g.mu.Unlock()
 				continue
@@ -212,7 +211,6 @@ func (g *Group) start(ctx context.Context, querier datasource.Querier, nts []not
 				t = time.NewTicker(g.Interval)
 			}
 			g.mu.Unlock()
-			groupReloadSucceeded.Inc()
 			logger.Infof("group %q re-started; interval=%v; concurrency=%d", g.Name, g.Interval, g.Concurrency)
 		case <-t.C:
 			g.metrics.iterationTotal.Inc()

--- a/app/vmalert/main.go
+++ b/app/vmalert/main.go
@@ -84,7 +84,6 @@ func main() {
 			}
 			configSuccess.Set(1)
 			configTimestamp.Set(fasttime.UnixTimestamp())
-			logger.Infof("Rules reloaded successfully from %q", *rulePath)
 		}
 	}()
 

--- a/app/vmalert/manager.go
+++ b/app/vmalert/manager.go
@@ -3,13 +3,14 @@ package main
 import (
 	"context"
 	"fmt"
+	"strings"
+	"sync"
+
 	"github.com/VictoriaMetrics/VictoriaMetrics/app/vmalert/config"
 	"github.com/VictoriaMetrics/VictoriaMetrics/app/vmalert/datasource"
 	"github.com/VictoriaMetrics/VictoriaMetrics/app/vmalert/notifier"
 	"github.com/VictoriaMetrics/VictoriaMetrics/app/vmalert/remotewrite"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/logger"
-	"strings"
-	"sync"
 )
 
 // manager controls group states

--- a/app/vmalert/manager.go
+++ b/app/vmalert/manager.go
@@ -108,16 +108,12 @@ func (m *manager) update(ctx context.Context, path []string, validateTpl, valida
 			continue
 		}
 		go func(og *Group, ng *Group) {
-			startAt := time.Now()
 			select {
 			case <-ctx.Done():
-				logger.Infof("group %q: context cancelled", og.Name)
 				return
 			case <-og.doneCh:
-				logger.Infof("group %q: received stop signal", og.Name)
 				return
 			case og.updateCh <- ng:
-				logger.Infof("group %q reload success, took %v seconds", og.Name, time.Since(startAt).Seconds())
 				return
 			}
 		}(og, ng)

--- a/app/vmalert/manager.go
+++ b/app/vmalert/manager.go
@@ -96,9 +96,9 @@ func (m *manager) update(ctx context.Context, path []string, validateTpl, valida
 
 	m.groupsMu.Lock()
 	for _, og := range m.groups {
-		startAt := time.Now()
 		ng, ok := groupsRegistry[og.ID()]
 		if !ok {
+			startAt := time.Now()
 			// old group is not present in new list
 			// and must be stopped and deleted
 			og.close()
@@ -108,18 +108,17 @@ func (m *manager) update(ctx context.Context, path []string, validateTpl, valida
 			continue
 		}
 		go func(og *Group, ng *Group) {
-			for {
-				select {
-				case <-ctx.Done():
-					logger.Infof("group %q: context cancelled", og.Name)
-					return
-				case <-og.doneCh:
-					logger.Infof("group %q: received stop signal", og.Name)
-					return
-				case og.updateCh <- ng:
-					logger.Infof("group %q reload success, took %v seconds", og.Name, time.Since(startAt).Seconds())
-					return
-				}
+			startAt := time.Now()
+			select {
+			case <-ctx.Done():
+				logger.Infof("group %q: context cancelled", og.Name)
+				return
+			case <-og.doneCh:
+				logger.Infof("group %q: received stop signal", og.Name)
+				return
+			case og.updateCh <- ng:
+				logger.Infof("group %q reload success, took %v seconds", og.Name, time.Since(startAt).Seconds())
+				return
 			}
 		}(og, ng)
 		delete(groupsRegistry, ng.ID())

--- a/app/vmalert/manager.go
+++ b/app/vmalert/manager.go
@@ -108,6 +108,7 @@ func (m *manager) update(ctx context.Context, path []string, validateTpl, valida
 			continue
 		}
 		go func(og *Group, ng *Group) {
+			groupReloadRequested.Inc()
 			select {
 			case <-ctx.Done():
 				return

--- a/app/vmalert/manager.go
+++ b/app/vmalert/manager.go
@@ -3,15 +3,13 @@ package main
 import (
 	"context"
 	"fmt"
-	"strings"
-	"sync"
-	"time"
-
 	"github.com/VictoriaMetrics/VictoriaMetrics/app/vmalert/config"
 	"github.com/VictoriaMetrics/VictoriaMetrics/app/vmalert/datasource"
 	"github.com/VictoriaMetrics/VictoriaMetrics/app/vmalert/notifier"
 	"github.com/VictoriaMetrics/VictoriaMetrics/app/vmalert/remotewrite"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/logger"
+	"strings"
+	"sync"
 )
 
 // manager controls group states
@@ -98,12 +96,11 @@ func (m *manager) update(ctx context.Context, path []string, validateTpl, valida
 	for _, og := range m.groups {
 		ng, ok := groupsRegistry[og.ID()]
 		if !ok {
-			startAt := time.Now()
 			// old group is not present in new list
 			// and must be stopped and deleted
 			og.close()
 			delete(m.groups, og.ID())
-			logger.Infof("group %q delete success, took %v seconds", og.Name, time.Since(startAt).Seconds())
+			logger.Infof("group %q stopped", og.Name)
 			og = nil
 			continue
 		}
@@ -122,9 +119,7 @@ func (m *manager) update(ctx context.Context, path []string, validateTpl, valida
 	}
 
 	for _, ng := range groupsRegistry {
-		startAt := time.Now()
 		m.startGroup(ctx, ng, restore)
-		logger.Infof("group %q new start success, took %v seconds", ng.Name, time.Since(startAt).Seconds())
 	}
 	m.groupsMu.Unlock()
 	return nil


### PR DESCRIPTION
app/vmalert/manager: change sending new group setting to old group in goroutine, so that long time cost group(rule execution time will block the rule reloading) won't block other group reloadings