### PR TITLE
Add Content-Encoding Header to remote-write request

### DIFF
--- a/app/vmalert/remotewrite/remotewrite.go
+++ b/app/vmalert/remotewrite/remotewrite.go
@@ -236,6 +236,9 @@ func (c *Client) send(ctx context.Context, data []byte) error {
 	if err != nil {
 		return fmt.Errorf("failed to create new HTTP request: %w", err)
 	}
+
+	req.Header.Set("Content-Encoding", "snappy")
+
 	if c.authCfg != nil {
 		if auth := c.authCfg.GetAuthHeader(); auth != "" {
 			req.Header.Set("Authorization", auth)

--- a/app/vmalert/remotewrite/remotewrite_test.go
+++ b/app/vmalert/remotewrite/remotewrite_test.go
@@ -80,6 +80,12 @@ func (rw *rwServer) handler(w http.ResponseWriter, r *http.Request) {
 		rw.err(w, fmt.Errorf("bad method %q", r.Method))
 		return
 	}
+
+	h := r.Header.Get("Content-Encoding") 
+	if h != "snappy" {
+		rw.err(w, fmt.Errorf("header read error: Content-Encoding is not snappy (%q)", h))
+	}
+
 	data, err := ioutil.ReadAll(r.Body)
 	if err != nil {
 		rw.err(w, fmt.Errorf("body read err: %w", err))


### PR DESCRIPTION
When vmalert does remote-write, the content is compressed with snappy, but the header does not explicitly state this.

I suggest adding Content-Encoding Header to remote-write requests to support proper decoding in server implementation.

References: 
* https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Encoding
* https://datatracker.ietf.org/doc/html/rfc2616#section-14.11