### PR TITLE
vmalert: add flag `disableAlertgroupLabel` for disabling extra label added to series

### DIFF
--- a/app/vmalert/README.md
+++ b/app/vmalert/README.md
@@ -373,6 +373,8 @@ The shortlist of configuration flags is the following:
     	Optional TLS server name to use for connections to -datasource.url. By default, the server name from -datasource.url is used
   -datasource.url string
     	VictoriaMetrics or vmselect url. Required parameter. E.g. http://127.0.0.1:8428
+  -disableAlertgroupLabel
+        Whether to disable adding group's name as label to generated alerts and time series.
   -dryRun -rule
     	Whether to check only config files without running vmalert. The rules file are validated. The -rule flag must be specified.
   -enableTCP6

--- a/app/vmalert/alerting.go
+++ b/app/vmalert/alerting.go
@@ -354,7 +354,7 @@ func (ar *AlertingRule) newAlert(m datasource.Metric, start time.Time, qFn notif
 	}
 	// label defined here to make override possible by
 	// time series labels.
-	if ar.GroupName != "" {
+	if !*disableAlertGroupLabel && ar.GroupName != "" {
 		a.Labels[alertGroupNameLabel] = ar.GroupName
 	}
 	for _, l := range m.Labels {

--- a/app/vmalert/main.go
+++ b/app/vmalert/main.go
@@ -52,6 +52,8 @@ eg. 'explore?orgId=1&left=[\"now-1h\",\"now\",\"VictoriaMetrics\",{\"expr\": \"{
 		" For example, if lookback=1h then range from now() to now()-1h will be scanned.")
 	remoteReadIgnoreRestoreErrors = flag.Bool("remoteRead.ignoreRestoreErrors", true, "Whether to ignore errors from remote storage when restoring alerts state on startup.")
 
+	disableAlertGroupLabel = flag.Bool("disableAlertgroupLabel", false, "Whether to disable adding group's name as label to generated alerts and time series.")
+
 	dryRun = flag.Bool("dryRun", false, "Whether to check only config files without running vmalert. The rules file are validated. The `-rule` flag must be specified.")
 )
 


### PR DESCRIPTION


The new label added in https://github.com/VictoriaMetrics/VictoriaMetrics/issues/611
may negatively impact deduplication in Alertmanager. The new flag supposed to give
an option to disable adding this label.

To enable flag just add `-disableAlertgroupLabel` to binary execution command.

https://github.com/VictoriaMetrics/VictoriaMetrics/issues/1532