### PR TITLE
vmselect: cover special cases for vmalert's routing in single-node version

### DIFF
--- a/app/vmalert/web.go
+++ b/app/vmalert/web.go
@@ -37,7 +37,7 @@ func initLinks() {
 		{"/-/reload", "reload configuration"},
 	}
 	navItems = []tpl.NavItem{
-		{Name: "vmalert", Url: "home"},
+		{Name: "vmalert", Url: "."},
 		{Name: "Groups", Url: "groups"},
 		{Name: "Alerts", Url: "alerts"},
 		{Name: "Notifiers", Url: "notifiers"},
@@ -67,8 +67,9 @@ func (rh *requestHandler) handler(w http.ResponseWriter, r *http.Request) bool {
 	}
 
 	switch r.URL.Path {
-	case "/", "/vmalert", "/vmalert/home":
+	case "/", "/vmalert", "/vmalert/":
 		if r.Method != "GET" {
+			httpserver.Errorf(w, r, "path %q supports only GET method", r.URL.Path)
 			return false
 		}
 		WriteWelcome(w, r)
@@ -146,6 +147,7 @@ func (rh *requestHandler) handler(w http.ResponseWriter, r *http.Request) bool {
 		// TODO: to remove in next versions
 
 		if !strings.HasSuffix(r.URL.Path, "/status") {
+			httpserver.Errorf(w, r, "unsupported path requested: %q ", r.URL.Path)
 			return false
 		}
 		alert, err := rh.alertByPath(strings.TrimPrefix(r.URL.Path, "/api/v1/"))

--- a/app/vmalert/web_test.go
+++ b/app/vmalert/web_test.go
@@ -52,7 +52,6 @@ func TestHandler(t *testing.T) {
 	t.Run("/", func(t *testing.T) {
 		getResp(ts.URL, nil, 200)
 		getResp(ts.URL+"/vmalert", nil, 200)
-		getResp(ts.URL+"/vmalert/home", nil, 200)
 	})
 
 	t.Run("/api/v1/alerts", func(t *testing.T) {

--- a/app/vmselect/main.go
+++ b/app/vmselect/main.go
@@ -214,6 +214,7 @@ func RequestHandler(w http.ResponseWriter, r *http.Request) bool {
 
 	if path == "/vmalert" {
 		http.Redirect(w, r, path+"/", http.StatusMovedPermanently)
+		return true
 	}
 	if strings.HasPrefix(path, "/vmalert/") {
 		vmalertRequests.Inc()

--- a/app/vmselect/main.go
+++ b/app/vmselect/main.go
@@ -213,6 +213,18 @@ func RequestHandler(w http.ResponseWriter, r *http.Request) bool {
 	}
 
 	if strings.HasPrefix(path, "/vmalert") {
+		if strings.HasSuffix(path, "/") {
+			newURL := strings.TrimSuffix(path, "/")
+			http.Redirect(w, r, newURL, http.StatusFound)
+			return true
+		}
+		// redirect to default home page
+		if strings.HasSuffix(path, "/vmalert") {
+			newURL := path + "/home"
+			http.Redirect(w, r, newURL, http.StatusFound)
+			return true
+		}
+
 		vmalertRequests.Inc()
 		if len(*vmalertProxyURL) == 0 {
 			w.WriteHeader(http.StatusBadRequest)

--- a/app/vmselect/main.go
+++ b/app/vmselect/main.go
@@ -212,19 +212,10 @@ func RequestHandler(w http.ResponseWriter, r *http.Request) bool {
 		return true
 	}
 
-	if strings.HasPrefix(path, "/vmalert") {
-		if strings.HasSuffix(path, "/") {
-			newURL := strings.TrimSuffix(path, "/")
-			http.Redirect(w, r, newURL, http.StatusFound)
-			return true
-		}
-		// redirect to default home page
-		if strings.HasSuffix(path, "/vmalert") {
-			newURL := path + "/home"
-			http.Redirect(w, r, newURL, http.StatusFound)
-			return true
-		}
-
+	if path == "/vmalert" {
+		http.Redirect(w, r, path+"/", http.StatusMovedPermanently)
+	}
+	if strings.HasPrefix(path, "/vmalert/") {
 		vmalertRequests.Inc()
 		if len(*vmalertProxyURL) == 0 {
 			w.WriteHeader(http.StatusBadRequest)


### PR DESCRIPTION
* remove trailing `/` from requests
* redirect to vmalert's home page when `/vmalert` is requested.

Signed-off-by: hagen1778 <roman@victoriametrics.com>