### PR TITLE
Update version of golangci-lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -267,7 +267,7 @@ golangci-lint: install-golangci-lint
 	golangci-lint run --exclude '(SA4003|SA1019|SA5011):' -D errcheck -D structcheck --timeout 2m
 
 install-golangci-lint:
-	which golangci-lint || curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(shell go env GOPATH)/bin v1.43.0
+	which golangci-lint || curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(shell go env GOPATH)/bin v1.44.0
 
 install-wwhrd:
 	which wwhrd || GO111MODULE=off go get github.com/frapposelli/wwhrd


### PR DESCRIPTION
Update version of golangci-lint from v1.43.0 to v1.44.0 in Makefile.
See https://github.com/golangci/golangci-lint/releases/tag/v1.44.0 .