### PR TITLE
vmbackup: fix panic when origin option is not specified

### DIFF
--- a/app/vmbackup/main.go
+++ b/app/vmbackup/main.go
@@ -92,7 +92,9 @@ func main() {
 	}
 	srcFS.MustStop()
 	dstFS.MustStop()
-	originFS.MustStop()
+	if originFS != nil {
+	        originFS.MustStop()
+	}
 }
 
 func usage() {


### PR DESCRIPTION
run with:
```
vmbackup -storageDataPath=/data1/srv/migrate/vmstorage -snapshotName=20201027132837-1641DC3A8C7825FC -credsFilePath=credentials -concurrency=10 -customS3Endpoint=http://s3.devops.i.mp.sz.io -dst=s3://victoria_metrics/snapshot -configFilePath=./config
```

got panic:
```bash
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x50 pc=0xbd72b7]

goroutine 1 [running]:
main.main()
	github.com/VictoriaMetrics/VictoriaMetrics/app/vmbackup/main.go:95 +0x3f7
```