### PR TITLE
rename serviceHealth group name to vm-health

### DIFF
--- a/deployment/docker/alerts.yml
+++ b/deployment/docker/alerts.yml
@@ -2,7 +2,7 @@
 # The alerts below are just recommendations and may require some updates
 # and threshold calibration according to every specific setup.
 groups:
-  - name: serviceHealth
+  - name: vm-health
     # note the `job` filter and update accordingly to your setup
     rules:
       # note the `job` filter and update accordingly to your setup


### PR DESCRIPTION
this causes conflicts in `victoria-metrics-k8s-stack` chart =)