### PR TITLE
Adding indexdbRotationDelay

### DIFF
--- a/app/vmstorage/main.go
+++ b/app/vmstorage/main.go
@@ -48,6 +48,8 @@ var (
 		"Excess series are logged and dropped. This can be useful for limiting series churn rate. See also -storage.maxHourlySeries")
 
 	minFreeDiskSpaceBytes = flagutil.NewBytes("storage.minFreeDiskSpaceBytes", 10e6, "The minimum free disk space at -storageDataPath after which the storage stops accepting new data")
+	indexdbRotationDelay  = flag.Duration("indexdbRotationDelay", 0, "Duration to wait to perform monthly index rotation"+
+		"This is useful for high churn cluster to perform rotation of one vmstorage server after another to avoid having them all overloaded at once")
 )
 
 // CheckTimeRange returns true if the given tr is denied for querying.
@@ -89,7 +91,7 @@ func InitWithoutMetrics(resetCacheIfNeeded func(mrs []storage.MetricRow)) {
 	logger.Infof("opening storage at %q with -retentionPeriod=%s", *DataPath, retentionPeriod)
 	startTime := time.Now()
 	WG = syncwg.WaitGroup{}
-	strg, err := storage.OpenStorage(*DataPath, retentionPeriod.Msecs, *maxHourlySeries, *maxDailySeries)
+	strg, err := storage.OpenStorage(*DataPath, retentionPeriod.Msecs, *maxHourlySeries, *maxDailySeries, indexdbRotationDelay.Milliseconds())
 	if err != nil {
 		logger.Fatalf("cannot open a storage at %s with -retentionPeriod=%s: %s", *DataPath, retentionPeriod, err)
 	}

--- a/lib/storage/search_test.go
+++ b/lib/storage/search_test.go
@@ -72,7 +72,7 @@ func TestSearchQueryMarshalUnmarshal(t *testing.T) {
 
 func TestSearch(t *testing.T) {
 	path := "TestSearch"
-	st, err := OpenStorage(path, 0, 0, 0)
+	st, err := OpenStorage(path, 0, 0, 0, 0)
 	if err != nil {
 		t.Fatalf("cannot open storage %q: %s", path, err)
 	}
@@ -121,7 +121,7 @@ func TestSearch(t *testing.T) {
 
 	// Re-open the storage in order to flush all the pending cached data.
 	st.MustClose()
-	st, err = OpenStorage(path, 0, 0, 0)
+	st, err = OpenStorage(path, 0, 0, 0, 0)
 	if err != nil {
 		t.Fatalf("cannot re-open storage %q: %s", path, err)
 	}

--- a/lib/storage/storage_timing_test.go
+++ b/lib/storage/storage_timing_test.go
@@ -17,7 +17,7 @@ func BenchmarkStorageAddRows(b *testing.B) {
 
 func benchmarkStorageAddRows(b *testing.B, rowsPerBatch int) {
 	path := fmt.Sprintf("BenchmarkStorageAddRows_%d", rowsPerBatch)
-	s, err := OpenStorage(path, 0, 0, 0)
+	s, err := OpenStorage(path, 0, 0, 0, 0)
 	if err != nil {
 		b.Fatalf("cannot open storage at %q: %s", path, err)
 	}


### PR DESCRIPTION
**Context:**
https://victoriametrics.slack.com/archives/CGZF1H6L9/p1643365185780299
A 7d retention cluster with about 20B metrics ingesting 8M datapoints/s. Every week, during indexdb rotation, cluster is unavailable for an hour because all storage nodes are above 80% CPU usage for the duration.

This would enable delay between vmstorage node index rotation in case of high load and prevent that they all go overloaded at once. The rerouting should handle a slow node at once.