### PR TITLE
add charset on targets response

### DIFF
--- a/app/vmagent/main.go
+++ b/app/vmagent/main.go
@@ -207,13 +207,13 @@ func requestHandler(w http.ResponseWriter, r *http.Request) bool {
 		return true
 	case "/targets":
 		promscrapeTargetsRequests.Inc()
-		w.Header().Set("Content-Type", "text/plain")
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 		showOriginalLabels, _ := strconv.ParseBool(r.FormValue("show_original_labels"))
 		promscrape.WriteHumanReadableTargetsStatus(w, showOriginalLabels)
 		return true
 	case "/api/v1/targets":
 		promscrapeAPIV1TargetsRequests.Inc()
-		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		state := r.FormValue("state")
 		promscrape.WriteAPIV1Targets(w, state)
 		return true


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/3659110/99037749-4b76f300-25bf-11eb-9e12-210aec78c923.png)
Label values may contain any Unicode characters.
I've only changed the two api's I'm using, there should be some other api that need to be added to charset as well.