### PR TITLE
app/vmauth: allow duplicate usernames

### DIFF
--- a/app/vmauth/auth_config.go
+++ b/app/vmauth/auth_config.go
@@ -260,8 +260,6 @@ func parseAuthConfig(data []byte) (map[string]*UserInfo, error) {
 		return nil, fmt.Errorf("`users` section cannot be empty in AuthConfig")
 	}
 	byAuthToken := make(map[string]*UserInfo, len(uis))
-	byUsername := make(map[string]bool, len(uis))
-	byBearerToken := make(map[string]bool, len(uis))
 	for i := range uis {
 		ui := &uis[i]
 		if ui.BearerToken == "" && ui.Username == "" {
@@ -269,12 +267,6 @@ func parseAuthConfig(data []byte) (map[string]*UserInfo, error) {
 		}
 		if ui.BearerToken != "" && ui.Username != "" {
 			return nil, fmt.Errorf("bearer_token=%q and username=%q cannot be set simultaneously", ui.BearerToken, ui.Username)
-		}
-		if byBearerToken[ui.BearerToken] {
-			return nil, fmt.Errorf("duplicate bearer_token found; bearer_token: %q", ui.BearerToken)
-		}
-		if byUsername[ui.Username] {
-			return nil, fmt.Errorf("duplicate username found; username: %q", ui.Username)
 		}
 		at1, at2 := getAuthTokens(ui.BearerToken, ui.Username, ui.Password)
 		if byAuthToken[at1] != nil {
@@ -311,7 +303,6 @@ func parseAuthConfig(data []byte) (map[string]*UserInfo, error) {
 				return nil, fmt.Errorf("password shouldn't be set for bearer_token %q", ui.BearerToken)
 			}
 			ui.requests = metrics.GetOrCreateCounter(fmt.Sprintf(`vmauth_user_requests_total{username=%q}`, name))
-			byBearerToken[ui.BearerToken] = true
 		}
 		if ui.Username != "" {
 			name := ui.Username
@@ -319,7 +310,6 @@ func parseAuthConfig(data []byte) (map[string]*UserInfo, error) {
 				name = ui.Name
 			}
 			ui.requests = metrics.GetOrCreateCounter(fmt.Sprintf(`vmauth_user_requests_total{username=%q}`, name))
-			byUsername[ui.Username] = true
 		}
 		byAuthToken[at1] = ui
 		byAuthToken[at2] = ui

--- a/app/vmauth/auth_config_test.go
+++ b/app/vmauth/auth_config_test.go
@@ -110,6 +110,18 @@ users:
 - username: foo
   url_prefix: https://sss.sss
 `)
+	// Duplicate users
+	f(`
+users:
+- username: foo
+  password: bar
+  url_prefix: http://foo.bar
+- username: bar
+  url_prefix: http://xxx.yyy
+- username: foo
+  password: bar
+  url_prefix: https://sss.sss
+`)
 
 	// Duplicate bearer_tokens
 	f(`
@@ -317,6 +329,28 @@ users:
 			},
 		},
 	})
+	// Multiple users with the same name
+	f(`
+users:
+- username: foo-same
+  password: baz
+  url_prefix: http://foo
+- username: foo-same
+  password: bar
+  url_prefix: https://bar/x///
+`, map[string]*UserInfo{
+		getAuthToken("", "foo-same", "baz"): {
+			Username:  "foo-same",
+			Password:  "baz",
+			URLPrefix: mustParseURL("http://foo"),
+		},
+		getAuthToken("", "foo-same", "bar"): {
+			Username:  "foo-same",
+			Password:  "bar",
+			URLPrefix: mustParseURL("https://bar/x"),
+		},
+	})
+
 }
 
 func getSrcPaths(paths []string) []*SrcPath {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,10 +16,12 @@ The following tip changes can be tested by building VictoriaMetrics components f
 ## tip
 
 * FEATURE: [MetricsQL](https://docs.victoriametrics.com/MetricsQL.html): execute left and right sides of certain operations in parallel. For example, `q1 or q2`, `aggr_func(q1) <op> q2`, `q1 <op> aggr_func(q1)`. This may improve query performance if VictoriaMetrics has enough free resources for parallel processing of both sides of the operation. See [this feature request](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/2886).
+* FEATURE: [vmauth](https://docs.victoriametrics.com/vmagent.html): allow duplicate username records with different passwords at configuration file. It should allow password rotation without username change.
 
 * BUGFIX: [vmagent](https://docs.victoriametrics.com/vmagent.html): restart all the scrape jobs during [config reload](https://docs.victoriametrics.com/vmagent.html#configuration-update) after `global` section is changed inside `-promscrape.config`. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/2884).
 * BUGFIX: [vmagent](https://docs.victoriametrics.com/vmagent.html): properly assume role with AWS ECS credentials. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/2875). Thanks to @transacid for [the fix](https://github.com/VictoriaMetrics/VictoriaMetrics/pull/2876).
 * BUGFIX: [MetricsQL](https://docs.victoriametrics.com/MetricsQL.html): return series from `q1` if `q2` doesn't return matching time series in the query `q1 ifnot q2`. Previously series from `q1` weren't returned in this case.
+
 
 ## [v1.79.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.79.0)
 


### PR DESCRIPTION
Usernames could be duplicate if it has uniq password.
vmauth makes routing based on auth token and username + password combination must be unique for this case.