### PR TITLE
vmagent: update SD duration histogram metric if SD is active

### DIFF
--- a/lib/promscrape/scraper.go
+++ b/lib/promscrape/scraper.go
@@ -256,7 +256,11 @@ func (scfg *scrapeConfig) run(globalStopCh <-chan struct{}) {
 		sws := scfg.getScrapeWork(cfg, swsPrev)
 		sg.update(sws)
 		swsPrev = sws
-		scfg.discoveryDuration.UpdateDuration(startTime)
+		if sg.scrapersStarted.Get() > 0 {
+			// update duration only if at least one scraper has started
+			// otherwise this SD is considered as inactive
+			scfg.discoveryDuration.UpdateDuration(startTime)
+		}
 	}
 	updateScrapeWork(cfg)
 	atomic.AddInt32(&PendingScrapeConfigs, -1)


### PR DESCRIPTION
The change updates histogram for registering SD update duration
only SD is considered as `active`. SD is active if at least
one scraper for this SD has started.

This change supposed to reduce metrics cardinality produced
by duration histogram which gets updated even if SD isn't configured.

See https://github.com/VictoriaMetrics/VictoriaMetrics/issues/2671

Signed-off-by: hagen1778 <roman@victoriametrics.com>