### PR TITLE
bug fix : ApplyRelabeling change metricName which result in  the chan…

### DIFF
--- a/app/vminsert/relabel/relabel.go
+++ b/app/vminsert/relabel/relabel.go
@@ -93,10 +93,12 @@ func (ctx *Ctx) ApplyRelabeling(labels []prompb.Label) []prompb.Label {
 	}
 	// Convert src to prompbmarshal.Label format suitable for relabeling.
 	tmpLabels := ctx.tmpLabels[:0]
+	oriNameEmpty := false
 	for _, label := range labels {
 		name := bytesutil.ToUnsafeString(label.Name)
 		if len(name) == 0 {
 			name = "__name__"
+			oriNameEmpty = true
 		}
 		value := bytesutil.ToUnsafeString(label.Value)
 		tmpLabels = append(tmpLabels, prompbmarshal.Label{
@@ -116,7 +118,7 @@ func (ctx *Ctx) ApplyRelabeling(labels []prompb.Label) []prompb.Label {
 	dst := labels[:0]
 	for _, label := range tmpLabels {
 		name := bytesutil.ToUnsafeBytes(label.Name)
-		if label.Name == "__name__" {
+		if oriNameEmpty && label.Name == "__name__" {
 			name = nil
 		}
 		value := bytesutil.ToUnsafeBytes(label.Value)


### PR DESCRIPTION
The relabel function in vminsert has the following bugs
1. Unmatched labels may also be modified, resulting in a large time complexity, causes the service to be unavailable
2. All labels whose labenName is `__name__` will become null after Relabel, which will cause the selected label to change after Relabel is enabled, resulting in the change of the route selected by the storage. As a result, storage index writes increase, resulting in service write backlog or even crash
