### PR TITLE
vmselect: cover special cases for vmalert's routing in cluster version

### DIFF
--- a/app/vmselect/main.go
+++ b/app/vmselect/main.go
@@ -343,6 +343,7 @@ func selectHandler(qt *querytracer.Tracer, startTime time.Time, w http.ResponseW
 
 	if p.Suffix == "prometheus/vmalert" {
 		http.Redirect(w, r, r.URL.Path+"/", http.StatusMovedPermanently)
+		return true
 	}
 	if strings.HasPrefix(p.Suffix, "prometheus/vmalert/") {
 		vmalertRequests.Inc()

--- a/app/vmselect/main.go
+++ b/app/vmselect/main.go
@@ -341,19 +341,10 @@ func selectHandler(qt *querytracer.Tracer, startTime time.Time, w http.ResponseW
 		return true
 	}
 
-	if strings.HasPrefix(p.Suffix, "prometheus/vmalert") {
-		if strings.HasSuffix(p.Suffix, "/") {
-			newURL := strings.TrimSuffix(r.URL.Path, "/")
-			http.Redirect(w, r, newURL, http.StatusFound)
-			return true
-		}
-		// redirect to default home page
-		if strings.HasSuffix(p.Suffix, "/vmalert") {
-			newURL := r.URL.Path + "/home"
-			http.Redirect(w, r, newURL, http.StatusFound)
-			return true
-		}
-
+	if p.Suffix == "prometheus/vmalert" {
+		http.Redirect(w, r, r.URL.Path+"/", http.StatusMovedPermanently)
+	}
+	if strings.HasPrefix(p.Suffix, "prometheus/vmalert/") {
 		vmalertRequests.Inc()
 		if len(*vmalertProxyURL) == 0 {
 			w.WriteHeader(http.StatusBadRequest)

--- a/app/vmselect/main.go
+++ b/app/vmselect/main.go
@@ -342,6 +342,18 @@ func selectHandler(qt *querytracer.Tracer, startTime time.Time, w http.ResponseW
 	}
 
 	if strings.HasPrefix(p.Suffix, "prometheus/vmalert") {
+		if strings.HasSuffix(p.Suffix, "/") {
+			newURL := strings.TrimSuffix(r.URL.Path, "/")
+			http.Redirect(w, r, newURL, http.StatusFound)
+			return true
+		}
+		// redirect to default home page
+		if strings.HasSuffix(p.Suffix, "/vmalert") {
+			newURL := r.URL.Path + "/home"
+			http.Redirect(w, r, newURL, http.StatusFound)
+			return true
+		}
+
 		vmalertRequests.Inc()
 		if len(*vmalertProxyURL) == 0 {
 			w.WriteHeader(http.StatusBadRequest)


### PR DESCRIPTION
* remove trailing `/` from requests
* redirect to vmalert's home page when `/vmalert` is requested.

Signed-off-by: hagen1778 <roman@victoriametrics.com>