### PR TITLE
lib/storage: prevent excessive loops when storage is in RO

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,7 @@ The following tip changes can be tested by building VictoriaMetrics components f
 
 ## tip
 
+* BUGFIX: prevent from excess CPU usage when the storage enters [read-only mode](https://docs.victoriametrics.com/Cluster-VictoriaMetrics.html#readonly-mode).
 
 ## [v1.80.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.80.0)
 

--- a/lib/storage/partition.go
+++ b/lib/storage/partition.go
@@ -952,22 +952,19 @@ func (pt *partition) partsMerger(mergerFunc func(isFinal bool) error) error {
 			isFinal = false
 			continue
 		}
-
-		if !errors.Is(err, errReadOnlyMode) {
-			if errors.Is(err, errForciblyStopped) {
-				// The merger has been stopped.
-				return nil
-			}
-			if !errors.Is(err, errNothingToMerge) {
-				return err
-			}
-			if finalMergeDelaySeconds > 0 && fasttime.UnixTimestamp()-lastMergeTime > finalMergeDelaySeconds {
-				// We have free time for merging into bigger parts.
-				// This should improve select performance.
-				lastMergeTime = fasttime.UnixTimestamp()
-				isFinal = true
-				continue
-			}
+		if errors.Is(err, errForciblyStopped) {
+			// The merger has been stopped.
+			return nil
+		}
+		if !errors.Is(err, errNothingToMerge) && !errors.Is(err, errReadOnlyMode) {
+			return err
+		}
+		if finalMergeDelaySeconds > 0 && fasttime.UnixTimestamp()-lastMergeTime > finalMergeDelaySeconds {
+			// We have free time for merging into bigger parts.
+			// This should improve select performance.
+			lastMergeTime = fasttime.UnixTimestamp()
+			isFinal = true
+			continue
 		}
 
 		// Nothing to merge. Sleep for a while and try again.

--- a/lib/storage/partition.go
+++ b/lib/storage/partition.go
@@ -569,7 +569,7 @@ func (pt *partition) addRowsPart(rows []rawRow) {
 		atomic.AddUint64(&pt.smallAssistedMerges, 1)
 		return
 	}
-	if errors.Is(err, errNothingToMerge) || errors.Is(err, errForciblyStopped) {
+	if errors.Is(err, errNothingToMerge) || errors.Is(err, errForciblyStopped) || errors.Is(err, errReadOnlyMode) {
 		return
 	}
 	logger.Panicf("FATAL: cannot merge small parts: %s", err)
@@ -952,19 +952,22 @@ func (pt *partition) partsMerger(mergerFunc func(isFinal bool) error) error {
 			isFinal = false
 			continue
 		}
-		if errors.Is(err, errForciblyStopped) {
-			// The merger has been stopped.
-			return nil
-		}
-		if !errors.Is(err, errNothingToMerge) {
-			return err
-		}
-		if finalMergeDelaySeconds > 0 && fasttime.UnixTimestamp()-lastMergeTime > finalMergeDelaySeconds {
-			// We have free time for merging into bigger parts.
-			// This should improve select performance.
-			lastMergeTime = fasttime.UnixTimestamp()
-			isFinal = true
-			continue
+
+		if !errors.Is(err, errReadOnlyMode) {
+			if errors.Is(err, errForciblyStopped) {
+				// The merger has been stopped.
+				return nil
+			}
+			if !errors.Is(err, errNothingToMerge) {
+				return err
+			}
+			if finalMergeDelaySeconds > 0 && fasttime.UnixTimestamp()-lastMergeTime > finalMergeDelaySeconds {
+				// We have free time for merging into bigger parts.
+				// This should improve select performance.
+				lastMergeTime = fasttime.UnixTimestamp()
+				isFinal = true
+				continue
+			}
 		}
 
 		// Nothing to merge. Sleep for a while and try again.
@@ -1012,11 +1015,13 @@ func (pt *partition) canBackgroundMerge() bool {
 	return atomic.LoadUint32(pt.isReadOnly) == 0
 }
 
+var errReadOnlyMode = fmt.Errorf("storage is in readonly mode")
+
 func (pt *partition) mergeBigParts(isFinal bool) error {
 	if !pt.canBackgroundMerge() {
 		// Do not perform merge in read-only mode, since this may result in disk space shortage.
 		// See https://github.com/VictoriaMetrics/VictoriaMetrics/issues/2603
-		return nil
+		return errReadOnlyMode
 	}
 	maxOutBytes := getMaxOutBytes(pt.bigPartsPath, bigMergeWorkersCount)
 
@@ -1032,7 +1037,7 @@ func (pt *partition) mergeSmallParts(isFinal bool) error {
 	if !pt.canBackgroundMerge() {
 		// Do not perform merge in read-only mode, since this may result in disk space shortage.
 		// See https://github.com/VictoriaMetrics/VictoriaMetrics/issues/2603
-		return nil
+		return errReadOnlyMode
 	}
 	// Try merging small parts to a big part at first.
 	maxBigPartOutBytes := getMaxOutBytes(pt.bigPartsPath, bigMergeWorkersCount)


### PR DESCRIPTION
Returning nil error when storage is in RO mode results
into excessive loops and function calls which could
result into CPU exhaustion. Returning an err instead
will trigger delays in the for loop and save some resources.

Signed-off-by: hagen1778 <roman@victoriametrics.com>



-------------------------

CPU pprof results from node potentially affected by this:

```
ROUTINE ======================== github.com/VictoriaMetrics/VictoriaMetrics/lib/storage.(*partition).partsMerger in github.com/VictoriaMetrics/VictoriaMetrics/lib/storage/partition.go
    57.33s     97.91s (flat, cum) 93.44% of Total
         .          .    941:func (pt *partition) partsMerger(mergerFunc func(isFinal bool) error) error {
         .       70ms    946:   for {
    40.88s     76.52s    947:           err := mergerFunc(isFinal)
     580ms      640ms    948:           if err == nil {
         .          .    949:                   // Try merging additional parts.
         .          .    950:                   sleepTime = minMergeSleepTime
     1.10s      5.68s    951:                   lastMergeTime = fasttime.UnixTimestamp()
         .          .    952:                   isFinal = false
     1.22s      1.22s    953:                   continue
         .          .    954:           }

    11.50s     11.54s    962:           if finalMergeDelaySeconds > 0 && fasttime.UnixTimestamp()-lastMergeTime > finalMergeDelaySeconds {
         .          .    963:                   // We have free time for merging into bigger parts.
         .          .    964:                   // This should improve select performance.
         .          .    965:                   lastMergeTime = fasttime.UnixTimestamp()
         .          .    966:                   isFinal = true
         .          .    967:                   continue
         .          .    968:           }

```

```
     9.18s      9.43s   1031:func (pt *partition) mergeSmallParts(isFinal bool) error {
     370ms      7.23s   1032:   if !pt.canBackgroundMerge() {
         .          .   1033:           // Do not perform merge in read-only mode, since this may result in disk space shortage.
         .          .   1034:           // See https://github.com/VictoriaMetrics/VictoriaMetrics/issues/2603
     6.62s      6.69s   1035:           return nil
         .          .   1036:   }

```