### PR TITLE
Error reporting

### DIFF
--- a/app/vmselect/prometheus/prometheus.go
+++ b/app/vmselect/prometheus/prometheus.go
@@ -886,7 +886,6 @@ func queryRangeHandler(qt *querytracer.Tracer, startTime time.Time, w http.Respo
 	}
 	result, err := promql.Exec(qt, &ec, query, false)
 	if err != nil {
-		err = fmt.Errorf("cannot execute query: %w", err)
 		return errWithContext(err, "-search.maxUniqueTimeseries")
 	}
 	if step < maxStepForPointsAdjustment.Milliseconds() {

--- a/lib/storage/errors.go
+++ b/lib/storage/errors.go
@@ -1,0 +1,11 @@
+package storage
+
+import (
+	"errors"
+	"fmt"
+)
+
+const FlagSeriesLimit = "-search.max*"
+
+var ErrSeriesLimit = errors.New(fmt.Sprintf("either narrow down the search or increase %s command-line "+
+	"flag values at vmselect; see https://docs.victoriametrics.com/#resource-usage-limits", FlagSeriesLimit))

--- a/lib/storage/errors.go
+++ b/lib/storage/errors.go
@@ -1,11 +1,10 @@
 package storage
 
 import (
-	"errors"
 	"fmt"
 )
 
 const FlagSeriesLimit = "-search.max*"
 
-var ErrSeriesLimit = errors.New(fmt.Sprintf("either narrow down the search or increase %s command-line "+
-	"flag values at vmselect; see https://docs.victoriametrics.com/#resource-usage-limits", FlagSeriesLimit))
+var ErrSeriesLimit = fmt.Errorf("either narrow down the search or increase %s command-line "+
+	"flag values at vmselect; see https://docs.victoriametrics.com/#resource-usage-limits", FlagSeriesLimit)

--- a/lib/storage/errors.go
+++ b/lib/storage/errors.go
@@ -4,7 +4,10 @@ import (
 	"fmt"
 )
 
+// FlagSeriesLimit contains a name of the flag name placeholder
+// for search limits reaching errors
 const FlagSeriesLimit = "-search.max*"
 
+// ErrSeriesLimit is a generic error for cases when search limit is reached
 var ErrSeriesLimit = fmt.Errorf("either narrow down the search or increase %s command-line "+
 	"flag values at vmselect; see https://docs.victoriametrics.com/#resource-usage-limits", FlagSeriesLimit)

--- a/lib/storage/index_db.go
+++ b/lib/storage/index_db.go
@@ -2217,8 +2217,7 @@ func (is *indexSearch) searchMetricIDsInternal(qt *querytracer.Tracer, tfss []*T
 			return nil, err
 		}
 		if metricIDs.Len() > maxMetrics {
-			return nil, fmt.Errorf("the number of matching timeseries exceeds %d; either narrow down the search "+
-				"or increase -search.max* command-line flag values at vmselect; see https://docs.victoriametrics.com/#resource-usage-limits", maxMetrics)
+			return nil, fmt.Errorf("the number of matching timeseries exceeds %d; %w", maxMetrics, ErrSeriesLimit)
 		}
 	}
 	return metricIDs, nil
@@ -2240,8 +2239,7 @@ func (is *indexSearch) updateMetricIDsForTagFilters(qt *querytracer.Tracer, metr
 	m, err := is.getMetricIDsForDateAndFilters(qt, 0, tfs, maxMetrics)
 	if err != nil {
 		if errors.Is(err, errFallbackToGlobalSearch) {
-			return fmt.Errorf("the number of matching timeseries exceeds %d; either narrow down the search "+
-				"or increase -search.max* command-line flag values at vmselect", maxMetrics)
+			return fmt.Errorf("the number of matching timeseries exceeds %d; %w", maxMetrics, ErrSeriesLimit)
 		}
 		return err
 	}


### PR DESCRIPTION
Changes 
```
error when executing query="up" on the time range (start=1653374261103, end=1655966261103, step=8100000): 
  cannot execute query: 
    cannot evaluate "up": 
      search error after reading 0 data blocks: 
        error when searching for tagFilters=[{__name__="up"}] on the time range [1653365861103..1655966261103]: 
          error when searching tsids: 
            the number of matching timeseries exceeds 2; either narrow down the search or increase -search.max* command-line flag values at vmselect
```

to

```
error when executing query="up" on the time range (start=1653374170842, end=1655966170842, step=8100000): 
  cannot evaluate "up": 
    search error after reading 0 data blocks: 
      error when searching for tagFilters=[{__name__="up"}] on the time range [1653365770842..1655966170842]: 
        error when searching tsids: 
          the number of matching timeseries exceeds 2; either narrow down the search or increase -search.maxUniqueTimeseries command-line flag values at vmselect; see https://docs.victoriametrics.com/#resource-usage-limits
```