### PR TITLE
fix(vmalert): don't drop the resolved alerts

### DIFF
--- a/app/vmalert/alerting.go
+++ b/app/vmalert/alerting.go
@@ -185,12 +185,6 @@ func (ar *AlertingRule) Exec(ctx context.Context, q datasource.Querier, series b
 		// if alert wasn't updated in this iteration
 		// means it is resolved already
 		if _, ok := updated[h]; !ok {
-			if a.State == notifier.StatePending {
-				// alert was in Pending state - it is not
-				// active anymore
-				delete(ar.alerts, h)
-				continue
-			}
 			a.State = notifier.StateInactive
 			continue
 		}

--- a/app/vmalert/alerting_test.go
+++ b/app/vmalert/alerting_test.go
@@ -248,7 +248,9 @@ func TestAlertingRule_Exec(t *testing.T) {
 				// empty step to reset and delete pending alerts
 				{},
 			},
-			map[uint64]*notifier.Alert{},
+			map[uint64]*notifier.Alert{
+				hash(metricWithLabels(t, "name", "foo")): {State: notifier.StateInactive},
+			},
 		},
 		{
 			newTestAlertingRule("for-pending=>firing=>inactive", defaultStep),


### PR DESCRIPTION
VictoriaMetrics is a great project,  but recently I've been having a bit of a problem with it. I'm using `vmalert` to send alerts. In some condition, 
In some cases, the system paging may be recovered within vmalert's scrape interval, so when vmalert completes the calculation, the alert will disappear. eg:

```bash
t0:  system paging
t1:   vmalert got a new alert -> send alerts into Alertmanager
t2:  system recovered
t1+interval: the alert is deleted, but Alertmanager doesn't know whether the alert is archived or not.
```
I think in this case, the alert should be sent out instead of deleted directly, otherwise, the downstream alertmanager may not be aware of the failure.