### PR TITLE
OpenBSD 6.8 port update (fix multi instance logging name, add restore, fix rcctl)

### DIFF
--- a/ports/OpenBSD/VictoriaMetrics/Makefile
+++ b/ports/OpenBSD/VictoriaMetrics/Makefile
@@ -1,4 +1,4 @@
-# $OpenBSD$
+# $OpenBSD: Makefile,v $
 
 COMMENT =		fast, cost-effective and scalable time series database
 
@@ -21,17 +21,18 @@ USE_GMAKE =		Yes
 
 MODULES =		lang/go
 MODGO_GOPATH =		${MODGO_WORKSPACE}
-
 SUBST_VARS =		VARBASE
 
 do-build:
 	cd ${WRKSRC} && GOOS=openbsd ${MAKE_ENV} ${MAKE_PROGRAM} victoria-metrics-pure
 	cd ${WRKSRC} && GOOS=openbsd ${MAKE_ENV} ${MAKE_PROGRAM} vmbackup
+	cd ${WRKSRC} && GOOS=openbsd ${MAKE_ENV} ${MAKE_PROGRAM} vmrestore
 
 do-install:
 	${INSTALL_PROGRAM} ./pkg/vmlogger.pl ${PREFIX}/bin/vmetricslogger.pl
 	${INSTALL_PROGRAM} ${WRKSRC}/bin/victoria-metrics-pure ${PREFIX}/bin/vmetrics
 	${INSTALL_PROGRAM} ${WRKSRC}/bin/vmbackup ${PREFIX}/bin/vmetricsbackup
+	${INSTALL_PROGRAM} ${WRKSRC}/bin/vmrestore ${PREFIX}/bin/vmetricsrestore
 	${INSTALL_DATA_DIR} ${PREFIX}/share/doc/vmetrics/
 	${INSTALL_DATA} ${WRKSRC}/README.md ${PREFIX}/share/doc/vmetrics/
 	${INSTALL_DATA} ${WRKSRC}/LICENSE ${PREFIX}/share/doc/vmetrics/

--- a/ports/OpenBSD/VictoriaMetrics/pkg/PLIST
+++ b/ports/OpenBSD/VictoriaMetrics/pkg/PLIST
@@ -5,6 +5,7 @@
 @rcscript ${RCDIR}/vmetrics
 @bin bin/vmetrics
 @bin bin/vmetricsbackup
+@bin bin/vmetricsrestore
 @bin bin/vmetricslogger.pl
 share/doc/vmetrics/
 share/doc/vmetrics/Articles.md

--- a/ports/OpenBSD/VictoriaMetrics/pkg/vmetrics.rc
+++ b/ports/OpenBSD/VictoriaMetrics/pkg/vmetrics.rc
@@ -8,12 +8,14 @@ daemon_user=_vmetrics
 
 . /etc/rc.d/rc.subr
 
-pexp="${daemon}.*"
+pexp="${daemon} -loggerDisableTimestamps ${daemon_flags}.*"
 rc_bg=YES
 rc_reload=NO
 
+me=`basename $0`
+
 rc_start() {
-	${rcexec} "${daemon} -loggerDisableTimestamps ${daemon_flags} < /dev/null 2>&1 | ${TRUEPREFIX}/bin/vmetricslogger.pl"
+	${rcexec} "${daemon} -loggerDisableTimestamps ${daemon_flags} < /dev/null 2>&1 | ${TRUEPREFIX}/bin/vmetricslogger.pl $me"
 }
 
 rc_cmd $1

--- a/ports/OpenBSD/VictoriaMetrics/pkg/vmlogger.pl
+++ b/ports/OpenBSD/VictoriaMetrics/pkg/vmlogger.pl
@@ -1,9 +1,9 @@
 #!/usr/bin/perl
 use Sys::Syslog qw(:standard :macros);
 
-openlog("victoria-metrics", "pid", "daemon");
+openlog($ARGV[0], "pid", "daemon");
 
-while (my $l = <>) {
+while (my $l = <STDIN>) {
   my @d = split /\t/, $l;
   # go level : "INFO", "WARN", "ERROR", "FATAL", "PANIC":
   my $lvl = $d[0];


### PR DESCRIPTION
OpenBSD 6.8 port update

fix multi instance logging name:
> use the name of the symlink of rcctl to name the log
, add restore
> add the vmrestore bin
, fix rcctl
> the no timestamp must be used consistently 