### PR TITLE
fix: change thrashing typo

### DIFF
--- a/lib/writeconcurrencylimiter/concurrencylimiter.go
+++ b/lib/writeconcurrencylimiter/concurrencylimiter.go
@@ -31,7 +31,7 @@ func Init() {
 // Do calls f with the limited concurrency.
 func Do(f func() error) error {
 	// Limit the number of conurrent f calls in order to prevent from excess
-	// memory usage and CPU trashing.
+	// memory usage and CPU thrashing.
 	select {
 	case ch <- struct{}{}:
 		err := f()


### PR DESCRIPTION
I found this typo while reading through VictoriaMetrics's source code. I believe the intent to write "thrashing" here.

Awesome project. Cheers!