### PR TITLE
vmalert: use rule's `evaluationInterval` as `step` param by default

### DIFF
--- a/app/vmalert/datasource/init.go
+++ b/app/vmalert/datasource/init.go
@@ -23,7 +23,8 @@ var (
 
 	lookBack  = flag.Duration("datasource.lookback", 0, `Lookback defines how far into the past to look when evaluating queries. For example, if the datasource.lookback=5m then param "time" with value now()-5m will be added to every query.`)
 	queryStep = flag.Duration("datasource.queryStep", 0, "queryStep defines how far a value can fallback to when evaluating queries. "+
-		"For example, if datasource.queryStep=15s then param \"step\" with value \"15s\" will be added to every query.")
+		"For example, if datasource.queryStep=15s then param \"step\" with value \"15s\" will be added to every query."+
+		"If queryStep isn't specified, rule's evaluationInterval will be used instead.")
 	maxIdleConnections = flag.Int("datasource.maxIdleConnections", 100, `Defines the number of idle (keep-alive connections) to each configured datasource. Consider setting this value equal to the value: groups_total * group.concurrency. Too low a value may result in a high number of sockets in TIME_WAIT state.`)
 )
 

--- a/app/vmalert/datasource/vm.go
+++ b/app/vmalert/datasource/vm.go
@@ -207,9 +207,13 @@ func (s *VMStorage) setPrometheusReqParams(r *http.Request, query string, timest
 	if s.evaluationInterval > 0 {
 		// see https://github.com/VictoriaMetrics/VictoriaMetrics/issues/1232
 		timestamp = timestamp.Truncate(s.evaluationInterval)
+		// set step as evaluationInterval by default
+		q.Set("step", s.evaluationInterval.String())
 	}
 	q.Set("time", fmt.Sprintf("%d", timestamp.Unix()))
+
 	if s.queryStep > 0 {
+		// override step with user-specified value
 		q.Set("step", s.queryStep.String())
 	}
 	r.URL.RawQuery = q.Encode()

--- a/app/vmalert/datasource/vm_test.go
+++ b/app/vmalert/datasource/vm_test.go
@@ -213,8 +213,9 @@ func TestPrepareReq(t *testing.T) {
 				evaluationInterval: 15 * time.Second,
 			},
 			func(t *testing.T, r *http.Request) {
-				tt := timestamp.Truncate(15 * time.Second)
-				exp := fmt.Sprintf("query=%s&time=%d", query, tt.Unix())
+				evalInterval := 15 * time.Second
+				tt := timestamp.Truncate(evalInterval)
+				exp := fmt.Sprintf("query=%s&step=%v&time=%d", query, evalInterval, tt.Unix())
 				checkEqualString(t, exp, r.URL.RawQuery)
 			},
 		},
@@ -225,14 +226,15 @@ func TestPrepareReq(t *testing.T) {
 				evaluationInterval: 15 * time.Second,
 			},
 			func(t *testing.T, r *http.Request) {
+				evalInterval := 15 * time.Second
 				tt := timestamp.Add(-time.Minute)
-				tt = tt.Truncate(15 * time.Second)
-				exp := fmt.Sprintf("query=%s&time=%d", query, tt.Unix())
+				tt = tt.Truncate(evalInterval)
+				exp := fmt.Sprintf("query=%s&step=%v&time=%d", query, evalInterval, tt.Unix())
 				checkEqualString(t, exp, r.URL.RawQuery)
 			},
 		},
 		{
-			"step",
+			"step override",
 			&VMStorage{
 				queryStep: time.Minute,
 			},


### PR DESCRIPTION
User still can override param by specifying `datasource.queryStep` flag.