### PR TITLE
Merging multitenant rw context by tenant into a single one per multitenantURL

### DIFF
--- a/app/vmagent/remotewrite/remotewrite.go
+++ b/app/vmagent/remotewrite/remotewrite.go
@@ -504,7 +504,7 @@ func (rwctx *remoteWriteCtx) Push(tss []prompbmarshal.TimeSeries, at *auth.Token
 			rwctx.pssNextIdxByTenant[*at] = new(uint64)
 		}
 		rwctx.pssByTenantLock.Unlock()
-		pss, _ := rwctx.pssByTenant[*at]
+		pss := rwctx.pssByTenant[*at]
 		idx := atomic.AddUint64(rwctx.pssNextIdxByTenant[*at], 1) % uint64(len(pss))
 		pss[idx].Push(tss)
 	} else {

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -1,6 +1,8 @@
 package auth
 
 import (
+	"bytes"
+	"encoding/binary"
 	"fmt"
 	"strconv"
 	"strings"
@@ -18,6 +20,21 @@ func (t *Token) String() string {
 		return fmt.Sprintf("%d", t.AccountID)
 	}
 	return fmt.Sprintf("%d:%d", t.AccountID, t.ProjectID)
+}
+
+// ToByteArray dumps a Token to a byte array of 8 bytes
+// This is useful with vmagent spooling with multitenancy enabled
+func (t *Token) ToByteArray() []byte {
+	buff := new(bytes.Buffer)
+	err := binary.Write(buff, binary.BigEndian, t.AccountID)
+	if err != nil {
+		fmt.Println(err)
+	}
+	err = binary.Write(buff, binary.BigEndian, t.ProjectID)
+	if err != nil {
+		fmt.Println(err)
+	}
+	return buff.Bytes()
 }
 
 // NewToken returns new Token for the given authToken
@@ -40,4 +57,12 @@ func NewToken(authToken string) (*Token, error) {
 		at.ProjectID = uint32(projectID)
 	}
 	return &at, nil
+}
+
+func NewTokenFromByteArray(array []byte) *Token {
+	return &Token{
+		binary.BigEndian.Uint32(array[:4]),
+		binary.BigEndian.Uint32(array[4:]),
+	}
+
 }

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -59,6 +59,8 @@ func NewToken(authToken string) (*Token, error) {
 	return &at, nil
 }
 
+// NewTokenFromByteArray deserializes a byte array into a Token
+// This is useful with vmagent spooling with multitenancy enabled
 func NewTokenFromByteArray(array []byte) *Token {
 	return &Token{
 		binary.BigEndian.Uint32(array[:4]),

--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -74,3 +74,16 @@ func TestNewTokenFailure(t *testing.T) {
 	// many int parts in the token"
 	f("1:2:3")
 }
+
+func TestToByteArray(t *testing.T) {
+	token, _ := NewToken("2:100")
+	b := token.ToByteArray()
+	token = NewTokenFromByteArray(b)
+	if token.AccountID != 2 {
+		t.Fatalf("expecting token.AccountID=2 got %d", token.AccountID)
+	}
+	if token.ProjectID != 100 {
+		t.Fatalf("expecting token.ProjectID=100 got %d", token.ProjectID)
+	}
+
+}


### PR DESCRIPTION
Context: https://github.com/VictoriaMetrics/VictoriaMetrics/issues/2970

Change:
- Sharing a single rwctx for each multitenanturl, effectively sharing the client and the fastqueue
- Prepending the tenant on blocks in the queue to allow the client to send the write request to the correct tenant

Benefit
- With this, there is now one queue/httpclient per multitenantURL, which makes the tuning deterministic and not factor of the number of tenant.