### PR TITLE
Remove trailing slash for URLPrefixes with specific path

### DIFF
--- a/app/vmauth/target_url.go
+++ b/app/vmauth/target_url.go
@@ -42,6 +42,7 @@ func createTargetURL(ui *UserInfo, uOrig *url.URL) (*url.URL, error) {
 	if !strings.HasPrefix(u.Path, "/") {
 		u.Path = "/" + u.Path
 	}
+	u.Path = strings.TrimSuffix(u.Path, "/")
 	for _, e := range ui.URLMap {
 		for _, sp := range e.SrcPaths {
 			if sp.match(u.Path) {

--- a/app/vmauth/target_url_test.go
+++ b/app/vmauth/target_url_test.go
@@ -26,7 +26,10 @@ func TestCreateTargetURLSuccess(t *testing.T) {
 	}, "", "http://foo.bar/.")
 	f(&UserInfo{
 		URLPrefix: mustParseURL("http://foo.bar"),
-	}, "/", "http://foo.bar/")
+	}, "/", "http://foo.bar")
+	f(&UserInfo{
+		URLPrefix: mustParseURL("http://foo.bar/federate"),
+	}, "/", "http://foo.bar/federate")
 	f(&UserInfo{
 		URLPrefix: mustParseURL("http://foo.bar"),
 	}, "a/b?c=d", "http://foo.bar/a/b?c=d")


### PR DESCRIPTION
I have a use-case where I want to grant a user access to the federate endpoint only. Unfortunately, when requesting root URLs from VMAuth, a trailing slash is always appended which then breaks the routing in VMSelect.

What happens:
Requesting `http://user1@vmauth.example.com` returns the error `unsupported path requested: "/select/0/prometheus/federate/"`

What I expected:
VMAuth routes to `/select/0/prometheus/federate` as defined in the config file.

This PR removes the trailing slash in these cases and adds a test to confirm it.

Example VMAuth config:
```yaml
users:
- username: "user1"
  password: "***"
  url_prefix: "http://mycluster/select/0/prometheus/federate"
```