### PR TITLE
lib/decimal: rename `significant decimal digits` to `significant figures`

### DIFF
--- a/app/vmagent/remotewrite/remotewrite.go
+++ b/app/vmagent/remotewrite/remotewrite.go
@@ -31,8 +31,8 @@ var (
 		"for each -remoteWrite.url. When buffer size reaches the configured maximum, then old data is dropped when adding new data to the buffer. "+
 		"Buffered data is stored in ~500MB chunks, so the minimum practical value for this flag is 500000000. "+
 		"Disk usage is unlimited if the value is set to 0")
-	decimalPlaces = flag.Int("remoteWrite.decimalPlaces", 0, "The number of significant decimal places to leave in metric values before writing them to remote storage. "+
-		"See https://en.wikipedia.org/wiki/Significant_figures . Zero value saves all the significant decimal places. "+
+	significantFigures = flag.Int("remoteWrite.significantFigures", 0, "The number of significant figures to leave in metric values before writing them to remote storage. "+
+		"See https://en.wikipedia.org/wiki/Significant_figures . Zero value saves all the significant figures. "+
 		"This option may be used for increasing on-disk compression level for the stored metrics")
 )
 
@@ -124,13 +124,13 @@ func Stop() {
 //
 // Note that wr may be modified by Push due to relabeling and rounding.
 func Push(wr *prompbmarshal.WriteRequest) {
-	if *decimalPlaces > 0 {
-		// Round values according to decimalPlaces
+	if *significantFigures > 0 {
+		// Round values according to significantFigures
 		for i := range wr.Timeseries {
 			samples := wr.Timeseries[i].Samples
 			for j := range samples {
 				s := &samples[j]
-				s.Value = decimal.Round(s.Value, *decimalPlaces)
+				s.Value = decimal.Round(s.Value, *significantFigures)
 			}
 		}
 	}

--- a/lib/decimal/decimal.go
+++ b/lib/decimal/decimal.go
@@ -256,7 +256,7 @@ func maxUpExponent(v int64) int16 {
 	}
 }
 
-// Round f to value with the given number of significant decimal digits.
+// Round f to value with the given number of significant figures.
 func Round(f float64, digits int) float64 {
 	if digits <= 0 || digits >= 18 {
 		return f


### PR DESCRIPTION
The previous notion was inconsistent with what `decimal.Round` does.
According to [wiki](https://en.wikipedia.org/wiki/Significant_figures) rounding
applied to all significant figures, not just decimal ones.