### PR TITLE
Add flag of S3ForcePathStyle

### DIFF
--- a/lib/backup/actions/util.go
+++ b/lib/backup/actions/util.go
@@ -21,6 +21,7 @@ var (
 	configProfile = flag.String("configProfile", "", "Profile name for S3 configs. If no set, the value of the environment variable will be loaded (AWS_PROFILE or AWS_DEFAULT_PROFILE), "+
 		"or if both not set, DefaultSharedConfigProfile is used")
 	customS3Endpoint = flag.String("customS3Endpoint", "", "Custom S3 endpoint for use with S3-compatible storages (e.g. MinIO). S3 is used if not set")
+	s3ForcePathStyle = flag.Bool("s3ForcePathStyle", true, "Prefixing endpoint with bucket name when set false, true by default.")
 )
 
 func runParallel(concurrency int, parts []common.Part, f func(p common.Part) error, progress func(elapsed time.Duration)) error {
@@ -219,12 +220,13 @@ func NewRemoteFS(path string) (common.RemoteFS, error) {
 		bucket := dir[:n]
 		dir = dir[n:]
 		fs := &s3remote.FS{
-			CredsFilePath:  *credsFilePath,
-			ConfigFilePath: *configFilePath,
-			CustomEndpoint: *customS3Endpoint,
-			ProfileName:    *configProfile,
-			Bucket:         bucket,
-			Dir:            dir,
+			CredsFilePath:    *credsFilePath,
+			ConfigFilePath:   *configFilePath,
+			CustomEndpoint:   *customS3Endpoint,
+			S3ForcePathStyle: *s3ForcePathStyle,
+			ProfileName:      *configProfile,
+			Bucket:           bucket,
+			Dir:              dir,
 		}
 		if err := fs.Init(); err != nil {
 			return nil, fmt.Errorf("cannot initialize connection to s3: %w", err)

--- a/lib/backup/s3remote/s3.go
+++ b/lib/backup/s3remote/s3.go
@@ -37,6 +37,9 @@ type FS struct {
 	// Set for using S3-compatible enpoint such as MinIO etc.
 	CustomEndpoint string
 
+	// Force to use path style for s3, true by default.
+	S3ForcePathStyle bool
+
 	// The name of S3 config profile to use.
 	ProfileName string
 
@@ -83,7 +86,7 @@ func (fs *FS) Init() error {
 		sess.Config.WithEndpoint(fs.CustomEndpoint)
 
 		// Disable prefixing endpoint with bucket name
-		sess.Config.WithS3ForcePathStyle(true)
+		sess.Config.WithS3ForcePathStyle(fs.S3ForcePathStyle)
 	} else {
 		// Determine bucket region.
 		ctx := context.Background()


### PR DESCRIPTION
In my case, i'm using aliyun oss for s3 and it must be need to me use virtual-hosted style URL.

And this PR just add flag for change `sess.Config.WithS3ForcePathStyle(true)` to `sess.Config.WithS3ForcePathStyle(fs.S3ForcePathStyle)`.

Thanks any review.  

I had really try to use flag of S3ForcePathStyle and it's working for me. 

like:  
```shell
(app/vmbackup)
go run main.go ... -dst=s3://smt-vmbackup/20211110 -s3ForcePathStyle=false