### PR TITLE
vmselect: limit `end` param max value by 2d in future

### DIFF
--- a/app/vmselect/prometheus/prometheus.go
+++ b/app/vmselect/prometheus/prometheus.go
@@ -1109,6 +1109,11 @@ func getCommonParams(r *http.Request, startTime time.Time, requireNonEmptyMatch 
 	if err != nil {
 		return nil, err
 	}
+	now := int64(fasttime.UnixTimestamp() * 1000)
+	maxTS := now + 2*24*3600*1000 // allow max +2 days from now
+	if end > maxTS {
+		end = maxTS
+	}
 	if end < start {
 		end = start
 	}


### PR DESCRIPTION
The change is applied only to service handlers like `/labels` or `/series`
and limits the `end` param by max value <= now() + 2 days. The same limit
is applied for the ingested data, so no reason to allow to request data
in future far than that.

The change is also needed for corner cases like https://github.com/VictoriaMetrics/VictoriaMetrics/issues/2669
where too high `end` value triggers inefficient global index search.

Signed-off-by: hagen1778 <roman@victoriametrics.com>