### PR TITLE
Add .github/workflows/check-based-on-master

### DIFF
--- a/.github/workflows/check-based-on-master.sh
+++ b/.github/workflows/check-based-on-master.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -x -e
+MASTER_ID=$(git rev-parse "origin/master")
+CURRENT_ID=$(git rev-parse "HEAD")
+BASED_ON_ID=$(git merge-base "$CURRENT_ID" "$MASTER_ID")
+
+if [[ "$MASTER_ID" != "$BASED_ON_ID" ]]
+then
+  echo "Current branch is based on $BASED_ON_ID, which is not the latest \`master\`: $MASTER_ID. Consider \`git rebase origin/master\`."
+  exit 1
+fi

--- a/.github/workflows/check-based-on-master.yml
+++ b/.github/workflows/check-based-on-master.yml
@@ -1,0 +1,18 @@
+name: check-based-on-master
+on:
+  pull_request:
+  push:
+    branches: [ master ]
+jobs:
+  hook:
+    name: Check whether this branch is based on master branch
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repo @ current branch
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 1000 # Hopefully current branch is less than 1000 commits from main
+      - name: Fetch origin/master
+        run: "git fetch origin master"
+      - name: Run check-based-on-master
+        run: .github/workflows/check-based-on-master.sh


### PR DESCRIPTION
This check will prevent merge commits that are not `git rebase`-d on the latest `master`. 

This check will not prevent squash commits, nor commits directly to master.

