### PR TITLE
vmselect: in promql evaluation, return bytes requested when rollup me…

### DIFF
--- a/app/vmselect/promql/eval.go
+++ b/app/vmselect/promql/eval.go
@@ -729,9 +729,10 @@ func evalRollupFuncWithMetricExpr(ec *EvalConfig, funcName string, rf rollupFunc
 		rss.Cancel()
 		return nil, fmt.Errorf("not enough memory for processing %d data points across %d time series with %d points in each time series; "+
 			"total available memory for concurrent requests: %d bytes; "+
+			"requested memory: %d bytes; "+
 			"possible solutions are: reducing the number of matching time series; switching to node with more RAM; "+
 			"increasing -memory.allowedPercent; increasing `step` query arg (%gs)",
-			rollupPoints, timeseriesLen*len(rcs), pointsPerTimeseries, rml.MaxSize, float64(ec.Step)/1e3)
+			rollupPoints, timeseriesLen*len(rcs), pointsPerTimeseries, rml.MaxSize, uint64(rollupMemorySize), float64(ec.Step)/1e3)
 	}
 	defer rml.Put(uint64(rollupMemorySize))
 


### PR DESCRIPTION
…mory limiter is unable to satisfy the request.

Problem: In scenarios where vmselect requires memory > what the rollup memory limiter allows, a useful error message is already returned, however is missing a helpful-to-know datapoint: _how much memory was requested_.

In a real-world scenario, having this information available allows operators of `vmselect` to make more informed decisions when adjusting resource limits.