### PR TITLE
vmstorage: fix query like `{foo=~"bar|"}` return extra timeseries cau…

### DIFF
--- a/lib/storage/index_db.go
+++ b/lib/storage/index_db.go
@@ -2744,10 +2744,9 @@ func (is *indexSearch) getMetricIDsForDateTagFilter(tf *tagFilter, date uint64, 
 		// Use global search if date isn't set.
 		kb.B = is.marshalCommonPrefix(kb.B[:0], nsPrefixTagToMetricIDs)
 	}
-	kb.B = append(kb.B, tf.prefix[len(commonPrefix):]...)
 	tfNew := *tf
 	tfNew.isNegative = false // isNegative for the original tf is handled by the caller.
-	tfNew.prefix = kb.B
+	tfNew.prefix = append(kb.B, tf.prefix[len(commonPrefix):]...)
 	metricIDs, loopsCount, err := is.getMetricIDsForTagFilter(&tfNew, maxMetrics, maxLoopsCount)
 	if err != nil {
 		return nil, loopsCount, err
@@ -2760,6 +2759,7 @@ func (is *indexSearch) getMetricIDsForDateTagFilter(tf *tagFilter, date uint64, 
 	// This fixes https://github.com/VictoriaMetrics/VictoriaMetrics/issues/1601
 	// See also https://github.com/VictoriaMetrics/VictoriaMetrics/issues/395
 	maxLoopsCount -= loopsCount
+	tfNew = tagFilter{}
 	if err := tfNew.Init(kb.B, tf.key, []byte(".+"), false, true); err != nil {
 		logger.Panicf(`BUG: cannot init tag filter: {%q=~".+"}: %s`, tf.key, err)
 	}


### PR DESCRIPTION
…se by negative filter transformation malfunction

1. L2749 make kb.B remain the value of comonPrefix instead of tf.prefix
2. L2762 avoid change tf.value from "bar|" to ".+r|"