### PR TITLE
Bug fix: use "parsedAlertRelabelConfigs" instead of "parsedRelabelConfigs" in AlertManager initialization

### DIFF
--- a/app/vmalert/notifier/config_watcher.go
+++ b/app/vmalert/notifier/config_watcher.go
@@ -166,7 +166,7 @@ func (cw *configWatcher) start() error {
 				if err != nil {
 					return fmt.Errorf("failed to parse labels for target %q: %s", target, err)
 				}
-				notifier, err := NewAlertManager(address, cw.genFn, cw.cfg.HTTPClientConfig, cw.cfg.parsedRelabelConfigs, cw.cfg.Timeout.Duration())
+				notifier, err := NewAlertManager(address, cw.genFn, cw.cfg.HTTPClientConfig, cw.cfg.parsedAlertRelabelConfigs, cw.cfg.Timeout.Duration())
 				if err != nil {
 					return fmt.Errorf("failed to init alertmanager for addr %q: %s", address, err)
 				}


### PR DESCRIPTION
I tried to use `notifier.config` and found that in my case alert relabeling is not working.

`notifier.config`:
```
scheme: "http"
static_configs:
  - targets: ["localhost:5555"]
alert_relabel_configs:
  - action: "replace"
    source_labels: ["__name__"]
    regex: ".*"
    target_label: "some_label"
    replacement: "som_value"
```

It does not work because unlike for `consul_sd_configs` and `dns_sd_configs` for `static_configs` AlertManager initializes with `parsedRelabelConfigs` instead of `parsedAlertRelabelConfigs`.