### PR TITLE
removes FileSize from backup part key

### DIFF
--- a/lib/backup/actions/restore.go
+++ b/lib/backup/actions/restore.go
@@ -133,9 +133,6 @@ func (r *Restore) Run() error {
 			}
 			deleteSize += size
 		}
-		if err != nil {
-			return err
-		}
 		if err := dst.RemoveEmptyDirs(); err != nil {
 			return fmt.Errorf("cannot remove empty directories at %s: %w", dst, err)
 		}

--- a/lib/backup/common/part.go
+++ b/lib/backup/common/part.go
@@ -34,7 +34,7 @@ type Part struct {
 }
 
 func (p *Part) key() string {
-	return fmt.Sprintf("%s%016X%016X%016X%016X", p.Path, p.FileSize, p.Offset, p.Size, p.ActualSize)
+	return fmt.Sprintf("%s%016X%016X%016X", p.Path, p.Offset, p.Size, p.ActualSize)
 }
 
 // String returns human-readable representation of the part.

--- a/lib/backup/common/part.go
+++ b/lib/backup/common/part.go
@@ -34,6 +34,7 @@ type Part struct {
 }
 
 func (p *Part) key() string {
+	// Do not use p.FileSize in the key, since it cannot be properly initialized when resuming the restore for partially restored file
 	return fmt.Sprintf("%s%016X%016X%016X", p.Path, p.Offset, p.Size, p.ActualSize)
 }
 


### PR DESCRIPTION
it should fix download restoration for backups.

 When calculating parts diff, old key wasn't able to match srcParts, even if some part chunks was downloaded.