### PR TITLE
vmalert: check if remoteWrite is configured for replay mode

### DIFF
--- a/app/vmalert/main.go
+++ b/app/vmalert/main.go
@@ -98,7 +98,7 @@ func main() {
 			logger.Fatalf("failed to init remoteWrite: %s", err)
 		}
 		if rw == nil {
-			logger.Fatalf("remoteWrite.url can't be empty")
+			logger.Fatalf("remoteWrite.url can't be empty in replay mode")
 		}
 		notifier.InitTemplateFunc(eu)
 		groupsCfg, err := config.Parse(*rulePath, *validateTemplates, *validateExpressions)

--- a/app/vmalert/main.go
+++ b/app/vmalert/main.go
@@ -97,6 +97,9 @@ func main() {
 		if err != nil {
 			logger.Fatalf("failed to init remoteWrite: %s", err)
 		}
+		if rw == nil {
+			logger.Fatalf("remoteWrite.url can't be empty")
+		}
 		notifier.InitTemplateFunc(eu)
 		groupsCfg, err := config.Parse(*rulePath, *validateTemplates, *validateExpressions)
 		if err != nil {


### PR DESCRIPTION
The purpose of `replay` mode is to backfill results of recording
or alerting rules. So `remoteWrite.url` should be required.
Otherwise, process can fail on attempt to send data.

Signed-off-by: hagen1778 <roman@victoriametrics.com>