### PR TITLE
vmalert: make group.ID() thread-safe

### DIFF
--- a/app/vmalert/group.go
+++ b/app/vmalert/group.go
@@ -123,6 +123,9 @@ func (g *Group) newRule(qb datasource.QuerierBuilder, rule config.Rule) Rule {
 // ID return unique group ID that consists of
 // rules file and group name
 func (g *Group) ID() uint64 {
+	g.mu.RLock()
+	defer g.mu.RUnlock()
+
 	hash := fnv.New64a()
 	hash.Write([]byte(g.File))
 	hash.Write([]byte("\xff"))


### PR DESCRIPTION
Commit fixes potential race condition when group update
and generating of ID() happens simultaneously.

