### PR TITLE
vmctl influx convert bool to number

### DIFF
--- a/app/vmctl/influx/parser.go
+++ b/app/vmctl/influx/parser.go
@@ -58,6 +58,12 @@ func toFloat64(v interface{}) (float64, error) {
 		return float64(i), nil
 	case string:
 		return strconv.ParseFloat(i, 64)
+	case bool:
+		if i {
+			return 1, nil
+		} else {
+			return 0, nil
+		}
 	default:
 		return 0, fmt.Errorf("unexpected value type %v", i)
 	}


### PR DESCRIPTION
When using `vmctl influx`, the import would fail importing boolean fields
with:

```
failed to convert value "some".0 to float64: unexpected value type true
```

This converts `true` to `1` and `false` to `0`.

Fixes #1709