### PR TITLE
vmalert: accept http.StatusOK for remotewrite

### DIFF
--- a/app/vmalert/remotewrite/remotewrite.go
+++ b/app/vmalert/remotewrite/remotewrite.go
@@ -244,7 +244,7 @@ func (c *Client) send(ctx context.Context, data []byte) error {
 			req.URL, err, len(data), r.Size())
 	}
 	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode != http.StatusNoContent {
+	if resp.StatusCode != http.StatusNoContent && resp.StatusCode != http.StatusOK {
 		body, _ := ioutil.ReadAll(resp.Body)
 		return fmt.Errorf("unexpected response code %d for %s. Response body %q",
 			resp.StatusCode, req.URL, body)


### PR DESCRIPTION
Some compatible backends respond with http.StatusOK for a successful remotewrite, so supporting that out of the box would be very handy