### PR TITLE
api  prometheus/api/v1/label/__name__/values default start time let vmstorage cpu will be very high

### DIFF
--- a/app/vmselect/prometheus/prometheus.go
+++ b/app/vmselect/prometheus/prometheus.go
@@ -1147,12 +1147,13 @@ func getExportParams(r *http.Request, startTime time.Time) (*commonParams, error
 // - extra_filters[]
 func getCommonParams(r *http.Request, startTime time.Time, requireNonEmptyMatch bool) (*commonParams, error) {
 	deadline := searchutils.GetDeadlineForQuery(r, startTime)
-	start, err := searchutils.GetTime(r, "start", 0)
+	ct := startTime.UnixNano() / 1e6
+	start, err := searchutils.GetTime(r, "start", ct-3*defaultStep)
 	if err != nil {
 		return nil, err
 	}
-	ct := startTime.UnixNano() / 1e6
 	end, err := searchutils.GetTime(r, "end", ct)
+
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
when call the prometheus/api/v1/label/\_\_name\_\_/values very, very many times when vmstorage -retentionPeriod is long time to set，when query time  not specified,start defalut is 0 very bad ，so modify default start values