### PR TITLE
lib/promscrape: fix vmagent tickerCh reload behaviour

### DIFF
--- a/lib/promscrape/scraper.go
+++ b/lib/promscrape/scraper.go
@@ -163,6 +163,7 @@ func runScraper(configFile string, pushData func(wr *prompbmarshal.WriteRequest)
 			cfgNew.mustRestart(cfg)
 			cfg = cfgNew
 			data = dataNew
+			marshaledData = cfgNew.marshal()
 			configData.Store(&marshaledData)
 		case <-globalStopCh:
 			cfg.mustStop()


### PR DESCRIPTION
I faced the issue with vmagent -promscrape.configCheckInterval option - its not working, at least with scrape_configs config part - any changes at relabel_configs or job addition\removal not loaded into runtime config, but in log i see messages that config was updated successfully

i tested locally and this fix works for me, now config really updates

commit that brings this bug cbfc7b7c924c5ebfa28fa1ffaa368b74cc105618
vmagent working version v1.68.0, broken since v1.69.0

