### PR TITLE
app/vminsert: allow to ingest datadog metrics with simpler tags - not enforcing key:value

### DIFF
--- a/app/vminsert/datadog/request_handler.go
+++ b/app/vminsert/datadog/request_handler.go
@@ -58,11 +58,14 @@ func insertRows(series []parser.Series, extraLabels []prompbmarshal.Label) error
 		ctx.AddLabel("host", ss.Host)
 		for _, tag := range ss.Tags {
 			n := strings.IndexByte(tag, ':')
+			var name, value string
 			if n < 0 {
-				return fmt.Errorf("cannot find ':' in tag %q", tag)
+				name = tag
+				value = "no_label_value"
+			} else {
+				name = tag[:n]
+				value = tag[n+1:]
 			}
-			name := tag[:n]
-			value := tag[n+1:]
 			if name == "host" {
 				name = "exported_host"
 			}


### PR DESCRIPTION
While in most cases Datadog tags are defined with the `KEY:VALUE` format, that is not always the case.
As per the [Datadog documentation](https://docs.datadoghq.com/getting_started/tagging/#define-tags)
> 4. A tag can be in the format **value** or **\<KEY\>:\<VALUE\>**.

In the case of Datadog shipping metrics with tags outside of the `KEY:VALUE` format, this new code creates a key/pair where the `key` is the actual tag being sent and the `value` is `no_label_value`

I'm unsure if the value `no_label_value` is any good. Maybe an empty string or the string `null` would be better? Anyhow, I'm not so much interested in the value of the label, but I'm more interested that the label is actually added.