### PR TITLE
vmalert: use absolute path for assets

### DIFF
--- a/app/vmalert/tpl/footer.qtpl
+++ b/app/vmalert/tpl/footer.qtpl
@@ -1,7 +1,7 @@
 {% func Footer() %}
         </main>
-        <script src="static/js/jquery-3.6.0.min.js" type="text/javascript"></script>
-        <script src="static/js/bootstrap.bundle.min.js" type="text/javascript"></script>
+        <script src="/static/js/jquery-3.6.0.min.js" type="text/javascript"></script>
+        <script src="/static/js/bootstrap.bundle.min.js" type="text/javascript"></script>
         <script type="text/javascript">
             function expandAll() {
                $('.collapse').addClass('show');

--- a/app/vmalert/tpl/footer.qtpl.go
+++ b/app/vmalert/tpl/footer.qtpl.go
@@ -22,8 +22,8 @@ func StreamFooter(qw422016 *qt422016.Writer) {
 //line app/vmalert/tpl/footer.qtpl:1
 	qw422016.N().S(`
         </main>
-        <script src="static/js/jquery-3.6.0.min.js" type="text/javascript"></script>
-        <script src="static/js/bootstrap.bundle.min.js" type="text/javascript"></script>
+        <script src="/static/js/jquery-3.6.0.min.js" type="text/javascript"></script>
+        <script src="/static/js/bootstrap.bundle.min.js" type="text/javascript"></script>
         <script type="text/javascript">
             function expandAll() {
                $('.collapse').addClass('show');

--- a/app/vmalert/tpl/header.qtpl
+++ b/app/vmalert/tpl/header.qtpl
@@ -3,7 +3,7 @@
 <html lang="en">
 <head>
     <title>vmalert{% if title != "" %} - {%s title %}{% endif %}</title>
-    <link href="static/css/bootstrap.min.css" rel="stylesheet" />
+    <link href="/static/css/bootstrap.min.css" rel="stylesheet" />
     <style>
         body{
           min-height: 75rem;

--- a/app/vmalert/tpl/header.qtpl.go
+++ b/app/vmalert/tpl/header.qtpl.go
@@ -35,7 +35,7 @@ func StreamHeader(qw422016 *qt422016.Writer, title string, pages []NavItem) {
 	}
 //line app/vmalert/tpl/header.qtpl:5
 	qw422016.N().S(`</title>
-    <link href="static/css/bootstrap.min.css" rel="stylesheet" />
+    <link href="/static/css/bootstrap.min.css" rel="stylesheet" />
     <style>
         body{
           min-height: 75rem;


### PR DESCRIPTION
Using relative path breaks assets loading on alert view page.

Signed-off-by: hagen1778 <roman@victoriametrics.com>

<img width="814" alt="image" src="https://user-images.githubusercontent.com/2902918/175547559-cd812dd6-ea0c-4d9c-a074-e167d38ddb13.png">


