### PR TITLE
Add headers compliant with Prometheus's remote-write format

### DIFF
--- a/app/vmalert/remotewrite/remotewrite.go
+++ b/app/vmalert/remotewrite/remotewrite.go
@@ -237,7 +237,12 @@ func (c *Client) send(ctx context.Context, data []byte) error {
 		return fmt.Errorf("failed to create new HTTP request: %w", err)
 	}
 
+	// RFC standard compliant headers
 	req.Header.Set("Content-Encoding", "snappy")
+	req.Header.Set("Content-Type", "application/x-protobuf")
+
+	// Prometheus compliant headers
+	req.Header.Set("X-Prometheus-Remote-Write-Version", "0.1.0")
 
 	if c.authCfg != nil {
 		if auth := c.authCfg.GetAuthHeader(); auth != "" {

--- a/app/vmalert/remotewrite/remotewrite_test.go
+++ b/app/vmalert/remotewrite/remotewrite_test.go
@@ -86,6 +86,16 @@ func (rw *rwServer) handler(w http.ResponseWriter, r *http.Request) {
 		rw.err(w, fmt.Errorf("header read error: Content-Encoding is not snappy (%q)", h))
 	}
 
+	h = r.Header.Get("Content-Type")
+	if h != "application/x-protobuf" {
+		rw.err(w, fmt.Errorf("header read error: Content-Type is not x-protobuf (%q)", h))
+	}
+
+	h = r.Header.Get("X-Prometheus-Remote-Write-Version")
+	if h != "0.1.0" {
+		rw.err(w, fmt.Errorf("header read error: X-Prometheus-Remote-Write-Version is not 0.1.0 (%q)", h))
+	}
+
 	data, err := ioutil.ReadAll(r.Body)
 	if err != nil {
 		rw.err(w, fmt.Errorf("body read err: %w", err))


### PR DESCRIPTION
* Add `Content-Type` header to vmalert's remote-write request
* Add `X-Prometheus-Remote-Write-Version` to vmalert's remote-write request
* (Out of scope) `User-Agent` would be out of the scope because adding this would require discussion of what information to include in the User-Agent, and the function input could be changed.

Ref:
* https://github.com/VictoriaMetrics/VictoriaMetrics/issues/2686
* https://github.com/VictoriaMetrics/VictoriaMetrics/pull/2685
* https://github1s.com/prometheus/prometheus/blob/HEAD/storage/remote/client.go#L198-L201


