### PR TITLE
Fix for #2038: Make correct __address__ value for dockerswarm promscrape

### DIFF
--- a/lib/promscrape/discovery/dockerswarm/tasks.go
+++ b/lib/promscrape/discovery/dockerswarm/tasks.go
@@ -94,6 +94,7 @@ func addTasksLabels(tasks []task, nodesLabels, servicesLabels []map[string]strin
 		}
 		addLabels(commonLabels, servicesLabels, "__meta_dockerswarm_service_id", task.ServiceID)
 		addLabels(commonLabels, nodesLabels, "__meta_dockerswarm_node_id", task.NodeID)
+		delete(commonLabels, "__address__")
 
 		for _, port := range task.Status.PortStatus.Ports {
 			if port.Protocol != "tcp" {
@@ -121,7 +122,7 @@ func addTasksLabels(tasks []task, nodesLabels, servicesLabels []map[string]strin
 						continue
 					}
 					m := map[string]string{
-						"__address": discoveryutils.JoinHostPort(ip.String(), ep.PublishedPort),
+						"__address__": discoveryutils.JoinHostPort(ip.String(), ep.PublishedPort),
 						"__meta_dockerswarm_task_port_publish_mode": ep.PublishMode,
 					}
 					for k, v := range commonLabels {

--- a/lib/promscrape/discovery/dockerswarm/tasks_test.go
+++ b/lib/promscrape/discovery/dockerswarm/tasks_test.go
@@ -167,7 +167,7 @@ func Test_addTasksLabels(t *testing.T) {
 			},
 			want: [][]prompbmarshal.Label{
 				discoveryutils.GetSortedLabels(map[string]string{
-					"__address__":                                   "172.31.40.97:9100",
+					"__address__":                                   "172.31.40.97:6379",
 					"__meta_dockerswarm_node_address":               "172.31.40.97",
 					"__meta_dockerswarm_node_availability":          "active",
 					"__meta_dockerswarm_node_engine_version":        "19.03.11",
@@ -295,9 +295,10 @@ func Test_addTasksLabels(t *testing.T) {
 						}{
 							Ports: []portConfig{
 								{
-									Protocol:    "tcp",
-									Name:        "redis",
-									PublishMode: "ingress",
+									Protocol:      "tcp",
+									Name:          "redis",
+									PublishMode:   "ingress",
+									PublishedPort: 6379,
 								},
 							}, VirtualIPs: []struct {
 								NetworkID string
@@ -315,8 +316,7 @@ func Test_addTasksLabels(t *testing.T) {
 			},
 			want: [][]prompbmarshal.Label{
 				discoveryutils.GetSortedLabels(map[string]string{
-					"__address":                                     "10.10.15.15:0",
-					"__address__":                                   "172.31.40.97:9100",
+					"__address__":                                   "10.10.15.15:6379",
 					"__meta_dockerswarm_network_id":                 "qs0hog6ldlei9ct11pr3c77v1",
 					"__meta_dockerswarm_network_ingress":            "true",
 					"__meta_dockerswarm_network_internal":           "false",


### PR DESCRIPTION
See #2038 for details. Fixed `__address__` field name on line 124 and removed it from commonLabels to avoid overwriting.