### PR TITLE
lib/httpserver: add option to control idle connection timeout

### DIFF
--- a/lib/httpserver/httpserver.go
+++ b/lib/httpserver/httpserver.go
@@ -42,6 +42,7 @@ var (
 		"Highly loaded server may require increased value for graceful shutdown")
 	shutdownDelay = flag.Duration("http.shutdownDelay", 0, "Optional delay before http server shutdown. During this dealy the servier returns non-OK responses "+
 		"from /health page, so load balancers can route new requests to other servers")
+	idleTimeout = flag.Duration("http.idleTimeout", 60*time.Second, "The maximum amount of time to wait for the next request when keep-alives are enabled")
 )
 
 var (
@@ -104,7 +105,7 @@ func serveWithListener(addr string, ln net.Listener, rh RequestHandler) {
 		TLSNextProto: make(map[string]func(*http.Server, *tls.Conn, http.Handler)),
 
 		ReadHeaderTimeout: 5 * time.Second,
-		IdleTimeout:       time.Minute,
+		IdleTimeout:       *idleTimeout,
 
 		// Do not set ReadTimeout and WriteTimeout here,
 		// since these timeouts must be controlled by request handlers.


### PR DESCRIPTION
This PR resolves the issue when VM instances (vmagent, vminsert) are located behind Load Balancer.

VictoriaMetrics has hardcoded IdleTimeut of 60s. Some collectors like Telegraf creates keep-alive connection (def 15s) and it is never closed because of reuse.

As a result, balancing does not work. 