### PR TITLE
fix vmagent imbalance problem when -promscrape.cluster.replicationFactor > 1 

### DIFF
--- a/lib/promscrape/config.go
+++ b/lib/promscrape/config.go
@@ -768,7 +768,7 @@ func needSkipScrapeWork(key string, membersCount, replicasCount, memberNum int) 
 			return false
 		}
 		idx++
-		if idx >= replicasCount {
+		if idx >= membersCount {
 			idx = 0
 		}
 	}


### PR DESCRIPTION
when -promscrape.cluster.replicationFactor > 1 

/path/to/vmagent -promscrape.cluster.membersCount=3 -promscrape.cluster.replicationFactor=2 -promscrape.cluster.memberNum=0 -promscrape.config=/path/to/config.yml ...
/path/to/vmagent -promscrape.cluster.membersCount=3 -promscrape.cluster.replicationFactor=2 -promscrape.cluster.memberNum=1 -promscrape.config=/path/to/config.yml ...
/path/to/vmagent -promscrape.cluster.membersCount=3 -promscrape.cluster.replicationFactor=2 -promscrape.cluster.memberNum=2 -promscrape.config=/path/to/config.yml ...

vmagent imbalance problem !