### PR TITLE
Remove unneeded label check

### DIFF
--- a/lib/storage/metric_name.go
+++ b/lib/storage/metric_name.go
@@ -472,10 +472,6 @@ func MarshalMetricNameRaw(dst []byte, labels []prompb.Label) []byte {
 			break
 		}
 		label := &labels[i]
-		if len(label.Value) == 0 {
-			// Skip labels without values, since they have no sense in prometheus.
-			continue
-		}
 		dst = marshalBytesFast(dst, label.Name)
 		dst = marshalBytesFast(dst, label.Value)
 	}


### PR DESCRIPTION
A tiny fix to eliminate a redundant size check. As far as I could see, seems like we already check exactly the same thing in L456.