### PR TITLE
changes restore alert request

### DIFF
--- a/app/vmalert/alerting.go
+++ b/app/vmalert/alerting.go
@@ -510,7 +510,7 @@ func (ar *AlertingRule) Restore(ctx context.Context, q datasource.Querier, lookb
 	// Get the last data point in range via MetricsQL `last_over_time`.
 	// We don't use plain PromQL since Prometheus doesn't support
 	// remote write protocol which is used for state persistence in vmalert.
-	expr := fmt.Sprintf("last_over_time(%s{alertname=%q%s}[%ds])",
+	expr := fmt.Sprintf("last_over_time(%s{alertname=%q%s})[%ds]",
 		alertForStateMetricName, ar.Name, labelsFilter, int(lookback.Seconds()))
 	qMetrics, err := q.Query(ctx, expr)
 	if err != nil {


### PR DESCRIPTION
adds subquery window for properly search last alert state
with request - last_over_time(ALERTS_FOR_STATE[1h]), it searchs ALERTS_FOR_STATE metric for default step = 5min and
calculates rollup function for last over, returning last data point
with last_over_time(ALERTS_FOR_STATE)[1h] - it searchs metric datapoints for last hour and applies last_over_time function for it with default interval