### PR TITLE
fix inmemoryBlock's Less method

### DIFF
--- a/lib/mergeset/encoding.go
+++ b/lib/mergeset/encoding.go
@@ -56,7 +56,7 @@ func (ib *inmemoryBlock) Less(i, j int) bool {
 	a.Start += cpLen
 	b.Start += cpLen
 	data := ib.data
-	return string(items[i].Bytes(data)) < string(items[j].Bytes(data))
+	return string(a.Bytes(data)) < string(b.Bytes(data))
 }
 
 func (ib *inmemoryBlock) Swap(i, j int) {


### PR DESCRIPTION
I modify a little code in method Less of inmemoryBlock. In this method, I guess Valialkin want to optimize the comparison between items with suffix, but it does not work. So I modify it and make it work now, please review, thanks.