### PR TITLE
vmalert: deprecate `/api/v1/groupID/alertID/status` link

### DIFF
--- a/app/vmalert/README.md
+++ b/app/vmalert/README.md
@@ -477,7 +477,8 @@ or time series modification via [relabeling](https://docs.victoriametrics.com/vm
 * `http://<vmalert-addr>` - UI;
 * `http://<vmalert-addr>/api/v1/rules` - list of all loaded groups and rules;
 * `http://<vmalert-addr>/api/v1/alerts` - list of all active alerts;
-* `http://<vmalert-addr>/api/v1/<groupID>/<alertID>/status"` - get alert status by ID.
+* `/api/v1/groupID/alertID/status` - [DEPRECATED]: use `api/v1/alert/status` instead. Get alert status by ID;
+* `/api/v1/alert/status?group_id=<int>&alert_id=<int>` - get alert status by passing `group_id` and `alert_id` GET params.
   Used as alert source in AlertManager.
 * `http://<vmalert-addr>/metrics` - application metrics.
 * `http://<vmalert-addr>/-/reload` - hot configuration reload.

--- a/app/vmalert/main.go
+++ b/app/vmalert/main.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net/url"
 	"os"
-	"strconv"
 	"strings"
 	"time"
 
@@ -237,7 +236,8 @@ func getExternalURL(externalURL, httpListenAddr string, isSecure bool) (*url.URL
 func getAlertURLGenerator(externalURL *url.URL, externalAlertSource string, validateTemplate bool) (notifier.AlertURLGenerator, error) {
 	if externalAlertSource == "" {
 		return func(alert notifier.Alert) string {
-			return fmt.Sprintf("%s/api/v1/%s/%s/status", externalURL, strconv.FormatUint(alert.GroupID, 10), strconv.FormatUint(alert.ID, 10))
+			return fmt.Sprintf("%s/api/v1/alert/status?%s=%d&%s=%d",
+				externalURL, paramGroupID, alert.GroupID, paramAlertID, alert.ID)
 		}, nil
 	}
 	if validateTemplate {

--- a/app/vmalert/main_test.go
+++ b/app/vmalert/main_test.go
@@ -41,7 +41,9 @@ func TestGetAlertURLGenerator(t *testing.T) {
 	if err != nil {
 		t.Errorf("unexpected error %s", err)
 	}
-	if exp := "https://victoriametrics.com/path/api/v1/42/2/status"; exp != fn(testAlert) {
+	exp := fmt.Sprintf("https://victoriametrics.com/path/api/v1/alert/status?%s=%d&%s=%d",
+		paramGroupID, testAlert.GroupID, paramAlertID, testAlert.ID)
+	if exp != fn(testAlert) {
 		t.Errorf("unexpected url want %s, got %s", exp, fn(testAlert))
 	}
 	_, err = getAlertURLGenerator(nil, "foo?{{invalid}}", true)

--- a/app/vmalert/web.qtpl
+++ b/app/vmalert/web.qtpl
@@ -182,7 +182,7 @@
                                 </td>
                                 <td>{%s ar.Value %}</td>
                                 <td>
-                                    <a href="{%s path.Join(pathPrefix, g.ID, ar.ID, "status") %}">Details</a>
+                                    <a href="{%s path.Join(pathPrefix, ar.WebLink()) %}">Details</a>
                                 </td>
                             </tr>
                         {% endfor %}

--- a/app/vmalert/web.qtpl.go
+++ b/app/vmalert/web.qtpl.go
@@ -618,7 +618,7 @@ func StreamListAlerts(qw422016 *qt422016.Writer, pathPrefix string, groupAlerts 
                                 <td>
                                     <a href="`)
 //line app/vmalert/web.qtpl:185
-					qw422016.E().S(path.Join(pathPrefix, g.ID, ar.ID, "status"))
+					qw422016.E().S(path.Join(pathPrefix, ar.WebLink()))
 //line app/vmalert/web.qtpl:185
 					qw422016.N().S(`">Details</a>
                                 </td>

--- a/app/vmalert/web_test.go
+++ b/app/vmalert/web_test.go
@@ -61,19 +61,19 @@ func TestHandler(t *testing.T) {
 			t.Errorf("expected 1 group got %d", length)
 		}
 	})
-	t.Run("/api/v1/0/0/status", func(t *testing.T) {
+	t.Run("/api/v1/alert/status?group_id=0&alert_id=0", func(t *testing.T) {
 		alert := &APIAlert{}
-		getResp(ts.URL+"/api/v1/0/0/status", alert, 200)
+		getResp(ts.URL+"/api/v1/alert/status?group_id=0&alert_id=0", alert, 200)
 		expAlert := ar.newAlertAPI(*ar.alerts[0])
 		if !reflect.DeepEqual(alert, expAlert) {
 			t.Errorf("expected %v is equal to %v", alert, expAlert)
 		}
 	})
-	t.Run("/api/v1/0/1/status", func(t *testing.T) {
-		getResp(ts.URL+"/api/v1/0/1/status", nil, 404)
+	t.Run("/api/v1/alert/status?group_id=0&alert_id=1", func(t *testing.T) {
+		getResp(ts.URL+"/api/v1/alert/status?group_id=0&alert_id=1", nil, 404)
 	})
-	t.Run("/api/v1/1/0/status", func(t *testing.T) {
-		getResp(ts.URL+"/api/v1/1/0/status", nil, 404)
+	t.Run("/api/v1/alert/status?group_id=1&alert_id=0", func(t *testing.T) {
+		getResp(ts.URL+"/api/v1/alert/status?group_id=1&alert_id=0", nil, 404)
 	})
 	t.Run("/", func(t *testing.T) {
 		getResp(ts.URL, nil, 200)

--- a/app/vmalert/web_types.go
+++ b/app/vmalert/web_types.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"time"
 )
 
@@ -31,6 +32,12 @@ type APIAlert struct {
 	SourceLink string `json:"source"`
 	// Restored shows whether Alert's state was restored on restart
 	Restored bool `json:"restored"`
+}
+
+// WebLink returns a link to the alert which can be used in UI.
+func (aa *APIAlert) WebLink() string {
+	return fmt.Sprintf("/alert/status?%s=%s&%s=%s",
+		paramGroupID, aa.GroupID, paramAlertID, aa.ID)
 }
 
 // APIGroup represents Group for WEB view

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -41,6 +41,10 @@ scrape_configs:
   * `vm_rows_read_per_series` - the number of raw samples read per queried series.
   * `vm_series_read_per_query` - the number of series read per query.
 
+* CHANGE: [vmalert](https://docs.victoriametrics.com/vmalert.html): deprecate link format `/api/v1/groupID/alertID/status` for accessing alert's state.
+  The new link format `/api/v1/alert/status?group_id=<int>&alert_id=<int>` will be used instead. The deprecated format
+  will be supported for a limited time until complete removal.
+
 * BUGFIX: [vmalert](https://docs.victoriametrics.com/vmalert.html): allow using `__name__` label (aka [metric name](https://prometheus.io/docs/prometheus/latest/querying/basics/#time-series-selectors)) in alerting annotations. For example:
 
 {% raw %}
@@ -54,6 +58,7 @@ scrape_configs:
 * BUGFIX: [vmagent](https://docs.victoriametrics.com/vmagent.html): properly reload changed `-promscrape.config` file when `-promscrape.configCheckInterval` option is set. The changed config file wasn't reloaded in this case since [v1.69.0](#v1690). See [this pull request](https://github.com/VictoriaMetrics/VictoriaMetrics/pull/2786). Thanks to @ttyv for the fix.
 * BUGFIX: [VictoriaMetrics cluster](https://docs.victoriametrics.com/Cluster-VictoriaMetrics.html): assume that the response is complete if `-search.denyPartialResponse` is enabled and up to `-replicationFactor - 1` `vmstorage` nodes are unavailable. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/1767).
 * BUGFIX: [vmselect](https://docs.victoriametrics.com/#vmselect): update `vm_partial_results_total` metric labels to be consistent with `vm_requests_total` labels.
+* BUGFIX: [vmalert](https://docs.victoriametrics.com/#vmselect): allow accessing all vmalert's pages via vmselect when `-vmalert.proxyURL` is configured.
 
 ## [v1.78.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.78.0)
 

--- a/docs/vmalert.md
+++ b/docs/vmalert.md
@@ -481,7 +481,8 @@ or time series modification via [relabeling](https://docs.victoriametrics.com/vm
 * `http://<vmalert-addr>` - UI;
 * `http://<vmalert-addr>/api/v1/rules` - list of all loaded groups and rules;
 * `http://<vmalert-addr>/api/v1/alerts` - list of all active alerts;
-* `http://<vmalert-addr>/api/v1/<groupID>/<alertID>/status"` - get alert status by ID.
+* `/api/v1/groupID/alertID/status` - [DEPRECATED]: use `api/v1/alert/status` instead. Get alert status by ID;
+* `/api/v1/alert/status?group_id=<int>&alert_id=<int>` - get alert status by passing `group_id` and `alert_id` GET params.
   Used as alert source in AlertManager.
 * `http://<vmalert-addr>/metrics` - application metrics.
 * `http://<vmalert-addr>/-/reload` - hot configuration reload.


### PR DESCRIPTION
Having alert status link `/api/v1/groupID/alertID/status` was a mistake.
It makes it harder to understand and manage. For example, this link
wasn't suitable for proxying requests from VictoriaMetrics to vmalert.

This commit introduces new link format `/api/v1/alert/status?group_id=<int>&alert_id=<int>`
and deprecates the old one.

With this change, it is now possible to proxy all requests from VictoriaMetrics
to vmalert when `-vmalert.proxyURL` is configured, including all UI pages of vmalert.

Signed-off-by: hagen1778 <roman@victoriametrics.com>