### PR TITLE
lib/auth: add tests for NewToken function

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -19,13 +19,13 @@ func NewToken(authToken string) (*Token, error) {
 		return nil, fmt.Errorf("unexpected number of items in authToken %q; got %d; want 1 or 2", authToken, len(tmp))
 	}
 	var at Token
-	accountID, err := strconv.Atoi(tmp[0])
+	accountID, err := strconv.ParseUint(tmp[0], 10, 32)
 	if err != nil {
 		return nil, fmt.Errorf("cannot parse accountID from %q: %w", tmp[0], err)
 	}
 	at.AccountID = uint32(accountID)
 	if len(tmp) > 1 {
-		projectID, err := strconv.Atoi(tmp[1])
+		projectID, err := strconv.ParseUint(tmp[1], 10, 32)
 		if err != nil {
 			return nil, fmt.Errorf("cannot parse projectID from %q: %w", tmp[1], err)
 		}

--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -1,0 +1,33 @@
+package auth
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestNewToken(t *testing.T) {
+	f := func(token string, want string, wantErr bool) {
+		t.Helper()
+		newToken, err := NewToken(token)
+		if (err != nil) != wantErr {
+			t.Errorf("NewToken() error = %v, wantErr %v", err, wantErr)
+			return
+		}
+		var got string
+		if newToken != nil {
+			got = fmt.Sprintf("%d:%d", newToken.AccountID, newToken.ProjectID)
+		}
+		if got != want {
+			t.Errorf("NewToken() got = %v, want %v", got, want)
+		}
+	}
+	f("", "", true)
+	f(":", "", true)
+	f("a:b", "", true)
+	f("1:", "", true)
+	f(":2", "", true)
+	f("::", "", true)
+	f("a:b:c", "", true)
+	f("1:2:3", "", true)
+	f("1:2", "1:2", false)
+}

--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -21,9 +21,9 @@ func TestNewTokenSuccess(t *testing.T) {
 
 	}
 	f("token with accountID and projectID", "1:2", "1:2")
-	f("correct uint32 accountID", "4294967295:1", "4294967295:1")
-	f("correct uint32 projectID", "1:4294967295", "1:4294967295")
-	f("correct uint32 accountID and projectID", "4294967295:4294967295", "4294967295:4294967295")
+	f("max uint32 accountID", "4294967295:1", "4294967295:1")
+	f("max uint32 projectID", "1:4294967295", "1:4294967295")
+	f("max uint32 accountID and projectID", "4294967295:4294967295", "4294967295:4294967295")
 }
 
 func TestNewTokenFailure(t *testing.T) {

--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -27,37 +27,33 @@ func TestNewTokenSuccess(t *testing.T) {
 }
 
 func TestNewTokenFailure(t *testing.T) {
-	f := func(name string, token string, want string) {
+	f := func(name string, token string) {
 		t.Helper()
 		t.Run(name, func(t *testing.T) {
 			newToken, err := NewToken(token)
 			if err == nil {
 				t.Fatalf("expecting non-nil error")
 			}
-			var got string
 			if newToken != nil {
-				got = fmt.Sprintf("%d:%d", newToken.AccountID, newToken.ProjectID)
-			}
-			if got != want {
-				t.Errorf("NewToken() got = %v, want %v", newToken, want)
+				t.Fatalf("expecting nil token")
 			}
 		})
 	}
-	f("empty token", "", "")
-	f("empty accountID and projectID", ":", "")
-	f("accountID and projectID not int values", "a:b", "")
-	f("missed projectID", "1:", "")
-	f("missed accountID", ":2", "")
-	f("large int value for accountID", "9223372036854775808:1", "")
-	f("large int value for projectID", "2:9223372036854775808", "")
-	f("both large int values incorrect", "9223372036854775809:9223372036854775808", "")
-	f("large uint32 values incorrect", "4294967297:4294967295", "")
-	f("negative accountID", "-100:100", "")
-	f("negative projectID", "100:-100", "")
-	f("negative accountID and projectID", "-100:-100", "")
-	f("accountID is string", "abcd:2", "")
-	f("projectID is string", "2:abcd", "")
-	f("empty many parts in the token", "::", "")
-	f("many string parts in the token", "a:b:c", "")
-	f("many int parts in the token", "1:2:3", "")
+	f("empty token", "")
+	f("empty accountID and projectID", ":")
+	f("accountID and projectID not int values", "a:b")
+	f("missed projectID", "1:")
+	f("missed accountID", ":2")
+	f("large int value for accountID", "9223372036854775808:1")
+	f("large int value for projectID", "2:9223372036854775808")
+	f("both large int values incorrect", "9223372036854775809:9223372036854775808")
+	f("large uint32 values incorrect", "4294967297:4294967295")
+	f("negative accountID", "-100:100")
+	f("negative projectID", "100:-100")
+	f("negative accountID and projectID", "-100:-100")
+	f("accountID is string", "abcd:2")
+	f("projectID is string", "2:abcd")
+	f("empty many parts in the token", "::")
+	f("many string parts in the token", "a:b:c")
+	f("many int parts in the token", "1:2:3")
 }

--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -5,29 +5,59 @@ import (
 	"testing"
 )
 
-func TestNewToken(t *testing.T) {
-	f := func(token string, want string, wantErr bool) {
+func TestNewTokenSuccess(t *testing.T) {
+	f := func(name string, token string, want string) {
 		t.Helper()
-		newToken, err := NewToken(token)
-		if (err != nil) != wantErr {
-			t.Errorf("NewToken() error = %v, wantErr %v", err, wantErr)
-			return
-		}
-		var got string
-		if newToken != nil {
-			got = fmt.Sprintf("%d:%d", newToken.AccountID, newToken.ProjectID)
-		}
-		if got != want {
-			t.Errorf("NewToken() got = %v, want %v", got, want)
-		}
+		t.Run(name, func(t *testing.T) {
+			newToken, err := NewToken(token)
+			if err != nil {
+				t.Fatalf("expecting nil error")
+			}
+			got := fmt.Sprintf("%d:%d", newToken.AccountID, newToken.ProjectID)
+			if got != want {
+				t.Errorf("NewToken() got = %v, want %v", newToken, want)
+			}
+		})
+
 	}
-	f("", "", true)
-	f(":", "", true)
-	f("a:b", "", true)
-	f("1:", "", true)
-	f(":2", "", true)
-	f("::", "", true)
-	f("a:b:c", "", true)
-	f("1:2:3", "", true)
-	f("1:2", "1:2", false)
+	f("token with accountID and projectID", "1:2", "1:2")
+	f("correct uint32 accountID", "4294967295:1", "4294967295:1")
+	f("correct uint32 projectID", "1:4294967295", "1:4294967295")
+	f("correct uint32 accountID and projectID", "4294967295:4294967295", "4294967295:4294967295")
+}
+
+func TestNewTokenFailure(t *testing.T) {
+	f := func(name string, token string, want string) {
+		t.Helper()
+		t.Run(name, func(t *testing.T) {
+			newToken, err := NewToken(token)
+			if err == nil {
+				t.Fatalf("expecting non-nil error")
+			}
+			var got string
+			if newToken != nil {
+				got = fmt.Sprintf("%d:%d", newToken.AccountID, newToken.ProjectID)
+			}
+			if got != want {
+				t.Errorf("NewToken() got = %v, want %v", newToken, want)
+			}
+		})
+	}
+	f("empty token", "", "")
+	f("empty accountID and projectID", ":", "")
+	f("accountID and projectID not int values", "a:b", "")
+	f("missed projectID", "1:", "")
+	f("missed accountID", ":2", "")
+	f("large int value for accountID", "9223372036854775808:1", "")
+	f("large int value for projectID", "2:9223372036854775808", "")
+	f("both large int values incorrect", "9223372036854775809:9223372036854775808", "")
+	f("large uint32 values incorrect", "4294967297:4294967295", "")
+	f("negative accountID", "-100:100", "")
+	f("negative projectID", "100:-100", "")
+	f("negative accountID and projectID", "-100:-100", "")
+	f("accountID is string", "abcd:2", "")
+	f("projectID is string", "2:abcd", "")
+	f("empty many parts in the token", "::", "")
+	f("many string parts in the token", "a:b:c", "")
+	f("many int parts in the token", "1:2:3", "")
 }


### PR DESCRIPTION
Implement test for NewToken function which parse token string and return token object.

There was a problem with type convertion
```golang
accountID, err := strconv.Atoi(tmp[0])

token.AccountID = uint32(accountID)
```
in that situation when we parse value as `int` and convert it to `uint32` value like `4294967297` will be converted to `1` so it would be incorrect behavior of the function

Signed-off-by: dmitryk-dk [d.kozlov@victoriametrics.com](mailto:d.kozlov@victoriametrics.com)