### PR TITLE
Add check-rebased Github action

### DIFF
--- a/.github/workflows/check-rebased.sh
+++ b/.github/workflows/check-rebased.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -x -e -u
+
+git fetch origin "$GITHUB_BASE_REF"
+
+BASE_ID=$(git rev-parse --verify "origin/$GITHUB_BASE_REF")
+CURRENT_ID=$(git rev-parse --verify "HEAD")
+
+# Oldest commit that's not in the base branch
+FIRST_BRANCH_ID=$(git rev-list "origin/$GITHUB_BASE_REF..HEAD" | tail -n 1)
+
+# Common ancestor (usually just parent of $FIRST_BRANCH_ID)
+# Command will return error 1 if not found anything. So we || true to proceed.
+FORK_POINT_ID=$(git merge-base "$FIRST_BRANCH_ID" "origin/$GITHUB_BASE_REF") || true
+
+if [[ -z "$FORK_POINT_ID" ]]
+then
+  echo "Current branch is not forked from its base branch origin/$GITHUB_BASE_REF"
+  exit 1
+fi
+
+if [[ "$BASE_ID" != "$FORK_POINT_ID" ]]
+then
+  echo "Current branch (at $CURRENT_ID) forked at $FORK_POINT_ID is not $BASE_ID (which is the latest \"$GITHUB_BASE_REF\")"
+  exit 1
+fi

--- a/.github/workflows/check-rebased.yml
+++ b/.github/workflows/check-rebased.yml
@@ -1,0 +1,17 @@
+name: check-rebased
+on:
+  pull_request:
+    types: [ synchronize, opened, reopened, edited ] # +edited (for triggering on PR base change)
+  push:
+    branches: [ main ]
+jobs:
+  hook:
+    name: Check whether current branch is based on its base branch
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repo @ current branch
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 1000 # Hopefully current branch is less than 1000 commits from main
+      - name: Run check-rebased.sh
+        run: .github/workflows/check-rebased.sh


### PR DESCRIPTION
Same as PR #1991, but taking into account that base branch is not necessarily `master`.

It will prevent merging in a branch that's not based on its base branch HEAD, leading to streamlined history.

Note it will not prevent squash commits, nor commits directly to base branch.

Also takes into account (prevents) intermediate merges from base into current branch -- let's see if we want it or not.