### PR TITLE
vm-select/Fix alerts endpoint for grafana8

### DIFF
--- a/app/vmselect/main.go
+++ b/app/vmselect/main.go
@@ -468,6 +468,12 @@ func selectHandler(startTime time.Time, w http.ResponseWriter, r *http.Request, 
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		fmt.Fprintf(w, "%s", `{"status":"success","data":{"groups":[]}}`)
 		return true
+	case "prometheus/rules":
+		// Return dumb placeholder for https://prometheus.io/docs/prometheus/latest/querying/api/#rules
+		rulesRequests.Inc()
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		fmt.Fprintf(w, "%s", `{"status":"success","data":{"groups":[]}}`)
+		return true
 	case "prometheus/api/v1/alerts":
 		// Return dumb placehloder for https://prometheus.io/docs/prometheus/latest/querying/api/#alerts
 		alertsRequests.Inc()


### PR DESCRIPTION
A small fix for grafana unified alerts to work properly with VM-Cluster.

More details here: https://github.com/VictoriaMetrics/VictoriaMetrics/issues/1493 