### PR TITLE
protection vmselect ,avoid metrics point too much let vmselect cup load very, very high

### DIFF
--- a/app/vmselect/netstorage/netstorage.go
+++ b/app/vmselect/netstorage/netstorage.go
@@ -310,7 +310,6 @@ func putUnpackWork(upw *unpackWork) {
 var unpackWorkPool sync.Pool
 
 var unpackWorkChs []chan *unpackWork
-var unpackWorkIdx uint32
 
 func init() {
 	unpackWorkChs = make([]chan *unpackWork, gomaxprocs)

--- a/app/vmstorage/transport/server.go
+++ b/app/vmstorage/transport/server.go
@@ -1078,7 +1078,9 @@ func (s *Server) processVMSelectSearch(ctx *vmselectRequestCtx) error {
 		ctx.sr.MetricBlockRef.BlockRef.MustReadBlock(&ctx.mb.Block, fetchData)
 
 		vmselectMetricBlocksRead.Inc()
-		vmselectMetricRowsRead.Add(ctx.mb.Block.RowsCount())
+		rowsCount := ctx.mb.Block.RowsCount()
+		vmselectMetricRowsRead.Add(rowsCount)
+		count += rowsCount
 		if count > *maxMetricsPointSearch {
 			fmt.Errorf("more than -search.maxMetricsPointSearch=%d point,discard more points", *maxMetricsPointSearch)
 			break

--- a/app/vmstorage/transport/server.go
+++ b/app/vmstorage/transport/server.go
@@ -1082,7 +1082,7 @@ func (s *Server) processVMSelectSearch(ctx *vmselectRequestCtx) error {
 		vmselectMetricRowsRead.Add(rowsCount)
 		count += rowsCount
 		if count > *maxMetricsPointSearch {
-			fmt.Errorf("more than -search.maxMetricsPointSearch=%d point,discard more points", *maxMetricsPointSearch)
+			logger.Errorf("more than -search.maxMetricsPointSearch=%d point,discard more points", *maxMetricsPointSearch)
 			break
 		}
 


### PR DESCRIPTION
<img width="1465" alt="" src="https://user-images.githubusercontent.com/6373972/126596317-898e1c41-2b3b-4e70-a6ed-b222bb41846f.png">
when i want to use  `-search.maxUniqueTimeseries`  limit too much point return vmselect，avoid vmselect cpu load high，but i found it useless，
<img width="761" alt="" src="https://user-images.githubusercontent.com/6373972/126597697-99557974-a001-4ebd-9a48-91d420dceb85.png">



so i want add `-search.maxMetricsPointSearch` to limit too much point return vmselect，so as to protect vmselect:
<img width="1738" alt="" src="https://user-images.githubusercontent.com/6373972/126596640-0f109787-d561-4f2d-b6b4-52b2016f4f9e.png">
