### PR TITLE
Update vmagent.md

### DIFF
--- a/docs/vmagent.md
+++ b/docs/vmagent.md
@@ -945,7 +945,7 @@ See the docs at https://docs.victoriametrics.com/vmagent.html .
      The maximum number of unique series vmagent can send to remote storage systems during the last 24 hours. Excess series are logged and dropped. This can be useful for limiting series churn rate. See https://docs.victoriametrics.com/vmagent.html#cardinality-limiter
   -remoteWrite.maxDiskUsagePerURL size
      The maximum file-based buffer size in bytes at -remoteWrite.tmpDataPath for each -remoteWrite.url. When buffer size reaches the configured maximum, then old data is dropped when adding new data to the buffer. Buffered data is stored in ~500MB chunks, so the minimum practical value for this flag is 500000000. Disk usage is unlimited if the value is set to 0
-     Supports the following optional suffixes for size values: KB, MB, GB, KiB, MiB, GiB (default 0)
+     Supports the following optional suffixes for size values: KB, MB, GB, KiB, MiB, GiB (default 1073741824)
   -remoteWrite.maxHourlySeries int
      The maximum number of unique series vmagent can send to remote storage systems during the last hour. Excess series are logged and dropped. This can be useful for limiting series cardinality. See https://docs.victoriametrics.com/vmagent.html#cardinality-limiter
   -remoteWrite.maxRowsPerBlock int


### PR DESCRIPTION
Actually default value for -remoteWrite.maxDiskUsagePerURL  command-line flag is 1073741824 bytes.
![image](https://user-images.githubusercontent.com/16287353/164966058-06a91f31-08e5-4e65-bd3b-dcd515e6725d.png)
