### PR TITLE
support downsampling

### DIFF
--- a/app/vmstorage/main.go
+++ b/app/vmstorage/main.go
@@ -45,6 +45,7 @@ var (
 		"If set to 2h, then the indexdb rotation is performed at 4am EET time (the timezone with +2h offset)")
 	minScrapeInterval = flag.Duration("dedup.minScrapeInterval", 0, "Leave only the last sample in every time series per each discrete interval "+
 		"equal to -dedup.minScrapeInterval > 0. See https://docs.victoriametrics.com/#deduplication for details")
+	downsampling = flag.String("downsampling.period", "", "-downsampling.period=30d:5m,180d:30m instructs VictoriaMetrics to deduplicate samples older than 30 days with 5 minutes interval and to deduplicate samples older than 180 days with 30 minutes interval interval.")
 
 	logNewSeries = flag.Bool("logNewSeries", false, "Whether to log new series. This option is for debug purposes only. It can lead to performance issues "+
 		"when big number of new series are ingested into VictoriaMetrics")
@@ -71,6 +72,7 @@ func main() {
 	pushmetrics.Init()
 
 	storage.SetDedupInterval(*minScrapeInterval)
+	storage.SetDownsampling(*downsampling)
 	storage.SetLogNewSeries(*logNewSeries)
 	storage.SetFinalMergeDelay(*finalMergeDelay)
 	storage.SetBigMergeWorkersCount(*bigMergeConcurrency)

--- a/lib/storage/dedup.go
+++ b/lib/storage/dedup.go
@@ -1,6 +1,10 @@
 package storage
 
 import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
 	"time"
 )
 
@@ -19,6 +23,106 @@ func GetDedupInterval() int64 {
 }
 
 var globalDedupInterval int64
+
+var meta []DownSamplingMeta
+
+//GetDownSamplingMeta returns the downsampling infos, which has been set via SetDownsampling.
+func GetDownSamplingMeta() []DownSamplingMeta {
+	return meta
+}
+
+//SetDownsampling set downsampling infos, like  -downsampling.period=30d:5m,180d:1h
+func SetDownsampling(downsampling string) {
+	if downsampling != "" {
+		//downsampling like 30d:5m,180d:30m
+		aggregates := strings.Split(downsampling, ",")
+		if len(aggregates) > 0 {
+			for _, v := range aggregates {
+				chunks := strings.Split(v, ":")
+				if len(chunks) > 0 {
+					duration, e1 := convertDuration(chunks[0])
+					downsamplingInterval, e2 := convertDuration(chunks[1])
+					if e1 == nil && e2 == nil {
+						if downsamplingInterval > 1 {
+							dm := DownSamplingMeta{Duration: duration,
+								DownsamplingInterval: downsamplingInterval}
+							meta = append(meta, dm)
+						}
+					}
+				}
+			}
+		}
+		if len(meta) > 1 {
+			sort.Slice(meta, func(i, j int) bool {
+				return meta[i].Duration > meta[j].Duration
+			})
+		}
+	}
+}
+
+//convertDuration parse downsampling like -downsampling.period=30d:5m,180d:1h
+func convertDuration(duration string) (time.Duration, error) {
+	/*
+		Golang's time library doesn't support many different
+		string formats (year, month, week, day) because they
+		aren't consistent ranges. But Java's library _does_.
+		Consequently, we'll need to handle all the custom
+		time ranges, and, to make the internal API call consistent,
+		we'll need to allow for durations that Go supports, too.
+		The nice thing is all the "broken" time ranges are > 1 hour,
+		so we can just make assumptions to convert them to a range in hours.
+		They aren't *good* assumptions, but they're reasonable
+		for this function.
+	*/
+	var actualDuration time.Duration
+	var err error
+	var timeValue int
+	if strings.HasSuffix(duration, "y") {
+		timeValue, err = strconv.Atoi(strings.Trim(duration, "y"))
+		if err != nil {
+			return 0, fmt.Errorf("invalid time range: %q", duration)
+		}
+		timeValue = timeValue * 365 * 24
+		actualDuration, err = time.ParseDuration(fmt.Sprintf("%vh", timeValue))
+		if err != nil {
+			return 0, fmt.Errorf("invalid time range: %q", duration)
+		}
+	} else if strings.HasSuffix(duration, "w") {
+		timeValue, err = strconv.Atoi(strings.Trim(duration, "w"))
+		if err != nil {
+			return 0, fmt.Errorf("invalid time range: %q", duration)
+		}
+		timeValue = timeValue * 7 * 24
+		actualDuration, err = time.ParseDuration(fmt.Sprintf("%vh", timeValue))
+		if err != nil {
+			return 0, fmt.Errorf("invalid time range: %q", duration)
+		}
+	} else if strings.HasSuffix(duration, "d") {
+		timeValue, err = strconv.Atoi(strings.Trim(duration, "d"))
+		if err != nil {
+			return 0, fmt.Errorf("invalid time range: %q", duration)
+		}
+		timeValue = timeValue * 24
+		actualDuration, err = time.ParseDuration(fmt.Sprintf("%vh", timeValue))
+		if err != nil {
+			return 0, fmt.Errorf("invalid time range: %q", duration)
+		}
+	} else if strings.HasSuffix(duration, "h") || strings.HasSuffix(duration, "m") || strings.HasSuffix(duration, "s") || strings.HasSuffix(duration, "ms") {
+		actualDuration, err = time.ParseDuration(duration)
+		if err != nil {
+			return 0, fmt.Errorf("invalid time range: %q", duration)
+		}
+	} else {
+		return 0, fmt.Errorf("invalid time duration string: %q", duration)
+	}
+	return actualDuration, nil
+}
+
+//DownSamplingMeta include Duration and DownsamplingInterval
+type DownSamplingMeta struct {
+	Duration             time.Duration
+	DownsamplingInterval time.Duration
+}
 
 func isDedupEnabled() bool {
 	return globalDedupInterval > 0


### PR DESCRIPTION
support downsampling


supports multi-level downsampling with -downsampling.period command-line flag. For example:

-downsampling.period=30d:5m instructs VictoriaMetrics to deduplicate samples older than 30 days with 5 minutes interval.

-downsampling.period=30d:5m,180d:1h instructs VictoriaMetrics to deduplicate samples older than 30 days with 5 minutes interval and to deduplicate samples older than 180 days with 1 hour interval.