### PR TITLE
rename alert group for cluster

### DIFF
--- a/deployment/docker/alerts.yml
+++ b/deployment/docker/alerts.yml
@@ -2,7 +2,7 @@
 # The alerts below are just recommendations and may require some updates
 # and threshold calibration according to every specific setup.
 groups:
-  - name: vm-health
+  - name: vmcluster-health
     # note the `job` filter and update accordingly to your setup
     rules:
       - alert: TooManyRestarts


### PR DESCRIPTION
rename alert group for cluster, so that they not overlap when you have vmsingle and vmcluster deployed alongside