### PR TITLE
app/vmalert: add metrics if config parsed failed

### DIFF
--- a/app/vmalert/main.go
+++ b/app/vmalert/main.go
@@ -266,6 +266,8 @@ func configReload(ctx context.Context, m *manager, groupsCfg []config.Group) {
 		}
 		newGroupsCfg, err := config.Parse(*rulePath, *validateTemplates, *validateExpressions)
 		if err != nil {
+			configReloadErrors.Inc()
+			configSuccess.Set(0)
 			logger.Errorf("cannot parse configuration file: %s", err)
 			continue
 		}


### PR DESCRIPTION
In our use case, vmalert failed to parse the config if rule templates are malformed. (e.g. expr is empty).
We prefer to see it happens and send alerts to us.