### PR TITLE
deployment/docker/docker-compose: expose port for vminsert

### DIFF
--- a/deployment/docker/README.md
+++ b/deployment/docker/README.md
@@ -9,8 +9,8 @@ For single version check [docker compose in master branch](https://github.com/Vi
 ## VictoriaMetrics
 
 VictoriaMetrics cluster in this environment consists of 
-vminsert, vmstorage and vmselect components. Only vmselect
-has exposed port `:8481` and the rest of components are available
+vminsert, vmstorage and vmselect components. vmselect
+has exposed port `:8481`, vminsert has exposed port `:8480` and the rest of components are available
 only inside of environment. 
 The communication scheme between components is the following:
 * [vmagent](#vmagent) sends scraped metrics to vminsert;

--- a/deployment/docker/docker-compose.yml
+++ b/deployment/docker/docker-compose.yml
@@ -64,7 +64,7 @@ services:
       - '--storageNode=vmstorage-1:8400'
       - '--storageNode=vmstorage-2:8400'
     ports:
-      - 8480
+      - 8480:8480
     restart: always
   vmselect:
     container_name: vmselect


### PR DESCRIPTION
When run `docker-compose up -d` **vminsert** will run on random generated port in OS and it can't be reached from curl/etc - see the screenshot below:
![image](https://user-images.githubusercontent.com/5650611/189609470-d146003b-e652-47a8-86c0-97ebe45e89d1.png)
This PR will fix this issue.