### PR TITLE
vmalert: sort groups at `/alerts` page

### DIFF
--- a/app/vmalert/web.go
+++ b/app/vmalert/web.go
@@ -251,6 +251,9 @@ func (rh *requestHandler) groupAlerts() []GroupAlerts {
 			})
 		}
 	}
+	sort.Slice(groupAlerts, func(i, j int) bool {
+		return groupAlerts[i].Group.Name < groupAlerts[j].Group.Name
+	})
 	return groupAlerts
 }
 


### PR DESCRIPTION
Sorting will produce deterministic output
of grops on the page.

Signed-off-by: hagen1778 <roman@victoriametrics.com>