### PR TITLE
deployment/docker-compose.yml: bump Grafana version to latest 9.1.0

### DIFF
--- a/deployment/docker/docker-compose.yml
+++ b/deployment/docker/docker-compose.yml
@@ -40,7 +40,7 @@ services:
     restart: always
   grafana:
     container_name: grafana
-    image: grafana/grafana:9.0.6
+    image: grafana/grafana:9.1.0
     depends_on:
       - "victoriametrics"
     ports:


### PR DESCRIPTION
see more at https://grafana.com/blog/2022/08/16/grafana-9.1-release/