### PR TITLE
app/victoria-metrics: replace ioutil package with os package

### DIFF
--- a/app/victoria-metrics/main_test.go
+++ b/app/victoria-metrics/main_test.go
@@ -6,7 +6,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net"
 	"net/http"
@@ -308,7 +307,7 @@ func readIn(readFor string, t *testing.T, insertTime time.Time) []test {
 		if filepath.Ext(path) != ".json" {
 			return nil
 		}
-		b, err := ioutil.ReadFile(path)
+		b, err := os.ReadFile(path)
 		s.noError(err)
 		item := test{}
 		s.noError(json.Unmarshal(b, &item))


### PR DESCRIPTION
Signed-off-by: Cosrider <cosrider7@gmail.com>

io/ioutil ReadFile 
// Deprecated: As of Go 1.16, this function simply calls os.ReadFile.

VictoriaMetrics is currently using go 1.17.