### PR TITLE
app/vmselect: make sorting for query result similar to Prometheus

### DIFF
--- a/app/vmselect/promql/exec.go
+++ b/app/vmselect/promql/exec.go
@@ -94,7 +94,7 @@ func timeseriesToResult(tss []*timeseries, maySort bool) ([]netstorage.Result, e
 	m := make(map[string]struct{}, len(tss))
 	bb := bbPool.Get()
 	for i, ts := range tss {
-		bb.B = marshalMetricNameSorted(bb.B[:0], &ts.MetricName)
+		bb.B = metricNameToBytes(bb.B[:0], &ts.MetricName)
 		if _, ok := m[string(bb.B)]; ok {
 			return nil, fmt.Errorf(`duplicate output timeseries: %s`, stringMetricName(&ts.MetricName))
 		}

--- a/app/vmselect/promql/exec_test.go
+++ b/app/vmselect/promql/exec_test.go
@@ -7294,7 +7294,6 @@ func TestExecError(t *testing.T) {
 func testResultsEqual(t *testing.T, result, resultExpected []netstorage.Result) {
 	t.Helper()
 	if len(result) != len(resultExpected) {
-		fmt.Println(result)
 		t.Fatalf(`unexpected timeseries count; got %d; want %d`, len(result), len(resultExpected))
 	}
 	for i := range result {

--- a/app/vmselect/promql/exec_test.go
+++ b/app/vmselect/promql/exec_test.go
@@ -1,6 +1,7 @@
 package promql
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -6954,7 +6955,8 @@ func TestExecSuccess(t *testing.T) {
 				Value: []byte("10"),
 			},
 		}
-		resultExpected := []netstorage.Result{r1, r2, r3, r4}
+		// expected sorted output for strings 1, 10, 2, 3
+		resultExpected := []netstorage.Result{r1, r4, r2, r3}
 		f(q, resultExpected)
 	})
 	t.Run(`count_values without (baz)`, func(t *testing.T) {
@@ -7006,6 +7008,44 @@ func TestExecSuccess(t *testing.T) {
 			},
 		}
 		resultExpected := []netstorage.Result{r1, r2, r3}
+		f(q, resultExpected)
+	})
+	t.Run(`result sorting`, func(t *testing.T) {
+		t.Parallel()
+		q := `label_set(1, "instance", "localhost:1001", "type", "free")
+			or label_set(1, "instance", "localhost:1001", "type", "buffers")
+			or label_set(1, "instance", "localhost:1000", "type", "buffers")
+			or label_set(1, "instance", "localhost:1000", "type", "free")
+`
+		r1 := netstorage.Result{
+			MetricName: metricNameExpected,
+			Values:     []float64{1, 1, 1, 1, 1, 1},
+			Timestamps: timestampsExpected,
+		}
+		testAddLabels(t, &r1.MetricName,
+			"instance", "localhost:1000", "type", "buffers")
+		r2 := netstorage.Result{
+			MetricName: metricNameExpected,
+			Values:     []float64{1, 1, 1, 1, 1, 1},
+			Timestamps: timestampsExpected,
+		}
+		testAddLabels(t, &r2.MetricName,
+			"instance", "localhost:1000", "type", "free")
+		r3 := netstorage.Result{
+			MetricName: metricNameExpected,
+			Values:     []float64{1, 1, 1, 1, 1, 1},
+			Timestamps: timestampsExpected,
+		}
+		testAddLabels(t, &r3.MetricName,
+			"instance", "localhost:1001", "type", "buffers")
+		r4 := netstorage.Result{
+			MetricName: metricNameExpected,
+			Values:     []float64{1, 1, 1, 1, 1, 1},
+			Timestamps: timestampsExpected,
+		}
+		testAddLabels(t, &r4.MetricName,
+			"instance", "localhost:1001", "type", "free")
+		resultExpected := []netstorage.Result{r1, r2, r3, r4}
 		f(q, resultExpected)
 	})
 }
@@ -7254,6 +7294,7 @@ func TestExecError(t *testing.T) {
 func testResultsEqual(t *testing.T, result, resultExpected []netstorage.Result) {
 	t.Helper()
 	if len(result) != len(resultExpected) {
+		fmt.Println(result)
 		t.Fatalf(`unexpected timeseries count; got %d; want %d`, len(result), len(resultExpected))
 	}
 	for i := range result {
@@ -7283,5 +7324,18 @@ func testMetricNamesEqual(t *testing.T, mn, mnExpected *storage.MetricName, pos 
 			t.Fatalf(`unexpected tag value for key %q at #%d,%d; got %q; want %q; metricGot=%s, metricExpected=%s`,
 				tag.Key, pos, i, tag.Value, tagExpected.Value, mn.String(), mnExpected.String())
 		}
+	}
+}
+
+func testAddLabels(t *testing.T, mn *storage.MetricName, labels ...string) {
+	t.Helper()
+	if len(labels)%2 > 0 {
+		t.Fatalf("uneven number of labels passed: %v", labels)
+	}
+	for i := 0; i < len(labels); i += 2 {
+		mn.Tags = append(mn.Tags, storage.Tag{
+			Key:   []byte(labels[i]),
+			Value: []byte(labels[i+1]),
+		})
 	}
 }

--- a/app/vmselect/promql/timeseries.go
+++ b/app/vmselect/promql/timeseries.go
@@ -318,6 +318,18 @@ func marshalMetricTagsFast(dst []byte, tags []storage.Tag) []byte {
 	return dst
 }
 
+func metricNameToBytes(dst []byte, mn *storage.MetricName) []byte {
+	dst = marshalBytesFast(dst, mn.MetricGroup)
+	sortMetricTags(mn.Tags)
+	for i := range mn.Tags {
+		tag := &mn.Tags[i]
+		dst = append(dst, tag.Key...)
+		dst = append(dst, tag.Value...)
+		dst = append(dst, ","...)
+	}
+	return dst
+}
+
 func marshalMetricNameSorted(dst []byte, mn *storage.MetricName) []byte {
 	dst = marshalBytesFast(dst, mn.MetricGroup)
 	sortMetricTags(mn.Tags)


### PR DESCRIPTION
Updated sorting allows to get the order of series in result similar or equal
to what Prometheus returns.
The change is needed for compatibility reasons.