### PR TITLE
app/vmctl: add flag to skip adding the InfluxDB 'db' label

### DIFF
--- a/app/vmctl/flags.go
+++ b/app/vmctl/flags.go
@@ -201,6 +201,7 @@ const (
 	influxFilterTimeStart           = "influx-filter-time-start"
 	influxFilterTimeEnd             = "influx-filter-time-end"
 	influxMeasurementFieldSeparator = "influx-measurement-field-separator"
+	influxSkipDatabaseLabel         = "influx-skip-database-label"
 )
 
 var (
@@ -257,6 +258,11 @@ var (
 			Name:  influxMeasurementFieldSeparator,
 			Usage: "The {separator} symbol used to concatenate {measurement} and {field} names into series name {measurement}{separator}{field}.",
 			Value: "_",
+		},
+		&cli.BoolFlag{
+			Name:  influxSkipDatabaseLabel,
+			Usage: "Wether to skip adding the label 'db' to timeseries.",
+			Value: false,
 		},
 	}
 )

--- a/app/vmctl/influx.go
+++ b/app/vmctl/influx.go
@@ -12,21 +12,23 @@ import (
 )
 
 type influxProcessor struct {
-	ic        *influx.Client
-	im        *vm.Importer
-	cc        int
-	separator string
+	ic          *influx.Client
+	im          *vm.Importer
+	cc          int
+	separator   string
+	skipDbLabel bool
 }
 
-func newInfluxProcessor(ic *influx.Client, im *vm.Importer, cc int, separator string) *influxProcessor {
+func newInfluxProcessor(ic *influx.Client, im *vm.Importer, cc int, separator string, skipDbLabel bool) *influxProcessor {
 	if cc < 1 {
 		cc = 1
 	}
 	return &influxProcessor{
-		ic:        ic,
-		im:        im,
-		cc:        cc,
-		separator: separator,
+		ic:          ic,
+		im:          im,
+		cc:          cc,
+		separator:   separator,
+		skipDbLabel: skipDbLabel,
 	}
 }
 
@@ -126,7 +128,7 @@ func (ip *influxProcessor) do(s *influx.Series) error {
 			Value: lp.Value,
 		}
 	}
-	if !containsDBLabel {
+	if !containsDBLabel && !ip.skipDbLabel {
 		labels = append(labels, vm.LabelPair{
 			Name:  dbLabel,
 			Value: ip.ic.Database(),

--- a/app/vmctl/main.go
+++ b/app/vmctl/main.go
@@ -104,7 +104,8 @@ func main() {
 						influxClient,
 						importer,
 						c.Int(influxConcurrency),
-						c.String(influxMeasurementFieldSeparator))
+						c.String(influxMeasurementFieldSeparator),
+						c.Bool(influxSkipDatabaseLabel))
 					return processor.run(c.Bool(globalSilent), c.Bool(globalVerbose))
 				},
 			},


### PR DESCRIPTION
Make it possible to migrate timeseries without changing labels
at all, including not adding the now optional 'db' label.