### PR TITLE
docs: make profiling commands more copy-friendly

### DIFF
--- a/README.md
+++ b/README.md
@@ -1505,7 +1505,7 @@ VictoriaMetrics provides handlers for collecting the following [Go profiles](htt
 <div class="with-copy" markdown="1">
 
 ```bash
-curl -s http://0.0.0.0:8428/debug/pprof/heap > mem.pprof
+curl http://0.0.0.0:8428/debug/pprof/heap > mem.pprof
 ```
 
 </div>
@@ -1515,7 +1515,7 @@ curl -s http://0.0.0.0:8428/debug/pprof/heap > mem.pprof
 <div class="with-copy" markdown="1">
 
 ```bash
-curl -s http://0.0.0.0:8428/debug/pprof/profile > cpu.pprof
+curl http://0.0.0.0:8428/debug/pprof/profile > cpu.pprof
 ```
 
 </div>

--- a/README.md
+++ b/README.md
@@ -1500,17 +1500,25 @@ for running ingestion benchmarks based on node_exporter metrics.
 
 VictoriaMetrics provides handlers for collecting the following [Go profiles](https://blog.golang.org/profiling-go-programs):
 
-* Memory profile. It can be collected with the following command:
+* Memory profile. It can be collected with the following command (replace `0.0.0.0` with hostname if needed):
+
+<div class="with-copy" markdown="1">
 
 ```bash
-curl -s http://<victoria-metrics-host>:8428/debug/pprof/heap > mem.pprof
+curl -s http://0.0.0.0:8428/debug/pprof/heap > mem.pprof
 ```
 
-* CPU profile. It can be collected with the following command:
+</div>
+
+* CPU profile. It can be collected with the following command (replace `0.0.0.0` with hostname if needed):
+
+<div class="with-copy" markdown="1">
 
 ```bash
-curl -s http://<victoria-metrics-host>:8428/debug/pprof/profile > cpu.pprof
+curl -s http://0.0.0.0:8428/debug/pprof/profile > cpu.pprof
 ```
+
+</div>
 
 The command for collecting CPU profile waits for 30 seconds before returning.
 

--- a/app/vmagent/README.md
+++ b/app/vmagent/README.md
@@ -690,7 +690,7 @@ ARM build may run on Raspberry Pi or on [energy-efficient ARM servers](https://b
 <div class="with-copy" markdown="1">
 
 ```bash
-curl -s http://0.0.0.0:8429/debug/pprof/heap > mem.pprof
+curl http://0.0.0.0:8429/debug/pprof/heap > mem.pprof
 ```
 
 </div>
@@ -700,7 +700,7 @@ curl -s http://0.0.0.0:8429/debug/pprof/heap > mem.pprof
 <div class="with-copy" markdown="1">
 
 ```bash
-curl -s http://0.0.0.0:8429/debug/pprof/profile > cpu.pprof
+curl http://0.0.0.0:8429/debug/pprof/profile > cpu.pprof
 ```
 
 </div>

--- a/app/vmagent/README.md
+++ b/app/vmagent/README.md
@@ -685,17 +685,25 @@ ARM build may run on Raspberry Pi or on [energy-efficient ARM servers](https://b
 
 `vmagent` provides handlers for collecting the following [Go profiles](https://blog.golang.org/profiling-go-programs):
 
-* Memory profile can be collected with the following command:
+* Memory profile can be collected with the following command (replace `0.0.0.0` with hostname if needed):
+
+<div class="with-copy" markdown="1">
 
 ```bash
-curl -s http://<vmagent-host>:8429/debug/pprof/heap > mem.pprof
+curl -s http://0.0.0.0:8429/debug/pprof/heap > mem.pprof
 ```
 
-* CPU profile can be collected with the following command:
+</div>
+
+* CPU profile can be collected with the following command (replace `0.0.0.0` with hostname if needed):
+
+<div class="with-copy" markdown="1">
 
 ```bash
-curl -s http://<vmagent-host>:8429/debug/pprof/profile > cpu.pprof
+curl -s http://0.0.0.0:8429/debug/pprof/profile > cpu.pprof
 ```
+
+</div>
 
 The command for collecting CPU profile waits for 30 seconds before returning.
 

--- a/app/vmauth/README.md
+++ b/app/vmauth/README.md
@@ -188,17 +188,25 @@ ROOT_IMAGE=scratch make package-vmauth
 
 `vmauth` provides handlers for collecting the following [Go profiles](https://blog.golang.org/profiling-go-programs):
 
-* Memory profile. It can be collected with the following command:
+* Memory profile. It can be collected with the following command (replace `0.0.0.0` with hostname if needed):
+
+<div class="with-copy" markdown="1">
 
 ```bash
-curl -s http://<vmauth-host>:8427/debug/pprof/heap > mem.pprof
+curl -s http://0.0.0.0:8427/debug/pprof/heap > mem.pprof
 ```
 
-* CPU profile. It can be collected with the following command:
+</div>
+
+* CPU profile. It can be collected with the following command (replace `0.0.0.0` with hostname if needed):
+
+<div class="with-copy" markdown="1">
 
 ```bash
-curl -s http://<vmauth-host>:8427/debug/pprof/profile > cpu.pprof
+curl -s http://0.0.0.0:8427/debug/pprof/profile > cpu.pprof
 ```
+
+</div>
 
 The command for collecting CPU profile waits for 30 seconds before returning.
 

--- a/app/vmauth/README.md
+++ b/app/vmauth/README.md
@@ -193,7 +193,7 @@ ROOT_IMAGE=scratch make package-vmauth
 <div class="with-copy" markdown="1">
 
 ```bash
-curl -s http://0.0.0.0:8427/debug/pprof/heap > mem.pprof
+curl http://0.0.0.0:8427/debug/pprof/heap > mem.pprof
 ```
 
 </div>
@@ -203,7 +203,7 @@ curl -s http://0.0.0.0:8427/debug/pprof/heap > mem.pprof
 <div class="with-copy" markdown="1">
 
 ```bash
-curl -s http://0.0.0.0:8427/debug/pprof/profile > cpu.pprof
+curl http://0.0.0.0:8427/debug/pprof/profile > cpu.pprof
 ```
 
 </div>

--- a/docs/Cluster-VictoriaMetrics.md
+++ b/docs/Cluster-VictoriaMetrics.md
@@ -421,18 +421,25 @@ All the cluster components provide the following handlers for [profiling](https:
 * `http://vmselect:8481/debug/pprof/heap` for memory profile and `http://vmselect:8481/debug/pprof/profile` for CPU profile
 * `http://vmstorage:8482/debug/pprof/heap` for memory profile and `http://vmstorage:8482/debug/pprof/profile` for CPU profile
 
-Example command for collecting cpu profile from `vmstorage`:
+Example command for collecting cpu profile from `vmstorage` (replace `0.0.0.0` with `vmstorage` hostname if needed):
+
+<div class="with-copy" markdown="1">
 
 ```bash
 curl -s http://vmstorage:8482/debug/pprof/profile > cpu.pprof
 ```
 
-Example command for collecting memory profile from `vminsert`:
+</div>
+
+Example command for collecting memory profile from `vmstorage` (replace `0.0.0.0` with `vmstorage` hostname if needed):
+
+<div class="with-copy" markdown="1">
 
 ```bash
-curl -s http://vminsert:8480/debug/pprof/heap > mem.pprof
+curl -s http://vminsert:8482/debug/pprof/heap > mem.pprof
 ```
 
+</div>
 
 ## Community and contributions
 

--- a/docs/Cluster-VictoriaMetrics.md
+++ b/docs/Cluster-VictoriaMetrics.md
@@ -426,7 +426,7 @@ Example command for collecting cpu profile from `vmstorage` (replace `0.0.0.0` w
 <div class="with-copy" markdown="1">
 
 ```bash
-curl -s http://vmstorage:8482/debug/pprof/profile > cpu.pprof
+curl http://vmstorage:8482/debug/pprof/profile > cpu.pprof
 ```
 
 </div>

--- a/docs/Cluster-VictoriaMetrics.md
+++ b/docs/Cluster-VictoriaMetrics.md
@@ -426,7 +426,7 @@ Example command for collecting cpu profile from `vmstorage` (replace `0.0.0.0` w
 <div class="with-copy" markdown="1">
 
 ```bash
-curl http://vmstorage:8482/debug/pprof/profile > cpu.pprof
+curl http://0.0.0.0:8482/debug/pprof/profile > cpu.pprof
 ```
 
 </div>
@@ -436,7 +436,7 @@ Example command for collecting memory profile from `vminsert` (replace `0.0.0.0`
 <div class="with-copy" markdown="1">
 
 ```bash
-curl http://vminsert:8480/debug/pprof/heap > mem.pprof
+curl http://0.0.0.0:8480/debug/pprof/heap > mem.pprof
 ```
 
 </div>

--- a/docs/Cluster-VictoriaMetrics.md
+++ b/docs/Cluster-VictoriaMetrics.md
@@ -431,12 +431,12 @@ curl -s http://vmstorage:8482/debug/pprof/profile > cpu.pprof
 
 </div>
 
-Example command for collecting memory profile from `vmstorage` (replace `0.0.0.0` with `vmstorage` hostname if needed):
+Example command for collecting memory profile from `vminsert` (replace `0.0.0.0` with `vminsert` hostname if needed):
 
 <div class="with-copy" markdown="1">
 
 ```bash
-curl -s http://vminsert:8482/debug/pprof/heap > mem.pprof
+curl http://vminsert:8480/debug/pprof/heap > mem.pprof
 ```
 
 </div>

--- a/docs/README.md
+++ b/docs/README.md
@@ -1515,7 +1515,7 @@ curl -s http://0.0.0.0:8428/debug/pprof/heap > mem.pprof
 <div class="with-copy" markdown="1">
 
 ```bash
-curl -s http://0.0.0.0:8428/debug/pprof/profile > cpu.pprof
+curl http://0.0.0.0:8428/debug/pprof/profile > cpu.pprof
 ```
 
 </div>

--- a/docs/README.md
+++ b/docs/README.md
@@ -1500,17 +1500,25 @@ for running ingestion benchmarks based on node_exporter metrics.
 
 VictoriaMetrics provides handlers for collecting the following [Go profiles](https://blog.golang.org/profiling-go-programs):
 
-* Memory profile. It can be collected with the following command:
+* Memory profile. It can be collected with the following command (replace `0.0.0.0` with hostname if needed):
+
+<div class="with-copy" markdown="1">
 
 ```bash
-curl -s http://<victoria-metrics-host>:8428/debug/pprof/heap > mem.pprof
+curl -s http://0.0.0.0:8428/debug/pprof/heap > mem.pprof
 ```
 
-* CPU profile. It can be collected with the following command:
+</div>
+
+* CPU profile. It can be collected with the following command (replace `0.0.0.0` with hostname if needed):
+
+<div class="with-copy" markdown="1">
 
 ```bash
-curl -s http://<victoria-metrics-host>:8428/debug/pprof/profile > cpu.pprof
+curl -s http://0.0.0.0:8428/debug/pprof/profile > cpu.pprof
 ```
+
+</div>
 
 The command for collecting CPU profile waits for 30 seconds before returning.
 

--- a/docs/Single-server-VictoriaMetrics.md
+++ b/docs/Single-server-VictoriaMetrics.md
@@ -1504,17 +1504,25 @@ for running ingestion benchmarks based on node_exporter metrics.
 
 VictoriaMetrics provides handlers for collecting the following [Go profiles](https://blog.golang.org/profiling-go-programs):
 
-* Memory profile. It can be collected with the following command:
+* Memory profile. It can be collected with the following command (replace `0.0.0.0` with hostname if needed):
+
+<div class="with-copy" markdown="1">
 
 ```bash
-curl -s http://<victoria-metrics-host>:8428/debug/pprof/heap > mem.pprof
+curl -s http://0.0.0.0:8428/debug/pprof/heap > mem.pprof
 ```
 
-* CPU profile. It can be collected with the following command:
+</div>
+
+* CPU profile. It can be collected with the following command (replace `0.0.0.0` with hostname if needed):
+
+<div class="with-copy" markdown="1">
 
 ```bash
-curl -s http://<victoria-metrics-host>:8428/debug/pprof/profile > cpu.pprof
+curl -s http://0.0.0.0:8428/debug/pprof/profile > cpu.pprof
 ```
+
+</div>
 
 The command for collecting CPU profile waits for 30 seconds before returning.
 

--- a/docs/Single-server-VictoriaMetrics.md
+++ b/docs/Single-server-VictoriaMetrics.md
@@ -1509,7 +1509,7 @@ VictoriaMetrics provides handlers for collecting the following [Go profiles](htt
 <div class="with-copy" markdown="1">
 
 ```bash
-curl -s http://0.0.0.0:8428/debug/pprof/heap > mem.pprof
+curl http://0.0.0.0:8428/debug/pprof/heap > mem.pprof
 ```
 
 </div>

--- a/docs/vmagent.md
+++ b/docs/vmagent.md
@@ -689,17 +689,25 @@ ARM build may run on Raspberry Pi or on [energy-efficient ARM servers](https://b
 
 `vmagent` provides handlers for collecting the following [Go profiles](https://blog.golang.org/profiling-go-programs):
 
-* Memory profile can be collected with the following command:
+* Memory profile can be collected with the following command (replace `0.0.0.0` with hostname if needed):
+
+<div class="with-copy" markdown="1">
 
 ```bash
-curl -s http://<vmagent-host>:8429/debug/pprof/heap > mem.pprof
+curl -s http://0.0.0.0:8429/debug/pprof/heap > mem.pprof
 ```
 
-* CPU profile can be collected with the following command:
+</div>
+
+* CPU profile can be collected with the following command (replace `0.0.0.0` with hostname if needed):
+
+<div class="with-copy" markdown="1">
 
 ```bash
-curl -s http://<vmagent-host>:8429/debug/pprof/profile > cpu.pprof
+curl -s http://0.0.0.0:8429/debug/pprof/profile > cpu.pprof
 ```
+
+</div>
 
 The command for collecting CPU profile waits for 30 seconds before returning.
 

--- a/docs/vmagent.md
+++ b/docs/vmagent.md
@@ -694,7 +694,7 @@ ARM build may run on Raspberry Pi or on [energy-efficient ARM servers](https://b
 <div class="with-copy" markdown="1">
 
 ```bash
-curl -s http://0.0.0.0:8429/debug/pprof/heap > mem.pprof
+curl http://0.0.0.0:8429/debug/pprof/heap > mem.pprof
 ```
 
 </div>
@@ -704,7 +704,7 @@ curl -s http://0.0.0.0:8429/debug/pprof/heap > mem.pprof
 <div class="with-copy" markdown="1">
 
 ```bash
-curl -s http://0.0.0.0:8429/debug/pprof/profile > cpu.pprof
+curl http://0.0.0.0:8429/debug/pprof/profile > cpu.pprof
 ```
 
 </div>

--- a/docs/vmauth.md
+++ b/docs/vmauth.md
@@ -192,17 +192,25 @@ ROOT_IMAGE=scratch make package-vmauth
 
 `vmauth` provides handlers for collecting the following [Go profiles](https://blog.golang.org/profiling-go-programs):
 
-* Memory profile. It can be collected with the following command:
+* Memory profile. It can be collected with the following command (replace `0.0.0.0` with hostname if needed):
+
+<div class="with-copy" markdown="1">
 
 ```bash
-curl -s http://<vmauth-host>:8427/debug/pprof/heap > mem.pprof
+curl -s http://0.0.0.0:8427/debug/pprof/heap > mem.pprof
 ```
 
-* CPU profile. It can be collected with the following command:
+</div>
+
+* CPU profile. It can be collected with the following command (replace `0.0.0.0` with hostname if needed):
+
+<div class="with-copy" markdown="1">
 
 ```bash
-curl -s http://<vmauth-host>:8427/debug/pprof/profile > cpu.pprof
+curl -s http://0.0.0.0:8427/debug/pprof/profile > cpu.pprof
 ```
+
+</div>
 
 The command for collecting CPU profile waits for 30 seconds before returning.
 

--- a/docs/vmauth.md
+++ b/docs/vmauth.md
@@ -197,7 +197,7 @@ ROOT_IMAGE=scratch make package-vmauth
 <div class="with-copy" markdown="1">
 
 ```bash
-curl -s http://0.0.0.0:8427/debug/pprof/heap > mem.pprof
+curl http://0.0.0.0:8427/debug/pprof/heap > mem.pprof
 ```
 
 </div>
@@ -207,7 +207,7 @@ curl -s http://0.0.0.0:8427/debug/pprof/heap > mem.pprof
 <div class="with-copy" markdown="1">
 
 ```bash
-curl -s http://0.0.0.0:8427/debug/pprof/profile > cpu.pprof
+curl http://0.0.0.0:8427/debug/pprof/profile > cpu.pprof
 ```
 
 </div>


### PR DESCRIPTION
The change adds `copy text` snippet to code examples
and replaces hostname placeholders with `0.0.0.0`.

Signed-off-by: hagen1778 <roman@victoriametrics.com>