### PR TITLE
makes filters optional for ec2 api requests

### DIFF
--- a/lib/promscrape/discovery/ec2/api.go
+++ b/lib/promscrape/discovery/ec2/api.go
@@ -414,14 +414,14 @@ func getSTSAPIResponse(action, stsEndpoint, roleARN string, reqBuilder func(apiU
 }
 
 // getEC2APIResponse performs EC2 API request with given action.
-func getEC2APIResponse(cfg *apiConfig, action, nextPageToken string) ([]byte, error) {
+func getEC2APIResponse(cfg *apiConfig, action, filters, nextPageToken string) ([]byte, error) {
 	ac, err := cfg.getFreshAPICredentials()
 	if err != nil {
 		return nil, fmt.Errorf("cannot obtain fresh credentials for EC2 API: %w", err)
 	}
 	apiURL := fmt.Sprintf("%s?Action=%s", cfg.ec2Endpoint, url.QueryEscape(action))
-	if len(cfg.filters) > 0 {
-		apiURL += "&" + cfg.filters
+	if len(filters) > 0 {
+		apiURL += "&" + filters
 	}
 	if len(nextPageToken) > 0 {
 		apiURL += fmt.Sprintf("&NextToken=%s", url.QueryEscape(nextPageToken))

--- a/lib/promscrape/discovery/ec2/instance.go
+++ b/lib/promscrape/discovery/ec2/instance.go
@@ -30,7 +30,7 @@ func getReservations(cfg *apiConfig) ([]Reservation, error) {
 	var rs []Reservation
 	pageToken := ""
 	for {
-		data, err := getEC2APIResponse(cfg, "DescribeInstances", pageToken)
+		data, err := getEC2APIResponse(cfg, "DescribeInstances", cfg.filters, pageToken)
 		if err != nil {
 			return nil, fmt.Errorf("cannot obtain instances: %w", err)
 		}
@@ -155,7 +155,7 @@ func getAZMap(cfg *apiConfig) map[string]string {
 
 func getAvailabilityZones(cfg *apiConfig) ([]AvailabilityZone, error) {
 	// See https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeAvailabilityZones.html
-	data, err := getEC2APIResponse(cfg, "DescribeAvailabilityZones", "")
+	data, err := getEC2APIResponse(cfg, "DescribeAvailabilityZones", "", "")
 	if err != nil {
 		return nil, fmt.Errorf("cannot obtain availability zones: %w", err)
 	}


### PR DESCRIPTION
filters can be applied only for DescribeInstances requests, like prometheus does.
related issue https://github.com/VictoriaMetrics/VictoriaMetrics/issues/1626