### PR TITLE
vmalert-989: return non-empty result in template func `query` stub to pass validation

### DIFF
--- a/app/vmalert/config/testdata/rules2-good.rules
+++ b/app/vmalert/config/testdata/rules2-good.rules
@@ -17,6 +17,7 @@ groups:
           (up == 1)
         labels:
           job: '{{ $labels.job }}'
+          dynamic: '{{ $x := query "up" | first | value }}{{ if eq 1.0 $x }}one{{ else }}unknown{{ end }}'
         annotations:
           description: Job {{ $labels.job }} is up!
           summary: All instances up {{ range query "up" }}

--- a/app/vmalert/notifier/template_func.go
+++ b/app/vmalert/notifier/template_func.go
@@ -178,7 +178,9 @@ func InitTemplateFunc(externalURL *url.URL) {
 		// it is present here only for validation purposes, when there is no
 		// provided datasource.
 		"query": func(q string) ([]datasource.Metric, error) {
-			return nil, nil
+			// return non-empty slice to pass validation with chained functions in template
+			// see issue #989 for details
+			return []datasource.Metric{{}}, nil
 		},
 		"first": func(metrics []datasource.Metric) (datasource.Metric, error) {
 			if len(metrics) > 0 {


### PR DESCRIPTION
On templates validation stage vmalert does not acutally send queries, so for complex
chained expression validation may fail. To avoid this, we add a blank sample in response
so validation can pass successfully. Later, during the rule execution, stub will be replaced
with real `query` function.

https://github.com/VictoriaMetrics/VictoriaMetrics/issues/989