### PR TITLE
Fix InfluxDB support on docker-compose deployment.

### DIFF
--- a/deployment/docker/docker-compose.yml
+++ b/deployment/docker/docker-compose.yml
@@ -21,7 +21,9 @@ services:
     image: victoriametrics/victoria-metrics
     ports:
       - 8428:8428
+      - 8428:8428/udp
       - 2003:2003
+      - 2003:2003/udp
       - 4242:4242
     volumes:
       - vmdata:/storage

--- a/deployment/docker/docker-compose.yml
+++ b/deployment/docker/docker-compose.yml
@@ -21,7 +21,8 @@ services:
     image: victoriametrics/victoria-metrics
     ports:
       - 8428:8428
-      - 8428:8428/udp
+      - 8089:8089
+      - 8089:8089/udp
       - 2003:2003
       - 2003:2003/udp
       - 4242:4242
@@ -32,6 +33,7 @@ services:
       - '--graphiteListenAddr=:2003'
       - '--opentsdbListenAddr=:4242'
       - '--httpListenAddr=:8428'
+      - '--influxListenAddr=:8089'
     networks:
       - vm_net
     restart: always


### PR DESCRIPTION
This is necessary for Proxmox VE External Metric Server support.
https://pve.proxmox.com/wiki/External_Metric_Server

Additionally created Grafana Dashboard for monitoring Proxmox VE hosts.
https://grafana.com/grafana/dashboards/13307

PS: Sorry, I didn't check with InfluxDB in the previous PR. My fall.