### PR TITLE
vmalert: keep the returned timestamp when persisting recording rule

### DIFF
--- a/app/vmalert/recording.go
+++ b/app/vmalert/recording.go
@@ -100,7 +100,7 @@ func (rr *RecordingRule) Exec(ctx context.Context, q datasource.Querier, series 
 	duplicates := make(map[uint64]prompbmarshal.TimeSeries, len(qMetrics))
 	var tss []prompbmarshal.TimeSeries
 	for _, r := range qMetrics {
-		ts := rr.toTimeSeries(r, rr.lastExecTime)
+		ts := rr.toTimeSeries(r, time.Unix(r.Timestamp, 0))
 		h := hashTimeSeries(ts)
 		if _, ok := duplicates[h]; ok {
 			rr.lastExecError = errDuplicate


### PR DESCRIPTION
Previously, vmalert used `lastExecTime` timestamp when writing recording rules
to the remote storage. This may be incorrect, if vmalert uses `datasource.lookback` flag,
which means rule's expression will be executed at some moment in the past.
To avoid such situations, vmalert now will use returned timestamp instead of `lastExecTime`.