### PR TITLE
app/vmselect: disable time-window adjustment for `min/max_over_time`

### DIFF
--- a/app/vmselect/promql/rollup.go
+++ b/app/vmselect/promql/rollup.go
@@ -174,6 +174,8 @@ var rollupFuncsCannotAdjustWindow = map[string]bool{
 	"zscore_over_time":    true,
 	"first_over_time":     true,
 	"last_over_time":      true,
+	"min_over_time":       true,
+	"max_over_time":       true,
 }
 
 var rollupFuncsRemoveCounterResets = map[string]bool{


### PR DESCRIPTION
Adjustment results into discrepancy between Prometheus and VM on time windows
smaller than scrape interval.