### PR TITLE
workflows: bump go version

### DIFF
--- a/.github/workflows/check-licenses.yml
+++ b/.github/workflows/check-licenses.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@main
         with:
-          go-version: 1.17
+          go-version: 1.19
         id: go
       - name: Code checkout
         uses: actions/checkout@master

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@main
         with:
-          go-version: 1.17
+          go-version: 1.19
         id: go
       - name: Code checkout
         uses: actions/checkout@master


### PR DESCRIPTION
Some new dependencies contain generics, so we bump go version for CI.

--------------------

See https://github.com/VictoriaMetrics/VictoriaMetrics/runs/7720327151?check_suite_focus=true

Signed-off-by: hagen1778 <roman@victoriametrics.com>