### PR TITLE
alerts: correct expression for `DiskRunsOutOfSpaceIn3Days`

### DIFF
--- a/deployment/docker/alerts.yml
+++ b/deployment/docker/alerts.yml
@@ -72,7 +72,7 @@ groups:
               sum(vm_data_size_bytes{type!="indexdb"}) /
               sum(vm_rows{type!="indexdb"})
              )
-          ) < 3 * 24 * 3600
+          ) < 3 * 24 * 3600 > 0
         for: 30m
         labels:
           severity: critical


### PR DESCRIPTION
The negative value for ETA can happen when deduplication is enabled
and `rate` over `vm_deduplicated_samples_total` becomes bigger
than actual ingestion rate.

Signed-off-by: hagen1778 <roman@victoriametrics.com>