### PR TITLE
dashboards: consistently use regexp filters for template vars

### DIFF
--- a/dashboards/clusterbytenant.json
+++ b/dashboards/clusterbytenant.json
@@ -475,7 +475,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(vm_tenant_used_tenant_bytes{job=\"$job_storage\", instance=~\"$instance\",accountID=~\"$accountID\",projectID=~\"$projectID\"}) by(accountID,projectID)",
+          "expr": "sum(vm_tenant_used_tenant_bytes{job=~\"$job_storage\", instance=~\"$instance\",accountID=~\"$accountID\",projectID=~\"$projectID\"}) by(accountID,projectID)",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,

--- a/dashboards/victoriametrics.json
+++ b/dashboards/victoriametrics.json
@@ -160,7 +160,7 @@
           "targets": [
             {
               "exemplar": true,
-              "expr": "sum(vm_rows{job=\"$job\", instance=~\"$instance\", type!=\"indexdb\"})",
+              "expr": "sum(vm_rows{job=~\"$job\", instance=~\"$instance\", type!=\"indexdb\"})",
               "format": "time_series",
               "instant": true,
               "interval": "",
@@ -226,7 +226,7 @@
           "targets": [
             {
               "exemplar": true,
-              "expr": "sum(vm_data_size_bytes{job=\"$job\", type!=\"indexdb\"})",
+              "expr": "sum(vm_data_size_bytes{job=~\"$job\", type!=\"indexdb\"})",
               "format": "time_series",
               "instant": true,
               "interval": "",
@@ -292,7 +292,7 @@
           "targets": [
             {
               "exemplar": true,
-              "expr": "sum(vm_data_size_bytes{job=\"$job\", type!=\"indexdb\"}) / sum(vm_rows{job=\"$job\", type!=\"indexdb\"})",
+              "expr": "sum(vm_data_size_bytes{job=~\"$job\", type!=\"indexdb\"}) / sum(vm_rows{job=~\"$job\", type!=\"indexdb\"})",
               "format": "time_series",
               "instant": true,
               "interval": "",
@@ -358,7 +358,7 @@
           "targets": [
             {
               "exemplar": true,
-              "expr": "sum(vm_allowed_memory_bytes{job=\"$job\", instance=~\"$instance\"})",
+              "expr": "sum(vm_allowed_memory_bytes{job=~\"$job\", instance=~\"$instance\"})",
               "format": "time_series",
               "instant": true,
               "interval": "",
@@ -423,7 +423,7 @@
           "targets": [
             {
               "exemplar": true,
-              "expr": "vm_app_uptime_seconds{job=\"$job\", instance=\"$instance\"}",
+              "expr": "vm_app_uptime_seconds{job=~\"$job\", instance=~\"$instance\"}",
               "instant": true,
               "interval": "",
               "legendFormat": "",
@@ -485,7 +485,7 @@
           "targets": [
             {
               "exemplar": true,
-              "expr": "sum(vm_rows{job=\"$job\", instance=~\"$instance\", type=\"indexdb\"})",
+              "expr": "sum(vm_rows{job=~\"$job\", instance=~\"$instance\", type=\"indexdb\"})",
               "format": "time_series",
               "instant": true,
               "interval": "",
@@ -551,7 +551,7 @@
           "targets": [
             {
               "exemplar": true,
-              "expr": "min(vm_free_disk_space_bytes{job=\"$job\", instance=~\"$instance\"})",
+              "expr": "min(vm_free_disk_space_bytes{job=~\"$job\", instance=~\"$instance\"})",
               "format": "time_series",
               "instant": true,
               "interval": "",
@@ -621,7 +621,7 @@
           "targets": [
             {
               "exemplar": true,
-              "expr": "sum(vm_available_cpu_cores{job=\"$job\", instance=~\"$instance\"})",
+              "expr": "sum(vm_available_cpu_cores{job=~\"$job\", instance=~\"$instance\"})",
               "format": "time_series",
               "instant": true,
               "interval": "",
@@ -687,7 +687,7 @@
           "targets": [
             {
               "exemplar": true,
-              "expr": "sum(vm_available_memory_bytes{job=\"$job\", instance=~\"$instance\"})",
+              "expr": "sum(vm_available_memory_bytes{job=~\"$job\", instance=~\"$instance\"})",
               "format": "time_series",
               "instant": true,
               "interval": "",
@@ -772,7 +772,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(vm_http_requests_total{job=\"$job\", instance=~\"$instance\", path!~\"/favicon.ico\"}[$__interval])) by (path) > 0",
+          "expr": "sum(rate(vm_http_requests_total{job=~\"$job\", instance=~\"$instance\", path!~\"/favicon.ico\"}[$__interval])) by (path) > 0",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -874,7 +874,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "max(vm_request_duration_seconds{job=\"$job\", instance=~\"$instance\", quantile=~\"(0.5|0.99)\"}) by (path, quantile) > 0",
+          "expr": "max(vm_request_duration_seconds{job=~\"$job\", instance=~\"$instance\", quantile=~\"(0.5|0.99)\"}) by (path, quantile) > 0",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{quantile}} ({{path}})",
@@ -981,7 +981,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "vm_cache_entries{job=\"$job\", instance=~\"$instance\", type=\"storage/hour_metric_ids\"}",
+          "expr": "vm_cache_entries{job=~\"$job\", instance=~\"$instance\", type=\"storage/hour_metric_ids\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Active time series",
@@ -1087,7 +1087,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(vm_cache_size_bytes{job=\"$job\", instance=\"$instance\"})",
+          "expr": "sum(vm_cache_size_bytes{job=~\"$job\", instance=~\"$instance\"})",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -1095,7 +1095,7 @@
           "refId": "A"
         },
         {
-          "expr": "max(vm_allowed_memory_bytes{job=\"$job\", instance=\"$instance\"})",
+          "expr": "max(vm_allowed_memory_bytes{job=~\"$job\", instance=~\"$instance\"})",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -1204,7 +1204,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(vm_concurrent_addrows_capacity{job=\"$job\", instance=\"$instance\"})",
+          "expr": "sum(vm_concurrent_addrows_capacity{job=~\"$job\", instance=~\"$instance\"})",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -1212,7 +1212,7 @@
           "refId": "A"
         },
         {
-          "expr": "sum(vm_concurrent_addrows_current{job=\"$job\", instance=\"$instance\"})",
+          "expr": "sum(vm_concurrent_addrows_current{job=~\"$job\", instance=~\"$instance\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "current",
@@ -1316,7 +1316,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(rate(vm_http_request_errors_total{job=\"$job\", instance=\"$instance\"}[$__interval])) by (path) > 0",
+          "expr": "sum(rate(vm_http_request_errors_total{job=~\"$job\", instance=~\"$instance\"}[$__interval])) by (path) > 0",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -1433,7 +1433,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(vm_rows_inserted_total{job=\"$job\", instance=\"$instance\"}[$__interval])) by (type) > 0",
+          "expr": "sum(rate(vm_rows_inserted_total{job=~\"$job\", instance=~\"$instance\"}[$__interval])) by (type) > 0",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -1537,7 +1537,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "vm_free_disk_space_bytes{job=\"$job\", instance=\"$instance\"} / ignoring(path) ((rate(vm_rows_added_to_storage_total{job=\"$job\", instance=\"$instance\"}[1d]) - ignoring(type) rate(vm_deduplicated_samples_total{job=\"$job\", instance=\"$instance\", type=\"merge\"}[1d])) * scalar(sum(vm_data_size_bytes{job=\"$job\", instance=\"$instance\", type!=\"indexdb\"}) / sum(vm_rows{job=\"$job\", instance=\"$instance\", type!=\"indexdb\"})))",
+          "expr": "vm_free_disk_space_bytes{job=~\"$job\", instance=~\"$instance\"} / ignoring(path) ((rate(vm_rows_added_to_storage_total{job=~\"$job\", instance=~\"$instance\"}[1d]) - ignoring(type) rate(vm_deduplicated_samples_total{job=~\"$job\", instance=~\"$instance\", type=\"merge\"}[1d])) * scalar(sum(vm_data_size_bytes{job=~\"$job\", instance=~\"$instance\", type!=\"indexdb\"}) / sum(vm_rows{job=~\"$job\", instance=~\"$instance\", type!=\"indexdb\"})))",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -1646,7 +1646,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(vm_rows{job=\"$job\", instance=~\"$instance\", type != \"indexdb\"})",
+          "expr": "sum(vm_rows{job=~\"$job\", instance=~\"$instance\", type != \"indexdb\"})",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -1654,7 +1654,7 @@
           "refId": "A"
         },
         {
-          "expr": "sum(vm_data_size_bytes{job=\"$job\", instance=~\"$instance\", type!=\"indexdb\"}) / sum(vm_rows{job=\"$job\", instance=~\"$instance\", type != \"indexdb\"})",
+          "expr": "sum(vm_data_size_bytes{job=~\"$job\", instance=~\"$instance\", type!=\"indexdb\"}) / sum(vm_rows{job=~\"$job\", instance=~\"$instance\", type != \"indexdb\"})",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -1762,7 +1762,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "vm_pending_rows{job=\"$job\", instance=~\"$instance\", type=\"storage\"}",
+          "expr": "vm_pending_rows{job=~\"$job\", instance=~\"$instance\", type=\"storage\"}",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -1770,7 +1770,7 @@
           "refId": "A"
         },
         {
-          "expr": "vm_pending_rows{job=\"$job\", instance=~\"$instance\", type=\"indexdb\"}",
+          "expr": "vm_pending_rows{job=~\"$job\", instance=~\"$instance\", type=\"indexdb\"}",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -1874,7 +1874,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(vm_data_size_bytes{job=\"$job\", instance=~\"$instance\", type!=\"indexdb\"})",
+          "expr": "sum(vm_data_size_bytes{job=~\"$job\", instance=~\"$instance\", type!=\"indexdb\"})",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -1882,7 +1882,7 @@
           "refId": "A"
         },
         {
-          "expr": "vm_free_disk_space_bytes{job=\"$job\", instance=\"$instance\"}",
+          "expr": "vm_free_disk_space_bytes{job=~\"$job\", instance=~\"$instance\"}",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -1984,7 +1984,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(vm_parts{job=\"$job\", instance=\"$instance\"}) by (type)",
+          "expr": "sum(vm_parts{job=~\"$job\", instance=~\"$instance\"}) by (type)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{type}}",
@@ -2086,7 +2086,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "vm_data_size_bytes{job=\"$job\", instance=~\"$instance\", type=\"indexdb\"}",
+          "expr": "vm_data_size_bytes{job=~\"$job\", instance=~\"$instance\", type=\"indexdb\"}",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -2187,7 +2187,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(vm_active_merges{job=\"$job\", instance=\"$instance\"}) by(type)",
+          "expr": "sum(vm_active_merges{job=~\"$job\", instance=~\"$instance\"}) by(type)",
           "legendFormat": "{{type}}",
           "refId": "A"
         }
@@ -2288,7 +2288,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(vm_rows_ignored_total{job=\"$job\", instance=\"$instance\"}) by (reason)",
+          "expr": "sum(vm_rows_ignored_total{job=~\"$job\", instance=~\"$instance\"}) by (reason)",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -2391,7 +2391,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(vm_rows_merged_total{job=\"$job\", instance=\"$instance\"}[5m])) by(type)",
+          "expr": "sum(rate(vm_rows_merged_total{job=~\"$job\", instance=~\"$instance\"}[5m])) by(type)",
           "legendFormat": "{{type}}",
           "refId": "A"
         }
@@ -2493,7 +2493,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(vm_log_messages_total{job=\"$job\", instance=\"$instance\"}[5m])) by (level) ",
+          "expr": "sum(rate(vm_log_messages_total{job=~\"$job\", instance=~\"$instance\"}[5m])) by (level) ",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -2611,13 +2611,13 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(vm_new_timeseries_created_total{job=\"$job\", instance=\"$instance\"}[5m]))",
+              "expr": "sum(rate(vm_new_timeseries_created_total{job=~\"$job\", instance=~\"$instance\"}[5m]))",
               "interval": "",
               "legendFormat": "churn rate",
               "refId": "A"
             },
             {
-              "expr": "sum(increase(vm_new_timeseries_created_total{job=\"$job\", instance=\"$instance\"}[24h]))",
+              "expr": "sum(increase(vm_new_timeseries_created_total{job=~\"$job\", instance=~\"$instance\"}[24h]))",
               "interval": "",
               "legendFormat": "new series over 24h",
               "refId": "B"
@@ -2717,7 +2717,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(vm_slow_queries_total{job=\"$job\", instance=\"$instance\"}[5m]))",
+              "expr": "sum(rate(vm_slow_queries_total{job=~\"$job\", instance=~\"$instance\"}[5m]))",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
@@ -2820,7 +2820,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(vm_slow_row_inserts_total{job=\"$job\", instance=\"$instance\"}[5m])) / sum(rate(vm_rows_inserted_total{job=\"$job\", instance=\"$instance\"}[5m]))",
+              "expr": "sum(rate(vm_slow_row_inserts_total{job=~\"$job\", instance=~\"$instance\"}[5m])) / sum(rate(vm_rows_inserted_total{job=~\"$job\", instance=~\"$instance\"}[5m]))",
               "format": "time_series",
               "hide": false,
               "interval": "",
@@ -2923,7 +2923,7 @@
           "targets": [
             {
               "exemplar": true,
-              "expr": "sum(increase(vm_metrics_with_dropped_labels_total{job=\"$job\", instance=\"$instance\"}[5m]))",
+              "expr": "sum(increase(vm_metrics_with_dropped_labels_total{job=~\"$job\", instance=~\"$instance\"}[5m]))",
               "format": "time_series",
               "hide": false,
               "interval": "",
@@ -3042,7 +3042,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(go_memstats_sys_bytes{job=\"$job\", instance=\"$instance\"}) + sum(vm_cache_size_bytes{job=\"$job\", instance=\"$instance\"})",
+              "expr": "sum(go_memstats_sys_bytes{job=~\"$job\", instance=~\"$instance\"}) + sum(vm_cache_size_bytes{job=~\"$job\", instance=~\"$instance\"})",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
@@ -3050,7 +3050,7 @@
               "refId": "A"
             },
             {
-              "expr": "sum(go_memstats_heap_inuse_bytes{job=\"$job\", instance=\"$instance\"}) + sum(vm_cache_size_bytes{job=\"$job\", instance=\"$instance\"})",
+              "expr": "sum(go_memstats_heap_inuse_bytes{job=~\"$job\", instance=~\"$instance\"}) + sum(vm_cache_size_bytes{job=~\"$job\", instance=~\"$instance\"})",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
@@ -3058,7 +3058,7 @@
               "refId": "B"
             },
             {
-              "expr": "sum(go_memstats_stack_inuse_bytes{job=\"$job\", instance=\"$instance\"})",
+              "expr": "sum(go_memstats_stack_inuse_bytes{job=~\"$job\", instance=~\"$instance\"})",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
@@ -3066,7 +3066,7 @@
               "refId": "C"
             },
             {
-              "expr": "sum(process_resident_memory_bytes{job=\"$job\", instance=\"$instance\"})",
+              "expr": "sum(process_resident_memory_bytes{job=~\"$job\", instance=~\"$instance\"})",
               "format": "time_series",
               "hide": false,
               "interval": "",
@@ -3076,7 +3076,7 @@
             },
             {
               "exemplar": true,
-              "expr": "sum(process_resident_memory_anon_bytes{job=\"$job\", instance=\"$instance\"})",
+              "expr": "sum(process_resident_memory_anon_bytes{job=~\"$job\", instance=~\"$instance\"})",
               "format": "time_series",
               "hide": false,
               "interval": "",
@@ -3178,7 +3178,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(process_cpu_seconds_total{job=\"$job\", instance=\"$instance\"}[5m])",
+              "expr": "rate(process_cpu_seconds_total{job=~\"$job\", instance=~\"$instance\"}[5m])",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
@@ -3285,7 +3285,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(process_open_fds{job=\"$job\", instance=\"$instance\"})",
+              "expr": "sum(process_open_fds{job=~\"$job\", instance=~\"$instance\"})",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 2,
@@ -3293,7 +3293,7 @@
               "refId": "A"
             },
             {
-              "expr": "min(process_max_fds{job=\"$job\", instance=\"$instance\"})",
+              "expr": "min(process_max_fds{job=~\"$job\", instance=~\"$instance\"})",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 2,
@@ -3401,7 +3401,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(process_io_storage_read_bytes_total{job=\"$job\", instance=\"$instance\"}[5m]))",
+              "expr": "sum(rate(process_io_storage_read_bytes_total{job=~\"$job\", instance=~\"$instance\"}[5m]))",
               "format": "time_series",
               "hide": false,
               "interval": "",
@@ -3410,7 +3410,7 @@
               "refId": "A"
             },
             {
-              "expr": "sum(rate(process_io_storage_written_bytes_total{job=\"$job\", instance=\"$instance\"}[5m]))",
+              "expr": "sum(rate(process_io_storage_written_bytes_total{job=~\"$job\", instance=~\"$instance\"}[5m]))",
               "format": "time_series",
               "hide": false,
               "interval": "",
@@ -3513,7 +3513,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(go_goroutines{job=\"$job\", instance=\"$instance\"})",
+              "expr": "sum(go_goroutines{job=~\"$job\", instance=~\"$instance\"})",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "gc duration",
@@ -3615,7 +3615,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(go_gc_duration_seconds_sum{job=\"$job\", instance=\"$instance\"}[5m]))\n/\nsum(rate(go_gc_duration_seconds_count{job=\"$job\", instance=\"$instance\"}[5m]))",
+              "expr": "sum(rate(go_gc_duration_seconds_sum{job=~\"$job\", instance=~\"$instance\"}[5m]))\n/\nsum(rate(go_gc_duration_seconds_count{job=~\"$job\", instance=~\"$instance\"}[5m]))",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "avg gc duration",
@@ -3715,7 +3715,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(process_num_threads{job=\"$job\", instance=\"$instance\"})",
+              "expr": "sum(process_num_threads{job=~\"$job\", instance=~\"$instance\"})",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "threads",
@@ -3817,7 +3817,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(vm_tcplistener_conns{job=\"$job\", instance=\"$instance\"})",
+              "expr": "sum(vm_tcplistener_conns{job=~\"$job\", instance=~\"$instance\"})",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
@@ -3920,7 +3920,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(vm_tcplistener_accepts_total{job=\"$job\", instance=\"$instance\"}[$__interval]))",
+              "expr": "sum(rate(vm_tcplistener_accepts_total{job=~\"$job\", instance=~\"$instance\"}[$__interval]))",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
@@ -4035,7 +4035,7 @@
         "allValue": null,
         "current": {},
         "datasource": "$ds",
-        "definition": "label_values(vm_app_version{job=\"$job\", instance=\"$instance\"},  version)",
+        "definition": "label_values(vm_app_version{job=~\"$job\", instance=~\"$instance\"},  version)",
         "description": null,
         "error": null,
         "hide": 2,
@@ -4045,7 +4045,7 @@
         "name": "version",
         "options": [],
         "query": {
-          "query": "label_values(vm_app_version{job=\"$job\", instance=\"$instance\"},  version)",
+          "query": "label_values(vm_app_version{job=~\"$job\", instance=~\"$instance\"},  version)",
           "refId": "VictoriaMetrics-version-Variable-Query"
         },
         "refresh": 1,

--- a/dashboards/vmagent.json
+++ b/dashboards/vmagent.json
@@ -1481,7 +1481,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(rate(vm_log_messages_total{job=\"$job\", instance=~\"$instance\"}[5m])) by (level) ",
+          "expr": "sum(rate(vm_log_messages_total{job=~\"$job\", instance=~\"$instance\"}[5m])) by (level) ",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -4382,7 +4382,7 @@
         "allValue": ".*",
         "current": {},
         "datasource": "$ds",
-        "definition": "label_values(vmagent_remotewrite_requests_total{job=\"$job\", instance=~\"$instance\"}, url)",
+        "definition": "label_values(vmagent_remotewrite_requests_total{job=~\"$job\", instance=~\"$instance\"}, url)",
         "description": "The remote write URLs",
         "error": null,
         "hide": 0,
@@ -4392,7 +4392,7 @@
         "name": "url",
         "options": [],
         "query": {
-          "query": "label_values(vmagent_remotewrite_requests_total{job=\"$job\", instance=~\"$instance\"}, url)",
+          "query": "label_values(vmagent_remotewrite_requests_total{job=~\"$job\", instance=~\"$instance\"}, url)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,


### PR DESCRIPTION
Template vars may contain regexp when `all` is selected (.*) or when multiple values are selected (foo|bar).
So they must be passed to regexp filters.