### PR TITLE
Improve documentation on OpenTSDB migration tool and fix a bug with hard offsets

### DIFF
--- a/app/vmctl/README.md
+++ b/app/vmctl/README.md
@@ -129,6 +129,10 @@ Chunking the data like this means each individual query returns faster, so we ca
 
 Retention strings essentially define the two levels of aggregation for our collected series.
 
+In our above example, `sum-1m-avg` would become:
+* First order: `sum`
+* Second order: `1m-avg-none`
+
 1. First-order aggregation addresses how to aggregate any un-mentioned tags.
   * This is, conceptually, directly opposite to how PromQL deals with tags. In OpenTSDB, if a tag isn't explicitly mentioned, all values assocaited with that tag will be aggregated.
   * It is recommended to use `sum` for the first aggregation because it is relatively quick and should not cause any changes to the incoming data (because we collect each individual series).

--- a/app/vmctl/README.md
+++ b/app/vmctl/README.md
@@ -123,12 +123,18 @@ http://opentsdb:4242/api/query?start=3h-ago&end=2h-ago&m=sum:1m-avg-none:<series
 ...
 http://opentsdb:4242/api/query?start=721h-ago&end=720h-ago&m=sum:1m-avg-none:<series>
 ```
-
 Chunking the data like this means each individual query returns faster, so we can start populating data into VictoriaMetrics quicker.
 
-These retention strings essentially define the two levels of aggregation for our collected series. It is recommended to use `sum` for the first aggregation because it is relatively quick and should not cause any changes to the incoming data (because we collect each individual series).
+### Retention strings
 
-The second order aggregation (`1m-avg` in our example) should (ideally) match the stat collection interval so we again avoid transforming incoming data.
+Retention strings essentially define the two levels of aggregation for our collected series.
+
+1. First-order aggregation addresses how to aggregate any un-mentioned tags.
+  * This is, conceptually, directly opposite to how PromQL deals with tags. In OpenTSDB, if a tag isn't explicitly mentioned, all values assocaited with that tag will be aggregated.
+  * It is recommended to use `sum` for the first aggregation because it is relatively quick and should not cause any changes to the incoming data (because we collect each individual series).
+2. Second-order aggregation (`1m-avg` in our example) defines any windowing that should occur before returning the data
+  * It is recommended to match the stat collection interval so we again avoid transforming incoming data.
+  * We do not allow for defining the "null value" portion of the rollup window (e.g. in the aggreagtion, `1m-avg-none`, the user cannot change `none`), as the goal of this tool is to avoid modifying incoming data.
 
 ### Restarting OpenTSDB migrations
 

--- a/app/vmctl/README.md
+++ b/app/vmctl/README.md
@@ -115,6 +115,15 @@ OpenTSDB migration works like so:
 
 This means that we must stream data from OpenTSDB to VictoriaMetrics in chunks. This is where concurrency for OpenTSDB comes in. We can query multiple chunks at once, but we shouldn't perform too many chunks at a time to avoid overloading the OpenTSDB cluster.
 
+```
+$ bin/vmctl opentsdb --otsdb-addr http://opentsdb:4242/ --otsdb-retentions sum-1m-avg:1h:1d --otsdb-filters system --otsdb-normalize --vm-addr http://victoria/
+OpenTSDB import mode
+2021/04/09 11:52:50 Will collect data starting at TS 1617990770
+2021/04/09 11:52:50 Loading all metrics from OpenTSDB for filters:  [system]
+Found 9 metrics to import. Continue? [Y/n] 
+2021/04/09 11:52:51 Starting work on system.load1
+23 / 402200 [>____________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________] 0.01% 2 p/s
+```
 
 ### Retention strings
 

--- a/app/vmctl/opentsdb.go
+++ b/app/vmctl/opentsdb.go
@@ -55,7 +55,12 @@ func (op *otsdbProcessor) run(silent bool) error {
 		return nil
 	}
 	op.im.ResetStats()
-	startTime := time.Now().Unix()
+	var startTime int64
+	if op.oc.HardTS != 0 {
+		startTime = op.oc.HardTS
+	} else {
+		startTime = time.Now().Unix()
+	}
 	queryRanges := 0
 	// pre-calculate the number of query ranges we'll be processing
 	for _, rt := range op.oc.Retentions {

--- a/app/vmctl/opentsdb/opentsdb.go
+++ b/app/vmctl/opentsdb/opentsdb.go
@@ -46,7 +46,7 @@ type Client struct {
 	Retentions []Retention
 	Filters    []string
 	Normalize  bool
-	HardTS	   int64
+	HardTS     int64
 }
 
 // Config contains fields required


### PR DESCRIPTION
I realized the documentation should actually describe how the queries work so a user doesn't have to read the code to understand it.

Also, there was a bug in how offsets were handled that I somehow missed in testing. That is fixed.