### PR TITLE
app/vmselect: `quantile` func compatiblity with Prometheus

### DIFF
--- a/app/vmselect/promql/exec_test.go
+++ b/app/vmselect/promql/exec_test.go
@@ -1,6 +1,7 @@
 package promql
 
 import (
+	"math"
 	"testing"
 	"time"
 
@@ -4620,7 +4621,7 @@ func TestExecSuccess(t *testing.T) {
 		q := `quantile_over_time(0.9, label_set(round(rand(0), 0.01), "__name__", "foo", "xx", "yy")[200s:5s])`
 		r := netstorage.Result{
 			MetricName: metricNameExpected,
-			Values:     []float64{0.89, 0.89, 0.95, 0.87, 0.92, 0.89},
+			Values:     []float64{0.893, 0.892, 0.9510000000000001, 0.8730000000000001, 0.9250000000000002, 0.891},
 			Timestamps: timestampsExpected,
 		}
 		r.MetricName.MetricGroup = []byte("foo")
@@ -4643,7 +4644,7 @@ func TestExecSuccess(t *testing.T) {
 		)`
 		r1 := netstorage.Result{
 			MetricName: metricNameExpected,
-			Values:     []float64{0.47, 0.57, 0.49, 0.54, 0.56, 0.53},
+			Values:     []float64{0.46499999999999997, 0.57, 0.485, 0.54, 0.555, 0.515},
 			Timestamps: timestampsExpected,
 		}
 		r1.MetricName.MetricGroup = []byte("foo")
@@ -4659,7 +4660,7 @@ func TestExecSuccess(t *testing.T) {
 		}
 		r2 := netstorage.Result{
 			MetricName: metricNameExpected,
-			Values:     []float64{0.89, 0.89, 0.95, 0.87, 0.92, 0.89},
+			Values:     []float64{0.893, 0.892, 0.9510000000000001, 0.8730000000000001, 0.9250000000000002, 0.891},
 			Timestamps: timestampsExpected,
 		}
 		r2.MetricName.MetricGroup = []byte("foo")
@@ -5278,7 +5279,7 @@ func TestExecSuccess(t *testing.T) {
 	})
 	t.Run(`bottomk_median(1)`, func(t *testing.T) {
 		t.Parallel()
-		q := `sort(bottomk_median(1, label_set(10, "foo", "bar") or label_set(time()/150, "baz", "sss")))`
+		q := `sort(bottomk_median(1, label_set(10, "foo", "bar") or label_set(time()/15, "baz", "sss")))`
 		r1 := netstorage.Result{
 			MetricName: metricNameExpected,
 			Values:     []float64{10, 10, 10, nan, nan, nan},
@@ -5532,9 +5533,10 @@ func TestExecSuccess(t *testing.T) {
 	t.Run(`quantile(-2)`, func(t *testing.T) {
 		t.Parallel()
 		q := `quantile(-2, label_set(10, "foo", "bar") or label_set(time()/150, "baz", "sss"))`
+		inf := math.Inf(-1)
 		r := netstorage.Result{
 			MetricName: metricNameExpected,
-			Values:     []float64{6.666666666666667, 8, 9.333333333333334, 10, 10, 10},
+			Values:     []float64{inf, inf, inf, inf, inf, inf},
 			Timestamps: timestampsExpected,
 		}
 		resultExpected := []netstorage.Result{r}
@@ -5545,7 +5547,7 @@ func TestExecSuccess(t *testing.T) {
 		q := `quantile(0.2, label_set(10, "foo", "bar") or label_set(time()/150, "baz", "sss"))`
 		r := netstorage.Result{
 			MetricName: metricNameExpected,
-			Values:     []float64{6.666666666666667, 8, 9.333333333333334, 10, 10, 10},
+			Values:     []float64{7.333333333333334, 8.4, 9.466666666666669, 10.133333333333333, 10.4, 10.666666666666668},
 			Timestamps: timestampsExpected,
 		}
 		resultExpected := []netstorage.Result{r}
@@ -5556,7 +5558,7 @@ func TestExecSuccess(t *testing.T) {
 		q := `quantile(0.5, label_set(10, "foo", "bar") or label_set(time()/150, "baz", "sss"))`
 		r := netstorage.Result{
 			MetricName: metricNameExpected,
-			Values:     []float64{10, 10, 10, 10.666666666666666, 12, 13.333333333333334},
+			Values:     []float64{8.333333333333334, 9, 9.666666666666668, 10.333333333333332, 11, 11.666666666666668},
 			Timestamps: timestampsExpected,
 		}
 		resultExpected := []netstorage.Result{r}
@@ -5567,7 +5569,7 @@ func TestExecSuccess(t *testing.T) {
 		q := `sort(quantiles("phi", 0.2, 0.5, label_set(10, "foo", "bar") or label_set(time()/150, "baz", "sss")))`
 		r1 := netstorage.Result{
 			MetricName: metricNameExpected,
-			Values:     []float64{6.666666666666667, 8, 9.333333333333334, 10, 10, 10},
+			Values:     []float64{7.333333333333334, 8.4, 9.466666666666669, 10.133333333333333, 10.4, 10.666666666666668},
 			Timestamps: timestampsExpected,
 		}
 		r1.MetricName.Tags = []storage.Tag{{
@@ -5576,7 +5578,7 @@ func TestExecSuccess(t *testing.T) {
 		}}
 		r2 := netstorage.Result{
 			MetricName: metricNameExpected,
-			Values:     []float64{10, 10, 10, 10.666666666666666, 12, 13.333333333333334},
+			Values:     []float64{8.333333333333334, 9, 9.666666666666668, 10.333333333333332, 11, 11.666666666666668},
 			Timestamps: timestampsExpected,
 		}
 		r2.MetricName.Tags = []storage.Tag{{
@@ -5591,7 +5593,7 @@ func TestExecSuccess(t *testing.T) {
 		q := `median(label_set(10, "foo", "bar") or label_set(time()/150, "baz", "sss"))`
 		r := netstorage.Result{
 			MetricName: metricNameExpected,
-			Values:     []float64{10, 10, 10, 10.666666666666666, 12, 13.333333333333334},
+			Values:     []float64{8.333333333333334, 9, 9.666666666666668, 10.333333333333332, 11, 11.666666666666668},
 			Timestamps: timestampsExpected,
 		}
 		resultExpected := []netstorage.Result{r}
@@ -5611,9 +5613,10 @@ func TestExecSuccess(t *testing.T) {
 	t.Run(`quantile(3)`, func(t *testing.T) {
 		t.Parallel()
 		q := `quantile(3, label_set(10, "foo", "bar") or label_set(time()/150, "baz", "sss"))`
+		inf := math.Inf(+1)
 		r := netstorage.Result{
 			MetricName: metricNameExpected,
-			Values:     []float64{10, 10, 10, 10.666666666666666, 12, 13.333333333333334},
+			Values:     []float64{inf, inf, inf, inf, inf, inf},
 			Timestamps: timestampsExpected,
 		}
 		resultExpected := []netstorage.Result{r}
@@ -5725,7 +5728,8 @@ func TestExecSuccess(t *testing.T) {
 		q := `range_quantile(0.5, time())`
 		r := netstorage.Result{
 			MetricName: metricNameExpected,
-			Values:     []float64{1600, 1600, 1600, 1600, 1600, 1600},
+			// time() results in [1000 1200 1400 1600 1800 2000]
+			Values:     []float64{1500, 1500, 1500, 1500, 1500, 1500},
 			Timestamps: timestampsExpected,
 		}
 		resultExpected := []netstorage.Result{r}
@@ -5736,7 +5740,8 @@ func TestExecSuccess(t *testing.T) {
 		q := `range_median(time())`
 		r := netstorage.Result{
 			MetricName: metricNameExpected,
-			Values:     []float64{1600, 1600, 1600, 1600, 1600, 1600},
+			// time() results in [1000 1200 1400 1600 1800 2000]
+			Values:     []float64{1500, 1500, 1500, 1500, 1500, 1500},
 			Timestamps: timestampsExpected,
 		}
 		resultExpected := []netstorage.Result{r}

--- a/app/vmselect/promql/rollup.go
+++ b/app/vmselect/promql/rollup.go
@@ -1089,16 +1089,14 @@ func newRollupQuantile(args []interface{}) (rollupFunc, error) {
 	rf := func(rfa *rollupFuncArg) float64 {
 		// There is no need in handling NaNs here, since they must be cleaned up
 		// before calling rollup funcs.
-		originValues := rfa.values
-		if len(originValues) == 0 {
+		values := rfa.values
+		if len(values) == 0 {
 			return rfa.prevValue
 		}
-		if len(originValues) == 1 {
+		if len(values) == 1 {
 			// Fast path - only a single value.
-			return originValues[0]
+			return values[0]
 		}
-		var values []float64
-		values = append(values, originValues...)
 		phi := phis[rfa.idx]
 		qv := quantile(phi, values)
 		return qv

--- a/app/vmselect/promql/rollup_test.go
+++ b/app/vmselect/promql/rollup_test.go
@@ -335,14 +335,14 @@ func TestRollupQuantileOverTime(t *testing.T) {
 		testRollupFunc(t, "quantile_over_time", args, &me, vExpected)
 	}
 
-	f(-123, 12)
-	f(-0.5, 12)
+	f(-123, math.Inf(-1))
+	f(-0.5, math.Inf(-1))
 	f(0, 12)
-	f(0.1, 21)
+	f(0.1, 22.1)
 	f(0.5, 34)
-	f(0.9, 99)
+	f(0.9, 94.50000000000001)
 	f(1, 123)
-	f(234, 123)
+	f(234, math.Inf(+1))
 }
 
 func TestRollupPredictLinear(t *testing.T) {

--- a/app/vmselect/promql/transform.go
+++ b/app/vmselect/promql/transform.go
@@ -1177,10 +1177,11 @@ func transformRangeQuantile(tfa *transformFuncArg) ([]*timeseries, error) {
 	}
 	phi := phis[0]
 	rvs := args[1]
+	var values []float64
 	for _, ts := range rvs {
 		lastIdx := -1
 		originValues := ts.Values
-		var values []float64
+		values = values[:0]
 		for i, v := range originValues {
 			if math.IsNaN(v) {
 				continue
@@ -1189,7 +1190,8 @@ func transformRangeQuantile(tfa *transformFuncArg) ([]*timeseries, error) {
 			lastIdx = i
 		}
 		if lastIdx >= 0 {
-			originValues[lastIdx] = quantile(phi, values)
+			sort.Float64s(values)
+			originValues[lastIdx] = quantileSorted(phi, values)
 		}
 	}
 	setLastValues(rvs)


### PR DESCRIPTION
The `quantile` func was previously calculated by https://github.com/valyala/histogram
package. The result of such calculation was always a real value corresponded to
requested quantile. While in Prometheus implementation interpolation is used.
Such difference may result into discrepency in output between Prometheus and
VictoriaMetrics.

This commit adds a Prometheus-like `quantile` function. It also used by other
functions which depend on it, such as `quantiles`, `quantile_over_time`, `median` etc.

https://github.com/VictoriaMetrics/VictoriaMetrics/issues/1625