### PR TITLE
[doc fix] status endpoint needs group ID, not group name

### DIFF
--- a/docs/vmalert.md
+++ b/docs/vmalert.md
@@ -177,7 +177,7 @@ rules configuration.
 `vmalert` runs a web-server (`-httpListenAddr`) for serving metrics and alerts endpoints:
 * `http://<vmalert-addr>/api/v1/groups` - list of all loaded groups and rules;
 * `http://<vmalert-addr>/api/v1/alerts` - list of all active alerts;
-* `http://<vmalert-addr>/api/v1/<groupName>/<alertID>/status" ` - get alert status by ID.
+* `http://<vmalert-addr>/api/v1/<groupID>/<alertID>/status" ` - get alert status by ID.
 Used as alert source in AlertManager.
 * `http://<vmalert-addr>/metrics` - application metrics.
 * `http://<vmalert-addr>/-/reload` - hot configuration reload.


### PR DESCRIPTION
Using the current doc, a cURL call will return something like

```
remoteAddr: "172.17.0.1:26778"; error in "/api/v1/AlertGroupName/AlertGroupID/status":
cannot parse groupID: strconv.ParseUint: parsing "AlertGroupName": invalid syntax
```

Using `/api/v1/AlertGroupID/AlertGroupID/status` returns the expected JSON.