### PR TITLE
vmselect: simplify errors returned to user for instant and range handlers

### DIFF
--- a/app/vmselect/main.go
+++ b/app/vmselect/main.go
@@ -500,6 +500,13 @@ func sendPrometheusError(w http.ResponseWriter, r *http.Request, err error) {
 		statusCode = esc.StatusCode
 	}
 	w.WriteHeader(statusCode)
+
+	var ure promql.UserReadableError
+	if errors.As(err, &ure) {
+		prometheus.WriteErrorResponse(w, statusCode, ure.Err)
+		return
+	}
+
 	prometheus.WriteErrorResponse(w, statusCode, err)
 }
 

--- a/app/vmselect/prometheus/prometheus.go
+++ b/app/vmselect/prometheus/prometheus.go
@@ -839,7 +839,7 @@ func queryRangeHandler(qt *querytracer.Tracer, startTime time.Time, w http.Respo
 	}
 	result, err := promql.Exec(qt, &ec, query, false)
 	if err != nil {
-		return fmt.Errorf("cannot execute query: %w", err)
+		return err
 	}
 	if step < maxStepForPointsAdjustment.Milliseconds() {
 		queryOffset := getLatencyOffsetMilliseconds()

--- a/app/vmselect/promql/eval.go
+++ b/app/vmselect/promql/eval.go
@@ -294,7 +294,7 @@ func evalExprInternal(qt *querytracer.Tracer, ec *EvalConfig, e metricsql.Expr) 
 func evalTransformFunc(qt *querytracer.Tracer, ec *EvalConfig, fe *metricsql.FuncExpr) ([]*timeseries, error) {
 	tf := getTransformFunc(fe.Name)
 	if tf == nil {
-		return nil, fmt.Errorf(`unknown func %q`, fe.Name)
+		return nil, UserReadableError{Err: fmt.Errorf(`unknown func %q`, fe.Name)}
 	}
 	args, err := evalExprs(qt, ec, fe.Args)
 	if err != nil {
@@ -336,7 +336,7 @@ func evalAggrFunc(qt *querytracer.Tracer, ec *EvalConfig, ae *metricsql.AggrFunc
 	}
 	af := getAggrFunc(ae.Name)
 	if af == nil {
-		return nil, fmt.Errorf(`unknown func %q`, ae.Name)
+		return nil, UserReadableError{Err: fmt.Errorf(`unknown func %q`, ae.Name)}
 	}
 	afa := &aggrFuncArg{
 		ae:   ae,
@@ -679,10 +679,10 @@ func evalRollupFunc(qt *querytracer.Tracer, ec *EvalConfig, funcName string, rf 
 	}
 	tssAt, err := evalExpr(qt, ec, re.At)
 	if err != nil {
-		return nil, fmt.Errorf("cannot evaluate `@` modifier: %w", err)
+		return nil, UserReadableError{Err: fmt.Errorf("cannot evaluate `@` modifier: %w", err)}
 	}
 	if len(tssAt) != 1 {
-		return nil, fmt.Errorf("`@` modifier must return a single series; it returns %d series instead", len(tssAt))
+		return nil, UserReadableError{Err: fmt.Errorf("`@` modifier must return a single series; it returns %d series instead", len(tssAt))}
 	}
 	atTimestamp := int64(tssAt[0].Values[0] * 1000)
 	ecNew := copyEvalConfig(ec)
@@ -742,7 +742,7 @@ func evalRollupFuncWithoutAt(qt *querytracer.Tracer, ec *EvalConfig, funcName st
 		rvs, err = evalRollupFuncWithSubquery(qt, ecNew, funcName, rf, expr, re)
 	}
 	if err != nil {
-		return nil, err
+		return nil, UserReadableError{Err: err}
 	}
 	if funcName == "absent_over_time" {
 		rvs = aggregateAbsentOverTime(ec, re.Expr, rvs)
@@ -964,7 +964,7 @@ func evalRollupFuncWithMetricExpr(qt *querytracer.Tracer, ec *EvalConfig, funcNa
 	sq := storage.NewSearchQuery(minTimestamp, ec.End, tfss, ec.MaxSeries)
 	rss, err := netstorage.ProcessSearchQuery(qt, sq, ec.Deadline)
 	if err != nil {
-		return nil, err
+		return nil, UserReadableError{Err: err}
 	}
 	rssLen := rss.Len()
 	if rssLen == 0 {
@@ -1000,12 +1000,12 @@ func evalRollupFuncWithMetricExpr(qt *querytracer.Tracer, ec *EvalConfig, funcNa
 	rml := getRollupMemoryLimiter()
 	if !rml.Get(uint64(rollupMemorySize)) {
 		rss.Cancel()
-		return nil, fmt.Errorf("not enough memory for processing %d data points across %d time series with %d points in each time series; "+
+		return nil, UserReadableError{Err: fmt.Errorf("not enough memory for processing %d data points across %d time series with %d points in each time series; "+
 			"total available memory for concurrent requests: %d bytes; "+
 			"requested memory: %d bytes; "+
 			"possible solutions are: reducing the number of matching time series; switching to node with more RAM; "+
 			"increasing -memory.allowedPercent; increasing `step` query arg (%gs)",
-			rollupPoints, timeseriesLen*len(rcs), pointsPerTimeseries, rml.MaxSize, uint64(rollupMemorySize), float64(ec.Step)/1e3)
+			rollupPoints, timeseriesLen*len(rcs), pointsPerTimeseries, rml.MaxSize, uint64(rollupMemorySize), float64(ec.Step)/1e3)}
 	}
 	defer rml.Put(uint64(rollupMemorySize))
 
@@ -1018,7 +1018,7 @@ func evalRollupFuncWithMetricExpr(qt *querytracer.Tracer, ec *EvalConfig, funcNa
 		tss, err = evalRollupNoIncrementalAggregate(qt, funcName, keepMetricNames, rss, rcs, preFunc, sharedTimestamps)
 	}
 	if err != nil {
-		return nil, err
+		return nil, UserReadableError{Err: err}
 	}
 	tss = mergeTimeseries(tssCached, tss, start, ec)
 	rollupResultCacheV.Put(qt, ec, expr, window, tss)

--- a/app/vmselect/promql/exec.go
+++ b/app/vmselect/promql/exec.go
@@ -26,6 +26,17 @@ var (
 		`This option is DEPRECATED in favor of {__graphite__="a.*.c"} syntax for selecting metrics matching the given Graphite metrics filter`)
 )
 
+// UserReadableError is a type of error which supposed
+// to be returned to the user without additional context.
+type UserReadableError struct {
+	Err error
+}
+
+// Error satisfies Error interface
+func (ure UserReadableError) Error() string {
+	return ure.Err.Error()
+}
+
 // Exec executes q for the given ec.
 func Exec(qt *querytracer.Tracer, ec *EvalConfig, q string, isFirstPointOnly bool) ([]netstorage.Result, error) {
 	if querystats.Enabled() {
@@ -73,7 +84,7 @@ func Exec(qt *querytracer.Tracer, ec *EvalConfig, q string, isFirstPointOnly boo
 		}
 		qt.Printf("round series values to %d decimal digits after the point", n)
 	}
-	return result, err
+	return result, nil
 }
 
 func maySortResults(e metricsql.Expr, tss []*timeseries) bool {


### PR DESCRIPTION
vmselect: introduce UserReadableError type of error

When read query fails, VM returns rich error message with
all the details. While these details might be useful
for debugging specific cases, they're usually too verbose 
for users. 
Introducing a new error type `UserReadableError` is supposed
to allow to return to user only the most important parts
of the error trace. This supposed to improve error readability
in web interfaces such as VMUI or Grafana.

The full error trace is still logged with the full context
and can be found in vmselect logs.

Signed-off-by: hagen1778 <roman@victoriametrics.com>

----------------------

**Examples**

The following error:
```
error when executing query="(node_filesystem_avail_bytes * 100) / node_filesystem_size_bytes < 10 and ON (instance, device, mountpoint) node_filesystem_readonly == 0" on the time range (start=1644472840554, end=1660024840554, step=48600000):
    cannot execute "(((node_filesystem_avail_bytes * 100) / node_filesystem_size_bytes) < 10) and on (instance, device, mountpoint) (node_filesystem_readonly == 0)":
        cannot execute "node_filesystem_readonly == 0":
            cannot evaluate "node_filesystem_readonly":
                search error after reading 0 data blocks:
                    error when searching for tagFilters=[{__name__="node_filesystem_readonly"}] on the time range [2022-02-09T04:25:00Z..2022-08-08T18:00:00Z]:
                        error when searching tsids: the number of matching timeseries exceeds 1; either narrow down the search or increase -search.max* command-line flag values at vmselect; see https://docs.victoriametrics.com/#resource-usage-limits
```
will be shown in UI as:
```
search error after reading 0 data blocks:
    error when searching for tagFilters=[{__name__="node_filesystem_readonly"}] on the time range [2022-02-09T04:25:00Z..2022-08-08T18:00:00Z]:
        error when searching tsids: the number of matching timeseries exceeds 1; either narrow down the search or increase -search.max* command-line flag values at vmselect; see https://docs.victoriametrics.com/#resource-usage-limits
```


The following error:
```
error when executing query="(node_filesystem_avail_bytes * 100) / node_filesystem_size_bytes < 10 and ON (instance, device, mountpoint) node_filesystem_readonly == 0" on the time range (start=1644473014383, end=1660025014383, step=48600000):
    cannot execute "(((node_filesystem_avail_bytes * 100) / node_filesystem_size_bytes) < 10) and on (instance, device, mountpoint) (node_filesystem_readonly == 0)":
        cannot execute "node_filesystem_readonly == 0":
            cannot evaluate "node_filesystem_readonly":
                not enough memory for processing 3210 data points across 10 time series with 321 points in each time series; total available memory for concurrent requests: 250 bytes; requested memory: 51360 bytes; possible solutions are: reducing the number of matching time series; switching to node with more RAM; increasing -memory.allowedPercent; increasing `step` query arg (48600s)
```
will be shown in UI as:
```
not enough memory for processing 3210 data points across 10 time series with 321 points in each time series; total available memory for concurrent requests: 250 bytes; requested memory: 51360 bytes; possible solutions are: reducing the number of matching time series; switching to node with more RAM; increasing -memory.allowedPercent; increasing `step` query arg (48600s)
```

The following error:
```
error when executing query="(node_filesystem_avail_bytes * 100) / node_filesystem_size_bytes < 10 and ON (instance, device, mountpoint) node_filesystem_readonly == 0 @ foo" on the time range (start=1644473183218, end=1660025183218, step=48600000):
    cannot execute "(((node_filesystem_avail_bytes * 100) / node_filesystem_size_bytes) < 10) and on (instance, device, mountpoint) (node_filesystem_readonly == 0 @ foo)":
        cannot execute "node_filesystem_readonly == 0 @ foo":
            cannot evaluate "0 @ foo":
                `@` modifier must return a single series; it returns 0 series instead
```
will be shown in UI as:
```
`@` modifier must return a single series; it returns 0 series instead
```