### PR TITLE
deployment/docker/Makefile: added docker-scan

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ all: \
 clean:
 	rm -rf bin/*
 
-publish: \
+publish: docker-scan \
 	publish-victoria-metrics \
 	publish-vmagent \
 	publish-vmalert \

--- a/deployment/docker/Makefile
+++ b/deployment/docker/Makefile
@@ -16,7 +16,10 @@ package-base:
 			--tag $(BASE_IMAGE) \
 			deployment/docker/base
 
-package-builder:
+docker-scan: package-base
+	docker scan --accept-license $(BASE_IMAGE) || (echo "❌ The build has been terminated because critical vulnerabilities were found in $(BASE_IMAGE)"; exit 1)
+
+package-builder: docker-scan
 	(docker image ls --format '{{.Repository}}:{{.Tag}}' | grep -q '$(BUILDER_IMAGE)$$') \
 		|| docker build \
 			--build-arg go_builder_image=$(GO_BUILDER_IMAGE) \

--- a/deployment/docker/Makefile
+++ b/deployment/docker/Makefile
@@ -19,7 +19,7 @@ package-base:
 docker-scan: package-base
 	docker scan --accept-license $(BASE_IMAGE) || (echo "❌ The build has been terminated because critical vulnerabilities were found in $(BASE_IMAGE)"; exit 1)
 
-package-builder: docker-scan
+package-builder:
 	(docker image ls --format '{{.Repository}}:{{.Tag}}' | grep -q '$(BUILDER_IMAGE)$$') \
 		|| docker build \
 			--build-arg go_builder_image=$(GO_BUILDER_IMAGE) \


### PR DESCRIPTION
`docker-scan` based on native `docker scan` functionality that use snyk.io, see https://docs.docker.com/engine/scan/
`docker-scan` will start after user run `make publish-release` and will call to build `BASE_IMAGE`  that will be scanned for vulnerabilities. If vulnerabilities are found, the release process will be terminated.