### PR TITLE
app/vmctl: add flag to handle Prometheus remote_write to InfluxDB

### DIFF
--- a/app/vmctl/flags.go
+++ b/app/vmctl/flags.go
@@ -202,6 +202,7 @@ const (
 	influxFilterTimeEnd             = "influx-filter-time-end"
 	influxMeasurementFieldSeparator = "influx-measurement-field-separator"
 	influxSkipDatabaseLabel         = "influx-skip-database-label"
+	influxPrometheusMode            = "influx-prometheus-mode"
 )
 
 var (
@@ -262,6 +263,11 @@ var (
 		&cli.BoolFlag{
 			Name:  influxSkipDatabaseLabel,
 			Usage: "Wether to skip adding the label 'db' to timeseries.",
+			Value: false,
+		},
+		&cli.BoolFlag{
+			Name:  influxPrometheusMode,
+			Usage: "Wether to restore the original timeseries name previously written from Prometheus to InfluxDB v1 via remote_write.",
 			Value: false,
 		},
 	}

--- a/app/vmctl/main.go
+++ b/app/vmctl/main.go
@@ -105,7 +105,8 @@ func main() {
 						importer,
 						c.Int(influxConcurrency),
 						c.String(influxMeasurementFieldSeparator),
-						c.Bool(influxSkipDatabaseLabel))
+						c.Bool(influxSkipDatabaseLabel),
+						c.Bool(influxPrometheusMode))
 					return processor.run(c.Bool(globalSilent), c.Bool(globalVerbose))
 				},
 			},


### PR DESCRIPTION
Make it possible to migrate timeseries while restoring the
original timeseries name previously written from Prometheus
to InfluxDB v1 via remote_write.

Fixes: https://github.com/VictoriaMetrics/vmctl/issues/8