### PR TITLE
docker-compose: add blackhole receiver for alertmanager

### DIFF
--- a/deployment/docker/alertmanager.yml
+++ b/deployment/docker/alertmanager.yml
@@ -1,0 +1,5 @@
+route:
+  receiver: blackhole
+
+receivers:
+  - name: blackhole

--- a/deployment/docker/docker-compose.yml
+++ b/deployment/docker/docker-compose.yml
@@ -77,6 +77,10 @@ services:
   alertmanager:
     container_name: alertmanager
     image:  prom/alertmanager
+    volumes:
+      - ./alertmanager.yml:/config/alertmanager.yml
+    command:
+      - '--config.file=/config/alertmanager.yml'
     ports:
       - 9093:9093
     networks:


### PR DESCRIPTION
Currently, alertmanager spams logs with `Notify attempt failed, will retry later` message
because default receiver is unreachable. The change updates default configuration with
blackhole receiver which means alertmanager will continue to accept alerts but won't make
attempts to send them anywhere.

https://github.com/VictoriaMetrics/VictoriaMetrics/issues/995