### PR TITLE
lib/storage: bump max merge concurrency for small parts to 15

### DIFF
--- a/lib/storage/partition.go
+++ b/lib/storage/partition.go
@@ -871,7 +871,7 @@ func hasActiveMerges(pws []*partWrapper) bool {
 
 var (
 	bigMergeWorkersCount   = getDefaultMergeConcurrency(4)
-	smallMergeWorkersCount = getDefaultMergeConcurrency(15)
+	smallMergeWorkersCount = getDefaultMergeConcurrency(16)
 )
 
 func getDefaultMergeConcurrency(max int) int {

--- a/lib/storage/partition.go
+++ b/lib/storage/partition.go
@@ -871,7 +871,7 @@ func hasActiveMerges(pws []*partWrapper) bool {
 
 var (
 	bigMergeWorkersCount   = getDefaultMergeConcurrency(4)
-	smallMergeWorkersCount = getDefaultMergeConcurrency(8)
+	smallMergeWorkersCount = getDefaultMergeConcurrency(15)
 )
 
 func getDefaultMergeConcurrency(max int) int {


### PR DESCRIPTION
The change is based on the feedback from users on github.
Thier examples show, that limit of 8 sometimes become a
bottleneck. Users report that without limit concurrency
can climb up to 15-20 merges at once.

See https://github.com/VictoriaMetrics/VictoriaMetrics/pull/2673#issuecomment-1218185978

Signed-off-by: hagen1778 <roman@victoriametrics.com>