### PR TITLE
alerts: lower the threshold for TooHighSlowInsertsRate

### DIFF
--- a/deployment/docker/alerts.yml
+++ b/deployment/docker/alerts.yml
@@ -187,13 +187,13 @@ groups:
              sum(rate(vm_slow_row_inserts_total[5m])) by(instance)
              /
              sum(rate(vm_rows_inserted_total[5m])) by (instance)
-           ) > 0.5
+           ) > 0.05
         for: 15m
         labels:
           severity: warning
         annotations:
           dashboard: "http://localhost:3000/d/wNf0q_kZk?viewPanel=68&var-instance={{ $labels.instance }}"
-          summary: "Percentage of slow inserts is more than 50% on \"{{ $labels.instance }}\" for the last 15m"
+          summary: "Percentage of slow inserts is more than 5% on \"{{ $labels.instance }}\" for the last 15m"
           description: "High rate of slow inserts on \"{{ $labels.instance }}\" may be a sign of resource exhaustion
             for the current load. It is likely more RAM is needed for optimal handling of the current number of active time series."
 


### PR DESCRIPTION
Lowering threshold from 50% to 5% will be more sufficient
for discovering un-healthy system state.