### PR TITLE
OpenBSD packaging files

### DIFF
--- a/ports/OpenBSD/README.md
+++ b/ports/OpenBSD/README.md
@@ -1,0 +1,11 @@
+# OpenBSD ports 
+
+Tested with Release 6.7
+
+The VictoriaMetrics DB must be place in `/usr/ports/sysutils` directory
+and the file `/usr/ports/infrastructure/db/user.list`
+should be modified with a new line
+```
+855 _vmetrics            _vmetrics       sysutils/VictoriaMetrics
+```
+

--- a/ports/OpenBSD/VictoriaMetrics/Makefile
+++ b/ports/OpenBSD/VictoriaMetrics/Makefile
@@ -1,0 +1,38 @@
+# $OpenBSD$
+
+COMMENT =		fast, cost-effective and scalable time series database
+
+GH_ACCOUNT =		VictoriaMetrics
+GH_PROJECT =		VictoriaMetrics
+GH_TAGNAME =		v1.44.0
+
+CATEGORIES =		sysutils
+
+HOMEPAGE =		https://victoriametrics.com/
+
+MAINTAINER =		VictoriaMetrics <info@victoriametrics.com>
+
+# Apache License 2.0
+PERMIT_PACKAGE =	Yes
+
+WANTLIB =		c pthread
+
+USE_GMAKE =		Yes
+
+MODULES=		lang/go
+MODGO_GOPATH=		${MODGO_WORKSPACE}
+
+do-build:
+	cd ${WRKSRC} && GOOS=openbsd ${MAKE_ENV} ${MAKE_PROGRAM} victoria-metrics-pure
+	cd ${WRKSRC} && GOOS=openbsd ${MAKE_ENV} ${MAKE_PROGRAM} vmbackup
+
+do-install:
+	${INSTALL_PROGRAM} ./pkg/vmlogger.pl ${PREFIX}/bin/vmetricslogger.pl
+	${INSTALL_PROGRAM} ${WRKSRC}/bin/victoria-metrics-pure ${PREFIX}/bin/vmetrics
+	${INSTALL_PROGRAM} ${WRKSRC}/bin/vmbackup ${PREFIX}/bin/vmetricsbackup
+	${INSTALL_DATA_DIR} ${PREFIX}/share/doc/vmetrics/
+	${INSTALL_DATA} ${WRKSRC}/README.md ${PREFIX}/share/doc/vmetrics/
+	${INSTALL_DATA} ${WRKSRC}/LICENSE ${PREFIX}/share/doc/vmetrics/
+	${INSTALL_DATA} ${WRKSRC}/docs/* ${PREFIX}/share/doc/vmetrics/
+
+.include <bsd.port.mk>

--- a/ports/OpenBSD/VictoriaMetrics/distinfo
+++ b/ports/OpenBSD/VictoriaMetrics/distinfo
@@ -1,0 +1,2 @@
+SHA256 (VictoriaMetrics-1.44.0.tar.gz) = OIXIyqiijWvAPDgq5wMoDpv1rENcIOWIcXmz4T5v1lU=
+SIZE (VictoriaMetrics-1.44.0.tar.gz) = 8898365

--- a/ports/OpenBSD/VictoriaMetrics/pkg/DESCR
+++ b/ports/OpenBSD/VictoriaMetrics/pkg/DESCR
@@ -1,0 +1,3 @@
+VictoriaMetrics is fast,
+cost-effective and scalable time-series database.
+

--- a/ports/OpenBSD/VictoriaMetrics/pkg/PLIST
+++ b/ports/OpenBSD/VictoriaMetrics/pkg/PLIST
@@ -1,0 +1,34 @@
+@comment $OpenBSD$
+@newgroup _vmetrics:855
+@newuser _vmetrics:855:_vmetrics:daemon:VictoriaMetrics:${VARBASE}/db/vmetrics:/sbin/nologin
+@sample ${SYSCONFDIR}/prometheus/
+@rcscript ${RCDIR}/vmetrics
+@bin bin/vmetricslogger.pl
+@bin bin/vmetrics
+@bin bin/vmetricsbackup
+share/doc/vmetrics/
+share/doc/vmetrics/Articles.md
+share/doc/vmetrics/CaseStudies.md
+share/doc/vmetrics/Cluster-VictoriaMetrics.md
+share/doc/vmetrics/ExtendedPromQL.md
+share/doc/vmetrics/FAQ.md
+share/doc/vmetrics/Home.md
+share/doc/vmetrics/LICENSE
+share/doc/vmetrics/MetricsQL.md
+share/doc/vmetrics/Quick-Start.md
+share/doc/vmetrics/README.md
+share/doc/vmetrics/Release-Guide.md
+share/doc/vmetrics/SampleSizeCalculations.md
+share/doc/vmetrics/Single-server-VictoriaMetrics.md
+share/doc/vmetrics/logo.png
+share/doc/vmetrics/robots.txt
+share/doc/vmetrics/vmagent.md
+share/doc/vmetrics/vmagent.png
+share/doc/vmetrics/vmalert.md
+share/doc/vmetrics/vmauth.md
+share/doc/vmetrics/vmbackup.md
+share/doc/vmetrics/vmrestore.md
+@mode 0755
+@owner _vmetrics
+@group _vmetrics
+@sample ${VARBASE}/db/vmetrics

--- a/ports/OpenBSD/VictoriaMetrics/pkg/vmetrics.rc
+++ b/ports/OpenBSD/VictoriaMetrics/pkg/vmetrics.rc
@@ -1,0 +1,19 @@
+#!/bin/sh
+#
+# $OpenBSD$
+
+daemon="${TRUEPREFIX}/bin/vmetrics"
+daemon_flags="-storageDataPath=/var/db/vmetrics/ ${daemon_flags}"
+daemon_user=_vmetrics
+
+. /etc/rc.d/rc.subr
+
+pexp="${daemon}.*"
+rc_bg=YES
+rc_reload=NO
+
+rc_start() {
+	${rcexec} "${daemon} -loggerDisableTimestamps ${daemon_flags} < /dev/null 2>&1 | ${TRUEPREFIX}/bin/vmetricslogger.pl"
+}
+
+rc_cmd $1

--- a/ports/OpenBSD/VictoriaMetrics/pkg/vmlogger.pl
+++ b/ports/OpenBSD/VictoriaMetrics/pkg/vmlogger.pl
@@ -1,0 +1,18 @@
+#!/usr/bin/perl
+use Sys::Syslog qw(:standard :macros);
+
+openlog("victoria-metrics", "pid", "daemon");
+
+while (my $l = <>) {
+  my @d = split /\t/, $l;
+  # go level : "INFO", "WARN", "ERROR", "FATAL", "PANIC":
+  my $lvl = $d[0];
+  $lvl = LOG_EMERG if ($lvl eq 'panic');
+  $lvl = 'crit' if ($lvl eq 'fatal');
+  $lvl = 'err' if ($lvl eq 'error');
+  $lvl = 'warning' if ($lvl eq 'warn');
+  chomp $d[2];
+  syslog( $lvl, $d[2] );
+}
+
+closelog();


### PR DESCRIPTION
This can be used to propose and integrate Victoria DB in a -OpenBSD- ports system.

I would have use package/OpenBSD but package assumed only debian .

The Directory can be zipped and send to ports@openbsd.org with [NEW] in object and package name 
by the/a maintainer