### PR TITLE
adds priority for extra_labels filters

### DIFF
--- a/app/vmselect/prometheus/prometheus.go
+++ b/app/vmselect/prometheus/prometheus.go
@@ -1255,8 +1255,27 @@ func addEnforcedFiltersToTagFilterss(dstTfss [][]storage.TagFilter, enforcedFilt
 			enforcedFilters,
 		}
 	}
+	if len(enforcedFilters) == 0 {
+		return dstTfss
+	}
+	etfByKey := make(map[string]struct{})
+	for _, etf := range enforcedFilters {
+		etfByKey[string(etf.Key)] = struct{}{}
+	}
+	// filter in place tag filters with the same key,
+	// as enforced tag filter.
 	for i := range dstTfss {
-		dstTfss[i] = append(dstTfss[i], enforcedFilters...)
+		dstTf := dstTfss[i]
+		n := 0
+		for x := range dstTf {
+			tf := dstTf[x]
+			if _, ok := etfByKey[string(tf.Key)]; !ok {
+				dstTf[n] = tf
+				n++
+			}
+		}
+		dstTf = dstTf[:n]
+		dstTfss[i] = append(dstTf, enforcedFilters...)
 	}
 	return dstTfss
 }

--- a/app/vmselect/prometheus/prometheus_test.go
+++ b/app/vmselect/prometheus/prometheus_test.go
@@ -231,6 +231,16 @@ func Test_addEnforcedFiltersToTagFilterss(t *testing.T) {
 			{tfFromKV("l1", "v1"), tfFromKV("ext-l1", "v2")},
 			{tfFromKV("l2", "v2"), tfFromKV("ext-l1", "v2")},
 		})
+	f(t, [][]storage.TagFilter{
+		{tfFromKV("l1", "v1")},
+		{tfFromKV("ext-l1", "v5"), tfFromKV("l2", "v12"), tfFromKV("ext-l1", "v7")},
+	},
+		[]storage.TagFilter{tfFromKV("ext-l1", "v2")},
+		[][]storage.TagFilter{
+			{tfFromKV("l1", "v1"), tfFromKV("ext-l1", "v2")},
+			{tfFromKV("l2", "v12"), tfFromKV("ext-l1", "v2")},
+		})
+
 }
 
 func Test_getEnforcedTagFiltersFromRequest(t *testing.T) {


### PR DESCRIPTION
if original tag filter matches enforced tag filter, original tag filter must be removed from query,
otherwise it breaks enforce logic