### PR TITLE
vmalert: support rules backfilling (aka `replay`)

### DIFF
--- a/app/vmalert/Makefile
+++ b/app/vmalert/Makefile
@@ -69,6 +69,15 @@ run-vmalert: vmalert
 		-evaluationInterval=3s \
 		-rule.configCheckInterval=10s
 
+replay-vmalert: vmalert
+	./bin/vmalert -rule=app/vmalert/config/testdata/rules-replay-good.rules \
+		-datasource.url=http://localhost:8428 \
+		-remoteWrite.url=http://localhost:8428 \
+		-external.label=cluster=east-1 \
+		-external.label=replica=a \
+		-replay.timeFrom=2021-05-11T07:21:43Z \
+		-replay.timeTo=2021-05-29T18:40:43Z
+
 vmalert-amd64:
 	CGO_ENABLED=1 GOARCH=amd64 $(MAKE) vmalert-local-with-goarch
 

--- a/app/vmalert/README.md
+++ b/app/vmalert/README.md
@@ -292,7 +292,7 @@ To see if `replayed` alert has fired in the past use the following PromQL/Metric
 ```
 ALERTS{alertname="your_alertname", alertstate="firing"}
 ```
-Execute the query against storage which was used for `-remoteWrite.url` during replay.
+Execute the query against storage which was used for `-remoteWrite.url` during the `replay`.
 
 ### Additional configuration
 
@@ -300,12 +300,12 @@ There are following non-required `replay` flags:
 
 * `-replay.maxDatapointsPerQuery` - the max number of data points expected to receive in one request.
 In two words, it affects the max time range for every `/query_range` request. The higher the value,
-the more requests will be issued during `replay`.
+the less requests will be issued during `replay`.
 * `-replay.ruleRetryAttempts` - when datasource fails to respond vmalert will make this number of retries
 per rule before giving up.
 * `-replay.rulesDelay` - delay between sequential rules execution. Important in cases if there are chaining
-(rules which depends on each other) rules. It is expected, that remote storage will be able to persist
-previously accepted data during the delay, so it will be available for the next rule queries. Also,
+(rules which depend on each other) rules. It is expected, that remote storage will be able to persist
+previously accepted data during the delay, so data will be available for the subsequent queries.
 Keep it equal or bigger than `-remoteWrite.flushInterval`.
 
 See full description for these flags in `./vmalert --help`.

--- a/app/vmalert/README.md
+++ b/app/vmalert/README.md
@@ -12,7 +12,8 @@ rules against configured address.
  support;
 * Integration with [Alertmanager](https://github.com/prometheus/alertmanager);
 * Keeps the alerts [state on restarts](#alerts-state-on-restarts);
-* Graphite datasource can be used for alerting and recording rules. See [these docs](#graphite) for details.
+* Graphite datasource can be used for alerting and recording rules. See [these docs](#graphite) for details;
+* Recording and Alerting rules backfilling (aka `replay`);
 * Lightweight without extra dependencies.
 
 ## Limitations
@@ -227,6 +228,93 @@ implements [Graphite Render API](https://graphite.readthedocs.io/en/stable/rende
 When using vmalert with both `graphite` and `prometheus` rules configured against cluster version of VM do not forget
 to set `-datasource.appendTypePrefix` flag to `true`, so vmalert can adjust URL prefix automatically based on query type.
 
+## Rules backfilling
+
+vmalert supports alerting and recording rules backfilling (aka `replay`). In replay mode vmalert
+can read the same rules configuration as normally, evaluate them on the given time range and backfill
+results via remote write to the configured storage. vmalert supports any PromQL/MetricsQL compatible
+data source for backfilling.
+
+### How it works
+
+In `replay` mode vmalert works as a cli-tool and exits immediately after work is done.
+To run vmalert in `replay` mode:
+```
+./bin/vmalert -rule=path/to/your.rules \        # path to files with rules you usually use with vmalert
+    -datasource.url=http://localhost:8428 \     # PromQL/MetricsQL compatible datasource
+    -remoteWrite.url=http://localhost:8428 \    # remote write compatible storage to persist results
+    -replay.timeFrom=2021-05-11T07:21:43Z \     # time from begin replay
+    -replay.timeTo=2021-05-29T18:40:43Z         # time to finish replay
+```
+
+The output of the command will look like the following:
+```
+Replay mode:
+from:   2021-05-11 07:21:43 +0000 UTC   # set by -replay.timeFrom
+to:     2021-05-29 18:40:43 +0000 UTC   # set by -replay.timeTo
+max data points per request: 1000       # set by -replay.maxDatapointsPerQuery
+
+Group "ReplayGroup"
+interval:       1m0s
+requests to make:       27
+max range per request:  16h40m0s
+> Rule "type:vm_cache_entries:rate5m" (ID: 1792509946081842725)
+27 / 27 [----------------------------------------------------------------------------------------------------] 100.00% 78 p/s
+> Rule "go_cgo_calls_count:rate5m" (ID: 17958425467471411582)
+27 / 27 [-----------------------------------------------------------------------------------------------------] 100.00% ? p/s
+
+Group "vmsingleReplay"
+interval:       30s
+requests to make:       54
+max range per request:  8h20m0s
+> Rule "RequestErrorsToAPI" (ID: 17645863024999990222)
+54 / 54 [-----------------------------------------------------------------------------------------------------] 100.00% ? p/s
+> Rule "TooManyLogs" (ID: 9042195394653477652)
+54 / 54 [-----------------------------------------------------------------------------------------------------] 100.00% ? p/s
+2021-06-07T09:59:12.098Z        info    app/vmalert/replay.go:68        replay finished! Imported 511734 samples
+```
+
+In `replay` mode all groups are executed sequentially one-by-one. Rules within the group are
+executed sequentially as well (`concurrency` setting is ignored). Vmalert sends rule's expression
+to [/query_range](https://prometheus.io/docs/prometheus/latest/querying/api/#range-queries) endpoint
+of the configured `-datasource.url`. Returned data then processed according to the rule type and
+backfilled to `-remoteWrite.url` via [Remote Write protocol](https://prometheus.io/docs/prometheus/latest/storage/#remote-storage-integrations).
+Vmalert respects `evaluationInterval` value set by flag or per-group during the replay.
+
+#### Recording rules
+
+Result of recording rules `replay` should match with results of normal rules evaluation.
+
+#### Alerting rules
+
+Result of alerting rules `replay` is time series reflecting [alert's state](#alerts-state-on-restarts).
+To see if `replayed` alert has fired in the past use the following PromQL/MetricsQL expression:
+```
+ALERTS{alertname="your_alertname", alertstate="firing"}
+```
+Execute the query against storage which was used for `-remoteWrite.url` during replay.
+
+### Additional configuration
+
+There are following non-required `replay` flags:
+
+* `-replay.maxDatapointsPerQuery` - the max number of data points expected to receive in one request.
+In two words, it affects the max time range for every `/query_range` request. The higher the value,
+the more requests will be issued during `replay`.
+* `-replay.ruleRetryAttempts` - when datasource fails to respond vmalert will make this number of retries
+per rule before giving up.
+* `-replay.rulesDelay` - delay between sequential rules execution. Important in cases if there are chaining
+(rules which depends on each other) rules. It is expected, that remote storage will be able to persist
+previously accepted data during the delay, so it will be available for the next rule queries. Also,
+Keep it equal or bigger than `-remoteWrite.flushInterval`.
+
+See full description for these flags in `./vmalert --help`.
+
+### Limitations
+
+* Graphite engine isn't supported yet;
+* `query` template function is disabled for performance reasons (might be changed in future);
+
 
 ## Configuration
 
@@ -387,6 +475,16 @@ The shortlist of configuration flags is the following:
         Optional TLS server name to use for connections to -remoteWrite.url. By default the server name from -remoteWrite.url is used
   -remoteWrite.url string
         Optional URL to VictoriaMetrics or vminsert where to persist alerts state and recording rules results in form of timeseries. E.g. http://127.0.0.1:8428
+  -replay.maxDatapointsPerQuery int
+        Max number of data points expected in one request. The higher the value, the less requests will be made during replay. (default 1000)
+  -replay.ruleRetryAttempts int
+        Defines how many retries to make before giving up on rule if request for it returns an error. (default 5)
+  -replay.rulesDelay duration
+        Delay between rules evaluation within the group. Could be important if there are chained rules inside of the groupand processing need to wait for previous rule results to be persisted by remote storage before evaluating the next rule. Keep it equal or bigger than -remoteWrite.flushInterval. (default 1s)
+  -replay.timeFrom string
+        The time filter in RFC3339 format to select time series with timestamp equal or higher than provided value. E.g. '2020-01-01T20:07:00Z'
+  -replay.timeTo string
+        The time filter in RFC3339 format to select timeseries with timestamp equal or lower than provided value. E.g. '2020-01-01T20:07:00Z'
   -rule array
         Path to the file with alert rules.
         Supports patterns. Flag can be specified multiple times.

--- a/app/vmalert/config/testdata/rules-replay-good.rules
+++ b/app/vmalert/config/testdata/rules-replay-good.rules
@@ -1,0 +1,39 @@
+groups:
+  - name: ReplayGroup
+    interval: 1m
+    concurrency: 1
+    rules:
+      - record: type:vm_cache_entries:rate5m
+        expr: sum(rate(vm_cache_entries[5m])) by (type)
+        labels:
+          recording: true
+      - record: go_cgo_calls_count:rate5m
+        expr: rate(go_cgo_calls_count{job="vmdb"}[5m])
+        labels:
+          recording: true
+
+  - name: vmsingleReplay
+    interval: 30s
+    concurrency: 2
+    rules:
+      - alert: RequestErrorsToAPI
+        expr: increase(vm_http_request_errors_total[5m]) > 0
+        for: 15m
+        labels:
+          severity: warning
+        annotations:
+          dashboard: "http://localhost:3000/d/wNf0q_kZk?viewPanel=35&var-instance={{ $labels.instance }}"
+          summary: "Too many errors served for path {{ $labels.path }} (instance {{ $labels.instance }})"
+          description: "Requests to path {{ $labels.path }} are receiving errors.
+            Please verify if clients are sending correct requests."
+
+      - alert: TooManyLogs
+        expr: sum(increase(vm_log_messages_total{level!="info"}[5m])) by (job, instance) > 0
+        for: 15m
+        labels:
+          severity: warning
+        annotations:
+          dashboard: "http://localhost:3000/d/wNf0q_kZk?viewPanel=67&var-instance={{ $labels.instance }}"
+          summary: "Too many logs printed for job \"{{ $labels.job }}\" ({{ $labels.instance }})"
+          description: "Logging rate for job \"{{ $labels.job }}\" ({{ $labels.instance }}) is {{ $value }} for last 15m.\n
+           Worth to check logs for specific error messages."

--- a/app/vmalert/datasource/datasource.go
+++ b/app/vmalert/datasource/datasource.go
@@ -2,26 +2,33 @@ package datasource
 
 import (
 	"context"
+	"time"
 )
+
+// Querier interface wraps Query and QueryRange methods
+type Querier interface {
+	Query(ctx context.Context, query string) ([]Metric, error)
+	QueryRange(ctx context.Context, query string, from, to time.Time) ([]Metric, error)
+}
 
 // QuerierBuilder builds Querier with given params.
 type QuerierBuilder interface {
 	BuildWithParams(params QuerierParams) Querier
 }
 
-// Querier interface wraps Query method which
-// executes given query and returns list of Metrics
-// as result
-type Querier interface {
-	Query(ctx context.Context, query string) ([]Metric, error)
+// QuerierParams params for Querier.
+type QuerierParams struct {
+	DataSourceType     *Type
+	EvaluationInterval time.Duration
+	// see https://docs.victoriametrics.com/#prometheus-querying-api-enhancements
+	ExtraLabels map[string]string
 }
 
 // Metric is the basic entity which should be return by datasource
-// It represents single data point with full list of labels
 type Metric struct {
-	Labels    []Label
-	Timestamp int64
-	Value     float64
+	Labels     []Label
+	Timestamps []int64
+	Values     []float64
 }
 
 // SetLabel adds or updates existing one label

--- a/app/vmalert/datasource/datasource_test.go
+++ b/app/vmalert/datasource/datasource_test.go
@@ -1,0 +1,18 @@
+package datasource
+
+import "testing"
+
+func TestMetric_Label(t *testing.T) {
+	m := &Metric{}
+
+	m.AddLabel("foo", "bar")
+	checkEqualString(t, "bar", m.Label("foo"))
+
+	m.SetLabel("foo", "baz")
+	checkEqualString(t, "baz", m.Label("foo"))
+
+	m.SetLabel("qux", "quux")
+	checkEqualString(t, "quux", m.Label("qux"))
+
+	checkEqualString(t, "", m.Label("non-existing"))
+}

--- a/app/vmalert/datasource/vm.go
+++ b/app/vmalert/datasource/vm.go
@@ -2,75 +2,12 @@ package datasource
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"strconv"
 	"strings"
 	"time"
 )
-
-type response struct {
-	Status string `json:"status"`
-	Data   struct {
-		ResultType string `json:"resultType"`
-		Result     []struct {
-			Labels map[string]string `json:"metric"`
-			TV     [2]interface{}    `json:"value"`
-		} `json:"result"`
-	} `json:"data"`
-	ErrorType string `json:"errorType"`
-	Error     string `json:"error"`
-}
-
-func (r response) metrics() ([]Metric, error) {
-	var ms []Metric
-	var m Metric
-	var f float64
-	var err error
-	for i, res := range r.Data.Result {
-		f, err = strconv.ParseFloat(res.TV[1].(string), 64)
-		if err != nil {
-			return nil, fmt.Errorf("metric %v, unable to parse float64 from %s: %w", res, res.TV[1], err)
-		}
-		m.Labels = nil
-		for k, v := range r.Data.Result[i].Labels {
-			m.AddLabel(k, v)
-		}
-		m.Timestamp = int64(res.TV[0].(float64))
-		m.Value = f
-		ms = append(ms, m)
-	}
-	return ms, nil
-}
-
-type graphiteResponse []graphiteResponseTarget
-
-type graphiteResponseTarget struct {
-	Target     string            `json:"target"`
-	Tags       map[string]string `json:"tags"`
-	DataPoints [][2]float64      `json:"datapoints"`
-}
-
-func (r graphiteResponse) metrics() []Metric {
-	var ms []Metric
-	for _, res := range r {
-		if len(res.DataPoints) < 1 {
-			continue
-		}
-		var m Metric
-		// add only last value to the result.
-		last := res.DataPoints[len(res.DataPoints)-1]
-		m.Value = last[0]
-		m.Timestamp = int64(last[1])
-		for k, v := range res.Tags {
-			m.AddLabel(k, v)
-		}
-		ms = append(ms, m)
-	}
-	return ms
-}
 
 // VMStorage represents vmstorage entity with ability to read and write metrics
 type VMStorage struct {
@@ -86,20 +23,6 @@ type VMStorage struct {
 	dataSourceType     Type
 	evaluationInterval time.Duration
 	extraLabels        []string
-}
-
-const queryPath = "/api/v1/query"
-const graphitePath = "/render"
-
-const prometheusPrefix = "/prometheus"
-const graphitePrefix = "/graphite"
-
-// QuerierParams params for Querier.
-type QuerierParams struct {
-	DataSourceType     *Type
-	EvaluationInterval time.Duration
-	// see https://docs.victoriametrics.com/#prometheus-querying-api-enhancements
-	ExtraLabels map[string]string
 }
 
 // Clone makes clone of VMStorage, shares http client.
@@ -149,9 +72,19 @@ func NewVMStorage(baseURL, basicAuthUser, basicAuthPass string, lookBack time.Du
 
 // Query executes the given query and returns parsed response
 func (s *VMStorage) Query(ctx context.Context, query string) ([]Metric, error) {
-	req, err := s.prepareReq(query, time.Now())
+	req, err := s.newRequestPOST()
 	if err != nil {
 		return nil, err
+	}
+
+	ts := time.Now()
+	switch s.dataSourceType.name {
+	case "", prometheusType:
+		s.setPrometheusInstantReqParams(req, query, ts)
+	case graphiteType:
+		s.setGraphiteReqParams(req, query, ts)
+	default:
+		return nil, fmt.Errorf("engine not found: %q", s.dataSourceType.name)
 	}
 
 	resp, err := s.do(ctx, req)
@@ -169,25 +102,32 @@ func (s *VMStorage) Query(ctx context.Context, query string) ([]Metric, error) {
 	return parseFn(req, resp)
 }
 
-func (s *VMStorage) prepareReq(query string, timestamp time.Time) (*http.Request, error) {
-	req, err := http.NewRequest("POST", s.datasourceURL, nil)
+// QueryRange executes the given query on the given time range.
+// For Prometheus type see https://prometheus.io/docs/prometheus/latest/querying/api/#range-queries
+// Graphite type isn't supported.
+func (s *VMStorage) QueryRange(ctx context.Context, query string, start, end time.Time) ([]Metric, error) {
+	if s.dataSourceType.name != prometheusType {
+		return nil, fmt.Errorf("%q is not supported for QueryRange", s.dataSourceType.name)
+	}
+	req, err := s.newRequestPOST()
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Set("Content-Type", "application/json; charset=utf-8")
-	if s.basicAuthPass != "" {
-		req.SetBasicAuth(s.basicAuthUser, s.basicAuthPass)
+	if start.IsZero() {
+		return nil, fmt.Errorf("start param is missing")
 	}
-
-	switch s.dataSourceType.name {
-	case "", prometheusType:
-		s.setPrometheusReqParams(req, query, timestamp)
-	case graphiteType:
-		s.setGraphiteReqParams(req, query, timestamp)
-	default:
-		return nil, fmt.Errorf("engine not found: %q", s.dataSourceType.name)
+	if end.IsZero() {
+		return nil, fmt.Errorf("end param is missing")
 	}
-	return req, nil
+	s.setPrometheusRangeReqParams(req, query, start, end)
+	resp, err := s.do(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+	return parsePrometheusResponse(req, resp)
 }
 
 func (s *VMStorage) do(ctx context.Context, req *http.Request) (*http.Response, error) {
@@ -203,80 +143,14 @@ func (s *VMStorage) do(ctx context.Context, req *http.Request) (*http.Response, 
 	return resp, nil
 }
 
-func (s *VMStorage) setPrometheusReqParams(r *http.Request, query string, timestamp time.Time) {
-	if s.appendTypePrefix {
-		r.URL.Path += prometheusPrefix
+func (s *VMStorage) newRequestPOST() (*http.Request, error) {
+	req, err := http.NewRequest("POST", s.datasourceURL, nil)
+	if err != nil {
+		return nil, err
 	}
-	r.URL.Path += queryPath
-	q := r.URL.Query()
-	q.Set("query", query)
-	if s.lookBack > 0 {
-		timestamp = timestamp.Add(-s.lookBack)
+	req.Header.Set("Content-Type", "application/json; charset=utf-8")
+	if s.basicAuthPass != "" {
+		req.SetBasicAuth(s.basicAuthUser, s.basicAuthPass)
 	}
-	if s.evaluationInterval > 0 {
-		// see https://github.com/VictoriaMetrics/VictoriaMetrics/issues/1232
-		timestamp = timestamp.Truncate(s.evaluationInterval)
-		// set step as evaluationInterval by default
-		q.Set("step", s.evaluationInterval.String())
-	}
-	q.Set("time", fmt.Sprintf("%d", timestamp.Unix()))
-
-	if s.queryStep > 0 {
-		// override step with user-specified value
-		q.Set("step", s.queryStep.String())
-	}
-	if s.roundDigits != "" {
-		q.Set("round_digits", s.roundDigits)
-	}
-	for _, l := range s.extraLabels {
-		q.Add("extra_label", l)
-	}
-	r.URL.RawQuery = q.Encode()
-}
-
-func (s *VMStorage) setGraphiteReqParams(r *http.Request, query string, timestamp time.Time) {
-	if s.appendTypePrefix {
-		r.URL.Path += graphitePrefix
-	}
-	r.URL.Path += graphitePath
-	q := r.URL.Query()
-	q.Set("format", "json")
-	q.Set("target", query)
-	from := "-5min"
-	if s.lookBack > 0 {
-		lookBack := timestamp.Add(-s.lookBack)
-		from = strconv.FormatInt(lookBack.Unix(), 10)
-	}
-	q.Set("from", from)
-	q.Set("until", "now")
-	r.URL.RawQuery = q.Encode()
-}
-
-const (
-	statusSuccess, statusError, rtVector = "success", "error", "vector"
-)
-
-func parsePrometheusResponse(req *http.Request, resp *http.Response) ([]Metric, error) {
-	r := &response{}
-	if err := json.NewDecoder(resp.Body).Decode(r); err != nil {
-		return nil, fmt.Errorf("error parsing prometheus metrics for %s: %w", req.URL, err)
-	}
-	if r.Status == statusError {
-		return nil, fmt.Errorf("response error, query: %s, errorType: %s, error: %s", req.URL, r.ErrorType, r.Error)
-	}
-	if r.Status != statusSuccess {
-		return nil, fmt.Errorf("unknown status: %s, Expected success or error ", r.Status)
-	}
-	if r.Data.ResultType != rtVector {
-		return nil, fmt.Errorf("unknown result type:%s. Expected vector", r.Data.ResultType)
-	}
-	return r.metrics()
-}
-
-func parseGraphiteResponse(req *http.Request, resp *http.Response) ([]Metric, error) {
-	r := &graphiteResponse{}
-	if err := json.NewDecoder(resp.Body).Decode(r); err != nil {
-		return nil, fmt.Errorf("error parsing graphite metrics for %s: %w", req.URL, err)
-	}
-	return r.metrics(), nil
+	return req, nil
 }

--- a/app/vmalert/datasource/vm_graphite_api.go
+++ b/app/vmalert/datasource/vm_graphite_api.go
@@ -1,0 +1,67 @@
+package datasource
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"time"
+)
+
+type graphiteResponse []graphiteResponseTarget
+
+type graphiteResponseTarget struct {
+	Target     string            `json:"target"`
+	Tags       map[string]string `json:"tags"`
+	DataPoints [][2]float64      `json:"datapoints"`
+}
+
+func (r graphiteResponse) metrics() []Metric {
+	var ms []Metric
+	for _, res := range r {
+		if len(res.DataPoints) < 1 {
+			continue
+		}
+		var m Metric
+		// add only last value to the result.
+		last := res.DataPoints[len(res.DataPoints)-1]
+		m.Values = append(m.Values, last[0])
+		m.Timestamps = append(m.Timestamps, int64(last[1]))
+		for k, v := range res.Tags {
+			m.AddLabel(k, v)
+		}
+		ms = append(ms, m)
+	}
+	return ms
+}
+
+func parseGraphiteResponse(req *http.Request, resp *http.Response) ([]Metric, error) {
+	r := &graphiteResponse{}
+	if err := json.NewDecoder(resp.Body).Decode(r); err != nil {
+		return nil, fmt.Errorf("error parsing graphite metrics for %s: %w", req.URL, err)
+	}
+	return r.metrics(), nil
+}
+
+const (
+	graphitePath   = "/render"
+	graphitePrefix = "/graphite"
+)
+
+func (s *VMStorage) setGraphiteReqParams(r *http.Request, query string, timestamp time.Time) {
+	if s.appendTypePrefix {
+		r.URL.Path += graphitePrefix
+	}
+	r.URL.Path += graphitePath
+	q := r.URL.Query()
+	q.Set("format", "json")
+	q.Set("target", query)
+	from := "-5min"
+	if s.lookBack > 0 {
+		lookBack := timestamp.Add(-s.lookBack)
+		from = strconv.FormatInt(lookBack.Unix(), 10)
+	}
+	q.Set("from", from)
+	q.Set("until", "now")
+	r.URL.RawQuery = q.Encode()
+}

--- a/app/vmalert/datasource/vm_prom_api.go
+++ b/app/vmalert/datasource/vm_prom_api.go
@@ -1,0 +1,170 @@
+package datasource
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"time"
+)
+
+type promResponse struct {
+	Status    string `json:"status"`
+	ErrorType string `json:"errorType"`
+	Error     string `json:"error"`
+	Data      struct {
+		ResultType string          `json:"resultType"`
+		Result     json.RawMessage `json:"result"`
+	} `json:"data"`
+}
+
+type promInstant struct {
+	Result []struct {
+		Labels map[string]string `json:"metric"`
+		TV     [2]interface{}    `json:"value"`
+	} `json:"result"`
+}
+
+type promRange struct {
+	Result []struct {
+		Labels map[string]string `json:"metric"`
+		TVs    [][2]interface{}  `json:"values"`
+	} `json:"result"`
+}
+
+func (r promInstant) metrics() ([]Metric, error) {
+	var result []Metric
+	var m Metric
+	for i, res := range r.Result {
+		f, err := strconv.ParseFloat(res.TV[1].(string), 64)
+		if err != nil {
+			return nil, fmt.Errorf("metric %v, unable to parse float64 from %s: %w", res, res.TV[1], err)
+		}
+		m.Labels = nil
+		for k, v := range r.Result[i].Labels {
+			m.AddLabel(k, v)
+		}
+		m.Timestamps = append(m.Timestamps, int64(res.TV[0].(float64)))
+		m.Values = append(m.Values, f)
+		result = append(result, m)
+
+		m.Values = m.Values[:0]
+		m.Labels = m.Labels[:0]
+		m.Timestamps = m.Timestamps[:0]
+	}
+	return result, nil
+}
+
+func (r promRange) metrics() ([]Metric, error) {
+	var result []Metric
+	for i, res := range r.Result {
+		var m Metric
+		for _, tv := range res.TVs {
+			f, err := strconv.ParseFloat(tv[1].(string), 64)
+			if err != nil {
+				return nil, fmt.Errorf("metric %v, unable to parse float64 from %s: %w", res, tv[1], err)
+			}
+			m.Values = append(m.Values, f)
+			m.Timestamps = append(m.Timestamps, int64(tv[0].(float64)))
+		}
+		if len(m.Values) < 1 || len(m.Timestamps) < 1 {
+			return nil, fmt.Errorf("metric %v contains no values", res)
+		}
+		m.Labels = nil
+		for k, v := range r.Result[i].Labels {
+			m.AddLabel(k, v)
+		}
+		result = append(result, m)
+	}
+	return result, nil
+}
+
+const (
+	statusSuccess, statusError = "success", "error"
+	rtVector, rtMatrix         = "vector", "matrix"
+)
+
+func parsePrometheusResponse(req *http.Request, resp *http.Response) ([]Metric, error) {
+	r := &promResponse{}
+	if err := json.NewDecoder(resp.Body).Decode(r); err != nil {
+		return nil, fmt.Errorf("error parsing prometheus metrics for %s: %w", req.URL, err)
+	}
+	if r.Status == statusError {
+		return nil, fmt.Errorf("response error, query: %s, errorType: %s, error: %s", req.URL, r.ErrorType, r.Error)
+	}
+	if r.Status != statusSuccess {
+		return nil, fmt.Errorf("unknown status: %s, Expected success or error ", r.Status)
+	}
+	switch r.Data.ResultType {
+	case rtVector:
+		var pi promInstant
+		if err := json.Unmarshal(r.Data.Result, &pi.Result); err != nil {
+			return nil, fmt.Errorf("umarshal err %s; \n %#v", err, string(r.Data.Result))
+		}
+		return pi.metrics()
+	case rtMatrix:
+		var pr promRange
+		if err := json.Unmarshal(r.Data.Result, &pr.Result); err != nil {
+			return nil, err
+		}
+		return pr.metrics()
+	default:
+		return nil, fmt.Errorf("unknown result type %q", r.Data.ResultType)
+	}
+}
+
+const (
+	prometheusInstantPath = "/api/v1/query"
+	prometheusRangePath   = "/api/v1/query_range"
+	prometheusPrefix      = "/prometheus"
+)
+
+func (s *VMStorage) setPrometheusInstantReqParams(r *http.Request, query string, timestamp time.Time) {
+	if s.appendTypePrefix {
+		r.URL.Path += prometheusPrefix
+	}
+	r.URL.Path += prometheusInstantPath
+	q := r.URL.Query()
+	if s.lookBack > 0 {
+		timestamp = timestamp.Add(-s.lookBack)
+	}
+	if s.evaluationInterval > 0 {
+		// see https://github.com/VictoriaMetrics/VictoriaMetrics/issues/1232
+		timestamp = timestamp.Truncate(s.evaluationInterval)
+	}
+	q.Set("time", fmt.Sprintf("%d", timestamp.Unix()))
+	r.URL.RawQuery = q.Encode()
+	s.setPrometheusReqParams(r, query)
+}
+
+func (s *VMStorage) setPrometheusRangeReqParams(r *http.Request, query string, start, end time.Time) {
+	if s.appendTypePrefix {
+		r.URL.Path += prometheusPrefix
+	}
+	r.URL.Path += prometheusRangePath
+	q := r.URL.Query()
+	q.Add("start", fmt.Sprintf("%d", start.Unix()))
+	q.Add("end", fmt.Sprintf("%d", end.Unix()))
+	r.URL.RawQuery = q.Encode()
+	s.setPrometheusReqParams(r, query)
+}
+
+func (s *VMStorage) setPrometheusReqParams(r *http.Request, query string) {
+	q := r.URL.Query()
+	q.Set("query", query)
+	if s.evaluationInterval > 0 {
+		// set step as evaluationInterval by default
+		q.Set("step", s.evaluationInterval.String())
+	}
+	if s.queryStep > 0 {
+		// override step with user-specified value
+		q.Set("step", s.queryStep.String())
+	}
+	if s.roundDigits != "" {
+		q.Set("round_digits", s.roundDigits)
+	}
+	for _, l := range s.extraLabels {
+		q.Add("extra_label", l)
+	}
+	r.URL.RawQuery = q.Encode()
+}

--- a/app/vmalert/manager_test.go
+++ b/app/vmalert/manager_test.go
@@ -49,6 +49,8 @@ func TestManagerUpdateConcurrent(t *testing.T) {
 		"config/testdata/rules1-good.rules",
 		"config/testdata/rules2-good.rules",
 	}
+	evalInterval := *evaluationInterval
+	defer func() { *evaluationInterval = evalInterval }()
 	*evaluationInterval = time.Millisecond
 	cfg := loadCfg(t, []string{paths[0]}, true, true)
 	if err := m.start(context.Background(), cfg); err != nil {

--- a/app/vmalert/notifier/alert_test.go
+++ b/app/vmalert/notifier/alert_test.go
@@ -83,14 +83,16 @@ func TestAlert_ExecTemplate(t *testing.T) {
 					{Name: "foo", Value: "bar"},
 					{Name: "baz", Value: "qux"},
 				},
-				Value: 1,
+				Values:     []float64{1},
+				Timestamps: []int64{1},
 			},
 			{
 				Labels: []datasource.Label{
 					{Name: "foo", Value: "garply"},
 					{Name: "baz", Value: "fred"},
 				},
-				Value: 2,
+				Values:     []float64{2},
+				Timestamps: []int64{1},
 			},
 		}, nil
 	}

--- a/app/vmalert/notifier/template_func.go
+++ b/app/vmalert/notifier/template_func.go
@@ -47,8 +47,8 @@ func datasourceMetricsToTemplateMetrics(ms []datasource.Metric) []metric {
 		}
 		mss = append(mss, metric{
 			Labels:    labelsMap,
-			Timestamp: m.Timestamp,
-			Value:     m.Value})
+			Timestamp: m.Timestamps[0],
+			Value:     m.Values[0]})
 	}
 	return mss
 }

--- a/app/vmalert/recording.go
+++ b/app/vmalert/recording.go
@@ -88,12 +88,30 @@ func (rr *RecordingRule) Close() {
 	metrics.UnregisterMetric(rr.metrics.errors.name)
 }
 
-// Exec executes RecordingRule expression via the given Querier.
-func (rr *RecordingRule) Exec(ctx context.Context, series bool) ([]prompbmarshal.TimeSeries, error) {
-	if !series {
-		return nil, nil
+// ExecRange executes recording rule on the given time range similarly to Exec.
+// It doesn't update internal states of the Rule and meant to be used just
+// to get time series for backfilling.
+func (rr *RecordingRule) ExecRange(ctx context.Context, start, end time.Time) ([]prompbmarshal.TimeSeries, error) {
+	series, err := rr.q.QueryRange(ctx, rr.Expr, start, end)
+	if err != nil {
+		return nil, err
 	}
+	duplicates := make(map[string]struct{}, len(series))
+	var tss []prompbmarshal.TimeSeries
+	for _, s := range series {
+		ts := rr.toTimeSeries(s)
+		key := stringifyLabels(ts)
+		if _, ok := duplicates[key]; ok {
+			return nil, fmt.Errorf("original metric %v; resulting labels %q: %w", s.Labels, key, errDuplicate)
+		}
+		duplicates[key] = struct{}{}
+		tss = append(tss, ts)
+	}
+	return tss, nil
+}
 
+// Exec executes RecordingRule expression via the given Querier.
+func (rr *RecordingRule) Exec(ctx context.Context) ([]prompbmarshal.TimeSeries, error) {
 	qMetrics, err := rr.q.Query(ctx, rr.Expr)
 	rr.mu.Lock()
 	defer rr.mu.Unlock()
@@ -107,7 +125,7 @@ func (rr *RecordingRule) Exec(ctx context.Context, series bool) ([]prompbmarshal
 	duplicates := make(map[string]struct{}, len(qMetrics))
 	var tss []prompbmarshal.TimeSeries
 	for _, r := range qMetrics {
-		ts := rr.toTimeSeries(r, time.Unix(r.Timestamp, 0))
+		ts := rr.toTimeSeries(r)
 		key := stringifyLabels(ts)
 		if _, ok := duplicates[key]; ok {
 			rr.lastExecError = errDuplicate
@@ -138,7 +156,7 @@ func stringifyLabels(ts prompbmarshal.TimeSeries) string {
 	return b.String()
 }
 
-func (rr *RecordingRule) toTimeSeries(m datasource.Metric, timestamp time.Time) prompbmarshal.TimeSeries {
+func (rr *RecordingRule) toTimeSeries(m datasource.Metric) prompbmarshal.TimeSeries {
 	labels := make(map[string]string)
 	for _, l := range m.Labels {
 		labels[l.Name] = l.Value
@@ -148,7 +166,7 @@ func (rr *RecordingRule) toTimeSeries(m datasource.Metric, timestamp time.Time) 
 	for k, v := range rr.Labels {
 		labels[k] = v
 	}
-	return newTimeSeries(m.Value, labels, timestamp)
+	return newTimeSeries(m.Values, m.Timestamps, labels)
 }
 
 // UpdateWith copies all significant fields.

--- a/app/vmalert/recording_test.go
+++ b/app/vmalert/recording_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/prompbmarshal"
 )
 
-func TestRecoridngRule_ToTimeSeries(t *testing.T) {
+func TestRecoridngRule_Exec(t *testing.T) {
 	timestamp := time.Now()
 	testCases := []struct {
 		rule    *RecordingRule
@@ -24,9 +24,9 @@ func TestRecoridngRule_ToTimeSeries(t *testing.T) {
 				"__name__", "bar",
 			)},
 			[]prompbmarshal.TimeSeries{
-				newTimeSeries(10, map[string]string{
+				newTimeSeries([]float64{10}, []int64{timestamp.UnixNano()}, map[string]string{
 					"__name__": "foo",
-				}, timestamp),
+				}),
 			},
 		},
 		{
@@ -37,18 +37,18 @@ func TestRecoridngRule_ToTimeSeries(t *testing.T) {
 				metricWithValueAndLabels(t, 3, "__name__", "baz", "job", "baz"),
 			},
 			[]prompbmarshal.TimeSeries{
-				newTimeSeries(1, map[string]string{
+				newTimeSeries([]float64{1}, []int64{timestamp.UnixNano()}, map[string]string{
 					"__name__": "foobarbaz",
 					"job":      "foo",
-				}, timestamp),
-				newTimeSeries(2, map[string]string{
+				}),
+				newTimeSeries([]float64{2}, []int64{timestamp.UnixNano()}, map[string]string{
 					"__name__": "foobarbaz",
 					"job":      "bar",
-				}, timestamp),
-				newTimeSeries(3, map[string]string{
+				}),
+				newTimeSeries([]float64{3}, []int64{timestamp.UnixNano()}, map[string]string{
 					"__name__": "foobarbaz",
 					"job":      "baz",
-				}, timestamp),
+				}),
 			},
 		},
 		{
@@ -59,16 +59,16 @@ func TestRecoridngRule_ToTimeSeries(t *testing.T) {
 				metricWithValueAndLabels(t, 2, "__name__", "foo", "job", "foo"),
 				metricWithValueAndLabels(t, 1, "__name__", "bar", "job", "bar")},
 			[]prompbmarshal.TimeSeries{
-				newTimeSeries(2, map[string]string{
+				newTimeSeries([]float64{2}, []int64{timestamp.UnixNano()}, map[string]string{
 					"__name__": "job:foo",
 					"job":      "foo",
 					"source":   "test",
-				}, timestamp),
-				newTimeSeries(1, map[string]string{
+				}),
+				newTimeSeries([]float64{1}, []int64{timestamp.UnixNano()}, map[string]string{
 					"__name__": "job:foo",
 					"job":      "bar",
 					"source":   "test",
-				}, timestamp),
+				}),
 			},
 		},
 	}
@@ -77,7 +77,7 @@ func TestRecoridngRule_ToTimeSeries(t *testing.T) {
 			fq := &fakeQuerier{}
 			fq.add(tc.metrics...)
 			tc.rule.q = fq
-			tss, err := tc.rule.Exec(context.TODO(), true)
+			tss, err := tc.rule.Exec(context.TODO())
 			if err != nil {
 				t.Fatalf("unexpected Exec err: %s", err)
 			}
@@ -88,7 +88,88 @@ func TestRecoridngRule_ToTimeSeries(t *testing.T) {
 	}
 }
 
-func TestRecoridngRule_ToTimeSeriesNegative(t *testing.T) {
+func TestRecoridngRule_ExecRange(t *testing.T) {
+	timestamp := time.Now()
+	testCases := []struct {
+		rule    *RecordingRule
+		metrics []datasource.Metric
+		expTS   []prompbmarshal.TimeSeries
+	}{
+		{
+			&RecordingRule{Name: "foo"},
+			[]datasource.Metric{metricWithValuesAndLabels(t, []float64{10, 20, 30},
+				"__name__", "bar",
+			)},
+			[]prompbmarshal.TimeSeries{
+				newTimeSeries([]float64{10, 20, 30},
+					[]int64{timestamp.UnixNano(), timestamp.UnixNano(), timestamp.UnixNano()},
+					map[string]string{
+						"__name__": "foo",
+					}),
+			},
+		},
+		{
+			&RecordingRule{Name: "foobarbaz"},
+			[]datasource.Metric{
+				metricWithValuesAndLabels(t, []float64{1}, "__name__", "foo", "job", "foo"),
+				metricWithValuesAndLabels(t, []float64{2, 3}, "__name__", "bar", "job", "bar"),
+				metricWithValuesAndLabels(t, []float64{4, 5, 6}, "__name__", "baz", "job", "baz"),
+			},
+			[]prompbmarshal.TimeSeries{
+				newTimeSeries([]float64{1}, []int64{timestamp.UnixNano()}, map[string]string{
+					"__name__": "foobarbaz",
+					"job":      "foo",
+				}),
+				newTimeSeries([]float64{2, 3}, []int64{timestamp.UnixNano(), timestamp.UnixNano()}, map[string]string{
+					"__name__": "foobarbaz",
+					"job":      "bar",
+				}),
+				newTimeSeries([]float64{4, 5, 6},
+					[]int64{timestamp.UnixNano(), timestamp.UnixNano(), timestamp.UnixNano()},
+					map[string]string{
+						"__name__": "foobarbaz",
+						"job":      "baz",
+					}),
+			},
+		},
+		{
+			&RecordingRule{Name: "job:foo", Labels: map[string]string{
+				"source": "test",
+			}},
+			[]datasource.Metric{
+				metricWithValueAndLabels(t, 2, "__name__", "foo", "job", "foo"),
+				metricWithValueAndLabels(t, 1, "__name__", "bar", "job", "bar")},
+			[]prompbmarshal.TimeSeries{
+				newTimeSeries([]float64{2}, []int64{timestamp.UnixNano()}, map[string]string{
+					"__name__": "job:foo",
+					"job":      "foo",
+					"source":   "test",
+				}),
+				newTimeSeries([]float64{1}, []int64{timestamp.UnixNano()}, map[string]string{
+					"__name__": "job:foo",
+					"job":      "bar",
+					"source":   "test",
+				}),
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.rule.Name, func(t *testing.T) {
+			fq := &fakeQuerier{}
+			fq.add(tc.metrics...)
+			tc.rule.q = fq
+			tss, err := tc.rule.ExecRange(context.TODO(), time.Now(), time.Now())
+			if err != nil {
+				t.Fatalf("unexpected Exec err: %s", err)
+			}
+			if err := compareTimeSeries(t, tc.expTS, tss); err != nil {
+				t.Fatalf("timeseries missmatch: %s", err)
+			}
+		})
+	}
+}
+
+func TestRecoridngRule_ExecNegative(t *testing.T) {
 	rr := &RecordingRule{Name: "job:foo", Labels: map[string]string{
 		"job": "test",
 	}}
@@ -97,7 +178,7 @@ func TestRecoridngRule_ToTimeSeriesNegative(t *testing.T) {
 	expErr := "connection reset by peer"
 	fq.setErr(errors.New(expErr))
 	rr.q = fq
-	_, err := rr.Exec(context.TODO(), true)
+	_, err := rr.Exec(context.TODO())
 	if err == nil {
 		t.Fatalf("expected to get err; got nil")
 	}
@@ -112,7 +193,7 @@ func TestRecoridngRule_ToTimeSeriesNegative(t *testing.T) {
 	fq.add(metricWithValueAndLabels(t, 1, "__name__", "foo", "job", "foo"))
 	fq.add(metricWithValueAndLabels(t, 2, "__name__", "foo", "job", "bar"))
 
-	_, err = rr.Exec(context.TODO(), true)
+	_, err = rr.Exec(context.TODO())
 	if err == nil {
 		t.Fatalf("expected to get err; got nil")
 	}

--- a/app/vmalert/replay.go
+++ b/app/vmalert/replay.go
@@ -1,0 +1,154 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/cheggaaa/pb/v3"
+
+	"github.com/VictoriaMetrics/VictoriaMetrics/app/vmalert/config"
+	"github.com/VictoriaMetrics/VictoriaMetrics/app/vmalert/datasource"
+	"github.com/VictoriaMetrics/VictoriaMetrics/app/vmalert/remotewrite"
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/logger"
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/prompbmarshal"
+)
+
+var (
+	replayFrom = flag.String("replay.timeFrom", "",
+		"The time filter in RFC3339 format to select time series with timestamp equal or higher than provided value. E.g. '2020-01-01T20:07:00Z'")
+	replayTo = flag.String("replay.timeTo", "",
+		"The time filter in RFC3339 format to select timeseries with timestamp equal or lower than provided value. E.g. '2020-01-01T20:07:00Z'")
+	replayRulesDelay = flag.Duration("replay.rulesDelay", time.Second,
+		"Delay between rules evaluation within the group. Could be important if there are chained rules inside of the group"+
+			"and processing need to wait for previous rule results to be persisted by remote storage before evaluating the next rule."+
+			"Keep it equal or bigger than -remoteWrite.flushInterval.")
+	replayMaxDatapoints = flag.Int("replay.maxDatapointsPerQuery", 1e3,
+		"Max number of data points expected in one request. The higher the value, the less requests will be made during replay.")
+	replayRuleRetryAttempts = flag.Int("replay.ruleRetryAttempts", 5,
+		"Defines how many retries to make before giving up on rule if request for it returns an error.")
+)
+
+func replay(groupsCfg []config.Group, qb datasource.QuerierBuilder, rw *remotewrite.Client) error {
+	if *replayMaxDatapoints < 1 {
+		return fmt.Errorf("replay.maxDatapointsPerQuery can't be lower than 1")
+	}
+	tFrom, err := time.Parse(time.RFC3339, *replayFrom)
+	if err != nil {
+		return fmt.Errorf("failed to parse %q: %s", *replayFrom, err)
+	}
+	tTo, err := time.Parse(time.RFC3339, *replayTo)
+	if err != nil {
+		return fmt.Errorf("failed to parse %q: %s", *replayTo, err)
+	}
+	labels := make(map[string]string)
+	for _, s := range *externalLabels {
+		if len(s) == 0 {
+			continue
+		}
+		n := strings.IndexByte(s, '=')
+		if n < 0 {
+			return fmt.Errorf("missing '=' in `-label`. It must contain label in the form `name=value`; got %q", s)
+		}
+		labels[s[:n]] = s[n+1:]
+	}
+
+	fmt.Printf("Replay mode:"+
+		"\nfrom: \t%v "+
+		"\nto: \t%v "+
+		"\nmax data points per request: %d\n",
+		tFrom, tTo, *replayMaxDatapoints)
+
+	var total int
+	for _, cfg := range groupsCfg {
+		ng := newGroup(cfg, qb, *evaluationInterval, labels)
+		total += ng.replay(tFrom, tTo, rw)
+	}
+	logger.Infof("replay finished! Imported %d samples", total)
+	if rw != nil {
+		return rw.Close()
+	}
+	return nil
+}
+
+func (g *Group) replay(start, end time.Time, rw *remotewrite.Client) int {
+	var total int
+	step := g.Interval * time.Duration(*replayMaxDatapoints)
+	ri := rangeIterator{start: start, end: end, step: step}
+	iterations := int(end.Sub(start)/step) + 1
+	fmt.Printf("\nGroup %q"+
+		"\ninterval: \t%v"+
+		"\nrequests to make: \t%d"+
+		"\nmax range per request: \t%v\n",
+		g.Name, g.Interval, iterations, step)
+	for _, rule := range g.Rules {
+		fmt.Printf("> Rule %q (ID: %d)\n", rule, rule.ID())
+		bar := pb.StartNew(iterations)
+
+	iteration:
+		for i := 0; ; i++ {
+			s, e := ri.next(i)
+			if s == e {
+				break iteration
+			}
+			n, err := replayRule(rule, s, e, rw)
+			if err != nil {
+				logger.Fatalf("rule %q: %s", rule, err)
+			}
+			total += n
+			bar.Increment()
+		}
+		bar.Finish()
+		// sleep to let remote storage to flush data on-disk
+		// so chained rules could be calculated correctly
+		time.Sleep(*replayRulesDelay)
+	}
+	return total
+}
+
+func replayRule(rule Rule, start, end time.Time, rw *remotewrite.Client) (int, error) {
+	var err error
+	var tss []prompbmarshal.TimeSeries
+	for i := 0; i < *replayRuleRetryAttempts; i++ {
+		tss, err = rule.ExecRange(context.Background(), start, end)
+		if err == nil {
+			break
+		}
+		logger.Errorf("attempt %d to execute rule %q failed: %s", i+1, rule, err)
+		time.Sleep(time.Second)
+		continue
+	}
+	if err != nil { // means all attempts failed
+		return 0, err
+	}
+	if len(tss) < 1 {
+		return 0, nil
+	}
+	var n int
+	for _, ts := range tss {
+		if err := rw.Push(ts); err != nil {
+			return n, fmt.Errorf("remote write failure: %s", err)
+		}
+		n += len(ts.Samples)
+	}
+	return n, nil
+}
+
+type rangeIterator struct {
+	start, end time.Time
+	step       time.Duration
+}
+
+func (ri rangeIterator) next(i int) (time.Time, time.Time) {
+	start := ri.start.Add(ri.step * time.Duration(i))
+	if start.After(ri.end) {
+		return ri.end, ri.end
+	}
+	end := start.Add(ri.step)
+	if end.After(ri.end) {
+		end = ri.end
+	}
+	return start, end
+}

--- a/app/vmalert/replay_test.go
+++ b/app/vmalert/replay_test.go
@@ -1,0 +1,243 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/VictoriaMetrics/VictoriaMetrics/app/vmalert/config"
+	"github.com/VictoriaMetrics/VictoriaMetrics/app/vmalert/datasource"
+)
+
+type fakeReplayQuerier struct {
+	fakeQuerier
+	registry map[string]map[string]struct{}
+}
+
+func (fr *fakeReplayQuerier) BuildWithParams(_ datasource.QuerierParams) datasource.Querier {
+	return fr
+}
+
+func (fr *fakeReplayQuerier) QueryRange(_ context.Context, q string, from, to time.Time) ([]datasource.Metric, error) {
+	key := fmt.Sprintf("%s+%s", from.Format("15:04:05"), to.Format("15:04:05"))
+	dps, ok := fr.registry[q]
+	if !ok {
+		return nil, fmt.Errorf("unexpected query received: %q", q)
+	}
+	_, ok = dps[key]
+	if !ok {
+		return nil, fmt.Errorf("unexpected time range received: %q", key)
+	}
+	delete(dps, key)
+	if len(fr.registry[q]) < 1 {
+		delete(fr.registry, q)
+	}
+	return nil, nil
+}
+
+func TestReplay(t *testing.T) {
+	testCases := []struct {
+		name     string
+		from, to string
+		maxDP    int
+		cfg      []config.Group
+		qb       *fakeReplayQuerier
+	}{
+		{
+			name:  "one rule + one response",
+			from:  "2021-01-01T12:00:00.000Z",
+			to:    "2021-01-01T12:02:00.000Z",
+			maxDP: 10,
+			cfg: []config.Group{
+				{Rules: []config.Rule{{Record: "foo", Expr: "sum(up)"}}},
+			},
+			qb: &fakeReplayQuerier{
+				registry: map[string]map[string]struct{}{
+					"sum(up)": {"12:00:00+12:02:00": {}},
+				},
+			},
+		},
+		{
+			name:  "one rule + multiple responses",
+			from:  "2021-01-01T12:00:00.000Z",
+			to:    "2021-01-01T12:02:30.000Z",
+			maxDP: 1,
+			cfg: []config.Group{
+				{Rules: []config.Rule{{Record: "foo", Expr: "sum(up)"}}},
+			},
+			qb: &fakeReplayQuerier{
+				registry: map[string]map[string]struct{}{
+					"sum(up)": {
+						"12:00:00+12:01:00": {},
+						"12:01:00+12:02:00": {},
+						"12:02:00+12:02:30": {},
+					},
+				},
+			},
+		},
+		{
+			name:  "datapoints per step",
+			from:  "2021-01-01T12:00:00.000Z",
+			to:    "2021-01-01T15:02:30.000Z",
+			maxDP: 60,
+			cfg: []config.Group{
+				{Interval: time.Minute, Rules: []config.Rule{{Record: "foo", Expr: "sum(up)"}}},
+			},
+			qb: &fakeReplayQuerier{
+				registry: map[string]map[string]struct{}{
+					"sum(up)": {
+						"12:00:00+13:00:00": {},
+						"13:00:00+14:00:00": {},
+						"14:00:00+15:00:00": {},
+						"15:00:00+15:02:30": {},
+					},
+				},
+			},
+		},
+		{
+			name:  "multiple recording rules + multiple responses",
+			from:  "2021-01-01T12:00:00.000Z",
+			to:    "2021-01-01T12:02:30.000Z",
+			maxDP: 1,
+			cfg: []config.Group{
+				{Rules: []config.Rule{{Record: "foo", Expr: "sum(up)"}}},
+				{Rules: []config.Rule{{Record: "bar", Expr: "max(up)"}}},
+			},
+			qb: &fakeReplayQuerier{
+				registry: map[string]map[string]struct{}{
+					"sum(up)": {
+						"12:00:00+12:01:00": {},
+						"12:01:00+12:02:00": {},
+						"12:02:00+12:02:30": {},
+					},
+					"max(up)": {
+						"12:00:00+12:01:00": {},
+						"12:01:00+12:02:00": {},
+						"12:02:00+12:02:30": {},
+					},
+				},
+			},
+		},
+		{
+			name:  "multiple alerting rules + multiple responses",
+			from:  "2021-01-01T12:00:00.000Z",
+			to:    "2021-01-01T12:02:30.000Z",
+			maxDP: 1,
+			cfg: []config.Group{
+				{Rules: []config.Rule{{Alert: "foo", Expr: "sum(up) > 1"}}},
+				{Rules: []config.Rule{{Alert: "bar", Expr: "max(up) < 1"}}},
+			},
+			qb: &fakeReplayQuerier{
+				registry: map[string]map[string]struct{}{
+					"sum(up) > 1": {
+						"12:00:00+12:01:00": {},
+						"12:01:00+12:02:00": {},
+						"12:02:00+12:02:30": {},
+					},
+					"max(up) < 1": {
+						"12:00:00+12:01:00": {},
+						"12:01:00+12:02:00": {},
+						"12:02:00+12:02:30": {},
+					},
+				},
+			},
+		},
+	}
+
+	from, to, maxDP := *replayFrom, *replayTo, *replayMaxDatapoints
+	retries, delay := *replayRuleRetryAttempts, *replayRulesDelay
+	defer func() {
+		*replayFrom, *replayTo = from, to
+		*replayMaxDatapoints, *replayRuleRetryAttempts = maxDP, retries
+		*replayRulesDelay = delay
+	}()
+
+	*replayRuleRetryAttempts = 1
+	*replayRulesDelay = time.Millisecond
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			*replayFrom = tc.from
+			*replayTo = tc.to
+			*replayMaxDatapoints = tc.maxDP
+			if err := replay(tc.cfg, tc.qb, nil); err != nil {
+				t.Fatalf("replay failed: %s", err)
+			}
+			if len(tc.qb.registry) > 0 {
+				t.Fatalf("not all requests were sent: %#v", tc.qb.registry)
+			}
+		})
+	}
+}
+
+func TestRangeIterator(t *testing.T) {
+	testCases := []struct {
+		ri     rangeIterator
+		result [][2]time.Time
+	}{
+		{
+			ri: rangeIterator{
+				start: parseTime(t, "2021-01-01T12:00:00.000Z"),
+				end:   parseTime(t, "2021-01-01T12:30:00.000Z"),
+				step:  5 * time.Minute,
+			},
+			result: [][2]time.Time{
+				{parseTime(t, "2021-01-01T12:00:00.000Z"), parseTime(t, "2021-01-01T12:05:00.000Z")},
+				{parseTime(t, "2021-01-01T12:05:00.000Z"), parseTime(t, "2021-01-01T12:10:00.000Z")},
+				{parseTime(t, "2021-01-01T12:10:00.000Z"), parseTime(t, "2021-01-01T12:15:00.000Z")},
+				{parseTime(t, "2021-01-01T12:15:00.000Z"), parseTime(t, "2021-01-01T12:20:00.000Z")},
+				{parseTime(t, "2021-01-01T12:20:00.000Z"), parseTime(t, "2021-01-01T12:25:00.000Z")},
+				{parseTime(t, "2021-01-01T12:25:00.000Z"), parseTime(t, "2021-01-01T12:30:00.000Z")},
+				{parseTime(t, "2021-01-01T12:30:00.000Z"), parseTime(t, "2021-01-01T12:30:00.000Z")},
+			},
+		},
+		{
+			ri: rangeIterator{
+				start: parseTime(t, "2021-01-01T12:00:00.000Z"),
+				end:   parseTime(t, "2021-01-01T12:30:00.000Z"),
+				step:  45 * time.Minute,
+			},
+			result: [][2]time.Time{
+				{parseTime(t, "2021-01-01T12:00:00.000Z"), parseTime(t, "2021-01-01T12:30:00.000Z")},
+				{parseTime(t, "2021-01-01T12:30:00.000Z"), parseTime(t, "2021-01-01T12:30:00.000Z")},
+			},
+		},
+		{
+			ri: rangeIterator{
+				start: parseTime(t, "2021-01-01T12:00:12.000Z"),
+				end:   parseTime(t, "2021-01-01T12:00:17.000Z"),
+				step:  time.Second,
+			},
+			result: [][2]time.Time{
+				{parseTime(t, "2021-01-01T12:00:12.000Z"), parseTime(t, "2021-01-01T12:00:13.000Z")},
+				{parseTime(t, "2021-01-01T12:00:13.000Z"), parseTime(t, "2021-01-01T12:00:14.000Z")},
+				{parseTime(t, "2021-01-01T12:00:14.000Z"), parseTime(t, "2021-01-01T12:00:15.000Z")},
+				{parseTime(t, "2021-01-01T12:00:15.000Z"), parseTime(t, "2021-01-01T12:00:16.000Z")},
+			},
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("case %d", i), func(t *testing.T) {
+			for j := 0; j < len(tc.result); j++ {
+				s, e := tc.ri.next(j)
+				expS, expE := tc.result[j][0], tc.result[j][1]
+				if s != expS {
+					t.Errorf("expected to get start=%v; got %v", expS, s)
+				}
+				if e != expE {
+					t.Errorf("expected to get end=%v; got %v", expE, e)
+				}
+			}
+		})
+	}
+}
+
+func parseTime(t *testing.T, s string) time.Time {
+	t.Helper()
+	tt, err := time.Parse("2006-01-02T15:04:05.000Z", s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return tt
+}

--- a/app/vmalert/replay_test.go
+++ b/app/vmalert/replay_test.go
@@ -188,7 +188,6 @@ func TestRangeIterator(t *testing.T) {
 				{parseTime(t, "2021-01-01T12:15:00.000Z"), parseTime(t, "2021-01-01T12:20:00.000Z")},
 				{parseTime(t, "2021-01-01T12:20:00.000Z"), parseTime(t, "2021-01-01T12:25:00.000Z")},
 				{parseTime(t, "2021-01-01T12:25:00.000Z"), parseTime(t, "2021-01-01T12:30:00.000Z")},
-				{parseTime(t, "2021-01-01T12:30:00.000Z"), parseTime(t, "2021-01-01T12:30:00.000Z")},
 			},
 		},
 		{
@@ -213,21 +212,28 @@ func TestRangeIterator(t *testing.T) {
 				{parseTime(t, "2021-01-01T12:00:13.000Z"), parseTime(t, "2021-01-01T12:00:14.000Z")},
 				{parseTime(t, "2021-01-01T12:00:14.000Z"), parseTime(t, "2021-01-01T12:00:15.000Z")},
 				{parseTime(t, "2021-01-01T12:00:15.000Z"), parseTime(t, "2021-01-01T12:00:16.000Z")},
+				{parseTime(t, "2021-01-01T12:00:16.000Z"), parseTime(t, "2021-01-01T12:00:17.000Z")},
 			},
 		},
 	}
 
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("case %d", i), func(t *testing.T) {
-			for j := 0; j < len(tc.result); j++ {
-				s, e := tc.ri.next(j)
+			var j int
+			for tc.ri.next() {
+				if len(tc.result) < j+1 {
+					t.Fatalf("unexpected result for iterator on step %d: %v - %v",
+						j, tc.ri.s, tc.ri.e)
+				}
+				s, e := tc.ri.s, tc.ri.e
 				expS, expE := tc.result[j][0], tc.result[j][1]
 				if s != expS {
-					t.Errorf("expected to get start=%v; got %v", expS, s)
+					t.Fatalf("expected to get start=%v; got %v", expS, s)
 				}
 				if e != expE {
-					t.Errorf("expected to get end=%v; got %v", expE, e)
+					t.Fatalf("expected to get end=%v; got %v", expE, e)
 				}
+				j++
 			}
 		})
 	}

--- a/app/vmalert/rule.go
+++ b/app/vmalert/rule.go
@@ -3,21 +3,21 @@ package main
 import (
 	"context"
 	"errors"
-
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/prompbmarshal"
+	"time"
 )
 
 // Rule represents alerting or recording rule
 // that has unique ID, can be Executed and
 // updated with other Rule.
 type Rule interface {
-	// Returns unique ID that may be used for
+	// ID returns unique ID that may be used for
 	// identifying this Rule among others.
 	ID() uint64
 	// Exec executes the rule with given context
-	// and Querier. If returnSeries is true, Exec
-	// may return TimeSeries as result of execution
-	Exec(ctx context.Context, returnSeries bool) ([]prompbmarshal.TimeSeries, error)
+	Exec(ctx context.Context) ([]prompbmarshal.TimeSeries, error)
+	// ExecRange executes the rule on the given time range
+	ExecRange(ctx context.Context, start, end time.Time) ([]prompbmarshal.TimeSeries, error)
 	// UpdateWith performs modification of current Rule
 	// with fields of the given Rule.
 	UpdateWith(Rule) error

--- a/app/vmalert/utils.go
+++ b/app/vmalert/utils.go
@@ -7,17 +7,21 @@ import (
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/prompbmarshal"
 )
 
-func newTimeSeries(value float64, labels map[string]string, timestamp time.Time) prompbmarshal.TimeSeries {
-	ts := prompbmarshal.TimeSeries{}
-	ts.Samples = append(ts.Samples, prompbmarshal.Sample{
-		Value:     value,
-		Timestamp: timestamp.UnixNano() / 1e6,
-	})
+func newTimeSeries(values []float64, timestamps []int64, labels map[string]string) prompbmarshal.TimeSeries {
+	ts := prompbmarshal.TimeSeries{
+		Samples: make([]prompbmarshal.Sample, len(values)),
+	}
+	for i := range values {
+		ts.Samples[i] = prompbmarshal.Sample{
+			Value:     values[i],
+			Timestamp: time.Unix(timestamps[i], 0).UnixNano() / 1e6,
+		}
+	}
 	keys := make([]string, 0, len(labels))
 	for k := range labels {
 		keys = append(keys, k)
 	}
-	sort.Strings(keys)
+	sort.Strings(keys) // make order deterministic
 	for _, key := range keys {
 		ts.Labels = append(ts.Labels, prompbmarshal.Label{
 			Name:  key,


### PR DESCRIPTION
vmalert can `replay` configured rules in the past
and backfill results via remote write protocol.
It supports MetricsQL/PromQL storage as data source,
and can backfill data to remote write compatible
storage.

Supports recording and alerting rules `replay`. See more
details in README.

https://github.com/VictoriaMetrics/VictoriaMetrics/issues/836