### PR TITLE
app/vmselect: always return zero for `stddev` func if there is only one value

### DIFF
--- a/app/vmselect/promql/rollup.go
+++ b/app/vmselect/promql/rollup.go
@@ -1386,7 +1386,7 @@ func rollupStdvar(rfa *rollupFuncArg) float64 {
 	}
 	if len(values) == 1 {
 		// Fast path.
-		return values[0]
+		return 0
 	}
 	var avg float64
 	var count float64


### PR DESCRIPTION
The fix will always return zero if received set of items consists of one
element only, which also means no deviation.