### PR TITLE
lib/vmselectapi: update query complexity metrics

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -33,6 +33,7 @@ scrape_configs:
 ```
 
 * FEATURE: [query tracing](https://docs.victoriametrics.com/Single-server-VictoriaMetrics.html#query-tracing): show timestamps in query traces in human-readable format (aka `RFC3339` in UTC timezone) instead of milliseconds since Unix epoch. For example, `2022-06-27T10:32:54.506Z` instead of `1656325974506`.
+* FEATURE: [VictoriaMetrics cluster](https://docs.victoriametrics.com/Cluster-VictoriaMetrics.html): add histogram metrics `vm_vmselect_series_per_query` and `vm_vmselect_samples_per_series` for estimating query complexity. 
 
 * BUGFIX: [vmalert](https://docs.victoriametrics.com/vmalert.html): allow using `__name__` label (aka [metric name](https://prometheus.io/docs/prometheus/latest/querying/basics/#time-series-selectors)) in alerting annotations. For example `{{ $labels.__name__ }}: Too high connection number for "{{ $labels.instance }}`.
 * BUGFIX: limit max memory occupied by the cache, which stores parsed regular expressions. Previously too long regular expressions passed in [MetricsQL queries](https://docs.victoriametrics.com/MetricsQL.html) could result in big amounts of used memory (e.g. multiple of gigabytes). Now the max cache size for parsed regexps is limited to a a few megabytes.


### PR DESCRIPTION
Add two new histogram metrics:
* vm_vmselect_series_per_query - for registering number of series read per query;
* vm_vmselect_samples_per_series - for registering number of samples read per series.

These histgorams can be used for estimating peak memory usage by vmstorage and vmselect.
For example, the following query will give estimation of how many series read per query at max:
```
histogram_quantile(0.99, sum(rate(vm_vmselect_series_per_query[5m])) by (vmrange))
```

Metric `vm_vmselect_metric_rows_read_total` was removed in a favor of
`vm_vmselect_samples_per_series`.

Signed-off-by: hagen1778 <roman@victoriametrics.com>