### PR TITLE
logger: redact password for URL flags

### DIFF
--- a/lib/flagutil/url.go
+++ b/lib/flagutil/url.go
@@ -1,0 +1,44 @@
+package flagutil
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+var urlFlags = make(map[string]bool)
+
+// RegisterURLFlag registers flagName as a URL.
+//
+// This function must be called before starting logging.
+// The underlying map is not safe to use concurrently.
+//
+// URL flags have user:pass removed before logging.
+func RegisterURLFlag(flagName string) {
+	lname := strings.ToLower(flagName)
+	urlFlags[lname] = true
+}
+
+// IsURLFlag returns true if flag contains a flag name where the value
+// should be treated as a URL.
+func IsURLFlag(flagName string) bool {
+	lname := strings.ToLower(flagName)
+	if strings.Contains(lname, "url") {
+		return true
+	}
+	return urlFlags[lname]
+}
+
+// RedactURLPassword redacts the password for a given url flag
+func RedactURLFlagPassword(flagValue string) string {
+	parsed, err := url.Parse(flagValue)
+	if err != nil {
+		return flagValue // not parsable, so do nothing
+	}
+	if parsed.User != nil {
+		if pass, _ := parsed.User.Password(); pass != "" {
+			parsed.User = url.UserPassword(parsed.User.Username(), "REDACTED")
+		}
+	}
+	return fmt.Sprint(parsed)
+}

--- a/lib/flagutil/url_test.go
+++ b/lib/flagutil/url_test.go
@@ -1,0 +1,81 @@
+package flagutil
+
+import (
+	"testing"
+)
+
+func TestIsURLFlag(t *testing.T) {
+	testCases := []struct {
+		desc     string
+		flagName string
+		expected bool
+		register bool
+	}{
+		{
+			desc:     "contains url",
+			flagName: "remoteWrite.url",
+			expected: true,
+			register: false,
+		},
+		{
+			desc:     "does not contain url, registered",
+			flagName: "remoteWrite.target",
+			expected: true,
+			register: true,
+		},
+		{
+			desc:     "does not contain url, unregistered",
+			flagName: "remoteWrite.foo",
+			expected: false,
+			register: false,
+		},
+	}
+	for _, tC := range testCases {
+		t.Run(tC.desc, func(t *testing.T) {
+			if tC.register {
+				RegisterURLFlag(tC.flagName)
+			}
+			result := IsURLFlag(tC.flagName)
+			if tC.expected != result {
+				t.Errorf("unexpected result; got %t; want %t", result, tC.expected)
+			}
+		})
+	}
+}
+
+func TestRedactURLFlagPassword(t *testing.T) {
+	testCases := []struct {
+		desc      string
+		flagValue string
+		expected  string
+	}{
+		{
+			desc:      "valid url, no user:pass",
+			flagValue: "http://hostname:1234/path",
+			expected:  "http://hostname:1234/path",
+		},
+		{
+			desc:      "valid url, user:pass",
+			flagValue: "http://foo:bar@hostname:1234/path",
+			expected:  "http://foo:REDACTED@hostname:1234/path",
+		},
+		{
+			desc:      "valid url, user, no pass",
+			flagValue: "http://foo:@hostname:1234/path",
+			expected:  "http://foo:@hostname:1234/path",
+		},
+		{
+			desc:      "invalid url, user, no pass",
+			flagValue: "not-a-url",
+			expected:  "not-a-url",
+		},
+	}
+	for _, tC := range testCases {
+		t.Run(tC.desc, func(t *testing.T) {
+			result := RedactURLFlagPassword(tC.flagValue)
+			if tC.expected != result {
+				t.Errorf("unexpected result; got %s; want %s", result, tC.expected)
+			}
+		})
+	}
+}

--- a/lib/logger/flag.go
+++ b/lib/logger/flag.go
@@ -17,6 +17,9 @@ func logAllFlags() {
 		if flagutil.IsSecretFlag(lname) {
 			value = "secret"
 		}
+		if flagutil.IsURLFlag(lname) {
+			value = flagutil.RedactURLFlagPassword(value)
+		}
 		Infof("flag %q=%q", f.Name, value)
 	})
 }


### PR DESCRIPTION
It is possible to leak passwords and similar secrets for URL flags, e.g.
`remoteWrite.url`, when a user:pass is supplied, as this is logged out
by the flag logger.

To reduce the chance of misuse, add some handling for URL flags that
redacts the password prior to logging, if present.