### PR TITLE
Fix for issue #2255 - matchTagFilters for positive empty-match filters

### DIFF
--- a/lib/storage/index_db.go
+++ b/lib/storage/index_db.go
@@ -2152,14 +2152,19 @@ func matchTagFilters(mn *MetricName, tfs []*tagFilter, kb *bytesutil.ByteBuffer)
 			tagMatched = true
 			break
 		}
-		if !tagSeen && tf.isNegative && !tf.isEmptyMatch {
+		if !tagSeen && (!tf.isNegative && tf.isEmptyMatch || tf.isNegative && !tf.isEmptyMatch) {
+			// tf contains positive empty-match filter for non-existing tag key
+			//
+			// OR 
+			//
 			// tf contains negative filter for non-exsisting tag key
 			// and this filter doesn't match empty string, i.e. {non_existing_tag_key!="foobar"}
 			// Such filter matches anything.
 			//
 			// Note that the filter `{non_existing_tag_key!~"|foobar"}` shouldn't match anything,
 			// since it is expected that it matches non-empty `non_existing_tag_key`.
-			// See https://github.com/VictoriaMetrics/VictoriaMetrics/issues/546 for details.
+			// See https://github.com/VictoriaMetrics/VictoriaMetrics/issues/546 and 
+			// https://github.com/VictoriaMetrics/VictoriaMetrics/issues/2255 for details.
 			continue
 		}
 		if tagMatched {

--- a/lib/storage/index_db.go
+++ b/lib/storage/index_db.go
@@ -2153,10 +2153,10 @@ func matchTagFilters(mn *MetricName, tfs []*tagFilter, kb *bytesutil.ByteBuffer)
 			break
 		}
 		if !tagSeen && (!tf.isNegative && tf.isEmptyMatch || tf.isNegative && !tf.isEmptyMatch) {
-			// tf contains positive empty-match filter for non-existing tag key, i.e. 
+			// tf contains positive empty-match filter for non-existing tag key, i.e.
 			// {non_existing_tag_key=~"foobar|"}
 			//
-			// OR 
+			// OR
 			//
 			// tf contains negative filter for non-exsisting tag key
 			// and this filter doesn't match empty string, i.e. {non_existing_tag_key!="foobar"}
@@ -2164,7 +2164,7 @@ func matchTagFilters(mn *MetricName, tfs []*tagFilter, kb *bytesutil.ByteBuffer)
 			//
 			// Note that the filter `{non_existing_tag_key!~"|foobar"}` shouldn't match anything,
 			// since it is expected that it matches non-empty `non_existing_tag_key`.
-			// See https://github.com/VictoriaMetrics/VictoriaMetrics/issues/546 and 
+			// See https://github.com/VictoriaMetrics/VictoriaMetrics/issues/546 and
 			// https://github.com/VictoriaMetrics/VictoriaMetrics/issues/2255 for details.
 			continue
 		}

--- a/lib/storage/index_db.go
+++ b/lib/storage/index_db.go
@@ -2153,7 +2153,8 @@ func matchTagFilters(mn *MetricName, tfs []*tagFilter, kb *bytesutil.ByteBuffer)
 			break
 		}
 		if !tagSeen && (!tf.isNegative && tf.isEmptyMatch || tf.isNegative && !tf.isEmptyMatch) {
-			// tf contains positive empty-match filter for non-existing tag key
+			// tf contains positive empty-match filter for non-existing tag key, i.e. 
+			// {non_existing_tag_key=~"foobar|"}
 			//
 			// OR 
 			//

--- a/lib/storage/index_db_test.go
+++ b/lib/storage/index_db_test.go
@@ -1181,10 +1181,10 @@ func TestMatchTagFilters(t *testing.T) {
 	if !ok {
 		t.Fatalf("Should match")
 	}
-	
+
 	// Positive empty match by non-existing tag
 	tfs.Reset()
-	if err := tfs.Add([]byte("non-existing-tag"), []byte("foobar|"), false , true); err != nil {
+	if err := tfs.Add([]byte("non-existing-tag"), []byte("foobar|"), false, true); err != nil {
 		t.Fatalf("cannot add regexp, positive filter: %s", err)
 	}
 	ok, err = matchTagFilters(&mn, toTFPointers(tfs.tfs), &bb)

--- a/lib/storage/index_db_test.go
+++ b/lib/storage/index_db_test.go
@@ -1181,6 +1181,19 @@ func TestMatchTagFilters(t *testing.T) {
 	if !ok {
 		t.Fatalf("Should match")
 	}
+	
+	// Positive empty match by non-existing tag
+	tfs.Reset()
+	if err := tfs.Add([]byte("non-existing-tag"), []byte("foobar|"), false , true); err != nil {
+		t.Fatalf("cannot add regexp, positive filter: %s", err)
+	}
+	ok, err = matchTagFilters(&mn, toTFPointers(tfs.tfs), &bb)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if !ok {
+		t.Fatalf("Should match")
+	}
 
 	// Negative match by non-existing tag
 	tfs.Reset()


### PR DESCRIPTION
Proposed fix for issue #2255 - positive empty-match filters (ex. {non_existing_tag_key=~"foobar|"}) should return samples that do not contain the non_existing_tag_key.