### PR TITLE
vmalert - add dryRun

### DIFF
--- a/app/vmalert/main.go
+++ b/app/vmalert/main.go
@@ -62,7 +62,15 @@ func main() {
 	cgroup.UpdateGOMAXPROCSToCPUQuota()
 
 	if *dryRun {
-		checkConfigs()
+		u, _ := url.Parse("https://victoriametrics.com/")
+		notifier.InitTemplateFunc(u)
+		groups, err := config.Parse(*rulePath, true, true)
+		if err != nil {
+			logger.Fatalf(err.Error())
+		}
+		if len(groups) == 0 {
+			logger.Fatalf("No rules for validation. Please specify path to file(s) with alerting and/or recording rules using `-rule` flag")
+		}
 		return
 	}
 	ctx, cancel := context.WithCancel(context.Background())
@@ -203,17 +211,6 @@ func getAlertURLGenerator(externalURL *url.URL, externalAlertSource string, vali
 		}
 		return fmt.Sprintf("%s/%s", externalURL, templated["tpl"])
 	}, nil
-}
-
-func checkConfigs() {
-	u, _ := url.Parse("https://victoriametrics.com/")
-	notifier.InitTemplateFunc(u)
-	if len(*rulePath) == 0 {
-		logger.Fatalf("No rules for validation. Please specify path to file(s) with alerting and/or recording rules using `-rule` flag")
-	}
-	if _, err := config.Parse(*rulePath, true, true); err != nil {
-		logger.Fatalf(err.Error())
-	}
 }
 
 func usage() {


### PR DESCRIPTION
add dryRun flag for checking rules in config the error output looks like:

```
2020-10-17T12:11:12.393Z	fatal app/vmalert/main.go:219	config parsing errors:
invalid group "group" in file "config/testdata/dir/rules0-bad.rules": invalid annotations for rule "group"."InvalidAnnotations": errors(1): key "summary", template "{{ $value }": error parsing annotation: template: :1: unexpected "}" in operand
group name "sameGroup" duplicate in file "config/testdata/dir/rules1-bad.rules"
invalid group "group" in file "config/testdata/dir/rules2-bad.rules": invalid labels for rule "group"."UnkownLabelFunction": errors(1): key "summary", template "{{ value|query }}": error parsing annotation: template: :1: function "value" not defined
invalid group "group" in file "config/testdata/dir/rules3-bad.rules": invalid rule "group"."": either `record` or `alert` must be set
invalid group "group" in file "config/testdata/dir/rules4-bad.rules": invalid rule "group"."rows": either `record` or `alert` must be set
```