### PR TITLE
Update alpine linux base image to the latest v3.15.2

### DIFF
--- a/deployment/docker/Makefile
+++ b/deployment/docker/Makefile
@@ -2,8 +2,8 @@
 
 DOCKER_NAMESPACE := victoriametrics
 
-ROOT_IMAGE ?= alpine:3.15.0
-CERTS_IMAGE := alpine:3.15.0
+ROOT_IMAGE ?= alpine:3.15.2
+CERTS_IMAGE := alpine:3.15.2
 GO_BUILDER_IMAGE := golang:1.18.0-alpine
 BUILDER_IMAGE := local/builder:2.0.0-$(shell echo $(GO_BUILDER_IMAGE) | tr :/ __)-1
 BASE_IMAGE := local/base:1.1.3-$(shell echo $(ROOT_IMAGE) | tr :/ __)-$(shell echo $(CERTS_IMAGE) | tr :/ __)


### PR DESCRIPTION
Update alpine linux base image to the latest v3.15.2 which has fix for CVE-2022-0778.
See https://alpinelinux.org/posts/Alpine-3.15.2-released.html