### PR TITLE
Add support for Token authorization scheme in vmauth

### DIFF
--- a/app/vmauth/main.go
+++ b/app/vmauth/main.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httputil"
 	"net/url"
 	"os"
+	"strings"
 	"sync"
 	"time"
 
@@ -71,6 +72,11 @@ func requestHandler(w http.ResponseWriter, r *http.Request) bool {
 		w.Header().Set("WWW-Authenticate", `Basic realm="Restricted"`)
 		http.Error(w, "missing `Authorization` request header", http.StatusUnauthorized)
 		return true
+	}
+	if strings.HasPrefix(authToken, "Token ") {
+		// Handle InfluxDB's proprietary token authentication scheme as a bearer token authentication
+		// See https://docs.influxdata.com/influxdb/v2.0/api/
+		authToken = strings.Replace(authToken, "Token", "Bearer", 1)
 	}
 	ac := authConfig.Load().(map[string]*UserInfo)
 	ui := ac[authToken]


### PR DESCRIPTION
This pull request addresses [issue #1897](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/1897).

Proposed solution is to consider the "Token" scheme equivalent to the "Bearer" scheme and simply replace the string when handling the HTTP request.