### PR TITLE
app/vmstorage: add "/internal/force_flush" endpoint

### DIFF
--- a/lib/storage/storage.go
+++ b/lib/storage/storage.go
@@ -191,8 +191,8 @@ func OpenStorage(path string, retentionMsecs int64) (*Storage, error) {
 	return s, nil
 }
 
-// debugFlush flushes recently added storage data, so it becomes visible to search.
-func (s *Storage) debugFlush() {
+// DebugFlush flushes recently added storage data, so it becomes visible to search.
+func (s *Storage) DebugFlush() {
 	s.tb.flushRawRows()
 	s.idb().tb.DebugFlush()
 }

--- a/lib/storage/storage_test.go
+++ b/lib/storage/storage_test.go
@@ -557,7 +557,7 @@ func testStorageDeleteMetrics(s *Storage, workerNum int) error {
 			return fmt.Errorf("unexpected error when adding mrs: %w", err)
 		}
 	}
-	s.debugFlush()
+	s.DebugFlush()
 
 	// Verify tag values exist
 	tvs, err := s.SearchTagValues(workerTag, 1e5, noDeadline)


### PR DESCRIPTION
As discussed briefly in Slack, it would be nice to have this endpoint to use a live victoriametrics instance in testing, when some other component writes some data into it and expects it to be available without waiting for background flushing to kick in.

~~I have implemented it to reuse `forceMergeAuthKey` instead of adding a new key to minimise the scope of the change. I am aware that the name is not very suitable, but both endpoints are internal and do a similar thing: trigger a background process without having to wait for it.~~

Golang is not my "native" tongue, so happy to revisit the changeset until it is good enough to get accepted, but I have also enabled editing by maintainers to speed up one-liner suggestions.