### PR TITLE
deployment/docker/docker-compose.yml: update Grafana from v8.5.1 to v9.0.2 for VictoriaMetrics Single 

### DIFF
--- a/deployment/docker/docker-compose.yml
+++ b/deployment/docker/docker-compose.yml
@@ -40,7 +40,7 @@ services:
     restart: always
   grafana:
     container_name: grafana
-    image: grafana/grafana:8.5.1
+    image: grafana/grafana:9.0.2
     depends_on:
       - "victoriametrics"
     ports:


### PR DESCRIPTION
See https://grafana.com/blog/2022/06/14/grafana-9.0-release-oss-and-cloud-features