### PR TITLE
Change default value of '-remoteWrite.queues' to cgroup.AvailableCPUs * 2

### DIFF
--- a/app/vmagent/README.md
+++ b/app/vmagent/README.md
@@ -719,7 +719,7 @@ See the docs at https://docs.victoriametrics.com/vmagent.html .
     	Optional proxy URL for writing data to -remoteWrite.url. Supported proxies: http, https, socks5. Example: -remoteWrite.proxyURL=socks5://proxy:1234
     	Supports an array of values separated by comma or specified via multiple flags.
   -remoteWrite.queues int
-    	The number of concurrent queues to each -remoteWrite.url. Set more queues if default number of queues isn't enough for sending high volume of collected data to remote storage (default 4)
+    	The number of concurrent queues to each -remoteWrite.url. Set more queues if default number of queues isn't enough for sending high volume of collected data to remote storage (default 2 * numberOfAvailableCPUs)
   -remoteWrite.rateLimit array
     	Optional rate limit in bytes per second for data sent to -remoteWrite.url. By default the rate limit is disabled. It can be useful for limiting load on remote storage when big amounts of buffered data is sent after temporary unavailability of the remote storage
     	Supports array of values separated by comma or specified via multiple flags.

--- a/app/vmagent/remotewrite/remotewrite.go
+++ b/app/vmagent/remotewrite/remotewrite.go
@@ -29,7 +29,7 @@ var (
 	tmpDataPath = flag.String("remoteWrite.tmpDataPath", "vmagent-remotewrite-data", "Path to directory where temporary data for remote write component is stored. "+
 		"See also -remoteWrite.maxDiskUsagePerURL")
 	queues = flag.Int("remoteWrite.queues", cgroup.AvailableCPUs() * 2, "The number of concurrent queues to each -remoteWrite.url. Set more queues if default number of queues "+
-		"isn't enough for sending high volume of collected data to remote storage")
+		"isn't enough for sending high volume of collected data to remote storage. Default value if 2 * numberOfAvailableCPUs")
 	showRemoteWriteURL = flag.Bool("remoteWrite.showURL", false, "Whether to show -remoteWrite.url in the exported metrics. "+
 		"It is hidden by default, since it can contain sensitive info such as auth key")
 	maxPendingBytesPerURL = flagutil.NewBytes("remoteWrite.maxDiskUsagePerURL", 0, "The maximum file-based buffer size in bytes at -remoteWrite.tmpDataPath "+

--- a/app/vmagent/remotewrite/remotewrite.go
+++ b/app/vmagent/remotewrite/remotewrite.go
@@ -28,7 +28,7 @@ var (
 		"Pass multiple -remoteWrite.url flags in order to write data concurrently to multiple remote storage systems")
 	tmpDataPath = flag.String("remoteWrite.tmpDataPath", "vmagent-remotewrite-data", "Path to directory where temporary data for remote write component is stored. "+
 		"See also -remoteWrite.maxDiskUsagePerURL")
-	queues = flag.Int("remoteWrite.queues", 4, "The number of concurrent queues to each -remoteWrite.url. Set more queues if default number of queues "+
+	queues = flag.Int("remoteWrite.queues", cgroup.AvailableCPUs() * 2, "The number of concurrent queues to each -remoteWrite.url. Set more queues if default number of queues "+
 		"isn't enough for sending high volume of collected data to remote storage")
 	showRemoteWriteURL = flag.Bool("remoteWrite.showURL", false, "Whether to show -remoteWrite.url in the exported metrics. "+
 		"It is hidden by default, since it can contain sensitive info such as auth key")


### PR DESCRIPTION
# Overview
Default value of vmagent option '-remotewrite.queues' is 4 and default
size of vmagent ScheudleUnmarshalWorkers is number of CPUs, when available
CPUs is much greater than 4, e.g 32, worker are competing push queues
which will increase scrape interval and may cause scrape timeout.

# Background & Motivation
We have a vmagnet deployed in k8s pod which consumes 32 cores CPU and scrapes 24k active targets. We found that scraping of kube-state-metrics timeout with error message `context deadline exceeded` and scrape duration is about 45s shown in vmagent targets page. When we request the kube-state-metrics endpoint in vmagent container, it costs nearly 1s. 

![wecom-temp-a8bb0bb843d5b97efde5468b4ff84f78](https://user-images.githubusercontent.com/8848479/122182476-e5d44780-cebc-11eb-8b43-bcd9b66f2a1b.png)
<img width="570" alt="wecom-temp-a04c328080e11854961b4492129a48e2" src="https://user-images.githubusercontent.com/8848479/122182508-eb319200-cebc-11eb-8ae3-9e5f807d395e.png">

As shown in following picture, when we increase the option `-remoteWrite.queues` from 10 to 64, the scrape duration decreased to 9s. Timeout error disappeared!
<img width="1273" alt="wecom-temp-5f154c0fa5340a0c14de437e80af2146" src="https://user-images.githubusercontent.com/8848479/122183169-8dea1080-cebd-11eb-838a-c1154b546b71.png">


**So we recommend that change the default value of option `-remoteWrite.queues` to 2 * numberOfCPUs to avoid scraping context deadline exceed due to competing push mutex.**

The diff of pprof mutex dump shows that lock competing of function `pendingseries.Push` decreased 50%.

![image](https://user-images.githubusercontent.com/8848479/122184229-9bec6100-cebe-11eb-8cb6-de04a56645ed.png)


# Changes

1. Change default value of vmagent option `-remoteWrite.queues` to `2 * numberOfCPUs`

# Attachments
The pprof mutex and profile dump of vmagent with 10 queues and 64 queues are here. 
[vmagent-pprof.zip](https://github.com/VictoriaMetrics/VictoriaMetrics/files/6661374/vmagent-pprof.zip)
