### PR TITLE
deployment: fix typo in vmalert docker-compose definition

### DIFF
--- a/deployment/docker/docker-compose.yml
+++ b/deployment/docker/docker-compose.yml
@@ -71,6 +71,7 @@ services:
       # display source of alerts in grafana
       - '-external.url=http://127.0.0.1:3000' #grafana outside container
       - '--external.alert.source=explore?orgId=1&left=["now-1h","now","VictoriaMetrics",{"expr":"{{$$expr|quotesEscape|crlfEscape|queryEscape}}"},{"mode":"Metrics"},{"ui":[true,true,true,"none"]}]' ## when copypaste the line be aware of '$$' for escaping in '$expr'    networks:
+    networks:
       - vm_net
     restart: always
   alertmanager:


### PR DESCRIPTION
Fix a typo introduced in 1eecc214ff58364fecdf3b25f7d3a0bf99de9fb0