### PR TITLE
Show gce sdconfig zone on vmagent:8429/config

### DIFF
--- a/lib/promscrape/discovery/gce/gce.go
+++ b/lib/promscrape/discovery/gce/gce.go
@@ -54,6 +54,11 @@ func (z *ZoneYAML) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	return nil
 }
 
+// MarshalYAML implements yaml.Marshaler
+func (z ZoneYAML) MarshalYAML() (interface{}, error) {
+	return z.zones, nil
+}
+
 // GetLabels returns gce labels according to sdc.
 func (sdc *SDConfig) GetLabels(baseDir string) ([]map[string]string, error) {
 	cfg, err := getAPIConfig(sdc)

--- a/lib/promscrape/discovery/gce/gce_test.go
+++ b/lib/promscrape/discovery/gce/gce_test.go
@@ -1,0 +1,27 @@
+package gce
+
+import (
+	"testing"
+
+	"gopkg.in/yaml.v2"
+)
+
+func TestMarshallingSDConfigWithZoneYAML(t *testing.T) {
+	sdConfig := SDConfig{
+		Project: "test-project",
+		Zone: ZoneYAML{
+			zones: []string{"zone-a", "zone-b"},
+		},
+	}
+
+	data, err := yaml.Marshal(sdConfig)
+	if err != nil {
+		t.Fatalf("unexpected non-nil error")
+	}
+
+	strData := string(data)
+	expected := "project: test-project\nzone:\n- zone-a\n- zone-b\n"
+	if strData != expected {
+		t.Fatalf("unexpected marshal:\ngot \n%vwant\n%v", strData, expected)
+	}
+}


### PR DESCRIPTION
Previously, `gce_sd_config` shows `zone` as `{}` instead of the content of the configuration, as shown in this test result before implementation:

```
--- FAIL: TestMarshallingSDConfigWithZoneYAML (0.00s)
    [...]/VictoriaMetrics/lib/promscrape/discovery/gce/gce_test.go:25: unexpected marshal:
        got 
        project: test-project
        zone: {}
        want
        project: test-project
        zone:
        - zone-a
        - zone-b
FAIL
FAIL	github.com/VictoriaMetrics/VictoriaMetrics/lib/promscrape/discovery/gce	1.049s
FAIL
```

This pull requests implements `Marshaler` interface on `ZoneYAML` so zones may be displayed properly.