### PR TITLE
disable response compression on websocket

### DIFF
--- a/lib/httpserver/httpserver.go
+++ b/lib/httpserver/httpserver.go
@@ -306,6 +306,9 @@ func maybeGzipResponseWriter(w http.ResponseWriter, r *http.Request) http.Respon
 	if *disableResponseCompression {
 		return w
 	}
+	if r.Header.Get("Connection") == "Upgrade" {
+		return w
+	}
 	ae := r.Header.Get("Accept-Encoding")
 	if ae == "" {
 		return w


### PR DESCRIPTION
I want to import httpserver in VictoriaLogs and need to disable compression on the websocket connection.