### PR TITLE
vmctl: explicitly set `::tag` type for labels selector in `influx` mode

### DIFF
--- a/app/vmctl/influx/influx.go
+++ b/app/vmctl/influx/influx.go
@@ -61,7 +61,7 @@ func (s Series) fetchQuery(timeFilter string) string {
 	}
 	for i, pair := range s.LabelPairs {
 		pairV := valueEscaper.Replace(pair.Value)
-		fmt.Fprintf(f, " %q='%s'", pair.Name, pairV)
+		fmt.Fprintf(f, " %q::tag='%s'", pair.Name, pairV)
 		if i != len(s.LabelPairs)-1 {
 			f.WriteString(" and")
 		}

--- a/app/vmctl/influx/influx_test.go
+++ b/app/vmctl/influx/influx_test.go
@@ -19,7 +19,7 @@ func TestFetchQuery(t *testing.T) {
 					},
 				},
 			},
-			expected: `select "value" from "cpu" where "foo"='bar'`,
+			expected: `select "value" from "cpu" where "foo"::tag='bar'`,
 		},
 		{
 			s: Series{
@@ -36,7 +36,7 @@ func TestFetchQuery(t *testing.T) {
 					},
 				},
 			},
-			expected: `select "value" from "cpu" where "foo"='bar' and "baz"='qux'`,
+			expected: `select "value" from "cpu" where "foo"::tag='bar' and "baz"::tag='qux'`,
 		},
 		{
 			s: Series{
@@ -50,7 +50,7 @@ func TestFetchQuery(t *testing.T) {
 				},
 			},
 			timeFilter: "time >= now()",
-			expected:   `select "value" from "cpu" where "foo"='b\'ar' and time >= now()`,
+			expected:   `select "value" from "cpu" where "foo"::tag='b\'ar' and time >= now()`,
 		},
 		{
 			s: Series{
@@ -68,7 +68,7 @@ func TestFetchQuery(t *testing.T) {
 				},
 			},
 			timeFilter: "time >= now()",
-			expected:   `select "value" from "cpu" where "name"='dev-mapper-centos\\x2dswap.swap' and "state"='dev-mapp\'er-c\'en\'tos' and time >= now()`,
+			expected:   `select "value" from "cpu" where "name"::tag='dev-mapper-centos\\x2dswap.swap' and "state"::tag='dev-mapp\'er-c\'en\'tos' and time >= now()`,
 		},
 		{
 			s: Series{


### PR DESCRIPTION
The `::tag` type is needed in cases when field and tag names are equal, which
results into unexpected results in InfluxQL. Setting the type explicitly helps
InfluxDB to understand which exact column we apply filter to.

https://github.com/VictoriaMetrics/VictoriaMetrics/issues/1299