### PR TITLE
lib/{bytesutil,fs,storaga,mergset}: removes copy from MustReadAt

### DIFF
--- a/app/vmselect/netstorage/tmp_blocks_file.go
+++ b/app/vmselect/netstorage/tmp_blocks_file.go
@@ -150,7 +150,7 @@ func (tbf *tmpBlocksFile) MustReadBlockRefAt(partRef storage.PartRef, addr tmpBl
 		bb := tmpBufPool.Get()
 		defer tmpBufPool.Put(bb)
 		bb.B = bytesutil.ResizeNoCopyMayOverallocate(bb.B, addr.size)
-		tbf.r.MustReadAt(bb.B, int64(addr.offset))
+		bb.B = tbf.r.MustReadAt(bb.B, int64(addr.offset))
 		buf = bb.B
 	}
 	var br storage.BlockRef

--- a/lib/bytesutil/bytebuffer.go
+++ b/lib/bytesutil/bytebuffer.go
@@ -36,17 +36,24 @@ func (bb *ByteBuffer) Write(p []byte) (int, error) {
 	return len(p), nil
 }
 
-// MustReadAt reads len(p) bytes starting from the given offset.
-func (bb *ByteBuffer) MustReadAt(p []byte, offset int64) {
+// MustReadAt must read len(p) bytes from offset off to p and returns read bytes.
+// Returned slice cannot be modified.
+func (bb *ByteBuffer) MustReadAt(p []byte, offset int64) []byte {
 	if offset < 0 {
 		logger.Panicf("BUG: cannot read at negative offset=%d", offset)
 	}
 	if offset > int64(len(bb.B)) {
 		logger.Panicf("BUG: too big offset=%d; cannot exceed len(bb.B)=%d", offset, len(bb.B))
 	}
-	if n := copy(p, bb.B[offset:]); n < len(p) {
-		logger.Panicf("BUG: EOF occurred after reading %d bytes out of %d bytes at offset %d", n, len(p), offset)
+	dstLen := len(p)
+	p = bb.B[offset:]
+	if dstLen < len(p) {
+		p = p[:dstLen]
 	}
+	if dstLen != len(p) {
+		logger.Panicf("BUG: EOF occurred after reading %d bytes out of %d bytes at offset %d", len(p), dstLen, offset)
+	}
+	return p
 }
 
 // ReadFrom reads all the data from r to bb until EOF.

--- a/lib/bytesutil/bytebuffer_test.go
+++ b/lib/bytesutil/bytebuffer_test.go
@@ -232,7 +232,7 @@ func TestByteBufferMustReadAt(t *testing.T) {
 				t.Fatalf("expecting non-nil error when reading at negative offset")
 			}
 		}()
-		bb.MustReadAt(p, -1)
+		p = bb.MustReadAt(p, -1)
 	}()
 
 	// Try reading past the end of buffer
@@ -242,18 +242,18 @@ func TestByteBufferMustReadAt(t *testing.T) {
 				t.Fatalf("expecting non-nil error when reading past the end of buffer")
 			}
 		}()
-		bb.MustReadAt(p, int64(len(testStr))+1)
+		p = bb.MustReadAt(p, int64(len(testStr))+1)
 	}()
 
 	// Try reading the first byte
 	n := len(p)
-	bb.MustReadAt(p, 0)
+	p = bb.MustReadAt(p, 0)
 	if string(p) != testStr[:n] {
 		t.Fatalf("unexpected value read: %q; want %q", p, testStr[:n])
 	}
 
 	// Try reading the last byte
-	bb.MustReadAt(p, int64(len(testStr))-1)
+	p = bb.MustReadAt(p, int64(len(testStr))-1)
 	if string(p) != testStr[len(testStr)-1:] {
 		t.Fatalf("unexpected value read: %q; want %q", p, testStr[len(testStr)-1:])
 	}
@@ -271,7 +271,7 @@ func TestByteBufferMustReadAt(t *testing.T) {
 
 	// Try reading multiple bytes from the middle
 	p = make([]byte, 3)
-	bb.MustReadAt(p, 2)
+	p = bb.MustReadAt(p, 2)
 	if string(p) != testStr[2:2+len(p)] {
 		t.Fatalf("unexpected value read: %q; want %q", p, testStr[2:2+len(p)])
 	}

--- a/lib/mergeset/part_search.go
+++ b/lib/mergeset/part_search.go
@@ -275,7 +275,7 @@ func (ps *partSearch) nextBHS() error {
 
 func (ps *partSearch) readIndexBlock(mr *metaindexRow) (*indexBlock, error) {
 	ps.compressedIndexBuf = bytesutil.ResizeNoCopyMayOverallocate(ps.compressedIndexBuf, int(mr.indexBlockSize))
-	ps.p.indexFile.MustReadAt(ps.compressedIndexBuf, int64(mr.indexBlockOffset))
+	ps.compressedIndexBuf = ps.p.indexFile.MustReadAt(ps.compressedIndexBuf, int64(mr.indexBlockOffset))
 
 	var err error
 	ps.indexBuf, err = encoding.DecompressZSTD(ps.indexBuf[:0], ps.compressedIndexBuf)
@@ -312,10 +312,10 @@ func (ps *partSearch) readInmemoryBlock(bh *blockHeader) (*inmemoryBlock, error)
 	ps.sb.Reset()
 
 	ps.sb.itemsData = bytesutil.ResizeNoCopyMayOverallocate(ps.sb.itemsData, int(bh.itemsBlockSize))
-	ps.p.itemsFile.MustReadAt(ps.sb.itemsData, int64(bh.itemsBlockOffset))
+	ps.sb.itemsData = ps.p.itemsFile.MustReadAt(ps.sb.itemsData, int64(bh.itemsBlockOffset))
 
 	ps.sb.lensData = bytesutil.ResizeNoCopyMayOverallocate(ps.sb.lensData, int(bh.lensBlockSize))
-	ps.p.lensFile.MustReadAt(ps.sb.lensData, int64(bh.lensBlockOffset))
+	ps.sb.lensData = ps.p.lensFile.MustReadAt(ps.sb.lensData, int64(bh.lensBlockOffset))
 
 	ib := getInmemoryBlock()
 	if err := ib.UnmarshalData(&ps.sb, bh.firstItem, bh.commonPrefix, bh.itemsCount, bh.marshalType); err != nil {

--- a/lib/storage/part_search.go
+++ b/lib/storage/part_search.go
@@ -212,7 +212,7 @@ func skipSmallMetaindexRows(metaindex []metaindexRow, tsid *TSID) []metaindexRow
 
 func (ps *partSearch) readIndexBlock(mr *metaindexRow) (*indexBlock, error) {
 	ps.compressedIndexBuf = bytesutil.ResizeNoCopyMayOverallocate(ps.compressedIndexBuf, int(mr.IndexBlockSize))
-	ps.p.indexFile.MustReadAt(ps.compressedIndexBuf, int64(mr.IndexBlockOffset))
+	ps.compressedIndexBuf = ps.p.indexFile.MustReadAt(ps.compressedIndexBuf, int64(mr.IndexBlockOffset))
 
 	var err error
 	ps.indexBuf, err = encoding.DecompressZSTD(ps.indexBuf[:0], ps.compressedIndexBuf)

--- a/lib/storage/search.go
+++ b/lib/storage/search.go
@@ -76,10 +76,10 @@ func (br *BlockRef) MustReadBlock(dst *Block, fetchData bool) {
 	}
 
 	dst.timestampsData = bytesutil.ResizeNoCopyMayOverallocate(dst.timestampsData, int(br.bh.TimestampsBlockSize))
-	br.p.timestampsFile.MustReadAt(dst.timestampsData, int64(br.bh.TimestampsBlockOffset))
+	dst.timestampsData = br.p.timestampsFile.MustReadAt(dst.timestampsData, int64(br.bh.TimestampsBlockOffset))
 
 	dst.valuesData = bytesutil.ResizeNoCopyMayOverallocate(dst.valuesData, int(br.bh.ValuesBlockSize))
-	br.p.valuesFile.MustReadAt(dst.valuesData, int64(br.bh.ValuesBlockOffset))
+	dst.valuesData = br.p.valuesFile.MustReadAt(dst.valuesData, int64(br.bh.ValuesBlockOffset))
 }
 
 // MetricBlockRef contains reference to time series block for a single metric.


### PR DESCRIPTION
read data directly from mmaped buffer
it should reduce CPU consumption
https://github.com/VictoriaMetrics/VictoriaMetrics/issues/2291