### PR TITLE
Fix duplicate crawl targets

### DIFF
--- a/lib/promscrape/scraper.go
+++ b/lib/promscrape/scraper.go
@@ -324,8 +324,8 @@ func (sg *scraperGroup) update(sws []*ScrapeWork) {
 	var swsToStart []*ScrapeWork
 	for _, sw := range sws {
 		key := sw.key()
-		originalLabels := swsMap[key]
-		if originalLabels != nil {
+		originalLabels, ok := swsMap[key]
+		if ok {
 			if !*suppressDuplicateScrapeTargetErrors {
 				logger.Errorf("skipping duplicate scrape target with identical labels; endpoint=%s, labels=%s; "+
 					"make sure service discovery and relabeling is set up properly; "+


### PR DESCRIPTION
If the promscrape.dropOriginalLabels flag is turned on, it will result in duplicate target crawling. This is because originalLabels is always nil. 
Thanks bentol for pointing this out. https://github.com/VictoriaMetrics/VictoriaMetrics/issues/1664#issuecomment-940605503

result:
![image](https://user-images.githubusercontent.com/3192136/143564177-f796de92-736f-44bc-a8eb-ffe2b17fa6b1.png)


 Related issues:  #1830 