### PR TITLE
vmalert-974: fix order for labels templating

### DIFF
--- a/app/vmalert/config/testdata/rules2-good.rules
+++ b/app/vmalert/config/testdata/rules2-good.rules
@@ -15,8 +15,11 @@ groups:
       - alert: ExampleAlertAlwaysFiring
         expr: sum by(job)
           (up == 1)
+        labels:
+          job: '{{ $labels.job }}'
         annotations:
-          summary: Instances up {{ range query "up" }}
+          description: Job {{ $labels.job }} is up!
+          summary: All instances up {{ range query "up" }}
             {{ . | label "instance" }}
             {{ end }}
       - record: handler:requests:rate5m


### PR DESCRIPTION
The change fixes bug caused by https://github.com/VictoriaMetrics/VictoriaMetrics/commit/3adf8c5a6f4a8eea5f2025dd53ba975d42f8b8d1.

https://github.com/VictoriaMetrics/VictoriaMetrics/issues/974

------------------

@f41gh7 pls see the test cases in PR. I'd appreciate your review and feel free to suggest additional test cases we may want to check.