### PR TITLE
app/vmctl: add description about `influx-skip-database-label` flag

### DIFF
--- a/app/vmctl/README.md
+++ b/app/vmctl/README.md
@@ -242,6 +242,7 @@ Found 40000 timeseries to import. Continue? [Y/n] y
 Vmctl maps InfluxDB data the same way as VictoriaMetrics does by using the following rules:
 
 - `influx-database` arg is mapped into `db` label value unless `db` tag exists in the InfluxDB line.
+If you want to skip this mapping just enable flag `influx-skip-database-label`.
 - Field names are mapped to time series names prefixed with {measurement}{separator} value,
 where {separator} equals to _ by default.
 It can be changed with `--influx-measurement-field-separator` command-line flag.

--- a/docs/vmctl.md
+++ b/docs/vmctl.md
@@ -246,6 +246,7 @@ Found 40000 timeseries to import. Continue? [Y/n] y
 Vmctl maps InfluxDB data the same way as VictoriaMetrics does by using the following rules:
 
 - `influx-database` arg is mapped into `db` label value unless `db` tag exists in the InfluxDB line.
+If you want to skip this mapping just enable flag `influx-skip-database-label`.
 - Field names are mapped to time series names prefixed with {measurement}{separator} value,
 where {separator} equals to _ by default.
 It can be changed with `--influx-measurement-field-separator` command-line flag.


### PR DESCRIPTION
In the documentation there is no mentions about `influx-skip-database-label`. Added it in the place where user can have questions


Signed-off-by: dmitryk-dk [d.kozlov@victoriametrics.com](mailto:d.kozlov@victoriametrics.com)