### PR TITLE
vmui: fix default server path

### DIFF
--- a/app/vmui/packages/vmui/src/utils/default-server-url.ts
+++ b/app/vmui/packages/vmui/src/utils/default-server-url.ts
@@ -1,3 +1,3 @@
 export const getDefaultServer = (): string => {
-  return window.location.href.replace(/\/(?:prometheus\/)?(?:graph|vmui)\/.*/, "/prometheus/");
+  return window.location.href.replace(/\/(?:prometheus\/)?(?:graph|vmui)\/.*/, "/prometheus");
 };


### PR DESCRIPTION
Fixes double slash bug in queries:
`http://example.com/prometheus//api/v1/label/__name__/values`

