### PR TITLE
fix: sort time series before doing logical binary operations

### DIFF
--- a/app/vmselect/promql/binary_op.go
+++ b/app/vmselect/promql/binary_op.go
@@ -3,6 +3,7 @@ package promql
 import (
 	"fmt"
 	"math"
+	"sort"
 	"strings"
 
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/logger"
@@ -394,6 +395,11 @@ func createTimeseriesMapByTagSet(be *metricsql.BinaryOpExpr, left, right []*time
 			}
 			bb.B = marshalMetricTagsSorted(bb.B[:0], mn)
 			m[string(bb.B)] = append(m[string(bb.B)], ts)
+		}
+		for k := range m {
+			sort.Slice(m[k], func(i, j int) bool {
+				return m[k][i].MetricName.String() < m[k][j].MetricName.String()
+			})
 		}
 		storage.PutMetricName(mn)
 		bbPool.Put(bb)


### PR DESCRIPTION
Hi, I found an issue while querying `metric_name unless on (same_tag_name_and_value) metric_name`. This kind of query should always return an empty result, but sometimes vm returns a non-empty result. I looked into the code and found that timeseries are not sorted before doing the binary operations.

```go
func binaryOpUnless(bfa *binaryOpFuncArg) ([]*timeseries, error) {
	mLeft, mRight := createTimeseriesMapByTagSet(bfa.be, bfa.left, bfa.right)
	var rvs []*timeseries
	for k, tssLeft := range mLeft {
		tssRight := mRight[k]
		if tssRight == nil {
			rvs = append(rvs, tssLeft...)
			continue
		}
		// Add gaps to tssLeft if the are no gaps at valuesRight.
		valuesRight := tssRight[0].Values // if the left and right timeseries is not sorted in same order, the code down below won't work as expected.
		for _, tsLeft := range tssLeft {
			valuesLeft := tsLeft.Values
			for i, v := range valuesRight {
				if !math.IsNaN(v) {
					valuesLeft[i] = nan
				}
			}
		}
		tssLeft = removeNaNs(tssLeft)
		rvs = append(rvs, tssLeft...)
	}
	return rvs, nil
}
```

So I make the timeseries sorted inside the function `createTimeseriesMapByTagSet`.