### PR TITLE
dashboards: use `vm_concurrent_select_current` instead of `vm_concurrent_queries`

### DIFF
--- a/dashboards/victoriametrics.json
+++ b/dashboards/victoriametrics.json
@@ -5630,7 +5630,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(max_over_time(vm_concurrent_queries{job=~\"$job_select\", instance=~\"$instance\"}[1m]))",
+              "expr": "sum(max_over_time(vm_concurrent_select_current{job=~\"$job_select\", instance=~\"$instance\"}[1m]))",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,


### PR DESCRIPTION
Using metric `vm_concurrent_queries` in relation to `vm_concurrent_select_capacity`
is incorrect. Switching to `vm_concurrent_select_current` in `Concurrent selects` panel.

Signed-off-by: hagen1778 <roman@victoriametrics.com>