### PR TITLE
vmalert: properly init SIGHUP listener before starting group manager

### DIFF
--- a/app/vmalert/main_test.go
+++ b/app/vmalert/main_test.go
@@ -102,8 +102,9 @@ groups:
 	}
 
 	syncCh := make(chan struct{})
+	sighupCh := procutil.NewSighupChan()
 	go func() {
-		configReload(ctx, m, nil)
+		configReload(ctx, m, nil, sighupCh)
 		close(syncCh)
 	}()
 


### PR DESCRIPTION
Regression was introduced during code refactoring. It potentially
could lead to situation when SIGHUP signals were ignored while
vmalert was still busy with initing group manager.

