### PR TITLE
vmalert: add nocache=1 param for QueryRange API method of datasource component

### DIFF
--- a/app/vmalert/datasource/vm_prom_api.go
+++ b/app/vmalert/datasource/vm_prom_api.go
@@ -140,6 +140,10 @@ func (s *VMStorage) setPrometheusRangeReqParams(r *http.Request, query string, s
 	q := r.URL.Query()
 	q.Add("start", fmt.Sprintf("%d", start.Unix()))
 	q.Add("end", fmt.Sprintf("%d", end.Unix()))
+	// prevent queries from caching and boundaries aligning
+	// when querying VictoriaMetrics datasource.
+	// Is needed only for replay feature.
+	q.Add("nocache", "1")
 	r.URL.RawQuery = q.Encode()
 	s.setPrometheusReqParams(r, query)
 }


### PR DESCRIPTION
The `nocache=1` param is VictoriaMetrics specific parameter which prevents it
from caching and boundaries aligning for queries. We set it to avoid cache
pollution in `replay` mode and also to avoid unnecessary time range boundaries
alignment.