### PR TITLE
dashboard: use unit `short` for `Labels limit exceeded` panel

### DIFF
--- a/dashboards/victoriametrics.json
+++ b/dashboards/victoriametrics.json
@@ -3028,7 +3028,7 @@
           "yaxes": [
             {
               "decimals": 2,
-              "format": "percentunit",
+              "format": "short",
               "label": null,
               "logBase": 1,
               "max": null,


### PR DESCRIPTION
https://github.com/VictoriaMetrics/VictoriaMetrics/issues/1206