### PR TITLE
github/dependabot.yml: disable versions update for vmui

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,7 @@ updates:
     directory: "/app/vmui/packages/vmui/web"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 0
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
@@ -24,3 +25,4 @@ updates:
     directory: "/app/vmui/packages/vmui"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 0


### PR DESCRIPTION
The change disables versions autopupdate for vmui package.
The change has no impact on security updates, which have a separate,
internal limit of ten open pull requests.

See https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#open-pull-requests-limit

Signed-off-by: hagen1778 <roman@victoriametrics.com>