### PR TITLE
vmalert: remove trailing slash for static notifier addresses

### DIFF
--- a/app/vmalert/notifier/init.go
+++ b/app/vmalert/notifier/init.go
@@ -3,6 +3,7 @@ package notifier
 import (
 	"flag"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/flagutil"
@@ -93,6 +94,7 @@ func notifiersFromFlags(gen AlertURLGenerator) ([]Notifier, error) {
 				Password: promauth.NewSecret(basicAuthPassword.GetOptionalArg(i)),
 			},
 		}
+		addr = strings.TrimSuffix(addr, "/")
 		am, err := NewAlertManager(addr+alertManagerPath, gen, authCfg, time.Minute)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
This would make addresses `http://localhost:9093` and `http://localhost:9093/`
both to result into `http://localhost:9093/api/v2/alerts`.

Signed-off-by: hagen1778 <roman@victoriametrics.com>