### PR TITLE
Changed the level type in alerts.yml for TooManyLogs alert

### DIFF
--- a/deployment/docker/alerts.yml
+++ b/deployment/docker/alerts.yml
@@ -125,7 +125,7 @@ groups:
             When VictoriaMetrics constantly hits the limit it means that storage is overloaded and requires more CPU."
 
       - alert: TooManyLogs
-        expr: sum(increase(vm_log_messages_total{level!="info"}[5m])) by (job, instance) > 0
+        expr: sum(increase(vm_log_messages_total{level!="error"}[5m])) by (job, instance) > 0
         for: 15m
         labels:
           severity: warning

--- a/deployment/docker/alerts.yml
+++ b/deployment/docker/alerts.yml
@@ -125,7 +125,7 @@ groups:
             When VictoriaMetrics constantly hits the limit it means that storage is overloaded and requires more CPU."
 
       - alert: TooManyLogs
-        expr: sum(increase(vm_log_messages_total{level!="error"}[5m])) by (job, instance) > 0
+        expr: sum(increase(vm_log_messages_total{level="error"}[5m])) by (job, instance) > 0
         for: 15m
         labels:
           severity: warning


### PR DESCRIPTION
{level!="info"} - can lead to some unnecessary spam in case of slow queries.
{level="error"} - will alert only on  "error"