### PR TITLE
vmui: copy pairs on click in legend

### DIFF
--- a/app/vmui/packages/vmui/src/components/Legend/legend.css
+++ b/app/vmui/packages/vmui/src/components/Legend/legend.css
@@ -34,7 +34,7 @@
     grid-gap: 6px;
     align-items: start;
     justify-content: start;
-    padding: 5px 10px;
+    padding: 7px 50px 7px 10px;
     background-color: #FFF;
     cursor: pointer;
     transition: 0.2s ease;
@@ -56,12 +56,25 @@
     border-style: solid;
     box-sizing: border-box;
     transition: 0.2s ease;
-    margin: 3px 0;
 }
 
 .legendLabel {
     font-size: 11px;
+    line-height: 12px;
     font-weight: normal;
+}
+
+.legendFreeFields {
+    padding: 3px;
+    cursor: pointer;
+}
+
+.legendFreeFields:hover {
+    text-decoration: underline;
+}
+
+.legendFreeFields:not(:last-child):after {
+    content: ",";
 }
 
 .legendWrapperHotkey {

--- a/app/vmui/packages/vmui/src/utils/uplot/series.ts
+++ b/app/vmui/packages/vmui/src/utils/uplot/series.ts
@@ -10,6 +10,7 @@ export const getSeriesItem = (d: MetricResult, hideSeries: string[]): Series => 
   return {
     label,
     dash: getDashLine(d.group),
+    class: JSON.stringify(d.metric),
     width: 1.4,
     stroke: getColorLine(d.group, label),
     show: !includesHideSeries(label, d.group, hideSeries),
@@ -25,7 +26,8 @@ export const getLegendItem = (s: Series, group: number): LegendItem => ({
   group,
   label: s.label || "",
   color: s.stroke as string,
-  checked: s.show || false
+  checked: s.show || false,
+  freeFormFields: JSON.parse(s.class || "{}"),
 });
 
 export const getHideSeries = ({hideSeries, legend, metaKey, series}: HideSeriesArgs): string[] => {

--- a/app/vmui/packages/vmui/src/utils/uplot/types.ts
+++ b/app/vmui/packages/vmui/src/utils/uplot/types.ts
@@ -36,4 +36,5 @@ export interface LegendItem {
     label: string;
     color: string;
     checked: boolean;
+    freeFormFields: {[key: string]: string};
 }


### PR DESCRIPTION
Added the ability to copy label="value" when clicking on pairs in the legend ([task card](https://github.com/VictoriaMetrics/VictoriaMetrics/projects/2#card-64915508))

<img src="https://i.imgur.com/3Cxr7xr.png"/>