### PR TITLE
alerts: make alerting rule `RPCErrors` compatible with PromQL

### DIFF
--- a/deployment/docker/alerts.yml
+++ b/deployment/docker/alerts.yml
@@ -82,7 +82,16 @@ groups:
             Please verify if clients are sending correct requests."
 
       - alert: RPCErrors
-        expr: sum(increase({__name__=~"vm_rpc_.*_errors_total"}[5m])) by(job, instance) > 0
+        expr: |
+          (
+           sum(increase(vm_rpc_connection_errors_total[5m])) by(job, instance)
+           +
+           sum(increase(vm_rpc_dial_errors_total[5m])) by(job, instance)
+           +
+           sum(increase(vm_rpc_handshake_errors_total[5m])) by(job, instance)
+           +
+           sum(increase(vm_rpc_reroute_errors_total[5m])) by(job, instance)
+          ) > 0
         for: 15m
         labels:
           severity: warning


### PR DESCRIPTION
Original query can't be executed via PromQL which results in error
if expression is evaluated by Prometheus. The new expression is
compatible with both engines.