### PR TITLE
docs: make link to logos zip absolute

### DIFF
--- a/README.md
+++ b/README.md
@@ -1515,7 +1515,7 @@ Report bugs and propose new features [here](https://github.com/VictoriaMetrics/V
 
 ## VictoriaMetrics Logo
 
-[Zip](VM_logo.zip) contains three folders with different image orientations (main color and inverted version).
+[Zip](https://github.com/VictoriaMetrics/VictoriaMetrics/blob/master/VM_logo.zip) contains three folders with different image orientations (main color and inverted version).
 
 Files included in each folder:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1515,7 +1515,7 @@ Report bugs and propose new features [here](https://github.com/VictoriaMetrics/V
 
 ## VictoriaMetrics Logo
 
-[Zip](VM_logo.zip) contains three folders with different image orientations (main color and inverted version).
+[Zip](https://github.com/VictoriaMetrics/VictoriaMetrics/blob/master/VM_logo.zip) contains three folders with different image orientations (main color and inverted version).
 
 Files included in each folder:
 

--- a/docs/Single-server-VictoriaMetrics.md
+++ b/docs/Single-server-VictoriaMetrics.md
@@ -1519,7 +1519,7 @@ Report bugs and propose new features [here](https://github.com/VictoriaMetrics/V
 
 ## VictoriaMetrics Logo
 
-[Zip](VM_logo.zip) contains three folders with different image orientations (main color and inverted version).
+[Zip](https://github.com/VictoriaMetrics/VictoriaMetrics/blob/master/VM_logo.zip) contains three folders with different image orientations (main color and inverted version).
 
 Files included in each folder:
 


### PR DESCRIPTION
The relative link won't work for github-docs website,
so we're changing it to absolute link.

Signed-off-by: hagen1778 <roman@victoriametrics.com>