### PR TITLE
Add omitempty for DisableCompression and DisableKeepAlive fields in ScrapeConfig

### DIFF
--- a/lib/promauth/config.go
+++ b/lib/promauth/config.go
@@ -13,18 +13,18 @@ import (
 //
 // See https://prometheus.io/docs/prometheus/latest/configuration/configuration/#tls_config
 type TLSConfig struct {
-	CAFile             string `yaml:"ca_file"`
-	CertFile           string `yaml:"cert_file"`
-	KeyFile            string `yaml:"key_file"`
-	ServerName         string `yaml:"server_name"`
+	CAFile             string `yaml:"ca_file,omitempty"`
+	CertFile           string `yaml:"cert_file,omitempty"`
+	KeyFile            string `yaml:"key_file,omitempty"`
+	ServerName         string `yaml:"server_name,omitempty"`
 	InsecureSkipVerify bool   `yaml:"insecure_skip_verify"`
 }
 
 // BasicAuthConfig represents basic auth config.
 type BasicAuthConfig struct {
 	Username     string `yaml:"username"`
-	Password     string `yaml:"password"`
-	PasswordFile string `yaml:"password_file"`
+	Password     string `yaml:"password,omitempty"`
+	PasswordFile string `yaml:"password_file,omitempty"`
 }
 
 // Config is auth config.

--- a/lib/promauth/config.go
+++ b/lib/promauth/config.go
@@ -17,7 +17,7 @@ type TLSConfig struct {
 	CertFile           string `yaml:"cert_file,omitempty"`
 	KeyFile            string `yaml:"key_file,omitempty"`
 	ServerName         string `yaml:"server_name,omitempty"`
-	InsecureSkipVerify bool   `yaml:"insecure_skip_verify"`
+	InsecureSkipVerify bool   `yaml:"insecure_skip_verify,omitempty"`
 }
 
 // BasicAuthConfig represents basic auth config.

--- a/lib/promrelabel/config.go
+++ b/lib/promrelabel/config.go
@@ -14,13 +14,13 @@ import (
 //
 // See https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
 type RelabelConfig struct {
-	SourceLabels []string `yaml:"source_labels"`
-	Separator    *string  `yaml:"separator"`
-	TargetLabel  string   `yaml:"target_label"`
-	Regex        *string  `yaml:"regex"`
-	Modulus      uint64   `yaml:"modulus"`
-	Replacement  *string  `yaml:"replacement"`
-	Action       string   `yaml:"action"`
+	SourceLabels []string `yaml:"source_labels,flow,omitempty"`
+	Separator    *string  `yaml:"separator,omitempty"`
+	TargetLabel  string   `yaml:"target_label,omitempty"`
+	Regex        *string  `yaml:"regex,omitempty"`
+	Modulus      uint64   `yaml:"modulus,omitempty"`
+	Replacement  *string  `yaml:"replacement,omitempty"`
+	Action       string   `yaml:"action,omitempty"`
 }
 
 // LoadRelabelConfigs loads relabel configs from the given path.

--- a/lib/promscrape/config.go
+++ b/lib/promscrape/config.go
@@ -82,9 +82,9 @@ type ScrapeConfig struct {
 	SampleLimit          int                         `yaml:"sample_limit"`
 
 	// These options are supported only by lib/promscrape.
-	DisableCompression bool `yaml:"disable_compression"`
-	DisableKeepAlive   bool `yaml:"disable_keepalive"`
-	StreamParse        bool `yaml:"stream_parse"`
+	DisableCompression bool `yaml:"disable_compression,omitempty"`
+	DisableKeepAlive   bool `yaml:"disable_keepalive,omitempty"`
+	StreamParse        bool `yaml:"stream_parse,omitempty"`
 
 	// This is set in loadConfig
 	swc *scrapeWorkConfig

--- a/lib/promscrape/config.go
+++ b/lib/promscrape/config.go
@@ -37,7 +37,7 @@ var (
 // Config represents essential parts from Prometheus config defined at https://prometheus.io/docs/prometheus/latest/configuration/configuration/
 type Config struct {
 	Global        GlobalConfig   `yaml:"global"`
-	ScrapeConfigs []ScrapeConfig `yaml:"scrape_configs,omitempty"`
+	ScrapeConfigs []ScrapeConfig `yaml:"scrape_configs"`
 
 	// This is set to the directory from where the config has been loaded.
 	baseDir string
@@ -102,7 +102,7 @@ type FileSDConfig struct {
 //
 // See https://prometheus.io/docs/prometheus/latest/configuration/configuration/#static_config
 type StaticConfig struct {
-	Targets []string          `yaml:"targets,omitempty"`
+	Targets []string          `yaml:"targets"`
 	Labels  map[string]string `yaml:"labels,omitempty"`
 }
 

--- a/lib/promscrape/config.go
+++ b/lib/promscrape/config.go
@@ -37,7 +37,7 @@ var (
 // Config represents essential parts from Prometheus config defined at https://prometheus.io/docs/prometheus/latest/configuration/configuration/
 type Config struct {
 	Global        GlobalConfig   `yaml:"global"`
-	ScrapeConfigs []ScrapeConfig `yaml:"scrape_configs"`
+	ScrapeConfigs []ScrapeConfig `yaml:"scrape_configs,omitempty"`
 
 	// This is set to the directory from where the config has been loaded.
 	baseDir string
@@ -47,9 +47,9 @@ type Config struct {
 //
 // See https://prometheus.io/docs/prometheus/latest/configuration/configuration/
 type GlobalConfig struct {
-	ScrapeInterval time.Duration     `yaml:"scrape_interval"`
-	ScrapeTimeout  time.Duration     `yaml:"scrape_timeout"`
-	ExternalLabels map[string]string `yaml:"external_labels"`
+	ScrapeInterval time.Duration     `yaml:"scrape_interval,omitempty"`
+	ScrapeTimeout  time.Duration     `yaml:"scrape_timeout,omitempty"`
+	ExternalLabels map[string]string `yaml:"external_labels,omitempty"`
 }
 
 // ScrapeConfig represents essential parts for `scrape_config` section of Prometheus config.
@@ -57,29 +57,29 @@ type GlobalConfig struct {
 // See https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scrape_config
 type ScrapeConfig struct {
 	JobName              string                      `yaml:"job_name"`
-	ScrapeInterval       time.Duration               `yaml:"scrape_interval"`
-	ScrapeTimeout        time.Duration               `yaml:"scrape_timeout"`
-	MetricsPath          string                      `yaml:"metrics_path"`
-	HonorLabels          bool                        `yaml:"honor_labels"`
-	HonorTimestamps      bool                        `yaml:"honor_timestamps"`
-	Scheme               string                      `yaml:"scheme"`
-	Params               map[string][]string         `yaml:"params"`
-	BasicAuth            *promauth.BasicAuthConfig   `yaml:"basic_auth"`
-	BearerToken          string                      `yaml:"bearer_token"`
-	BearerTokenFile      string                      `yaml:"bearer_token_file"`
-	TLSConfig            *promauth.TLSConfig         `yaml:"tls_config"`
-	StaticConfigs        []StaticConfig              `yaml:"static_configs"`
-	FileSDConfigs        []FileSDConfig              `yaml:"file_sd_configs"`
-	KubernetesSDConfigs  []kubernetes.SDConfig       `yaml:"kubernetes_sd_configs"`
-	OpenStackSDConfigs   []openstack.SDConfig        `yaml:"openstack_sd_configs"`
-	ConsulSDConfigs      []consul.SDConfig           `yaml:"consul_sd_configs"`
-	DockerSwarmConfigs   []dockerswarm.SDConfig      `yaml:"dockerswarm_sd_configs"`
-	DNSSDConfigs         []dns.SDConfig              `yaml:"dns_sd_configs"`
-	EC2SDConfigs         []ec2.SDConfig              `yaml:"ec2_sd_configs"`
-	GCESDConfigs         []gce.SDConfig              `yaml:"gce_sd_configs"`
-	RelabelConfigs       []promrelabel.RelabelConfig `yaml:"relabel_configs"`
-	MetricRelabelConfigs []promrelabel.RelabelConfig `yaml:"metric_relabel_configs"`
-	SampleLimit          int                         `yaml:"sample_limit"`
+	ScrapeInterval       time.Duration               `yaml:"scrape_interval,omitempty"`
+	ScrapeTimeout        time.Duration               `yaml:"scrape_timeout,omitempty"`
+	MetricsPath          string                      `yaml:"metrics_path,omitempty"`
+	HonorLabels          bool                        `yaml:"honor_labels,omitempty"`
+	HonorTimestamps      bool                        `yaml:"honor_timestamps,omitempty"`
+	Scheme               string                      `yaml:"scheme,omitempty"`
+	Params               map[string][]string         `yaml:"params,omitempty"`
+	BasicAuth            *promauth.BasicAuthConfig   `yaml:"basic_auth,omitempty"`
+	BearerToken          string                      `yaml:"bearer_token,omitempty"`
+	BearerTokenFile      string                      `yaml:"bearer_token_file,omitempty"`
+	TLSConfig            *promauth.TLSConfig         `yaml:"tls_config,omitempty"`
+	StaticConfigs        []StaticConfig              `yaml:"static_configs,omitempty"`
+	FileSDConfigs        []FileSDConfig              `yaml:"file_sd_configs,omitempty"`
+	KubernetesSDConfigs  []kubernetes.SDConfig       `yaml:"kubernetes_sd_configs,omitempty"`
+	OpenStackSDConfigs   []openstack.SDConfig        `yaml:"openstack_sd_configs,omitempty"`
+	ConsulSDConfigs      []consul.SDConfig           `yaml:"consul_sd_configs,omitempty"`
+	DockerSwarmConfigs   []dockerswarm.SDConfig      `yaml:"dockerswarm_sd_configs,omitempty"`
+	DNSSDConfigs         []dns.SDConfig              `yaml:"dns_sd_configs,omitempty"`
+	EC2SDConfigs         []ec2.SDConfig              `yaml:"ec2_sd_configs,omitempty"`
+	GCESDConfigs         []gce.SDConfig              `yaml:"gce_sd_configs,omitempty"`
+	RelabelConfigs       []promrelabel.RelabelConfig `yaml:"relabel_configs,omitempty"`
+	MetricRelabelConfigs []promrelabel.RelabelConfig `yaml:"metric_relabel_configs,omitempty"`
+	SampleLimit          int                         `yaml:"sample_limit,omitempty"`
 
 	// These options are supported only by lib/promscrape.
 	DisableCompression bool `yaml:"disable_compression,omitempty"`
@@ -102,8 +102,8 @@ type FileSDConfig struct {
 //
 // See https://prometheus.io/docs/prometheus/latest/configuration/configuration/#static_config
 type StaticConfig struct {
-	Targets []string          `yaml:"targets"`
-	Labels  map[string]string `yaml:"labels"`
+	Targets []string          `yaml:"targets,omitempty"`
+	Labels  map[string]string `yaml:"labels,omitempty"`
 }
 
 func loadStaticConfigs(path string) ([]StaticConfig, error) {

--- a/lib/promscrape/discovery/consul/consul.go
+++ b/lib/promscrape/discovery/consul/consul.go
@@ -16,10 +16,10 @@ type SDConfig struct {
 	Scheme       string              `yaml:"scheme,omitempty"`
 	Username     string              `yaml:"username"`
 	Password     string              `yaml:"password"`
-	TLSConfig    *promauth.TLSConfig `yaml:"tls_config"`
+	TLSConfig    *promauth.TLSConfig `yaml:"tls_config,omitempty"`
 	Services     []string            `yaml:"services,omitempty"`
 	Tags         []string            `yaml:"tags,omitempty"`
-	NodeMeta     map[string]string   `yaml:"node_meta"`
+	NodeMeta     map[string]string   `yaml:"node_meta,omitempty"`
 	TagSeparator *string             `yaml:"tag_separator,omitempty"`
 	AllowStale   bool                `yaml:"allow_stale,omitempty"`
 	// RefreshInterval time.Duration `yaml:"refresh_interval"`

--- a/lib/promscrape/discovery/consul/consul.go
+++ b/lib/promscrape/discovery/consul/consul.go
@@ -10,18 +10,18 @@ import (
 //
 // See https://prometheus.io/docs/prometheus/latest/configuration/configuration/#consul_sd_config
 type SDConfig struct {
-	Server       string              `yaml:"server"`
+	Server       string              `yaml:"server,omitempty"`
 	Token        *string             `yaml:"token"`
 	Datacenter   string              `yaml:"datacenter"`
-	Scheme       string              `yaml:"scheme"`
+	Scheme       string              `yaml:"scheme,omitempty"`
 	Username     string              `yaml:"username"`
 	Password     string              `yaml:"password"`
 	TLSConfig    *promauth.TLSConfig `yaml:"tls_config"`
-	Services     []string            `yaml:"services"`
-	Tags         []string            `yaml:"tags"`
+	Services     []string            `yaml:"services,omitempty"`
+	Tags         []string            `yaml:"tags,omitempty"`
 	NodeMeta     map[string]string   `yaml:"node_meta"`
-	TagSeparator *string             `yaml:"tag_separator"`
-	AllowStale   bool                `yaml:"allow_stale"`
+	TagSeparator *string             `yaml:"tag_separator,omitempty"`
+	AllowStale   bool                `yaml:"allow_stale,omitempty"`
 	// RefreshInterval time.Duration `yaml:"refresh_interval"`
 	// refresh_interval is obtained from `-promscrape.consulSDCheckInterval` command-line option.
 }

--- a/lib/promscrape/discovery/dns/dns.go
+++ b/lib/promscrape/discovery/dns/dns.go
@@ -17,7 +17,7 @@ import (
 // See https://prometheus.io/docs/prometheus/latest/configuration/configuration/#dns_sd_config
 type SDConfig struct {
 	Names []string `yaml:"names"`
-	Type  string   `yaml:"type"`
+	Type  string   `yaml:"type,omitempty"`
 	Port  *int     `yaml:"port"`
 	// RefreshInterval time.Duration `yaml:"refresh_interval"`
 	// refresh_interval is obtained from `-promscrape.dnsSDCheckInterval` command-line option.

--- a/lib/promscrape/discovery/dns/dns.go
+++ b/lib/promscrape/discovery/dns/dns.go
@@ -18,7 +18,7 @@ import (
 type SDConfig struct {
 	Names []string `yaml:"names"`
 	Type  string   `yaml:"type,omitempty"`
-	Port  *int     `yaml:"port"`
+	Port  *int     `yaml:"port,omitempty"`
 	// RefreshInterval time.Duration `yaml:"refresh_interval"`
 	// refresh_interval is obtained from `-promscrape.dnsSDCheckInterval` command-line option.
 }

--- a/lib/promscrape/discovery/dockerswarm/dockerswarm.go
+++ b/lib/promscrape/discovery/dockerswarm/dockerswarm.go
@@ -12,7 +12,7 @@ import (
 type SDConfig struct {
 	Host string `yaml:"host"`
 	// TODO: add support for proxy_url
-	TLSConfig *promauth.TLSConfig `yaml:"tls_config"`
+	TLSConfig *promauth.TLSConfig `yaml:"tls_config,omitempty"`
 	Role      string              `yaml:"role"`
 	Port      int                 `yaml:"port,omitempty"`
 	// refresh_interval is obtained from `-promscrape.dockerswarmSDCheckInterval` command-line option

--- a/lib/promscrape/discovery/dockerswarm/dockerswarm.go
+++ b/lib/promscrape/discovery/dockerswarm/dockerswarm.go
@@ -14,11 +14,11 @@ type SDConfig struct {
 	// TODO: add support for proxy_url
 	TLSConfig *promauth.TLSConfig `yaml:"tls_config"`
 	Role      string              `yaml:"role"`
-	Port      int                 `yaml:"port"`
+	Port      int                 `yaml:"port,omitempty"`
 	// refresh_interval is obtained from `-promscrape.dockerswarmSDCheckInterval` command-line option
-	BasicAuth       *promauth.BasicAuthConfig `yaml:"basic_auth"`
-	BearerToken     string                    `yaml:"bearer_token"`
-	BearerTokenFile string                    `yaml:"bearer_token_file"`
+	BasicAuth       *promauth.BasicAuthConfig `yaml:"basic_auth,omitempty"`
+	BearerToken     string                    `yaml:"bearer_token,omitempty"`
+	BearerTokenFile string                    `yaml:"bearer_token_file,omitempty"`
 }
 
 // GetLabels returns dockerswarm labels according to sdc.

--- a/lib/promscrape/discovery/ec2/ec2.go
+++ b/lib/promscrape/discovery/ec2/ec2.go
@@ -9,12 +9,12 @@ import (
 // See https://prometheus.io/docs/prometheus/latest/configuration/configuration/#ec2_sd_config
 type SDConfig struct {
 	Region    string `yaml:"region,omitempty"`
-	Endpoint  string `yaml:"endpoint"`
+	Endpoint  string `yaml:"endpoint,omitempty"`
 	AccessKey string `yaml:"access_key,omitempty"`
 	SecretKey string `yaml:"secret_key,omitempty"`
 	// TODO add support for Profile, not working atm
-	Profile string `yaml:"profile"`
-	RoleARN string `yaml:"role_arn"`
+	Profile string `yaml:"profile,omitempty"`
+	RoleARN string `yaml:"role_arn,omitempty"`
 	// RefreshInterval time.Duration `yaml:"refresh_interval"`
 	// refresh_interval is obtained from `-promscrape.ec2SDCheckInterval` command-line option.
 	Port    *int     `yaml:"port,omitempty"`

--- a/lib/promscrape/discovery/ec2/ec2.go
+++ b/lib/promscrape/discovery/ec2/ec2.go
@@ -8,17 +8,17 @@ import (
 //
 // See https://prometheus.io/docs/prometheus/latest/configuration/configuration/#ec2_sd_config
 type SDConfig struct {
-	Region    string `yaml:"region"`
+	Region    string `yaml:"region,omitempty"`
 	Endpoint  string `yaml:"endpoint"`
-	AccessKey string `yaml:"access_key"`
-	SecretKey string `yaml:"secret_key"`
+	AccessKey string `yaml:"access_key,omitempty"`
+	SecretKey string `yaml:"secret_key,omitempty"`
 	// TODO add support for Profile, not working atm
 	Profile string `yaml:"profile"`
 	RoleARN string `yaml:"role_arn"`
 	// RefreshInterval time.Duration `yaml:"refresh_interval"`
 	// refresh_interval is obtained from `-promscrape.ec2SDCheckInterval` command-line option.
-	Port    *int     `yaml:"port"`
-	Filters []Filter `yaml:"filters"`
+	Port    *int     `yaml:"port,omitempty"`
+	Filters []Filter `yaml:"filters,omitempty"`
 }
 
 // Filter is ec2 filter.

--- a/lib/promscrape/discovery/gce/gce.go
+++ b/lib/promscrape/discovery/gce/gce.go
@@ -10,7 +10,7 @@ import (
 type SDConfig struct {
 	Project string   `yaml:"project"`
 	Zone    ZoneYAML `yaml:"zone"`
-	Filter  string   `yaml:"filter"`
+	Filter  string   `yaml:"filter,omitempty"`
 	// RefreshInterval time.Duration `yaml:"refresh_interval"`
 	// refresh_interval is obtained from `-promscrape.gceSDCheckInterval` command-line option.
 	Port         *int    `yaml:"port,omitempty"`

--- a/lib/promscrape/discovery/gce/gce.go
+++ b/lib/promscrape/discovery/gce/gce.go
@@ -13,8 +13,8 @@ type SDConfig struct {
 	Filter  string   `yaml:"filter"`
 	// RefreshInterval time.Duration `yaml:"refresh_interval"`
 	// refresh_interval is obtained from `-promscrape.gceSDCheckInterval` command-line option.
-	Port         *int    `yaml:"port"`
-	TagSeparator *string `yaml:"tag_separator"`
+	Port         *int    `yaml:"port,omitempty"`
+	TagSeparator *string `yaml:"tag_separator,omitempty"`
 }
 
 // ZoneYAML holds info about zones.

--- a/lib/promscrape/discovery/kubernetes/kubernetes.go
+++ b/lib/promscrape/discovery/kubernetes/kubernetes.go
@@ -10,13 +10,13 @@ import (
 //
 // See https://prometheus.io/docs/prometheus/latest/configuration/configuration/#kubernetes_sd_config
 type SDConfig struct {
-	APIServer       string                    `yaml:"api_server"`
+	APIServer       string                    `yaml:"api_server,omitempty"`
 	Role            string                    `yaml:"role"`
-	BasicAuth       *promauth.BasicAuthConfig `yaml:"basic_auth"`
-	BearerToken     string                    `yaml:"bearer_token"`
-	BearerTokenFile string                    `yaml:"bearer_token_file"`
-	TLSConfig       *promauth.TLSConfig       `yaml:"tls_config"`
-	Namespaces      Namespaces                `yaml:"namespaces"`
+	BasicAuth       *promauth.BasicAuthConfig `yaml:"basic_auth,omitempty"`
+	BearerToken     string                    `yaml:"bearer_token,omitempty"`
+	BearerTokenFile string                    `yaml:"bearer_token_file,omitempty"`
+	TLSConfig       *promauth.TLSConfig       `yaml:"tls_config,omitempty"`
+	Namespaces      Namespaces                `yaml:"namespaces,omitempty"`
 	Selectors       []Selector                `yaml:"selectors"`
 }
 

--- a/lib/promscrape/discovery/kubernetes/kubernetes.go
+++ b/lib/promscrape/discovery/kubernetes/kubernetes.go
@@ -17,7 +17,7 @@ type SDConfig struct {
 	BearerTokenFile string                    `yaml:"bearer_token_file,omitempty"`
 	TLSConfig       *promauth.TLSConfig       `yaml:"tls_config,omitempty"`
 	Namespaces      Namespaces                `yaml:"namespaces,omitempty"`
-	Selectors       []Selector                `yaml:"selectors"`
+	Selectors       []Selector                `yaml:"selectors,omitempty"`
 }
 
 // Namespaces represents namespaces for SDConfig

--- a/lib/promscrape/discovery/openstack/openstack.go
+++ b/lib/promscrape/discovery/openstack/openstack.go
@@ -25,10 +25,10 @@ type SDConfig struct {
 	Region                      string `yaml:"region"`
 	// RefreshInterval time.Duration `yaml:"refresh_interval"`
 	// refresh_interval is obtained from `-promscrape.openstackSDCheckInterval` command-line option.
-	Port         int                 `yaml:"port"`
-	AllTenants   bool                `yaml:"all_tenants"`
+	Port         int                 `yaml:"port,omitempty"`
+	AllTenants   bool                `yaml:"all_tenants,omitempty"`
 	TLSConfig    *promauth.TLSConfig `yaml:"tls_config"`
-	Availability string              `yaml:"availability"`
+	Availability string              `yaml:"availability,omitempty"`
 }
 
 // GetLabels returns gce labels according to sdc.

--- a/lib/promscrape/discovery/openstack/openstack.go
+++ b/lib/promscrape/discovery/openstack/openstack.go
@@ -10,24 +10,24 @@ import (
 //
 // See https://prometheus.io/docs/prometheus/latest/configuration/configuration/#openstack_sd_config
 type SDConfig struct {
-	IdentityEndpoint            string `yaml:"identity_endpoint"`
-	Username                    string `yaml:"username"`
-	UserID                      string `yaml:"userid"`
-	Password                    string `yaml:"password"`
-	ProjectName                 string `yaml:"project_name"`
-	ProjectID                   string `yaml:"project_id"`
-	DomainName                  string `yaml:"domain_name"`
-	DomainID                    string `yaml:"domain_id"`
-	ApplicationCredentialName   string `yaml:"application_credential_name"`
-	ApplicationCredentialID     string `yaml:"application_credential_id"`
-	ApplicationCredentialSecret string `yaml:"application_credential_secret"`
+	IdentityEndpoint            string `yaml:"identity_endpoint,omitempty"`
+	Username                    string `yaml:"username,omitempty"`
+	UserID                      string `yaml:"userid,omitempty"`
+	Password                    string `yaml:"password,omitempty"`
+	ProjectName                 string `yaml:"project_name,omitempty"`
+	ProjectID                   string `yaml:"project_id,omitempty"`
+	DomainName                  string `yaml:"domain_name,omitempty"`
+	DomainID                    string `yaml:"domain_id,omitempty"`
+	ApplicationCredentialName   string `yaml:"application_credential_name,omitempty"`
+	ApplicationCredentialID     string `yaml:"application_credential_id,omitempty"`
+	ApplicationCredentialSecret string `yaml:"application_credential_secret,omitempty"`
 	Role                        string `yaml:"role"`
 	Region                      string `yaml:"region"`
 	// RefreshInterval time.Duration `yaml:"refresh_interval"`
 	// refresh_interval is obtained from `-promscrape.openstackSDCheckInterval` command-line option.
 	Port         int                 `yaml:"port,omitempty"`
 	AllTenants   bool                `yaml:"all_tenants,omitempty"`
-	TLSConfig    *promauth.TLSConfig `yaml:"tls_config"`
+	TLSConfig    *promauth.TLSConfig `yaml:"tls_config,omitempty"`
 	Availability string              `yaml:"availability,omitempty"`
 }
 


### PR DESCRIPTION
Added the "omitempty" option for the DisableCompression and DisableKeepAlive fields in ScrapeConfig.

We use your models in our code and would like to be able to leave these fields empty. I think, it's not going to be a problem.
