### PR TITLE
vmui: prevent reset relative time

### DIFF
--- a/app/vmui/packages/vmui/src/state/common/reducer.ts
+++ b/app/vmui/packages/vmui/src/state/common/reducer.ts
@@ -65,7 +65,7 @@ const query = getQueryArray();
 
 export const initialState: AppState = {
   serverUrl: getDefaultServer(),
-  displayType: getQueryStringValue("g0.tab", "chart") as DisplayType,
+  displayType: getQueryStringValue("g0.tab", "chart") as DisplayType || "chart",
   query: query, // demo_memory_usage_bytes
   queryHistory: query.map(q => ({index: 0, values: [q]})),
   time: {

--- a/app/vmui/packages/vmui/src/utils/time.ts
+++ b/app/vmui/packages/vmui/src/utils/time.ts
@@ -131,13 +131,13 @@ export const relativeTimeOptions: RelativeTimeOption[] = [
   ...o
 }));
 
-export const getRelativeTime = (relativeTimeId?: string) => {
+export const getRelativeTime = ({relativeTimeId, defaultDuration, defaultEndInput}:
+                                  { relativeTimeId?: string, defaultDuration: string, defaultEndInput: Date }) => {
   const id = relativeTimeId || getQueryStringValue("g0.relative_time", "") as string;
   const target = relativeTimeOptions.find(d => d.id === id);
-  if (!target) return {};
   return {
     relativeTimeId: id,
-    relativeDuration: target.duration,
-    relativeUntil: target.until()
+    duration: target ? target.duration : defaultDuration,
+    endInput: target ? target.until() : defaultEndInput
   };
 };


### PR DESCRIPTION
Fixed:
- the selected relative time range is reset to the previous one on the graph when new query is entered.
- when clicking on Prometheus line during graph editing in Grafana, vmui doesn't show the graph until explicit click on the graph tab.

 the issues mentioned [here](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/2402#issuecomment-1115817302) and [here](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/2402#issuecomment-1115830648)