### PR TITLE
new feature: debug relabeling

### DIFF
--- a/app/vminsert/relabel/relabel.go
+++ b/app/vminsert/relabel/relabel.go
@@ -101,7 +101,7 @@ func (ctx *Ctx) ApplyRelabeling(labels []prompb.Label) []prompb.Label {
 	}
 
 	// Apply relabeling
-	tmpLabels = pcs.Apply(tmpLabels, 0, true)
+	tmpLabels = pcs.Apply(tmpLabels, 0, true, pcs.RelabelDebug)
 	ctx.tmpLabels = tmpLabels
 	if len(tmpLabels) == 0 {
 		metricsDropped.Inc()

--- a/docs/vmagent.md
+++ b/docs/vmagent.md
@@ -225,6 +225,7 @@ The relabeling can be defined in the following places:
 
 * At the `scrape_config -> relabel_configs` section in `-promscrape.config` file. This relabeling is applied to target labels.
 * At the `scrape_config -> metric_relabel_configs` section in `-promscrape.config` file. This relabeling is applied to all the scraped metrics in the given `scrape_config`.
+* By setting the `relabel_debug` property of a `scrape_configs` target section in the `-promscrape.config` file to `true`, one is able to instruct the vmagent to just log the metric before and after relabeling and skip its submission to servers. This way it is much easier to understand and check scraped relabeled metrics before poisoning servers with it.
 * At the `-remoteWrite.relabelConfig` file. This relabeling is aplied to all the collected metrics before sending them to remote storage.
 * At the `-remoteWrite.urlRelabelConfig` files. This relabeling is applied to metrics before sending them to the corresponding `-remoteWrite.url`.
 

--- a/lib/promrelabel/config.go
+++ b/lib/promrelabel/config.go
@@ -26,6 +26,7 @@ type RelabelConfig struct {
 // ParsedConfigs represents parsed relabel configs.
 type ParsedConfigs struct {
 	prcs []*parsedRelabelConfig
+	RelabelDebug bool
 }
 
 // Len returns the number of relabel configs in pcs.

--- a/lib/promscrape/scrapework.go
+++ b/lib/promscrape/scrapework.go
@@ -512,7 +512,10 @@ func (sw *scrapeWork) addRowToTimeseries(wc *writeRequestCtx, r *parser.Row, tim
 	labelsLen := len(wc.labels)
 	wc.labels = appendLabels(wc.labels, r.Metric, r.Tags, sw.Config.Labels, sw.Config.HonorLabels)
 	if needRelabel {
-		wc.labels = sw.Config.MetricRelabelConfigs.Apply(wc.labels, labelsLen, true)
+		wc.labels = sw.Config.MetricRelabelConfigs.Apply(wc.labels, labelsLen, true, sw.Config.MetricRelabelConfigs.RelabelDebug)
+		if sw.Config.MetricRelabelConfigs.RelabelDebug {
+			return	// avoid submission
+		}
 	} else {
 		wc.labels = promrelabel.FinalizeLabels(wc.labels[:labelsLen], wc.labels[labelsLen:])
 		promrelabel.SortLabels(wc.labels[labelsLen:])


### PR DESCRIPTION
Use scrape_configs[x].relabel_debug = true to log metric names incl.
labels before and after relabeling. After relabeling related metrics
get dropped, i.e. not submitted to servers.

See #1343