### PR TITLE
Added UDP protocol support for Graphite/Influx in docker-compose deployment

### DIFF
--- a/deployment/docker/docker-compose.yml
+++ b/deployment/docker/docker-compose.yml
@@ -21,7 +21,9 @@ services:
     image: victoriametrics/victoria-metrics
     ports:
       - 8428:8428
+      - 8428:8428/udp
       - 2003:2003
+      - 2003:2003/udp
       - 4242:4242
     volumes:
       - vmdata:/storage


### PR DESCRIPTION
This is necessary for Proxmox VE External Metric Server support.
https://pve.proxmox.com/wiki/External_Metric_Server