### PR TITLE
lib/promrelabel: fix expected test result

### DIFF
--- a/lib/promrelabel/config_test.go
+++ b/lib/promrelabel/config_test.go
@@ -55,7 +55,7 @@ func TestRelabelConfigMarshalUnmarshal(t *testing.T) {
 - regex:
   - 'fo.+'
   - '.*ba[r-z]a'
-`, "- regex:\n  - fo.+\n  - .*ba[r-z]a\n")
+`, "- regex: fo.+|.*ba[r-z]a\n")
 	f(`- regex: foo|bar`, "- regex:\n  - foo\n  - bar\n")
 	f(`- regex: True`, `- regex: "true"`+"\n")
 	f(`- regex: true`, `- regex: "true"`+"\n")


### PR DESCRIPTION
follow-up after 68c4ec9472bba3011c7f70a526a4ae6d99410be5

Signed-off-by: hagen1778 <roman@victoriametrics.com>