### PR TITLE
app/vmctl: fix empty/skipped labels after db label

### DIFF
--- a/app/vmctl/influx.go
+++ b/app/vmctl/influx.go
@@ -120,7 +120,6 @@ func (ip *influxProcessor) do(s *influx.Series) error {
 	for i, lp := range s.LabelPairs {
 		if lp.Name == dbLabel {
 			containsDBLabel = true
-			break
 		}
 		labels[i] = vm.LabelPair{
 			Name:  lp.Name,


### PR DESCRIPTION
Do not assume the db label to be the last one and also
make sure we are not skipping it and everything afterwards.
Breaking the loop would cause following labels to be empty.