### PR TITLE
vmui: add lists of top queries

### DIFF
--- a/app/vmui/packages/vmui/src/App.tsx
+++ b/app/vmui/packages/vmui/src/App.tsx
@@ -5,6 +5,7 @@ import {StateProvider} from "./state/common/StateContext";
 import {AuthStateProvider} from "./state/auth/AuthStateContext";
 import {GraphStateProvider} from "./state/graph/GraphStateContext";
 import {CardinalityStateProvider} from "./state/cardinality/CardinalityStateContext";
+import {TopQueriesStateProvider} from "./state/topQueries/TopQueriesStateContext";
 import THEME from "./theme/theme";
 import { ThemeProvider, StyledEngineProvider } from "@mui/material/styles";
 import CssBaseline from "@mui/material/CssBaseline";
@@ -16,6 +17,7 @@ import CustomPanel from "./components/CustomPanel/CustomPanel";
 import HomeLayout from "./components/Home/HomeLayout";
 import DashboardsLayout from "./components/PredefinedPanels/DashboardsLayout";
 import CardinalityPanel from "./components/CardinalityPanel/CardinalityPanel";
+import TopQueries from "./components/TopQueries/TopQueries";
 
 
 const App: FC = () => {
@@ -30,15 +32,18 @@ const App: FC = () => {
               <AuthStateProvider> {/* Auth related info - optionally persisted to Local Storage */}
                 <GraphStateProvider> {/* Graph settings */}
                   <CardinalityStateProvider> {/* Cardinality settings */}
-                    <SnackbarProvider> {/* Display various snackbars */}
-                      <Routes>
-                        <Route path={"/"} element={<HomeLayout/>}>
-                          <Route path={router.home} element={<CustomPanel/>}/>
-                          <Route path={router.dashboards} element={<DashboardsLayout/>}/>
-                          <Route path={router.cardinality} element={<CardinalityPanel/>} />
-                        </Route>
-                      </Routes>
-                    </SnackbarProvider>
+                    <TopQueriesStateProvider> {/* Top Queries settings */}
+                      <SnackbarProvider> {/* Display various snackbars */}
+                        <Routes>
+                          <Route path={"/"} element={<HomeLayout/>}>
+                            <Route path={router.home} element={<CustomPanel/>}/>
+                            <Route path={router.dashboards} element={<DashboardsLayout/>}/>
+                            <Route path={router.cardinality} element={<CardinalityPanel/>} />
+                            <Route path={router.topQueries} element={<TopQueries/>} />
+                          </Route>
+                        </Routes>
+                      </SnackbarProvider>
+                    </TopQueriesStateProvider>
                   </CardinalityStateProvider>
                 </GraphStateProvider>
               </AuthStateProvider>

--- a/app/vmui/packages/vmui/src/api/top-queries.ts
+++ b/app/vmui/packages/vmui/src/api/top-queries.ts
@@ -1,0 +1,3 @@
+export const getTopQueries = (server: string, topN: number | null, maxLifetime?: string) => (
+  `${server}/api/v1/status/top_queries?topN=${topN || ""}&maxLifetime=${maxLifetime || ""}`
+);

--- a/app/vmui/packages/vmui/src/components/CustomPanel/Views/JsonView.tsx
+++ b/app/vmui/packages/vmui/src/components/CustomPanel/Views/JsonView.tsx
@@ -3,9 +3,10 @@ import {InstantMetricResult} from "../../../api/types";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import {useSnack} from "../../../contexts/Snackbar";
+import {TopQuery} from "../../../types";
 
 export interface JsonViewProps {
-  data: InstantMetricResult[];
+  data: InstantMetricResult[] | TopQuery[];
 }
 
 const JsonView: FC<JsonViewProps> = ({data}) => {

--- a/app/vmui/packages/vmui/src/components/Header/Header.tsx
+++ b/app/vmui/packages/vmui/src/components/Header/Header.tsx
@@ -61,8 +61,26 @@ const Header: FC = () => {
   const {date} = useCardinalityState();
   const cardinalityDispatch = useCardinalityDispatch();
 
-  const {search, pathname} = useLocation();
   const navigate = useNavigate();
+  const {search, pathname} = useLocation();
+  const routes = [
+    {
+      label: "Custom panel",
+      value: router.home,
+    },
+    {
+      label: "Dashboards",
+      value: router.dashboards,
+    },
+    {
+      label: "Cardinality",
+      value: router.cardinality,
+    },
+    {
+      label: "Top queries",
+      value: router.topQueries,
+    }
+  ];
 
   const [activeMenu, setActiveMenu] = useState(pathname);
 
@@ -102,13 +120,15 @@ const Header: FC = () => {
       <Box sx={{ml: 8}}>
         <Tabs value={activeMenu} textColor="inherit" TabIndicatorProps={{style: {background: "white"}}}
           onChange={(e, val) => setActiveMenu(val)}>
-          <Tab label="Custom panel" value={router.home} component={RouterLink} to={`${router.home}${search}`}/>
-          <Tab label="Dashboards" value={router.dashboards} component={RouterLink} to={`${router.dashboards}${search}`}/>
-          <Tab
-            label="Cardinality"
-            value={router.cardinality}
-            component={RouterLink}
-            to={`${router.cardinality}${search}`}/>
+          {routes.map(r => (
+            <Tab
+              key={`${r.label}_${r.value}`}
+              label={r.label}
+              value={r.value}
+              component={RouterLink}
+              to={`${r.value}${search}`}
+            />
+          ))}
         </Tabs>
       </Box>
       <Box display="flex" gap={1} alignItems="center" ml="auto" mr={0}>

--- a/app/vmui/packages/vmui/src/components/PredefinedPanels/PredefinedDashboard.tsx
+++ b/app/vmui/packages/vmui/src/components/PredefinedPanels/PredefinedDashboard.tsx
@@ -78,7 +78,7 @@ const PredefinedDashboard: FC<PredefinedDashboardProps> = ({index, title, panels
 
   return <Accordion defaultExpanded={!index} sx={{boxShadow: "none"}}>
     <AccordionSummary
-      sx={{px: 3, bgcolor: "rgba(227, 242, 253, 0.6)"}}
+      sx={{px: 3, bgcolor: "primary.light"}}
       aria-controls={`panel${index}-content`}
       id={`panel${index}-header`}
       expandIcon={<ExpandMoreIcon />}

--- a/app/vmui/packages/vmui/src/components/TopQueries/TopQueries.tsx
+++ b/app/vmui/packages/vmui/src/components/TopQueries/TopQueries.tsx
@@ -63,7 +63,7 @@ const TopQueries: FC = () => {
           <Box mr={2} flexGrow={1}>
             <TextField
               fullWidth
-              label="During the last time"
+              label="Max lifetime"
               size="medium"
               variant="outlined"
               value={maxLifetime}

--- a/app/vmui/packages/vmui/src/components/TopQueries/TopQueries.tsx
+++ b/app/vmui/packages/vmui/src/components/TopQueries/TopQueries.tsx
@@ -1,0 +1,139 @@
+import React, {ChangeEvent, FC, useEffect, useMemo, KeyboardEvent} from "react";
+import Box from "@mui/material/Box";
+import {useFetchTopQueries} from "../../hooks/useFetchTopQueries";
+import Spinner from "../common/Spinner";
+import Alert from "@mui/material/Alert";
+import TopQueryPanel from "./TopQueryPanel/TopQueryPanel";
+import Tooltip from "@mui/material/Tooltip";
+import Typography from "@mui/material/Typography";
+import TextField from "@mui/material/TextField";
+import {useTopQueriesDispatch, useTopQueriesState} from "../../state/topQueries/TopQueriesStateContext";
+import {formatPrettyNumber} from "../../utils/uplot/helpers";
+import {isSupportedDuration} from "../../utils/time";
+import IconButton from "@mui/material/IconButton";
+import PlayCircleOutlineIcon from "@mui/icons-material/PlayCircleOutline";
+import RestartAltIcon from "@mui/icons-material/RestartAlt";
+import dayjs from "dayjs";
+
+const exampleDuration = "30ms, 15s, 3d4h, 1y2w";
+
+const TopQueries: FC = () => {
+  const {data, error, loading} = useFetchTopQueries();
+  const {topN, maxLifetime} = useTopQueriesState();
+  const topQueriesDispatch = useTopQueriesDispatch();
+
+  const maxLifetimeValid = useMemo(() => {
+    const durItems = maxLifetime.trim().split(" ");
+    const durObject = durItems.reduce((prev, curr) => {
+      const dur = isSupportedDuration(curr);
+      return dur ? {...prev, ...dur} : {...prev};
+    }, {});
+    const delta = dayjs.duration(durObject).asMilliseconds();
+    return !!delta;
+  }, [maxLifetime]);
+
+  const onTopNChange = (e: ChangeEvent<HTMLTextAreaElement|HTMLInputElement>) => {
+    topQueriesDispatch({type: "SET_TOP_N", payload: +e.target.value});
+  };
+
+  const onMaxLifetimeChange = (e: ChangeEvent<HTMLTextAreaElement|HTMLInputElement>) => {
+    topQueriesDispatch({type: "SET_MAX_LIFE_TIME", payload: e.target.value});
+  };
+
+  const onApplyQuery = () => {
+    topQueriesDispatch({type: "SET_RUN_QUERY"});
+  };
+
+  const onKeyDown = (e: KeyboardEvent) => {
+    if (e.key === "Enter") onApplyQuery();
+  };
+
+  useEffect(() => {
+    if (!data) return;
+    if (!topN) topQueriesDispatch({type: "SET_TOP_N", payload: +data.topN});
+    if (!maxLifetime) topQueriesDispatch({type: "SET_MAX_LIFE_TIME", payload: data.maxLifetime});
+  }, [data]);
+
+  return (
+    <Box p={4} style={{minHeight: "calc(100vh - 64px)"}}>
+      {loading && <Spinner isLoading={true} height={"100%"}/>}
+
+      <Box boxShadow="rgba(99, 99, 99, 0.2) 0px 2px 8px 0px;" p={4} pb={2} m={-4} mb={4}>
+        <Box display={"flex"} alignItems={"flex"} mb={2}>
+          <Box mr={2} flexGrow={1}>
+            <TextField
+              fullWidth
+              label="During the last time"
+              size="medium"
+              variant="outlined"
+              value={maxLifetime}
+              error={!maxLifetimeValid}
+              helperText={!maxLifetimeValid ? "Invalid duration value" : `For example ${exampleDuration}`}
+              onChange={onMaxLifetimeChange}
+              onKeyDown={onKeyDown}
+            />
+          </Box>
+          <Box mr={2}>
+            <TextField
+              fullWidth
+              label="Number of returned queries"
+              type="number"
+              size="medium"
+              variant="outlined"
+              value={topN}
+              error={!!(topN && topN < 1)}
+              helperText={topN && topN < 1 ? "Number must be bigger than zero" : " "}
+              onChange={onTopNChange}
+              onKeyDown={onKeyDown}
+            />
+          </Box>
+          <Box>
+            <Tooltip title="Apply">
+              <IconButton onClick={onApplyQuery} sx={{height: "49px", width: "49px"}}>
+                <PlayCircleOutlineIcon/>
+              </IconButton>
+            </Tooltip>
+          </Box>
+        </Box>
+        <Typography variant="body1" pt={2}>
+            VictoriaMetrics tracks the last&nbsp;
+          <Tooltip arrow title={<Typography>search.queryStats.lastQueriesCount</Typography>}>
+            <b style={{cursor: "default"}}>
+              {data ? formatPrettyNumber(data["search.queryStats.lastQueriesCount"]) : "search.queryStats.lastQueriesCount"}
+            </b>
+          </Tooltip>
+            &nbsp;queries with durations at least&nbsp;
+          <Tooltip arrow title={<Typography>search.queryStats.minQueryDuration</Typography>}>
+            <b style={{cursor: "default"}}>
+              {data ? data["search.queryStats.minQueryDuration"] : "search.queryStats.minQueryDuration"}
+            </b>
+          </Tooltip>
+        </Typography>
+      </Box>
+
+      {error && <Alert color="error" severity="error" sx={{whiteSpace: "pre-wrap", my: 2}}>{error}</Alert>}
+
+      {data && (<>
+        <Box>
+          <TopQueryPanel
+            rows={data.topByCount}
+            title={"Top by count"}
+            description={"The most frequently executed queries"}
+          />
+          <TopQueryPanel
+            rows={data.topByAvgDuration}
+            title={"Top by avg duration"}
+            description={"Queries that took the most average execution time"}
+          />
+          <TopQueryPanel
+            rows={data.topBySumDuration}
+            title={"Top by sum duration"}
+            description={"Queries that took the highest summary execution time"}
+          />
+        </Box>
+      </>)}
+    </Box>
+  );
+};
+
+export default TopQueries;

--- a/app/vmui/packages/vmui/src/components/TopQueries/TopQueryPanel/TopQueryPanel.tsx
+++ b/app/vmui/packages/vmui/src/components/TopQueries/TopQueryPanel/TopQueryPanel.tsx
@@ -1,0 +1,89 @@
+import React, {FC, useState} from "react";
+import Box from "@mui/material/Box";
+import {TopQuery} from "../../../types";
+import Typography from "@mui/material/Typography";
+import Tooltip from "@mui/material/Tooltip";
+import InfoIcon from "@mui/icons-material/Info";
+import Accordion from "@mui/material/Accordion";
+import AccordionSummary from "@mui/material/AccordionSummary";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import AccordionDetails from "@mui/material/AccordionDetails";
+import Tabs from "@mui/material/Tabs";
+import Tab from "@mui/material/Tab";
+import TableChartIcon from "@mui/icons-material/TableChart";
+import CodeIcon from "@mui/icons-material/Code";
+import TopQueryTable from "../TopQueryTable/TopQueryTable";
+import JsonView from "../../CustomPanel/Views/JsonView";
+
+interface TopQueryPanelProps {
+  rows: TopQuery[],
+  title: string,
+  description: string
+}
+const tabs = ["table", "JSON"];
+
+const TopQueryPanel: FC<TopQueryPanelProps> = ({rows, title, description}) => {
+
+  const [activeTab, setActiveTab] = useState(0);
+
+  return (
+    <Accordion
+      defaultExpanded={true}
+      sx={{
+        mt: 2,
+        border: "1px solid",
+        borderColor: "primary.light",
+        boxShadow: "none",
+        "&:before": {
+          opacity: 0
+        }
+      }}
+    >
+      <AccordionSummary
+        sx={{
+          p: 2,
+          bgcolor: "primary.light",
+          minHeight: "64px",
+          ".MuiAccordionSummary-content": { display: "flex", alignItems: "center" },
+        }}
+        expandIcon={<ExpandMoreIcon />}
+      >
+        <Tooltip arrow title={description}>
+          <InfoIcon color="info" sx={{mr: 1}}/>
+        </Tooltip>
+        <Typography variant="h6" component="h6">
+          {title}
+        </Typography>
+      </AccordionSummary>
+      <AccordionDetails sx={{p: 0}}>
+        <Box width={"100%"}>
+          <Box sx={{ borderBottom: 1, borderColor: "divider" }}>
+            <Tabs
+              value={activeTab}
+              onChange={(e, val) => setActiveTab(val)}
+              sx={{minHeight: "0", marginBottom: "-1px"}}
+            >
+              {tabs.map((title: string, i: number) =>
+                <Tab
+                  key={title}
+                  label={title}
+                  aria-controls={`tabpanel-${i}`}
+                  id={`${title}_${i}`}
+                  iconPosition={"start"}
+                  sx={{minHeight: "41px"}}
+                  icon={ i === 0 ? <TableChartIcon /> : <CodeIcon /> } />
+              )}
+            </Tabs>
+          </Box>
+          {activeTab === 0 && <TopQueryTable rows={rows}/>}
+          {activeTab === 1 && <Box m={2}><JsonView data={rows} /></Box>}
+        </Box>
+      </AccordionDetails>
+      <Box >
+
+      </Box>
+    </Accordion>
+  );
+};
+
+export default TopQueryPanel;

--- a/app/vmui/packages/vmui/src/components/TopQueries/TopQueryTable/TopQueryTable.tsx
+++ b/app/vmui/packages/vmui/src/components/TopQueries/TopQueryTable/TopQueryTable.tsx
@@ -1,0 +1,72 @@
+import React, {FC, useState, useMemo} from "react";
+import TableContainer from "@mui/material/TableContainer";
+import Table from "@mui/material/Table";
+import TableHead from "@mui/material/TableHead";
+import TableRow from "@mui/material/TableRow";
+import TableCell from "@mui/material/TableCell";
+import TableBody from "@mui/material/TableBody";
+import TableSortLabel from "@mui/material/TableSortLabel";
+import {TopQuery} from "../../../types";
+import {getComparator, stableSort} from "../../Table/helpers";
+
+interface TopQueryTableProps {
+  rows: TopQuery[],
+}
+type ColumnKeys = keyof TopQuery;
+const columns: ColumnKeys[] = ["query", "timeRangeSeconds", "avgDurationSeconds", "count", "accountID", "projectID"];
+
+const TopQueryTable:FC<TopQueryTableProps> = ({rows}) => {
+
+  const [orderBy, setOrderBy] = useState("count");
+  const [orderDir, setOrderDir] = useState<"asc" | "desc">("desc");
+
+  const sortedList = useMemo(() => stableSort(rows as [], getComparator(orderDir, orderBy)),
+    [rows, orderBy, orderDir]);
+
+  const sortHandler = (key: string) => {
+    setOrderDir((prev) => prev === "asc" && orderBy === key ? "desc" : "asc");
+    setOrderBy(key);
+  };
+
+  return <TableContainer>
+    <Table
+      sx={{minWidth: 750}}
+      aria-labelledby="tableTitle"
+    >
+      <TableHead>
+        <TableRow>
+          {columns.map((col) => (
+            <TableCell key={col} sx={{ borderBottomColor: "primary.light" }}>
+              <TableSortLabel
+                active={orderBy === col}
+                direction={orderDir}
+                onClick={() => sortHandler(col)}
+              >
+                {col}
+              </TableSortLabel>
+            </TableCell>
+          ))}
+        </TableRow>
+      </TableHead>
+      <TableBody>
+        {sortedList.map((row, rowIndex) => (
+          <TableRow key={rowIndex}>
+            {columns.map((col) => (
+              <TableCell
+                key={col}
+                sx={{
+                  borderBottom: rowIndex === rows.length - 1 ? "none" : "",
+                  borderBottomColor: "primary.light"
+                }}
+              >
+                {row[col] || "-"}
+              </TableCell>
+            ))}
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  </TableContainer>;
+};
+
+export default TopQueryTable;

--- a/app/vmui/packages/vmui/src/hooks/useFetchTopQueries.ts
+++ b/app/vmui/packages/vmui/src/hooks/useFetchTopQueries.ts
@@ -1,0 +1,48 @@
+import { useEffect, useState } from "react";
+import {ErrorTypes} from "../types";
+import {getAppModeEnable, getAppModeParams} from "../utils/app-mode";
+import {useAppState} from "../state/common/StateContext";
+import {useMemo} from "preact/compat";
+import {getTopQueries} from "../api/top-queries";
+import {TopQueriesData} from "../types";
+import {useTopQueriesState} from "../state/topQueries/TopQueriesStateContext";
+
+export const useFetchTopQueries = () => {
+  const appModeEnable = getAppModeEnable();
+  const {serverURL: appServerUrl} = getAppModeParams();
+  const {serverUrl} = useAppState();
+  const {topN, maxLifetime, runQuery} = useTopQueriesState();
+
+  const [data, setData] = useState<TopQueriesData | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<ErrorTypes | string>();
+
+  const server = useMemo(() => appModeEnable ? appServerUrl : serverUrl,
+    [appModeEnable, serverUrl, appServerUrl]);
+  const fetchUrl = useMemo(() => getTopQueries(server, topN, maxLifetime), [server, topN, maxLifetime]);
+
+  const fetchData = async () => {
+    setLoading(true);
+    try {
+      const response = await fetch(fetchUrl);
+      const resp = await response.json();
+      setData(response.ok ? resp : null);
+      setError(String(resp.error || ""));
+    } catch (e) {
+      if (e instanceof Error && e.name !== "AbortError") {
+        setError(`${e.name}: ${e.message}`);
+      }
+    }
+    setLoading(false);
+  };
+
+  useEffect(() => {
+    fetchData();
+  }, [runQuery]);
+
+  return {
+    data,
+    error,
+    loading
+  };
+};

--- a/app/vmui/packages/vmui/src/router/index.ts
+++ b/app/vmui/packages/vmui/src/router/index.ts
@@ -2,6 +2,7 @@ const router = {
   home: "/",
   dashboards: "/dashboards",
   cardinality: "/cardinality",
+  topQueries: "/top-queries",
 };
 
 export interface RouterOptions {

--- a/app/vmui/packages/vmui/src/state/common/StateContext.tsx
+++ b/app/vmui/packages/vmui/src/state/common/StateContext.tsx
@@ -19,14 +19,14 @@ export const initialPrepopulatedState = Object.entries(initialState)
   }), {}) as AppState;
 
 export const StateProvider: FC = ({children}) => {
-  const location = useLocation();
+  const {pathname} = useLocation();
 
   const [state, dispatch] = useReducer(reducer, initialPrepopulatedState);
 
   useEffect(() => {
-    if (location.pathname === router.cardinality) return;
+    if (pathname !== router.dashboards || pathname !== router.home) return;
     setQueryStringValue(state as unknown as Record<string, unknown>);
-  }, [state, location]);
+  }, [state, pathname]);
 
   const contextValue = useMemo(() => {
     return { state, dispatch };

--- a/app/vmui/packages/vmui/src/state/topQueries/TopQueriesStateContext.tsx
+++ b/app/vmui/packages/vmui/src/state/topQueries/TopQueriesStateContext.tsx
@@ -1,0 +1,35 @@
+import React, {createContext, FC, useContext, useEffect, useMemo, useReducer} from "preact/compat";
+import {Action, TopQueriesState, initialState, reducer} from "./reducer";
+import {Dispatch} from "react";
+import {useLocation} from "react-router-dom";
+import {setQueryStringValue} from "../../utils/query-string";
+import router from "../../router";
+
+type TopQueriesStateContextType = { state: TopQueriesState, dispatch: Dispatch<Action> };
+
+export const TopQueriesStateContext = createContext<TopQueriesStateContextType>({} as TopQueriesStateContextType);
+
+export const useTopQueriesState = (): TopQueriesState => useContext(TopQueriesStateContext).state;
+export const useTopQueriesDispatch = (): Dispatch<Action> => useContext(TopQueriesStateContext).dispatch;
+
+export const TopQueriesStateProvider: FC = ({children}) => {
+  const location = useLocation();
+
+  const [state, dispatch] = useReducer(reducer, initialState);
+
+  useEffect(() => {
+    if (location.pathname !== router.topQueries) return;
+    setQueryStringValue(state as unknown as Record<string, unknown>);
+  }, [state, location]);
+
+  const contextValue = useMemo(() => {
+    return { state, dispatch };
+  }, [state, dispatch]);
+
+
+  return <TopQueriesStateContext.Provider value={contextValue}>
+    {children}
+  </TopQueriesStateContext.Provider>;
+};
+
+

--- a/app/vmui/packages/vmui/src/state/topQueries/reducer.ts
+++ b/app/vmui/packages/vmui/src/state/topQueries/reducer.ts
@@ -1,0 +1,41 @@
+import {getQueryStringValue} from "../../utils/query-string";
+
+export interface TopQueriesState {
+  maxLifetime: string,
+  topN: number | null,
+  runQuery: number
+}
+
+export type Action =
+  | { type: "SET_TOP_N", payload: number | null }
+  | { type: "SET_MAX_LIFE_TIME", payload: string }
+  | { type: "SET_RUN_QUERY" }
+
+
+export const initialState: TopQueriesState = {
+  topN: getQueryStringValue("topN", null) as number,
+  maxLifetime: getQueryStringValue("maxLifetime", "") as string,
+  runQuery: 0
+};
+
+export function reducer(state: TopQueriesState, action: Action): TopQueriesState {
+  switch (action.type) {
+    case "SET_TOP_N":
+      return {
+        ...state,
+        topN: action.payload
+      };
+    case "SET_MAX_LIFE_TIME":
+      return {
+        ...state,
+        maxLifetime: action.payload
+      };
+    case "SET_RUN_QUERY":
+      return {
+        ...state,
+        runQuery: state.runQuery + 1
+      };
+    default:
+      throw new Error();
+  }
+}

--- a/app/vmui/packages/vmui/src/theme/theme.ts
+++ b/app/vmui/packages/vmui/src/theme/theme.ts
@@ -3,7 +3,8 @@ import {createTheme} from "@mui/material/styles";
 const THEME = createTheme({
   palette: {
     primary: {
-      main: "#3F51B5"
+      main: "#3F51B5",
+      light: "#e3f2fd"
     },
     secondary: {
       main: "#F50057"
@@ -17,7 +18,7 @@ const THEME = createTheme({
       styleOverrides: {
         root: {
           position: "absolute",
-          top: "36px",
+          bottom: "-16px",
           left: "2px",
           margin: 0,
         }

--- a/app/vmui/packages/vmui/src/types/index.ts
+++ b/app/vmui/packages/vmui/src/types/index.ts
@@ -69,3 +69,22 @@ export interface RelativeTimeOption {
   title: string,
   isDefault?: boolean,
 }
+
+export interface TopQuery {
+  accountID: number
+  avgDurationSeconds: number
+  count: number
+  projectID: number
+  query: string
+  timeRangeSeconds: number
+}
+
+export interface TopQueriesData {
+  maxLifetime: string
+  "search.queryStats.lastQueriesCount": number
+  "search.queryStats.minQueryDuration": string
+  topN: string
+  topByAvgDuration: TopQuery[]
+  topByCount: TopQuery[]
+  topBySumDuration: TopQuery[]
+}

--- a/app/vmui/packages/vmui/src/utils/query-string.ts
+++ b/app/vmui/packages/vmui/src/utils/query-string.ts
@@ -19,6 +19,10 @@ const stateToUrlParams = {
     "match": "match[]",
     "extraLabel": "extra_label",
     "focusLabel": "focusLabel"
+  },
+  [router.topQueries]: {
+    "topN": "topN",
+    "maxLifetime": "maxLifetime",
   }
 };
 


### PR DESCRIPTION
Added a page with a few lists of top queries:
- the most frequently executed queries - `topByCount`
- queries that took the most average execution time - `topByAvgDuration`
- queries that took the highest summary execution time - `topBySumDuration`

The number of returned queries can be limited via the "Number of returned queries" field (`topN` query arg).
Old queries can be filtered out with the "Max lifetime" field (`maxLifetime` query arg).

The view as a table (can be switched to JSON).

#2707