### PR TITLE
vmui: fix query for json and table tabs

### DIFF
--- a/app/vmui/packages/vmui/src/api/query-range.ts
+++ b/app/vmui/packages/vmui/src/api/query-range.ts
@@ -4,6 +4,6 @@ export const getQueryRangeUrl = (server: string, query: string, period: TimePara
   `${server}/api/v1/query_range?query=${encodeURIComponent(query)}&start=${period.start}&end=${period.end}&step=${period.step}${nocache ? "&nocache=1" : ""}${queryTracing ? "&trace=1" : ""}`;
 
 export const getQueryUrl = (server: string, query: string, period: TimeParams, queryTracing: boolean): string =>
-  `${server}/api/v1/query?query=${encodeURIComponent(query)}&time=${period.end}${queryTracing ? "&trace=1" : ""}`;
+  `${server}/api/v1/query?query=${encodeURIComponent(query)}&time=${period.end}&step=${period.step}${queryTracing ? "&trace=1" : ""}`;
 
 export const getQueryOptions = (server: string) => `${server}/api/v1/label/__name__/values`;

--- a/app/vmui/packages/vmui/src/api/query-range.ts
+++ b/app/vmui/packages/vmui/src/api/query-range.ts
@@ -4,6 +4,6 @@ export const getQueryRangeUrl = (server: string, query: string, period: TimePara
   `${server}/api/v1/query_range?query=${encodeURIComponent(query)}&start=${period.start}&end=${period.end}&step=${period.step}${nocache ? "&nocache=1" : ""}${queryTracing ? "&trace=1" : ""}`;
 
 export const getQueryUrl = (server: string, query: string, period: TimeParams, queryTracing: boolean): string =>
-  `${server}/api/v1/query?query=${encodeURIComponent(query)}&start=${period.start}&end=${period.end}&step=${period.step}${queryTracing ? "&trace=1" : ""}`;
+  `${server}/api/v1/query?query=${encodeURIComponent(query)}&time=${period.end}${queryTracing ? "&trace=1" : ""}`;
 
 export const getQueryOptions = (server: string) => `${server}/api/v1/label/__name__/values`;


### PR DESCRIPTION
Update query for ```JSON``` and ```Table``` tabs. This fix will use instant query like it described in
https://prometheus.io/docs/prometheus/latest/querying/api/#instant-queries

Related issue:
https://github.com/VictoriaMetrics/VictoriaMetrics/issues/2781

Signed-off-by: dmitryk-dk [d.kozlov@victoriametrics.com](mailto:d.kozlov@victoriametrics.com)