### PR TITLE
lib/storage: optimize convert multiple values regexp filter to composite tag filter

### DIFF
--- a/lib/storage/tag_filters.go
+++ b/lib/storage/tag_filters.go
@@ -28,13 +28,16 @@ func convertToCompositeTagFilterss(tfss []*TagFilters) []*TagFilters {
 func convertToCompositeTagFilters(tfs *TagFilters) []*TagFilters {
 	tfssCompiled := make([]*TagFilters, 0)
 
-	// Search for metric name filter, which must be used for creating composite filters.
+	// Search for filters on metric name, which will be used for creating composite filters.
 	var names [][]byte
 	hasPositiveFilter := false
 	for _, tf := range tfs.tfs {
 		if len(tf.key) == 0 && !tf.isNegative && !tf.isRegexp {
 			names = [][]byte{tf.value}
 		} else if len(tf.key) == 0 && !tf.isNegative && tf.isRegexp && len(tf.orSuffixes) > 0 {
+			// Split the filter {__name__=~"name1|...|nameN", other_filters}
+			// into `name1{other_filters}`, ..., `nameN{other_filters}`
+			// and generate composite filters for each of them
 			names = names[:0]
 			for _, orSuffix := range tf.orSuffixes {
 				names = append(names, []byte(orSuffix))

--- a/lib/storage/tag_filters_test.go
+++ b/lib/storage/tag_filters_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestConvertToCompositeTagFilters(t *testing.T) {
-	f := func(tfs, resultExpected []TagFilter) {
+	f := func(tfs []TagFilter, resultExpected [][]TagFilter) {
 		t.Helper()
 		tfsCompiled := NewTagFilters()
 		for _, tf := range tfs {
@@ -15,15 +15,19 @@ func TestConvertToCompositeTagFilters(t *testing.T) {
 				t.Fatalf("cannot add tf=%s: %s", tf.String(), err)
 			}
 		}
-		resultCompiled := convertToCompositeTagFilters(tfsCompiled)
-		result := make([]TagFilter, len(resultCompiled.tfs))
-		for i, tf := range resultCompiled.tfs {
-			result[i] = TagFilter{
-				Key:        tf.key,
-				Value:      tf.value,
-				IsNegative: tf.isNegative,
-				IsRegexp:   tf.isRegexp,
+		resultCompileds := convertToCompositeTagFilters(tfsCompiled)
+		result := make([][]TagFilter, len(resultCompileds))
+		for i, resultCompiled := range resultCompileds {
+			tfs := make([]TagFilter, len(resultCompiled.tfs))
+			for i, tf := range resultCompiled.tfs {
+				tfs[i] = TagFilter{
+					Key:        tf.key,
+					Value:      tf.value,
+					IsNegative: tf.isNegative,
+					IsRegexp:   tf.isRegexp,
+				}
 			}
+			result[i] = tfs
 		}
 		if !reflect.DeepEqual(result, resultExpected) {
 			t.Fatalf("unexpected result;\ngot\n%+v\nwant\n%+v", result, resultExpected)
@@ -31,7 +35,7 @@ func TestConvertToCompositeTagFilters(t *testing.T) {
 	}
 
 	// Empty filters
-	f(nil, []TagFilter{})
+	f(nil, [][]TagFilter{{}})
 
 	// A single non-name filter
 	f([]TagFilter{
@@ -41,12 +45,14 @@ func TestConvertToCompositeTagFilters(t *testing.T) {
 			IsNegative: false,
 			IsRegexp:   false,
 		},
-	}, []TagFilter{
+	}, [][]TagFilter{
 		{
-			Key:        []byte("foo"),
-			Value:      []byte("bar"),
-			IsNegative: false,
-			IsRegexp:   false,
+			{
+				Key:        []byte("foo"),
+				Value:      []byte("bar"),
+				IsNegative: false,
+				IsRegexp:   false,
+			},
 		},
 	})
 
@@ -64,18 +70,20 @@ func TestConvertToCompositeTagFilters(t *testing.T) {
 			IsNegative: true,
 			IsRegexp:   false,
 		},
-	}, []TagFilter{
+	}, [][]TagFilter{
 		{
-			Key:        []byte("foo"),
-			Value:      []byte("bar"),
-			IsNegative: false,
-			IsRegexp:   false,
-		},
-		{
-			Key:        []byte("x"),
-			Value:      []byte("yy"),
-			IsNegative: true,
-			IsRegexp:   false,
+			{
+				Key:        []byte("foo"),
+				Value:      []byte("bar"),
+				IsNegative: false,
+				IsRegexp:   false,
+			},
+			{
+				Key:        []byte("x"),
+				Value:      []byte("yy"),
+				IsNegative: true,
+				IsRegexp:   false,
+			},
 		},
 	})
 
@@ -87,12 +95,14 @@ func TestConvertToCompositeTagFilters(t *testing.T) {
 			IsNegative: false,
 			IsRegexp:   false,
 		},
-	}, []TagFilter{
+	}, [][]TagFilter{
 		{
-			Key:        nil,
-			Value:      []byte("bar"),
-			IsNegative: false,
-			IsRegexp:   false,
+			{
+				Key:        nil,
+				Value:      []byte("bar"),
+				IsNegative: false,
+				IsRegexp:   false,
+			},
 		},
 	})
 
@@ -110,18 +120,20 @@ func TestConvertToCompositeTagFilters(t *testing.T) {
 			IsNegative: false,
 			IsRegexp:   false,
 		},
-	}, []TagFilter{
+	}, [][]TagFilter{
 		{
-			Key:        nil,
-			Value:      []byte("bar"),
-			IsNegative: false,
-			IsRegexp:   false,
-		},
-		{
-			Key:        nil,
-			Value:      []byte("baz"),
-			IsNegative: false,
-			IsRegexp:   false,
+			{
+				Key:        nil,
+				Value:      []byte("bar"),
+				IsNegative: false,
+				IsRegexp:   false,
+			},
+			{
+				Key:        nil,
+				Value:      []byte("baz"),
+				IsNegative: false,
+				IsRegexp:   false,
+			},
 		},
 	})
 
@@ -139,12 +151,14 @@ func TestConvertToCompositeTagFilters(t *testing.T) {
 			IsNegative: false,
 			IsRegexp:   false,
 		},
-	}, []TagFilter{
+	}, [][]TagFilter{
 		{
-			Key:        []byte("\xfe\x03barfoo"),
-			Value:      []byte("abc"),
-			IsNegative: false,
-			IsRegexp:   false,
+			{
+				Key:        []byte("\xfe\x03barfoo"),
+				Value:      []byte("abc"),
+				IsNegative: false,
+				IsRegexp:   false,
+			},
 		},
 	})
 
@@ -162,18 +176,20 @@ func TestConvertToCompositeTagFilters(t *testing.T) {
 			IsNegative: true,
 			IsRegexp:   false,
 		},
-	}, []TagFilter{
+	}, [][]TagFilter{
 		{
-			Key:        nil,
-			Value:      []byte("bar"),
-			IsNegative: false,
-			IsRegexp:   false,
-		},
-		{
-			Key:        []byte("\xfe\x03barfoo"),
-			Value:      []byte("abc"),
-			IsNegative: true,
-			IsRegexp:   false,
+			{
+				Key:        nil,
+				Value:      []byte("bar"),
+				IsNegative: false,
+				IsRegexp:   false,
+			},
+			{
+				Key:        []byte("\xfe\x03barfoo"),
+				Value:      []byte("abc"),
+				IsNegative: true,
+				IsRegexp:   false,
+			},
 		},
 	})
 
@@ -197,18 +213,20 @@ func TestConvertToCompositeTagFilters(t *testing.T) {
 			IsNegative: false,
 			IsRegexp:   true,
 		},
-	}, []TagFilter{
+	}, [][]TagFilter{
 		{
-			Key:        []byte("\xfe\x03barfoo"),
-			Value:      []byte("abc"),
-			IsNegative: true,
-			IsRegexp:   false,
-		},
-		{
-			Key:        []byte("\xfe\x03bara"),
-			Value:      []byte("b.+"),
-			IsNegative: false,
-			IsRegexp:   true,
+			{
+				Key:        []byte("\xfe\x03barfoo"),
+				Value:      []byte("abc"),
+				IsNegative: true,
+				IsRegexp:   false,
+			},
+			{
+				Key:        []byte("\xfe\x03bara"),
+				Value:      []byte("b.+"),
+				IsNegative: false,
+				IsRegexp:   true,
+			},
 		},
 	})
 
@@ -232,18 +250,20 @@ func TestConvertToCompositeTagFilters(t *testing.T) {
 			IsNegative: false,
 			IsRegexp:   false,
 		},
-	}, []TagFilter{
+	}, [][]TagFilter{
 		{
-			Key:        nil,
-			Value:      []byte("bar"),
-			IsNegative: false,
-			IsRegexp:   false,
-		},
-		{
-			Key:        []byte("\xfe\x03bazfoo"),
-			Value:      []byte("abc"),
-			IsNegative: false,
-			IsRegexp:   false,
+			{
+				Key:        nil,
+				Value:      []byte("bar"),
+				IsNegative: false,
+				IsRegexp:   false,
+			},
+			{
+				Key:        []byte("\xfe\x03bazfoo"),
+				Value:      []byte("abc"),
+				IsNegative: false,
+				IsRegexp:   false,
+			},
 		},
 	})
 
@@ -261,12 +281,14 @@ func TestConvertToCompositeTagFilters(t *testing.T) {
 			IsNegative: false,
 			IsRegexp:   true,
 		},
-	}, []TagFilter{
+	}, [][]TagFilter{
 		{
-			Key:        []byte("\xfe\x03barfoo"),
-			Value:      []byte("abc"),
-			IsNegative: false,
-			IsRegexp:   false,
+			{
+				Key:        []byte("\xfe\x03barfoo"),
+				Value:      []byte("abc"),
+				IsNegative: false,
+				IsRegexp:   false,
+			},
 		},
 	})
 
@@ -284,12 +306,14 @@ func TestConvertToCompositeTagFilters(t *testing.T) {
 			IsNegative: false,
 			IsRegexp:   true,
 		},
-	}, []TagFilter{
+	}, [][]TagFilter{
 		{
-			Key:        []byte("\xfe\x03barfoo"),
-			Value:      []byte("abc.+"),
-			IsNegative: false,
-			IsRegexp:   true,
+			{
+				Key:        []byte("\xfe\x03barfoo"),
+				Value:      []byte("abc.+"),
+				IsNegative: false,
+				IsRegexp:   true,
+			},
 		},
 	})
 
@@ -307,18 +331,20 @@ func TestConvertToCompositeTagFilters(t *testing.T) {
 			IsNegative: false,
 			IsRegexp:   false,
 		},
-	}, []TagFilter{
+	}, [][]TagFilter{
 		{
-			Key:        nil,
-			Value:      []byte("bar"),
-			IsNegative: false,
-			IsRegexp:   false,
-		},
-		{
-			Key:        []byte("__graphite__"),
-			Value:      []byte("foo.*.bar"),
-			IsNegative: false,
-			IsRegexp:   false,
+			{
+				Key:        nil,
+				Value:      []byte("bar"),
+				IsNegative: false,
+				IsRegexp:   false,
+			},
+			{
+				Key:        []byte("__graphite__"),
+				Value:      []byte("foo.*.bar"),
+				IsNegative: false,
+				IsRegexp:   false,
+			},
 		},
 	})
 
@@ -342,18 +368,20 @@ func TestConvertToCompositeTagFilters(t *testing.T) {
 			IsNegative: false,
 			IsRegexp:   false,
 		},
-	}, []TagFilter{
+	}, [][]TagFilter{
 		{
-			Key:        []byte("\xfe\x03barfoo"),
-			Value:      []byte("abc"),
-			IsNegative: false,
-			IsRegexp:   false,
-		},
-		{
-			Key:        []byte("__graphite__"),
-			Value:      []byte("foo.*.bar"),
-			IsNegative: false,
-			IsRegexp:   false,
+			{
+				Key:        []byte("\xfe\x03barfoo"),
+				Value:      []byte("abc"),
+				IsNegative: false,
+				IsRegexp:   false,
+			},
+			{
+				Key:        []byte("__graphite__"),
+				Value:      []byte("foo.*.bar"),
+				IsNegative: false,
+				IsRegexp:   false,
+			},
 		},
 	})
 
@@ -371,12 +399,143 @@ func TestConvertToCompositeTagFilters(t *testing.T) {
 			IsNegative: false,
 			IsRegexp:   false,
 		},
-	}, []TagFilter{
+	}, [][]TagFilter{
 		{
-			Key:        []byte("\xfe\x03barfoo"),
+			{
+				Key:        []byte("\xfe\x03barfoo"),
+				Value:      []byte("abc"),
+				IsNegative: false,
+				IsRegexp:   false,
+			},
+		},
+	})
+
+	// Multiple values regexp filter, which can be converted to non-regexp, with non-name filter.
+	f([]TagFilter{
+		{
+			Key:        nil,
+			Value:      []byte("bar|foo"),
+			IsNegative: false,
+			IsRegexp:   true,
+		},
+		{
+			Key:        []byte("foo"),
 			Value:      []byte("abc"),
 			IsNegative: false,
 			IsRegexp:   false,
+		},
+	}, [][]TagFilter{
+		{
+			{
+				Key:        []byte("\xfe\x03barfoo"),
+				Value:      []byte("abc"),
+				IsNegative: false,
+				IsRegexp:   false,
+			},
+		},
+		{
+			{
+				Key:        []byte("\xfe\x03foofoo"),
+				Value:      []byte("abc"),
+				IsNegative: false,
+				IsRegexp:   false,
+			},
+		},
+	})
+
+	// Two multiple values regexp filter, which can be converted to non-regexp, with non-name filter.
+	f([]TagFilter{
+		{
+			Key:        nil,
+			Value:      []byte("bar|foo"),
+			IsNegative: false,
+			IsRegexp:   true,
+		},
+		{
+			Key:        nil,
+			Value:      []byte("abc|def"),
+			IsNegative: false,
+			IsRegexp:   true,
+		},
+		{
+			Key:        []byte("face"),
+			Value:      []byte("air"),
+			IsNegative: false,
+			IsRegexp:   false,
+		},
+	}, [][]TagFilter{
+		{
+			{
+				Key:        nil,
+				Value:      []byte("bar|foo"),
+				IsNegative: false,
+				IsRegexp:   true,
+			},
+			{
+				Key:        []byte("\xfe\x03abcface"),
+				Value:      []byte("air"),
+				IsNegative: false,
+				IsRegexp:   false,
+			},
+		},
+		{
+			{
+				Key:        nil,
+				Value:      []byte("bar|foo"),
+				IsNegative: false,
+				IsRegexp:   true,
+			},
+			{
+				Key:        []byte("\xfe\x03defface"),
+				Value:      []byte("air"),
+				IsNegative: false,
+				IsRegexp:   false,
+			},
+		},
+	})
+
+	// Multiple values regexp filter with a single negative filter
+	f([]TagFilter{
+		{
+			Key:        nil,
+			Value:      []byte("bar|foo"),
+			IsNegative: false,
+			IsRegexp:   true,
+		},
+		{
+			Key:        []byte("foo"),
+			Value:      []byte("abc"),
+			IsNegative: true,
+			IsRegexp:   false,
+		},
+	}, [][]TagFilter{
+		{
+			{
+				Key:        nil,
+				Value:      []byte("bar|foo"),
+				IsNegative: false,
+				IsRegexp:   true,
+			},
+			{
+				Key:        []byte("\xfe\x03barfoo"),
+				Value:      []byte("abc"),
+				IsNegative: true,
+				IsRegexp:   false,
+			},
+		},
+		{
+			{
+				Key:        nil,
+				Value:      []byte("bar|foo"),
+				IsNegative: false,
+				IsRegexp:   true,
+			},
+			{
+				Key:        []byte("\xfe\x03foofoo"),
+				Value:      []byte("abc"),
+				IsNegative: true,
+				IsRegexp:   false,
+			},
 		},
 	})
 
@@ -394,18 +553,20 @@ func TestConvertToCompositeTagFilters(t *testing.T) {
 			IsNegative: true,
 			IsRegexp:   false,
 		},
-	}, []TagFilter{
+	}, [][]TagFilter{
 		{
-			Key:        nil,
-			Value:      []byte("bar.+"),
-			IsNegative: false,
-			IsRegexp:   true,
-		},
-		{
-			Key:        []byte("foo"),
-			Value:      []byte("abc"),
-			IsNegative: true,
-			IsRegexp:   false,
+			{
+				Key:        nil,
+				Value:      []byte("bar.+"),
+				IsNegative: false,
+				IsRegexp:   true,
+			},
+			{
+				Key:        []byte("foo"),
+				Value:      []byte("abc"),
+				IsNegative: true,
+				IsRegexp:   false,
+			},
 		},
 	})
 
@@ -423,12 +584,14 @@ func TestConvertToCompositeTagFilters(t *testing.T) {
 			IsNegative: false,
 			IsRegexp:   true,
 		},
-	}, []TagFilter{
+	}, [][]TagFilter{
 		{
-			Key:        nil,
-			Value:      []byte("bar"),
-			IsNegative: false,
-			IsRegexp:   false,
+			{
+				Key:        nil,
+				Value:      []byte("bar"),
+				IsNegative: false,
+				IsRegexp:   false,
+			},
 		},
 	})
 }


### PR DESCRIPTION
This pull request optimizes queries with `{__name__=~"name_1|...|name_N"}` filters. 

![image](https://user-images.githubusercontent.com/3659110/132942277-084d6e85-3d00-4aae-ae4b-672cc263ab66.png)

In a microservice, we may use different message queue systems similar to rabbitmq & kafka & pulsar, and their metrics have their own names. When I calculate the consumption success rate of all the message queue systems, I need to join all the metrics to query them, and it is most convenient to use such syntax.
```
1 - (sum(rate({__name__=~"infra_alimq_consumer_processing_errors_total|infra_kafka_consumer_processing_errors_total", service="$service", region=~"$region", venv=~"$venv"}))) / (sum(rate({__name__=~"infra_alimq_consumer_processing_duration_seconds_count|infra_kafka_consumer_processing_duration_seconds_count", service="$service", region=~"$region", venv=~"$venv"}))) or vector(1)
```

Yes, the design of the metrics here may not be good, they could have the same name to distinguish the system by label. But it's a historical design, and it's hard for me to modify it now.
