### PR TITLE
app/{vmselect, vminsert}: fails with error when user defines equal addresses in the `-storageNodes` flag

### DIFF
--- a/app/vminsert/main.go
+++ b/app/vminsert/main.go
@@ -83,6 +83,9 @@ func main() {
 	if len(*storageNodes) == 0 {
 		logger.Fatalf("missing -storageNode arg")
 	}
+	if duplicatedAddr := checkDuplicates(*storageNodes); duplicatedAddr != "" {
+		logger.Fatalf("found equal addresses of storage nodes in the -storageNodes flag: %q", duplicatedAddr)
+	}
 	hashSeed := uint64(0)
 	if *clusternativeListenAddr != "" {
 		// Use different hash seed for the second level of vminsert nodes in multi-level cluster setup.
@@ -354,4 +357,15 @@ vminsert accepts data via popular data ingestion protocols and routes it to vmst
 See the docs at https://docs.victoriametrics.com/Cluster-VictoriaMetrics.html .
 `
 	flagutil.Usage(s)
+}
+
+func checkDuplicates(arr []string) string {
+	visited := make(map[string]struct{})
+	for _, s := range arr {
+		if _, ok := visited[s]; ok {
+			return s
+		}
+		visited[s] = struct{}{}
+	}
+	return ""
 }

--- a/app/vmselect/main.go
+++ b/app/vmselect/main.go
@@ -85,6 +85,10 @@ func main() {
 	if len(*storageNodes) == 0 {
 		logger.Fatalf("missing -storageNode arg")
 	}
+	if duplicatedAddr := checkDuplicates(*storageNodes); duplicatedAddr != "" {
+		logger.Fatalf("found equal addresses of storage nodes in the -storageNodes flag: %q", duplicatedAddr)
+	}
+
 	netstorage.InitStorageNodes(*storageNodes)
 	logger.Infof("started netstorage in %.3f seconds", time.Since(startTime).Seconds())
 
@@ -770,4 +774,15 @@ func initVMAlertProxy() {
 	}
 	vmalertProxyHost = proxyURL.Host
 	vmalertProxy = httputil.NewSingleHostReverseProxy(proxyURL)
+}
+
+func checkDuplicates(arr []string) string {
+	visited := make(map[string]struct{})
+	for _, s := range arr {
+		if _, ok := visited[s]; ok {
+			return s
+		}
+		visited[s] = struct{}{}
+	}
+	return ""
 }


### PR DESCRIPTION
If user defines equal addresses in `-storageNode` flag vminsert or vmselect will show error.

Related issue: https://github.com/VictoriaMetrics/VictoriaMetrics/issues/3076