### PR TITLE
vmalert: fix mistake with object reuse while parsing response

### DIFF
--- a/app/vmalert/datasource/vm_prom_api.go
+++ b/app/vmalert/datasource/vm_prom_api.go
@@ -34,23 +34,18 @@ type promRange struct {
 
 func (r promInstant) metrics() ([]Metric, error) {
 	var result []Metric
-	var m Metric
 	for i, res := range r.Result {
 		f, err := strconv.ParseFloat(res.TV[1].(string), 64)
 		if err != nil {
 			return nil, fmt.Errorf("metric %v, unable to parse float64 from %s: %w", res, res.TV[1], err)
 		}
-		m.Labels = nil
+		var m Metric
 		for k, v := range r.Result[i].Labels {
 			m.AddLabel(k, v)
 		}
 		m.Timestamps = append(m.Timestamps, int64(res.TV[0].(float64)))
 		m.Values = append(m.Values, f)
 		result = append(result, m)
-
-		m.Values = m.Values[:0]
-		m.Labels = m.Labels[:0]
-		m.Timestamps = m.Timestamps[:0]
 	}
 	return result, nil
 }

--- a/app/vmalert/datasource/vm_test.go
+++ b/app/vmalert/datasource/vm_test.go
@@ -66,7 +66,7 @@ func TestVMInstantQuery(t *testing.T) {
 		case 5:
 			w.Write([]byte(`{"status":"success","data":{"resultType":"matrix"}}`))
 		case 6:
-			w.Write([]byte(`{"status":"success","data":{"resultType":"vector","result":[{"metric":{"__name__":"vm_rows"},"value":[1583786142,"13763"]}]}}`))
+			w.Write([]byte(`{"status":"success","data":{"resultType":"vector","result":[{"metric":{"__name__":"vm_rows"},"value":[1583786142,"13763"]},{"metric":{"__name__":"vm_requests"},"value":[1583786140,"2000"]}]}}`))
 		}
 	})
 
@@ -100,16 +100,23 @@ func TestVMInstantQuery(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected %s", err)
 	}
-	if len(m) != 1 {
-		t.Fatalf("expected 1 metric  got %d in %+v", len(m), m)
+	if len(m) != 2 {
+		t.Fatalf("expected 2 metrics got %d in %+v", len(m), m)
 	}
-	expected := Metric{
-		Labels:     []Label{{Value: "vm_rows", Name: "__name__"}},
-		Timestamps: []int64{1583786142},
-		Values:     []float64{13763},
+	expected := []Metric{
+		{
+			Labels:     []Label{{Value: "vm_rows", Name: "__name__"}},
+			Timestamps: []int64{1583786142},
+			Values:     []float64{13763},
+		},
+		{
+			Labels:     []Label{{Value: "vm_requests", Name: "__name__"}},
+			Timestamps: []int64{1583786140},
+			Values:     []float64{2000},
+		},
 	}
-	if !reflect.DeepEqual(m[0], expected) {
-		t.Fatalf("unexpected metric %+v want %+v", m[0], expected)
+	if !reflect.DeepEqual(m, expected) {
+		t.Fatalf("unexpected metric %+v want %+v", m, expected)
 	}
 
 	g := NewGraphiteType()
@@ -122,12 +129,12 @@ func TestVMInstantQuery(t *testing.T) {
 	if len(m) != 1 {
 		t.Fatalf("expected 1 metric  got %d in %+v", len(m), m)
 	}
-	expected = Metric{
+	exp := Metric{
 		Labels:     []Label{{Value: "constantLine(10)", Name: "name"}},
 		Timestamps: []int64{1611758403},
 		Values:     []float64{10},
 	}
-	if !reflect.DeepEqual(m[0], expected) {
+	if !reflect.DeepEqual(m[0], exp) {
 		t.Fatalf("unexpected metric %+v want %+v", m[0], expected)
 	}
 }


### PR DESCRIPTION
During the refactoring, the wrong optimisations was applied in
parse function which caused unintentional metric fields reset. 
The change removes this optimisation.

https://github.com/VictoriaMetrics/VictoriaMetrics/issues/1369