### PR TITLE
vmselect: fix vmrangeBucketsToLE func may panic when ts value equal zero

### DIFF
--- a/app/vmselect/promql/transform.go
+++ b/app/vmselect/promql/transform.go
@@ -572,19 +572,21 @@ func vmrangeBucketsToLE(tss []*timeseries) []*timeseries {
 			})
 		}
 		xss = xssNew
-		for i := range xss[0].ts.Values {
-			count := float64(0)
-			for _, xs := range xss {
-				ts := xs.ts
-				v := ts.Values[i]
-				if !math.IsNaN(v) && v > 0 {
-					count += v
+		if len(xss) > 0 {
+			for i := range xss[0].ts.Values {
+				count := float64(0)
+				for _, xs := range xss {
+					ts := xs.ts
+					v := ts.Values[i]
+					if !math.IsNaN(v) && v > 0 {
+						count += v
+					}
+					ts.Values[i] = count
 				}
-				ts.Values[i] = count
 			}
-		}
-		for _, xs := range xss {
-			rvs = append(rvs, xs.ts)
+			for _, xs := range xss {
+				rvs = append(rvs, xs.ts)
+			}
 		}
 	}
 	return rvs


### PR DESCRIPTION
if all timeseries value equal zero in [here](https://github.com/VictoriaMetrics/VictoriaMetrics/blob/cluster/app/vmselect/promql/transform.go#L543) and xspre can not match inf in [here](https://github.com/VictoriaMetrics/VictoriaMetrics/blob/cluster/app/vmselect/promql/transform.go#L567), 

<img width="517" alt="image" src="https://user-images.githubusercontent.com/32037815/180254361-85f4adbc-b833-4e70-899c-3c0d09ad748c.png"> 
this code will panic.

<img width="1582" alt="image" src="https://user-images.githubusercontent.com/32037815/180254904-3c1405f8-4398-4913-9ffe-9b1e0abf655e.png">
