### PR TITLE
vmalert: allow groups with empty rules for compatibility reasons

### DIFF
--- a/app/vmalert/config/config.go
+++ b/app/vmalert/config/config.go
@@ -76,9 +76,6 @@ func (g *Group) Validate(validateAnnotations, validateExpressions bool) error {
 	if g.Name == "" {
 		return fmt.Errorf("group name must be set")
 	}
-	if len(g.Rules) == 0 {
-		return fmt.Errorf("group %q can't contain no rules", g.Name)
-	}
 
 	uniqueRules := map[uint64]struct{}{}
 	for _, r := range g.Rules {

--- a/app/vmalert/config/config_test.go
+++ b/app/vmalert/config/config_test.go
@@ -96,10 +96,6 @@ func TestGroup_Validate(t *testing.T) {
 			expErr: "group name must be set",
 		},
 		{
-			group:  &Group{Name: "test"},
-			expErr: "contain no rules",
-		},
-		{
 			group: &Group{Name: "test",
 				Rules: []Rule{
 					{

--- a/app/vmalert/config/testdata/rules4-good.rules
+++ b/app/vmalert/config/testdata/rules4-good.rules
@@ -1,0 +1,8 @@
+groups:
+  - name: TestEmptyRules
+    interval: 2s
+    concurrency: 2
+    rules:
+
+  - name: TestNoRules
+    type: prometheus

--- a/app/vmalert/group.go
+++ b/app/vmalert/group.go
@@ -283,14 +283,15 @@ func (g *Group) start(ctx context.Context, nts []notifier.Notifier, rw *remotewr
 		case <-t.C:
 			g.metrics.iterationTotal.Inc()
 			iterationStart := time.Now()
-			resolveDuration := getResolveDuration(g.Interval)
-			errs := e.execConcurrently(ctx, g.Rules, g.Concurrency, resolveDuration)
-			for err := range errs {
-				if err != nil {
-					logger.Errorf("group %q: %s", g.Name, err)
+			if len(g.Rules) > 0 {
+				resolveDuration := getResolveDuration(g.Interval)
+				errs := e.execConcurrently(ctx, g.Rules, g.Concurrency, resolveDuration)
+				for err := range errs {
+					if err != nil {
+						logger.Errorf("group %q: %s", g.Name, err)
+					}
 				}
 			}
-
 			g.metrics.iterationDuration.UpdateDuration(iterationStart)
 		}
 	}


### PR DESCRIPTION
Prometheus allows to have groups with no rules, so we should support
it in vmalert as well for compatibility reasons.
It is also allowed to hot-reload empty groups by adding or removing rules.

Signed-off-by: hagen1778 <roman@victoriametrics.com>