### PR TITLE
Dashboards

### DIFF
--- a/dashboards/victoriametrics-cluster.json
+++ b/dashboards/victoriametrics-cluster.json
@@ -1,7 +1,8 @@
 {
   "__inputs": [],
   "__elements": {},
-  "__requires": [{
+  "__requires": [
+    {
       "type": "grafana",
       "id": "grafana",
       "name": "Grafana",
@@ -33,32 +34,35 @@
     }
   ],
   "annotations": {
-    "list": [{
-      "builtIn": 1,
-      "datasource": {
-        "type": "datasource",
-        "uid": "grafana"
-      },
-      "enable": true,
-      "hide": true,
-      "iconColor": "rgba(0, 211, 255, 1)",
-      "name": "Annotations & Alerts",
-      "target": {
-        "limit": 100,
-        "matchAny": false,
-        "tags": [],
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
         "type": "dashboard"
-      },
-      "type": "dashboard"
-    }]
+      }
+    ]
   },
-  "description": "Overview for cluster VictoriaMetrics v1.77.0 or higher",
+  "description": "Overview for cluster VictoriaMetrics v1.79.0 or higher",
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
   "id": null,
-  "iteration": 1659947950093,
-  "links": [{
+  "iteration": 1663336027743,
+  "links": [
+    {
       "icon": "doc",
       "tags": [],
       "targetBlank": true,
@@ -84,7 +88,8 @@
     }
   ],
   "liveNow": false,
-  "panels": [{
+  "panels": [
+    {
       "collapsed": true,
       "datasource": {
         "type": "prometheus",
@@ -97,7 +102,8 @@
         "y": 0
       },
       "id": 137,
-      "panels": [{
+      "panels": [
+        {
           "datasource": {
             "uid": "$ds"
           },
@@ -110,9 +116,11 @@
               "mappings": [],
               "thresholds": {
                 "mode": "absolute",
-                "steps": [{
-                  "color": "green"
-                }]
+                "steps": [
+                  {
+                    "color": "green"
+                  }
+                ]
               },
               "unit": "short"
             },
@@ -142,21 +150,23 @@
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "8.5.3",
-          "targets": [{
-            "datasource": {
-              "type": "prometheus",
-              "uid": "$ds"
-            },
-            "exemplar": true,
-            "expr": "sum(vm_rows{job=~\"$job_storage\", type!=\"indexdb\"})",
-            "format": "time_series",
-            "instant": true,
-            "interval": "",
-            "intervalFactor": 1,
-            "legendFormat": "",
-            "refId": "A"
-          }],
+          "pluginVersion": "9.0.3",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$ds"
+              },
+              "exemplar": true,
+              "expr": "sum(vm_rows{job=~\"$job_storage\", type!=\"indexdb\"})",
+              "format": "time_series",
+              "instant": true,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
           "title": "Total datapoints",
           "type": "stat"
         },
@@ -173,9 +183,11 @@
               "mappings": [],
               "thresholds": {
                 "mode": "absolute",
-                "steps": [{
-                  "color": "green"
-                }]
+                "steps": [
+                  {
+                    "color": "green"
+                  }
+                ]
               },
               "unit": "bytes"
             },
@@ -205,21 +217,23 @@
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "8.5.3",
-          "targets": [{
-            "datasource": {
-              "type": "prometheus",
-              "uid": "$ds"
-            },
-            "exemplar": true,
-            "expr": "min(vm_free_disk_space_bytes{job=~\"$job\", instance=~\"$instance\"})",
-            "format": "time_series",
-            "instant": true,
-            "interval": "",
-            "intervalFactor": 1,
-            "legendFormat": "",
-            "refId": "A"
-          }],
+          "pluginVersion": "9.0.3",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$ds"
+              },
+              "exemplar": true,
+              "expr": "min(vm_free_disk_space_bytes{job=~\"$job\", instance=~\"$instance\"})",
+              "format": "time_series",
+              "instant": true,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
           "title": "Min free disk space",
           "type": "stat"
         },
@@ -237,9 +251,11 @@
               "mappings": [],
               "thresholds": {
                 "mode": "absolute",
-                "steps": [{
-                  "color": "green"
-                }]
+                "steps": [
+                  {
+                    "color": "green"
+                  }
+                ]
               },
               "unit": "bytes"
             },
@@ -269,21 +285,23 @@
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "8.5.3",
-          "targets": [{
-            "datasource": {
-              "type": "prometheus",
-              "uid": "$ds"
-            },
-            "exemplar": true,
-            "expr": "sum(vm_data_size_bytes{job=~\"$job_storage\", type!=\"indexdb\"}) / sum(vm_rows{job=~\"$job_storage\", type!=\"indexdb\"})",
-            "format": "time_series",
-            "instant": true,
-            "interval": "",
-            "intervalFactor": 1,
-            "legendFormat": "",
-            "refId": "A"
-          }],
+          "pluginVersion": "9.0.3",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$ds"
+              },
+              "exemplar": true,
+              "expr": "sum(vm_data_size_bytes{job=~\"$job_storage\", type!=\"indexdb\"}) / sum(vm_rows{job=~\"$job_storage\", type!=\"indexdb\"})",
+              "format": "time_series",
+              "instant": true,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
           "title": "Bytes per point",
           "type": "stat"
         },
@@ -300,9 +318,11 @@
               "mappings": [],
               "thresholds": {
                 "mode": "absolute",
-                "steps": [{
-                  "color": "green"
-                }]
+                "steps": [
+                  {
+                    "color": "green"
+                  }
+                ]
               },
               "unit": "bytes"
             },
@@ -332,21 +352,23 @@
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "8.5.3",
-          "targets": [{
-            "datasource": {
-              "type": "prometheus",
-              "uid": "$ds"
-            },
-            "exemplar": true,
-            "expr": "sum(vm_allowed_memory_bytes{job=~\"$job\", instance=~\"$instance\"})",
-            "format": "time_series",
-            "instant": true,
-            "interval": "",
-            "intervalFactor": 1,
-            "legendFormat": "",
-            "refId": "A"
-          }],
+          "pluginVersion": "9.0.3",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$ds"
+              },
+              "exemplar": true,
+              "expr": "sum(vm_allowed_memory_bytes{job=~\"$job\", instance=~\"$instance\"})",
+              "format": "time_series",
+              "instant": true,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
           "title": "Allowed memory",
           "type": "stat"
         },
@@ -363,9 +385,11 @@
               "mappings": [],
               "thresholds": {
                 "mode": "absolute",
-                "steps": [{
-                  "color": "green"
-                }]
+                "steps": [
+                  {
+                    "color": "green"
+                  }
+                ]
               },
               "unit": "short"
             },
@@ -395,21 +419,23 @@
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "8.5.3",
-          "targets": [{
-            "datasource": {
-              "type": "prometheus",
-              "uid": "$ds"
-            },
-            "exemplar": true,
-            "expr": "sum(vm_rows{job=~\"$job_storage\", type=\"indexdb\"})",
-            "format": "time_series",
-            "instant": true,
-            "interval": "",
-            "intervalFactor": 1,
-            "legendFormat": "",
-            "refId": "A"
-          }],
+          "pluginVersion": "9.0.3",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$ds"
+              },
+              "exemplar": true,
+              "expr": "sum(vm_rows{job=~\"$job_storage\", type=\"indexdb\"})",
+              "format": "time_series",
+              "instant": true,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
           "title": "Index size",
           "type": "stat"
         },
@@ -427,9 +453,11 @@
               "mappings": [],
               "thresholds": {
                 "mode": "absolute",
-                "steps": [{
-                  "color": "green"
-                }]
+                "steps": [
+                  {
+                    "color": "green"
+                  }
+                ]
               },
               "unit": "bytes"
             },
@@ -459,21 +487,23 @@
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "8.5.3",
-          "targets": [{
-            "datasource": {
-              "type": "prometheus",
-              "uid": "$ds"
-            },
-            "exemplar": false,
-            "expr": "sum(vm_data_size_bytes{job=~\"$job_storage\"})",
-            "format": "time_series",
-            "instant": true,
-            "interval": "",
-            "intervalFactor": 1,
-            "legendFormat": "",
-            "refId": "A"
-          }],
+          "pluginVersion": "9.0.3",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$ds"
+              },
+              "exemplar": false,
+              "expr": "sum(vm_data_size_bytes{job=~\"$job_storage\"})",
+              "format": "time_series",
+              "instant": true,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
           "title": "Disk space usage",
           "type": "stat"
         },
@@ -490,9 +520,11 @@
               "mappings": [],
               "thresholds": {
                 "mode": "absolute",
-                "steps": [{
-                  "color": "green"
-                }]
+                "steps": [
+                  {
+                    "color": "green"
+                  }
+                ]
               },
               "unit": "short"
             },
@@ -522,21 +554,23 @@
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "8.5.3",
-          "targets": [{
-            "datasource": {
-              "type": "prometheus",
-              "uid": "$ds"
-            },
-            "exemplar": true,
-            "expr": "sum(vm_available_cpu_cores{job=~\"$job\", instance=~\"$instance\"})",
-            "format": "time_series",
-            "instant": true,
-            "interval": "",
-            "intervalFactor": 1,
-            "legendFormat": "",
-            "refId": "A"
-          }],
+          "pluginVersion": "9.0.3",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$ds"
+              },
+              "exemplar": true,
+              "expr": "sum(vm_available_cpu_cores{job=~\"$job\", instance=~\"$instance\"})",
+              "format": "time_series",
+              "instant": true,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
           "title": "Available CPU",
           "type": "stat"
         },
@@ -554,9 +588,11 @@
               "mappings": [],
               "thresholds": {
                 "mode": "absolute",
-                "steps": [{
-                  "color": "green"
-                }]
+                "steps": [
+                  {
+                    "color": "green"
+                  }
+                ]
               },
               "unit": "bytes"
             },
@@ -586,21 +622,23 @@
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "8.5.3",
-          "targets": [{
-            "datasource": {
-              "type": "prometheus",
-              "uid": "$ds"
-            },
-            "exemplar": true,
-            "expr": "sum(vm_available_memory_bytes{job=~\"$job\", instance=~\"$instance\"})",
-            "format": "time_series",
-            "instant": true,
-            "interval": "",
-            "intervalFactor": 1,
-            "legendFormat": "",
-            "refId": "A"
-          }],
+          "pluginVersion": "9.0.3",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$ds"
+              },
+              "exemplar": true,
+              "expr": "sum(vm_available_memory_bytes{job=~\"$job\", instance=~\"$instance\"})",
+              "format": "time_series",
+              "instant": true,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
           "title": "Available memory",
           "type": "stat"
         },
@@ -623,7 +661,8 @@
               "mappings": [],
               "thresholds": {
                 "mode": "absolute",
-                "steps": [{
+                "steps": [
+                  {
                     "color": "green"
                   },
                   {
@@ -633,25 +672,30 @@
                 ]
               }
             },
-            "overrides": [{
+            "overrides": [
+              {
                 "matcher": {
                   "id": "byName",
                   "options": "Time"
                 },
-                "properties": [{
-                  "id": "custom.hidden",
-                  "value": true
-                }]
+                "properties": [
+                  {
+                    "id": "custom.hidden",
+                    "value": true
+                  }
+                ]
               },
               {
                 "matcher": {
                   "id": "byName",
                   "options": "Value"
                 },
-                "properties": [{
-                  "id": "displayName",
-                  "value": "Count"
-                }]
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Count"
+                  }
+                ]
               }
             ]
           },
@@ -672,20 +716,22 @@
             },
             "showHeader": true
           },
-          "pluginVersion": "8.5.3",
-          "targets": [{
-            "datasource": {
-              "type": "prometheus",
-              "uid": "$ds"
-            },
-            "editorMode": "code",
-            "exemplar": false,
-            "expr": "sum(vm_app_version{job=~\"$job\", instance=~\"$instance\"}) by(job, short_version)",
-            "format": "table",
-            "instant": true,
-            "range": false,
-            "refId": "A"
-          }],
+          "pluginVersion": "9.0.3",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$ds"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "sum(vm_app_version{job=~\"$job\", instance=~\"$instance\"}) by(job, short_version)",
+              "format": "table",
+              "instant": true,
+              "range": false,
+              "refId": "A"
+            }
+          ],
           "type": "table"
         },
         {
@@ -734,7 +780,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "9.0.3",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -742,17 +788,19 @@
           "spaceLength": 10,
           "stack": false,
           "steppedLine": true,
-          "targets": [{
-            "datasource": {
-              "type": "prometheus",
-              "uid": "$ds"
-            },
-            "expr": "sort(sum(up{job=~\"$job\", instance=~\"$instance\"}) by (job, instance))",
-            "format": "time_series",
-            "instant": false,
-            "legendFormat": "{{instance}}({{job}})",
-            "refId": "A"
-          }],
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$ds"
+              },
+              "expr": "sort(sum(up{job=~\"$job\", instance=~\"$instance\"}) by (job, instance))",
+              "format": "time_series",
+              "instant": false,
+              "legendFormat": "{{instance}}({{job}})",
+              "refId": "A"
+            }
+          ],
           "thresholds": [],
           "timeRegions": [],
           "title": "Uptime",
@@ -767,7 +815,8 @@
             "show": true,
             "values": []
           },
-          "yaxes": [{
+          "yaxes": [
+            {
               "$$hashKey": "object:1177",
               "decimals": 0,
               "format": "none",
@@ -859,17 +908,19 @@
       "spaceLength": 10,
       "stack": true,
       "steppedLine": false,
-      "targets": [{
-        "datasource": {
-          "type": "prometheus",
-          "uid": "$ds"
-        },
-        "exemplar": true,
-        "expr": "sum(rate(vm_rows_inserted_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (type,accountID) > 0 ",
-        "interval": "",
-        "legendFormat": "{{type}}",
-        "refId": "A"
-      }],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$ds"
+          },
+          "exemplar": true,
+          "expr": "sum(rate(vm_rows_inserted_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (type,accountID) > 0 ",
+          "interval": "",
+          "legendFormat": "{{type}}",
+          "refId": "A"
+        }
+      ],
       "thresholds": [],
       "timeRegions": [],
       "title": "Datapoints ingestion rate ($instance)",
@@ -884,7 +935,8 @@
         "show": true,
         "values": []
       },
-      "yaxes": [{
+      "yaxes": [
+        {
           "format": "short",
           "logBase": 1,
           "min": "0",
@@ -916,7 +968,7 @@
         },
         "overrides": []
       },
-      "fill": 1,
+      "fill": 0,
       "fillGradient": 0,
       "gridPos": {
         "h": 8,
@@ -954,17 +1006,19 @@
       "spaceLength": 10,
       "stack": false,
       "steppedLine": false,
-      "targets": [{
-        "datasource": {
-          "type": "prometheus",
-          "uid": "$ds"
-        },
-        "expr": "sum(rate(vm_http_requests_total{job=~\"$job\", instance=~\"$instance.*\", path!~\"/favicon.ico\"}[$__rate_interval])) by (path) > 0",
-        "format": "time_series",
-        "intervalFactor": 1,
-        "legendFormat": "{{path}}",
-        "refId": "A"
-      }],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$ds"
+          },
+          "expr": "sum(rate(vm_http_requests_total{job=~\"$job\", instance=~\"$instance.*\", path!~\"/favicon.ico\"}[$__rate_interval])) by (path) > 0",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{path}}",
+          "refId": "A"
+        }
+      ],
       "thresholds": [],
       "timeRegions": [],
       "title": "Requests rate ($instance)",
@@ -979,13 +1033,16 @@
         "show": true,
         "values": []
       },
-      "yaxes": [{
+      "yaxes": [
+        {
+          "$$hashKey": "object:3307",
           "format": "short",
           "logBase": 1,
           "min": "0",
           "show": true
         },
         {
+          "$$hashKey": "object:3308",
           "format": "short",
           "logBase": 1,
           "min": "0",
@@ -1049,17 +1106,19 @@
       "spaceLength": 10,
       "stack": false,
       "steppedLine": false,
-      "targets": [{
-        "datasource": {
-          "type": "prometheus",
-          "uid": "$ds"
-        },
-        "expr": "sum(rate(vm_http_request_errors_total{job=~\"$job\", instance=~\"$instance.*\"}[$__rate_interval])) by (path) > 0",
-        "format": "time_series",
-        "intervalFactor": 1,
-        "legendFormat": "{{path}}",
-        "refId": "A"
-      }],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$ds"
+          },
+          "expr": "sum(rate(vm_http_request_errors_total{job=~\"$job\", instance=~\"$instance.*\"}[$__rate_interval])) by (path) > 0",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{path}}",
+          "refId": "A"
+        }
+      ],
       "thresholds": [],
       "timeRegions": [],
       "title": "Requests error rate ($instance)",
@@ -1074,7 +1133,8 @@
         "show": true,
         "values": []
       },
-      "yaxes": [{
+      "yaxes": [
+        {
           "format": "short",
           "logBase": 1,
           "min": "0",
@@ -1144,17 +1204,19 @@
       "spaceLength": 10,
       "stack": false,
       "steppedLine": false,
-      "targets": [{
-        "datasource": {
-          "type": "prometheus",
-          "uid": "$ds"
-        },
-        "expr": "max(vm_request_duration_seconds{job=~\"$job\", instance=~\"$instance\", quantile=~\"(0.5|0.99)\"}) by (path, quantile) > 0",
-        "format": "time_series",
-        "intervalFactor": 1,
-        "legendFormat": "{{quantile}} ({{path}})",
-        "refId": "A"
-      }],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$ds"
+          },
+          "expr": "max(vm_request_duration_seconds{job=~\"$job\", instance=~\"$instance\", quantile=~\"(0.5|0.99)\"}) by (path, quantile) > 0",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{quantile}} ({{path}})",
+          "refId": "A"
+        }
+      ],
       "thresholds": [],
       "timeRegions": [],
       "title": "Query duration ($instance)",
@@ -1169,13 +1231,16 @@
         "show": true,
         "values": []
       },
-      "yaxes": [{
+      "yaxes": [
+        {
+          "$$hashKey": "object:423",
           "format": "s",
           "logBase": 1,
           "min": "0",
           "show": true
         },
         {
+          "$$hashKey": "object:424",
           "format": "short",
           "logBase": 1,
           "min": "0",
@@ -1231,7 +1296,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "9.0.3",
       "pointradius": 1,
       "points": false,
       "renderer": "flot",
@@ -1239,7 +1304,8 @@
       "spaceLength": 10,
       "stack": false,
       "steppedLine": false,
-      "targets": [{
+      "targets": [
+        {
           "datasource": {
             "type": "prometheus",
             "uid": "$ds"
@@ -1287,7 +1353,8 @@
         "show": true,
         "values": []
       },
-      "yaxes": [{
+      "yaxes": [
+        {
           "format": "rps",
           "logBase": 1,
           "min": "0",
@@ -1306,10 +1373,11 @@
     },
     {
       "aliasColors": {},
-      "bars": false,
+      "bars": true,
       "dashLength": 10,
       "dashes": false,
       "datasource": {
+        "type": "prometheus",
         "uid": "$ds"
       },
       "description": "Shows the rate of logging the messages by their level. Unexpected spike in rate is a good reason to check logs.",
@@ -1341,7 +1409,7 @@
         "total": false,
         "values": true
       },
-      "lines": true,
+      "lines": false,
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
@@ -1349,7 +1417,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "9.0.3",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1357,20 +1425,24 @@
       "spaceLength": 10,
       "stack": false,
       "steppedLine": false,
-      "targets": [{
-        "datasource": {
-          "type": "prometheus",
-          "uid": "$ds"
-        },
-        "exemplar": true,
-        "expr": "sum(rate(vm_log_messages_total{job=~\"$job\",instance=~\"$instance.*\", level!=\"info\"}[$__rate_interval])) by (job, level) ",
-        "format": "time_series",
-        "hide": false,
-        "interval": "",
-        "intervalFactor": 1,
-        "legendFormat": "{{job}} - {{level}}",
-        "refId": "A"
-      }],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$ds"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum(rate(vm_log_messages_total{job=~\"$job\",instance=~\"$instance.*\", level!=\"info\"}[$__rate_interval])) by (job, level) > 0",
+          "format": "time_series",
+          "hide": false,
+          "interval": "5m",
+          "intervalFactor": 1,
+          "legendFormat": "{{job}} - {{level}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
       "thresholds": [],
       "timeRegions": [],
       "title": "Logging rate",
@@ -1385,13 +1457,16 @@
         "show": true,
         "values": []
       },
-      "yaxes": [{
+      "yaxes": [
+        {
+          "$$hashKey": "object:78",
           "format": "short",
           "logBase": 1,
           "min": "0",
           "show": true
         },
         {
+          "$$hashKey": "object:79",
           "format": "short",
           "logBase": 1,
           "show": true
@@ -1446,7 +1521,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "9.0.3",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1454,28 +1529,32 @@
       "spaceLength": 10,
       "stack": false,
       "steppedLine": false,
-      "targets": [{
-        "datasource": {
-          "type": "prometheus",
-          "uid": "$ds"
-        },
-        "exemplar": true,
-        "expr": "sum(vm_data_size_bytes{job=~\"$job_storage\", instance=~\"$instance\"}) by(instance) /\n(\n  sum(vm_free_disk_space_bytes{job=~\"$job_storage\", instance=~\"$instance\"}) by(instance) +\n  sum(vm_data_size_bytes{job=~\"$job_storage\", instance=~\"$instance\"}) by(instance)\n)",
-        "format": "time_series",
-        "interval": "",
-        "intervalFactor": 1,
-        "legendFormat": "{{instance}}",
-        "refId": "A"
-      }],
-      "thresholds": [{
-        "$$hashKey": "object:89",
-        "colorMode": "critical",
-        "fill": true,
-        "line": true,
-        "op": "gt",
-        "value": 0.8,
-        "yaxis": "left"
-      }],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$ds"
+          },
+          "exemplar": true,
+          "expr": "sum(vm_data_size_bytes{job=~\"$job_storage\", instance=~\"$instance\"}) by(instance) /\n(\n  sum(vm_free_disk_space_bytes{job=~\"$job_storage\", instance=~\"$instance\"}) by(instance) +\n  sum(vm_data_size_bytes{job=~\"$job_storage\", instance=~\"$instance\"}) by(instance)\n)",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [
+        {
+          "$$hashKey": "object:89",
+          "colorMode": "critical",
+          "fill": true,
+          "line": true,
+          "op": "gt",
+          "value": 0.8,
+          "yaxis": "left"
+        }
+      ],
       "timeRegions": [],
       "title": "Disk space used ($instance)",
       "tooltip": {
@@ -1489,7 +1568,8 @@
         "show": true,
         "values": []
       },
-      "yaxes": [{
+      "yaxes": [
+        {
           "format": "percentunit",
           "logBase": 1,
           "min": "0",
@@ -1544,17 +1624,19 @@
       },
       "lines": true,
       "linewidth": 1,
-      "links": [{
-        "targetBlank": true,
-        "title": "troubleshooting",
-        "url": "https://github.com/VictoriaMetrics/VictoriaMetrics/blob/master/README.md#troubleshooting"
-      }],
+      "links": [
+        {
+          "targetBlank": true,
+          "title": "troubleshooting",
+          "url": "https://github.com/VictoriaMetrics/VictoriaMetrics/blob/master/README.md#troubleshooting"
+        }
+      ],
       "nullPointMode": "null",
       "options": {
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "9.0.3",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1562,17 +1644,19 @@
       "spaceLength": 10,
       "stack": false,
       "steppedLine": false,
-      "targets": [{
-        "datasource": {
-          "type": "prometheus",
-          "uid": "$ds"
-        },
-        "expr": "sum(vm_cache_entries{job=~\"$job\", instance=~\"$instance.*\", type=\"storage/hour_metric_ids\"})",
-        "format": "time_series",
-        "intervalFactor": 1,
-        "legendFormat": "Active time series",
-        "refId": "A"
-      }],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$ds"
+          },
+          "expr": "sum(vm_cache_entries{job=~\"$job\", instance=~\"$instance.*\", type=\"storage/hour_metric_ids\"})",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "Active time series",
+          "refId": "A"
+        }
+      ],
       "thresholds": [],
       "timeRegions": [],
       "title": "Active time series ($instance)",
@@ -1587,13 +1671,16 @@
         "show": true,
         "values": []
       },
-      "yaxes": [{
+      "yaxes": [
+        {
+          "$$hashKey": "object:253",
           "format": "short",
           "logBase": 1,
           "min": "0",
           "show": true
         },
         {
+          "$$hashKey": "object:254",
           "format": "short",
           "logBase": 1,
           "min": "0",
@@ -1616,7 +1703,8 @@
         "y": 34
       },
       "id": 46,
-      "panels": [{
+      "panels": [
+        {
           "aliasColors": {},
           "bars": false,
           "dashLength": 10,
@@ -1661,7 +1749,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "9.0.3",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -1669,17 +1757,19 @@
           "spaceLength": 10,
           "stack": false,
           "steppedLine": false,
-          "targets": [{
-            "datasource": {
-              "type": "prometheus",
-              "uid": "$ds"
-            },
-            "exemplar": true,
-            "expr": "sum(process_resident_memory_bytes{job=~\"$job\", instance=~\"$instance\"}) by (job, instance)",
-            "interval": "",
-            "legendFormat": "{{instance}} ({{job}})",
-            "refId": "A"
-          }],
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$ds"
+              },
+              "exemplar": true,
+              "expr": "sum(process_resident_memory_bytes{job=~\"$job\", instance=~\"$instance\"}) by (job, instance)",
+              "interval": "",
+              "legendFormat": "{{instance}} ({{job}})",
+              "refId": "A"
+            }
+          ],
           "thresholds": [],
           "timeRegions": [],
           "title": "RSS memory usage ($instance)",
@@ -1694,7 +1784,8 @@
             "show": true,
             "values": []
           },
-          "yaxes": [{
+          "yaxes": [
+            {
               "format": "bytes",
               "logBase": 1,
               "min": "0",
@@ -1756,7 +1847,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "9.0.3",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -1764,17 +1855,19 @@
           "spaceLength": 10,
           "stack": false,
           "steppedLine": false,
-          "targets": [{
-            "datasource": {
-              "type": "prometheus",
-              "uid": "$ds"
-            },
-            "exemplar": true,
-            "expr": "sum(process_resident_memory_anon_bytes{job=~\"$job\", instance=~\"$instance\"}) by (job, instance)",
-            "interval": "",
-            "legendFormat": "{{instance}} ({{job}})",
-            "refId": "A"
-          }],
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$ds"
+              },
+              "exemplar": true,
+              "expr": "sum(process_resident_memory_anon_bytes{job=~\"$job\", instance=~\"$instance\"}) by (job, instance)",
+              "interval": "",
+              "legendFormat": "{{instance}} ({{job}})",
+              "refId": "A"
+            }
+          ],
           "thresholds": [],
           "timeRegions": [],
           "title": "RSS anonymous memory usage ($instance)",
@@ -1789,7 +1882,8 @@
             "show": true,
             "values": []
           },
-          "yaxes": [{
+          "yaxes": [
+            {
               "$$hashKey": "object:271",
               "format": "bytes",
               "logBase": 1,
@@ -1851,7 +1945,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "9.0.3",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -1859,19 +1953,21 @@
           "spaceLength": 10,
           "stack": false,
           "steppedLine": false,
-          "targets": [{
-            "datasource": {
-              "type": "prometheus",
-              "uid": "$ds"
-            },
-            "exemplar": true,
-            "expr": "sum(rate(process_cpu_seconds_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by(job, instance)",
-            "format": "time_series",
-            "interval": "",
-            "intervalFactor": 1,
-            "legendFormat": "{{instance}} ({{job}})",
-            "refId": "A"
-          }],
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$ds"
+              },
+              "exemplar": true,
+              "expr": "sum(rate(process_cpu_seconds_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by(job, instance)",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{instance}} ({{job}})",
+              "refId": "A"
+            }
+          ],
           "thresholds": [],
           "timeRegions": [],
           "title": "CPU ($instance)",
@@ -1886,7 +1982,8 @@
             "show": true,
             "values": []
           },
-          "yaxes": [{
+          "yaxes": [
+            {
               "format": "short",
               "logBase": 1,
               "min": "0",
@@ -1948,7 +2045,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "9.0.3",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -1956,28 +2053,32 @@
           "spaceLength": 10,
           "stack": false,
           "steppedLine": false,
-          "targets": [{
-            "datasource": {
-              "type": "prometheus",
-              "uid": "$ds"
-            },
-            "exemplar": false,
-            "expr": "sum(rate(process_cpu_seconds_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by(job, instance) / sum(process_cpu_cores_available{job=~\"$job\", instance=~\"$instance\"}) by(job, instance)",
-            "format": "time_series",
-            "interval": "",
-            "intervalFactor": 1,
-            "legendFormat": "{{instance}} ({{job}})",
-            "refId": "A"
-          }],
-          "thresholds": [{
-            "$$hashKey": "object:195",
-            "colorMode": "critical",
-            "fill": true,
-            "line": true,
-            "op": "gt",
-            "value": 0.9,
-            "yaxis": "left"
-          }],
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$ds"
+              },
+              "exemplar": false,
+              "expr": "sum(rate(process_cpu_seconds_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by(job, instance) / sum(process_cpu_cores_available{job=~\"$job\", instance=~\"$instance\"}) by(job, instance)",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{instance}} ({{job}})",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [
+            {
+              "$$hashKey": "object:195",
+              "colorMode": "critical",
+              "fill": true,
+              "line": true,
+              "op": "gt",
+              "value": 0.9,
+              "yaxis": "left"
+            }
+          ],
           "timeRegions": [],
           "title": "CPU percentage ($instance)",
           "tooltip": {
@@ -1991,7 +2092,8 @@
             "show": true,
             "values": []
           },
-          "yaxes": [{
+          "yaxes": [
+            {
               "$$hashKey": "object:75",
               "format": "percentunit",
               "logBase": 1,
@@ -2054,18 +2156,21 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "9.0.3",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
-          "seriesOverrides": [{
-            "alias": "/max.*/",
-            "color": "#C4162A"
-          }],
+          "seriesOverrides": [
+            {
+              "alias": "/max.*/",
+              "color": "#C4162A"
+            }
+          ],
           "spaceLength": 10,
           "stack": false,
           "steppedLine": false,
-          "targets": [{
+          "targets": [
+            {
               "datasource": {
                 "type": "prometheus",
                 "uid": "$ds"
@@ -2106,7 +2211,8 @@
             "show": true,
             "values": []
           },
-          "yaxes": [{
+          "yaxes": [
+            {
               "decimals": 0,
               "format": "short",
               "logBase": 2,
@@ -2168,7 +2274,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "9.0.3",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -2176,19 +2282,21 @@
           "spaceLength": 10,
           "stack": false,
           "steppedLine": false,
-          "targets": [{
-            "datasource": {
-              "type": "prometheus",
-              "uid": "$ds"
-            },
-            "exemplar": true,
-            "expr": "sum(rate(go_gc_duration_seconds_sum{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by(job, instance)\n/\nsum(rate(go_gc_duration_seconds_count{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by(job, instance)",
-            "format": "time_series",
-            "interval": "",
-            "intervalFactor": 2,
-            "legendFormat": "{{instance}} ({{job}})",
-            "refId": "A"
-          }],
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$ds"
+              },
+              "exemplar": true,
+              "expr": "sum(rate(go_gc_duration_seconds_sum{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by(job, instance)\n/\nsum(rate(go_gc_duration_seconds_count{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by(job, instance)",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 2,
+              "legendFormat": "{{instance}} ({{job}})",
+              "refId": "A"
+            }
+          ],
           "thresholds": [],
           "timeRegions": [],
           "title": "GC duration ($instance)",
@@ -2203,7 +2311,8 @@
             "show": true,
             "values": []
           },
-          "yaxes": [{
+          "yaxes": [
+            {
               "format": "s",
               "logBase": 1,
               "min": "0",
@@ -2263,7 +2372,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "9.0.3",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -2271,19 +2380,21 @@
           "spaceLength": 10,
           "stack": false,
           "steppedLine": false,
-          "targets": [{
-            "datasource": {
-              "type": "prometheus",
-              "uid": "$ds"
-            },
-            "exemplar": true,
-            "expr": "sum(go_goroutines{job=~\"$job\", instance=~\"$instance\"}) by(job, instance)",
-            "format": "time_series",
-            "interval": "",
-            "intervalFactor": 2,
-            "legendFormat": "{{instance}} ({{job}})",
-            "refId": "A"
-          }],
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$ds"
+              },
+              "exemplar": true,
+              "expr": "sum(go_goroutines{job=~\"$job\", instance=~\"$instance\"}) by(job, instance)",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 2,
+              "legendFormat": "{{instance}} ({{job}})",
+              "refId": "A"
+            }
+          ],
           "thresholds": [],
           "timeRegions": [],
           "title": "Goroutines ($instance)",
@@ -2298,7 +2409,8 @@
             "show": true,
             "values": []
           },
-          "yaxes": [{
+          "yaxes": [
+            {
               "decimals": 0,
               "format": "short",
               "logBase": 1,
@@ -2330,7 +2442,7 @@
             },
             "overrides": []
           },
-          "fill": 1,
+          "fill": 0,
           "fillGradient": 0,
           "gridPos": {
             "h": 8,
@@ -2360,18 +2472,22 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "9.0.3",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
-          "seriesOverrides": [{
-            "alias": "/read .*/",
-            "transform": "negative-Y"
-          }],
+          "seriesOverrides": [
+            {
+              "$$hashKey": "object:331",
+              "alias": "/read .*/",
+              "transform": "negative-Y"
+            }
+          ],
           "spaceLength": 10,
           "stack": false,
           "steppedLine": false,
-          "targets": [{
+          "targets": [
+            {
               "datasource": {
                 "type": "prometheus",
                 "uid": "$ds"
@@ -2413,12 +2529,15 @@
             "show": true,
             "values": []
           },
-          "yaxes": [{
+          "yaxes": [
+            {
+              "$$hashKey": "object:338",
               "format": "bytes",
               "logBase": 1,
               "show": true
             },
             {
+              "$$hashKey": "object:339",
               "format": "short",
               "logBase": 1,
               "min": "0",
@@ -2473,7 +2592,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "9.0.3",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -2481,19 +2600,21 @@
           "spaceLength": 10,
           "stack": false,
           "steppedLine": false,
-          "targets": [{
-            "datasource": {
-              "type": "prometheus",
-              "uid": "$ds"
-            },
-            "exemplar": true,
-            "expr": "sum(process_num_threads{job=~\"$job\", instance=~\"$instance\"}) by(job, instance)",
-            "format": "time_series",
-            "interval": "",
-            "intervalFactor": 2,
-            "legendFormat": "{{instance}} ({{job}})",
-            "refId": "A"
-          }],
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$ds"
+              },
+              "exemplar": true,
+              "expr": "sum(process_num_threads{job=~\"$job\", instance=~\"$instance\"}) by(job, instance)",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 2,
+              "legendFormat": "{{instance}} ({{job}})",
+              "refId": "A"
+            }
+          ],
           "thresholds": [],
           "timeRegions": [],
           "title": "Threads ($instance)",
@@ -2508,7 +2629,8 @@
             "show": true,
             "values": []
           },
-          "yaxes": [{
+          "yaxes": [
+            {
               "decimals": 0,
               "format": "short",
               "logBase": 1,
@@ -2562,7 +2684,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "9.0.3",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -2570,17 +2692,19 @@
           "spaceLength": 10,
           "stack": false,
           "steppedLine": false,
-          "targets": [{
-            "datasource": {
-              "type": "prometheus",
-              "uid": "$ds"
-            },
-            "exemplar": true,
-            "expr": "sum(vm_tcplistener_conns{job=~\"$job\", instance=~\"$instance\"}) by(job, instance)",
-            "interval": "",
-            "legendFormat": "{{instance}} ({{job}})",
-            "refId": "A"
-          }],
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$ds"
+              },
+              "exemplar": true,
+              "expr": "sum(vm_tcplistener_conns{job=~\"$job\", instance=~\"$instance\"}) by(job, instance)",
+              "interval": "",
+              "legendFormat": "{{instance}} ({{job}})",
+              "refId": "A"
+            }
+          ],
           "thresholds": [],
           "timeRegions": [],
           "title": "TCP connections ($instance)",
@@ -2595,7 +2719,8 @@
             "show": true,
             "values": []
           },
-          "yaxes": [{
+          "yaxes": [
+            {
               "format": "short",
               "logBase": 1,
               "show": true
@@ -2647,7 +2772,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "9.0.3",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -2655,17 +2780,19 @@
           "spaceLength": 10,
           "stack": false,
           "steppedLine": false,
-          "targets": [{
-            "datasource": {
-              "type": "prometheus",
-              "uid": "$ds"
-            },
-            "exemplar": true,
-            "expr": "sum(rate(vm_tcplistener_accepts_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by(job, instance)",
-            "interval": "",
-            "legendFormat": "{{instance}} ({{job}})",
-            "refId": "A"
-          }],
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$ds"
+              },
+              "exemplar": true,
+              "expr": "sum(rate(vm_tcplistener_accepts_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by(job, instance)",
+              "interval": "",
+              "legendFormat": "{{instance}} ({{job}})",
+              "refId": "A"
+            }
+          ],
           "thresholds": [],
           "timeRegions": [],
           "title": "TCP connections rate ($instance)",
@@ -2680,7 +2807,8 @@
             "show": true,
             "values": []
           },
-          "yaxes": [{
+          "yaxes": [
+            {
               "format": "short",
               "logBase": 1,
               "show": true
@@ -2711,7 +2839,8 @@
         "y": 35
       },
       "id": 106,
-      "panels": [{
+      "panels": [
+        {
           "aliasColors": {},
           "bars": false,
           "dashLength": 10,
@@ -2759,14 +2888,17 @@
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
-          "seriesOverrides": [{
-            "alias": "new series over 24h",
-            "yaxis": 2
-          }],
+          "seriesOverrides": [
+            {
+              "alias": "new series over 24h",
+              "yaxis": 2
+            }
+          ],
           "spaceLength": 10,
           "stack": false,
           "steppedLine": false,
-          "targets": [{
+          "targets": [
+            {
               "datasource": {
                 "type": "prometheus",
                 "uid": "$ds"
@@ -2804,7 +2936,8 @@
             "show": true,
             "values": []
           },
-          "yaxes": [{
+          "yaxes": [
+            {
               "format": "short",
               "logBase": 1,
               "min": "0",
@@ -2873,17 +3006,19 @@
           "spaceLength": 10,
           "stack": false,
           "steppedLine": false,
-          "targets": [{
-            "datasource": {
-              "type": "prometheus",
-              "uid": "$ds"
-            },
-            "exemplar": true,
-            "expr": "sum(rate(vm_indexdb_items_added_total{job=~\"$job_storage\", instance=~\"$instance\"}[$__rate_interval]))",
-            "interval": "",
-            "legendFormat": "items",
-            "refId": "A"
-          }],
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$ds"
+              },
+              "exemplar": true,
+              "expr": "sum(rate(vm_indexdb_items_added_total{job=~\"$job_storage\", instance=~\"$instance\"}[$__rate_interval]))",
+              "interval": "",
+              "legendFormat": "items",
+              "refId": "A"
+            }
+          ],
           "thresholds": [],
           "timeRegions": [],
           "title": "IndexDB items rate ($instance)",
@@ -2898,7 +3033,8 @@
             "show": true,
             "values": []
           },
-          "yaxes": [{
+          "yaxes": [
+            {
               "$$hashKey": "object:92",
               "format": "short",
               "logBase": 1,
@@ -2968,25 +3104,29 @@
           "spaceLength": 10,
           "stack": false,
           "steppedLine": false,
-          "targets": [{
-            "datasource": {
-              "type": "prometheus",
-              "uid": "$ds"
-            },
-            "expr": "sum(rate(vm_slow_row_inserts_total{job=~\"$job_storage\"}[$__rate_interval])) / sum(rate(vm_rows_inserted_total{job=~\"$job_insert\"}[$__rate_interval]))",
-            "interval": "",
-            "legendFormat": "slow inserts",
-            "refId": "A"
-          }],
-          "thresholds": [{
-            "$$hashKey": "object:72",
-            "colorMode": "critical",
-            "fill": true,
-            "line": true,
-            "op": "gt",
-            "value": 0.1,
-            "yaxis": "left"
-          }],
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$ds"
+              },
+              "expr": "sum(rate(vm_slow_row_inserts_total{job=~\"$job_storage\"}[$__rate_interval])) / sum(rate(vm_rows_inserted_total{job=~\"$job_insert\"}[$__rate_interval]))",
+              "interval": "",
+              "legendFormat": "slow inserts",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [
+            {
+              "$$hashKey": "object:72",
+              "colorMode": "critical",
+              "fill": true,
+              "line": true,
+              "op": "gt",
+              "value": 0.1,
+              "yaxis": "left"
+            }
+          ],
           "timeRegions": [],
           "title": "Slow inserts",
           "tooltip": {
@@ -3000,7 +3140,8 @@
             "show": true,
             "values": []
           },
-          "yaxes": [{
+          "yaxes": [
+            {
               "$$hashKey": "object:738",
               "format": "percentunit",
               "logBase": 1,
@@ -3070,16 +3211,18 @@
           "spaceLength": 10,
           "stack": false,
           "steppedLine": false,
-          "targets": [{
-            "datasource": {
-              "type": "prometheus",
-              "uid": "$ds"
-            },
-            "expr": "sum(rate(vm_slow_queries_total{job=~\"$job_select\", instance=~\"$instance\"}[$__rate_interval]))",
-            "interval": "",
-            "legendFormat": "slow queries rate",
-            "refId": "A"
-          }],
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$ds"
+              },
+              "expr": "sum(rate(vm_slow_queries_total{job=~\"$job_select\", instance=~\"$instance\"}[$__rate_interval]))",
+              "interval": "",
+              "legendFormat": "slow queries rate",
+              "refId": "A"
+            }
+          ],
           "thresholds": [],
           "timeRegions": [],
           "title": "Slow queries rate ($instance)",
@@ -3094,7 +3237,8 @@
             "show": true,
             "values": []
           },
-          "yaxes": [{
+          "yaxes": [
+            {
               "$$hashKey": "object:892",
               "format": "short",
               "logBase": 1,
@@ -3152,11 +3296,13 @@
           },
           "lines": true,
           "linewidth": 1,
-          "links": [{
-            "targetBlank": true,
-            "title": "Readonly mode",
-            "url": "https://docs.victoriametrics.com/Cluster-VictoriaMetrics.html#readonly-mode"
-          }],
+          "links": [
+            {
+              "targetBlank": true,
+              "title": "Readonly mode",
+              "url": "https://docs.victoriametrics.com/Cluster-VictoriaMetrics.html#readonly-mode"
+            }
+          ],
           "nullPointMode": "null",
           "options": {
             "alertThreshold": true
@@ -3170,19 +3316,21 @@
           "spaceLength": 10,
           "stack": false,
           "steppedLine": false,
-          "targets": [{
-            "datasource": {
-              "type": "prometheus",
-              "uid": "$ds"
-            },
-            "exemplar": true,
-            "expr": "sum(vm_rpc_vmstorage_is_read_only{job=~\"$job_insert\", instance=~\"$instance\"}) by(instance, addr)",
-            "format": "time_series",
-            "interval": "",
-            "intervalFactor": 1,
-            "legendFormat": "{{instance}} => {{addr}}",
-            "refId": "A"
-          }],
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$ds"
+              },
+              "exemplar": true,
+              "expr": "sum(vm_rpc_vmstorage_is_read_only{job=~\"$job_insert\", instance=~\"$instance\"}) by(instance, addr)",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{instance}} => {{addr}}",
+              "refId": "A"
+            }
+          ],
           "thresholds": [],
           "timeRegions": [],
           "title": "Storage in readonly status for vminsert ($instance)",
@@ -3197,7 +3345,8 @@
             "show": true,
             "values": []
           },
-          "yaxes": [{
+          "yaxes": [
+            {
               "$$hashKey": "object:536",
               "format": "short",
               "logBase": 1,
@@ -3269,20 +3418,22 @@
           "spaceLength": 10,
           "stack": false,
           "steppedLine": false,
-          "targets": [{
-            "datasource": {
-              "type": "prometheus",
-              "uid": "$ds"
-            },
-            "exemplar": true,
-            "expr": "sum(increase(vm_metrics_with_dropped_labels_total{job=~\"$job_insert\", instance=~\"$instance\"}[$__rate_interval]))",
-            "format": "time_series",
-            "hide": false,
-            "interval": "",
-            "intervalFactor": 1,
-            "legendFormat": "metrics with dropped labels",
-            "refId": "A"
-          }],
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$ds"
+              },
+              "exemplar": true,
+              "expr": "sum(increase(vm_metrics_with_dropped_labels_total{job=~\"$job_insert\", instance=~\"$instance\"}[$__rate_interval]))",
+              "format": "time_series",
+              "hide": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "metrics with dropped labels",
+              "refId": "A"
+            }
+          ],
           "thresholds": [],
           "timeRegions": [],
           "title": "Labels limit exceeded ($instance)",
@@ -3297,7 +3448,8 @@
             "show": true,
             "values": []
           },
-          "yaxes": [{
+          "yaxes": [
+            {
               "$$hashKey": "object:1046",
               "decimals": 2,
               "format": "short",
@@ -3319,7 +3471,7 @@
         },
         {
           "aliasColors": {},
-          "bars": false,
+          "bars": true,
           "dashLength": 10,
           "dashes": false,
           "datasource": {
@@ -3355,7 +3507,7 @@
             "total": false,
             "values": true
           },
-          "lines": true,
+          "lines": false,
           "linewidth": 1,
           "links": [],
           "nullPointMode": "null",
@@ -3371,27 +3523,29 @@
           "spaceLength": 10,
           "stack": false,
           "steppedLine": false,
-          "targets": [{
-            "datasource": {
-              "type": "prometheus",
-              "uid": "$ds"
-            },
-            "editorMode": "code",
-            "exemplar": true,
-            "expr": "sum(increase(vm_assisted_merges_total{job=~\"$job_storage\", instance=~\"$instance\"}[$__rate_interval])) by(type, instance) > 0",
-            "format": "time_series",
-            "interval": "",
-            "intervalFactor": 1,
-            "legendFormat": "__auto",
-            "range": true,
-            "refId": "A"
-          }],
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$ds"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "sum(increase(vm_assisted_merges_total{job=~\"$job_storage\", instance=~\"$instance\"}[$__rate_interval])) by(type, instance) > 0",
+              "format": "time_series",
+              "interval": "5m",
+              "intervalFactor": 1,
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A"
+            }
+          ],
           "thresholds": [],
           "timeRegions": [],
           "title": "Assisted merges ($instance)",
           "tooltip": {
             "shared": true,
-            "sort": 0,
+            "sort": 2,
             "value_type": "individual"
           },
           "type": "graph",
@@ -3400,7 +3554,8 @@
             "show": true,
             "values": []
           },
-          "yaxes": [{
+          "yaxes": [
+            {
               "$$hashKey": "object:536",
               "format": "short",
               "logBase": 1,
@@ -3466,17 +3621,21 @@
           "spaceLength": 10,
           "stack": false,
           "steppedLine": false,
-          "targets": [{
-            "datasource": {
-              "type": "prometheus",
-              "uid": "$ds"
-            },
-            "exemplar": true,
-            "expr": "vm_cache_size_bytes{job=~\"$job_storage\", instance=~\"$instance\"} / vm_cache_size_max_bytes{job=~\"$job\", instance=~\"$instance\"}",
-            "interval": "",
-            "legendFormat": "{{ instance }} / {{ type }}",
-            "refId": "A"
-          }],
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$ds"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "vm_cache_size_bytes{job=~\"$job_storage\", instance=~\"$instance\"} / vm_cache_size_max_bytes{job=~\"$job\", instance=~\"$instance\"}",
+              "interval": "",
+              "legendFormat": "{{ instance }} / {{ type }}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
           "thresholds": [],
           "timeRegions": [],
           "title": "Cache usage % by vmstorage ($instance)",
@@ -3491,7 +3650,8 @@
             "show": true,
             "values": []
           },
-          "yaxes": [{
+          "yaxes": [
+            {
               "$$hashKey": "object:107",
               "format": "percentunit",
               "logBase": 1,
@@ -3524,7 +3684,8 @@
         "y": 36
       },
       "id": 48,
-      "panels": [{
+      "panels": [
+        {
           "aliasColors": {},
           "bars": false,
           "dashLength": 10,
@@ -3577,7 +3738,8 @@
           "spaceLength": 10,
           "stack": false,
           "steppedLine": false,
-          "targets": [{
+          "targets": [
+            {
               "datasource": {
                 "type": "prometheus",
                 "uid": "$ds"
@@ -3614,7 +3776,8 @@
             "show": true,
             "values": []
           },
-          "yaxes": [{
+          "yaxes": [
+            {
               "$$hashKey": "object:1108",
               "format": "short",
               "logBase": 1,
@@ -3685,7 +3848,8 @@
           "spaceLength": 10,
           "stack": false,
           "steppedLine": false,
-          "targets": [{
+          "targets": [
+            {
               "datasource": {
                 "type": "prometheus",
                 "uid": "$ds"
@@ -3733,7 +3897,8 @@
             "show": true,
             "values": []
           },
-          "yaxes": [{
+          "yaxes": [
+            {
               "format": "short",
               "logBase": 1,
               "min": "0",
@@ -3755,6 +3920,7 @@
           "dashLength": 10,
           "dashes": false,
           "datasource": {
+            "type": "prometheus",
             "uid": "$ds"
           },
           "description": "The number of rows rerouted to the vmstorage node from other nodes when they were unhealthy.",
@@ -3802,19 +3968,21 @@
           "spaceLength": 10,
           "stack": false,
           "steppedLine": false,
-          "targets": [{
-            "datasource": {
-              "type": "prometheus",
-              "uid": "$ds"
-            },
-            "exemplar": true,
-            "expr": "sum(rate(vm_rpc_rows_rerouted_to_here_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by(addr)",
-            "format": "time_series",
-            "interval": "",
-            "intervalFactor": 1,
-            "legendFormat": "{{addr}}",
-            "refId": "A"
-          }],
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$ds"
+              },
+              "exemplar": true,
+              "expr": "sum(rate(vm_rpc_rows_rerouted_to_here_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by(addr) > 0",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{addr}}",
+              "refId": "A"
+            }
+          ],
           "thresholds": [],
           "timeRegions": [],
           "title": "Rows ($instance) rerouted to ",
@@ -3829,13 +3997,16 @@
             "show": true,
             "values": []
           },
-          "yaxes": [{
+          "yaxes": [
+            {
+              "$$hashKey": "object:701",
               "format": "rps",
               "logBase": 1,
               "min": "0",
               "show": true
             },
             {
+              "$$hashKey": "object:702",
               "format": "short",
               "logBase": 1,
               "show": true
@@ -3851,6 +4022,7 @@
           "dashLength": 10,
           "dashes": false,
           "datasource": {
+            "type": "prometheus",
             "uid": "$ds"
           },
           "description": "The number of rows rerouted from the vmstorage node to healthy nodes when the given node was unhealthy.",
@@ -3898,19 +4070,21 @@
           "spaceLength": 10,
           "stack": false,
           "steppedLine": false,
-          "targets": [{
-            "datasource": {
-              "type": "prometheus",
-              "uid": "$ds"
-            },
-            "exemplar": true,
-            "expr": "sum(rate(vm_rpc_rows_rerouted_from_here_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by(addr)",
-            "format": "time_series",
-            "interval": "",
-            "intervalFactor": 1,
-            "legendFormat": "{{addr}}",
-            "refId": "A"
-          }],
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$ds"
+              },
+              "exemplar": true,
+              "expr": "sum(rate(vm_rpc_rows_rerouted_from_here_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by(addr) > 0",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{addr}}",
+              "refId": "A"
+            }
+          ],
           "thresholds": [],
           "timeRegions": [],
           "title": "Rows ($instance) rerouted from",
@@ -3925,13 +4099,16 @@
             "show": true,
             "values": []
           },
-          "yaxes": [{
+          "yaxes": [
+            {
+              "$$hashKey": "object:761",
               "format": "rps",
               "logBase": 1,
               "min": "0",
               "show": true
             },
             {
+              "$$hashKey": "object:762",
               "format": "short",
               "logBase": 1,
               "min": "0",
@@ -3957,7 +4134,7 @@
             },
             "overrides": []
           },
-          "fill": 1,
+          "fill": 0,
           "fillGradient": 0,
           "gridPos": {
             "h": 8,
@@ -3986,18 +4163,21 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "9.0.3",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
-          "seriesOverrides": [{
-            "alias": "bytes",
-            "yaxis": 2
-          }],
+          "seriesOverrides": [
+            {
+              "alias": "bytes",
+              "yaxis": 2
+            }
+          ],
           "spaceLength": 10,
           "stack": false,
           "steppedLine": false,
-          "targets": [{
+          "targets": [
+            {
               "datasource": {
                 "type": "prometheus",
                 "uid": "$ds"
@@ -4030,13 +4210,16 @@
             "show": true,
             "values": []
           },
-          "yaxes": [{
+          "yaxes": [
+            {
+              "$$hashKey": "object:821",
               "format": "short",
               "logBase": 1,
               "min": "0",
               "show": true
             },
             {
+              "$$hashKey": "object:822",
               "format": "bytes",
               "logBase": 1,
               "min": "0",
@@ -4091,7 +4274,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "9.0.3",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -4099,15 +4282,17 @@
           "spaceLength": 10,
           "stack": false,
           "steppedLine": false,
-          "targets": [{
-            "datasource": {
-              "type": "prometheus",
-              "uid": "$ds"
-            },
-            "expr": "sum(rate(vm_tcpdialer_written_bytes_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) * 8",
-            "legendFormat": "network usage",
-            "refId": "A"
-          }],
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$ds"
+              },
+              "expr": "sum(rate(vm_tcpdialer_written_bytes_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) * 8",
+              "legendFormat": "network usage",
+              "refId": "A"
+            }
+          ],
           "thresholds": [],
           "timeRegions": [],
           "title": "RPC network usage ($instance)",
@@ -4122,7 +4307,8 @@
             "show": true,
             "values": []
           },
-          "yaxes": [{
+          "yaxes": [
+            {
               "format": "bps",
               "logBase": 1,
               "min": "0",
@@ -4154,12 +4340,14 @@
         "y": 37
       },
       "id": 60,
-      "panels": [{
+      "panels": [
+        {
           "aliasColors": {},
           "bars": false,
           "dashLength": 10,
           "dashes": false,
           "datasource": {
+            "type": "prometheus",
             "uid": "$ds"
           },
           "description": "VictoriaMetrics stores various caches in RAM. Memory size for these caches may be limited with -`memory.allowedPercent` flag. Line `max allowed` shows max allowed memory size for cache.",
@@ -4169,7 +4357,7 @@
             },
             "overrides": []
           },
-          "fill": 1,
+          "fill": 0,
           "fillGradient": 0,
           "gridPos": {
             "h": 8,
@@ -4204,16 +4392,19 @@
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
-          "seriesOverrides": [{
-            "alias": "max allowed",
-            "color": "#C4162A",
-            "fill": 0,
-            "stack": false
-          }],
+          "seriesOverrides": [
+            {
+              "alias": "max allowed",
+              "color": "#C4162A",
+              "fill": 0,
+              "stack": false
+            }
+          ],
           "spaceLength": 10,
           "stack": true,
           "steppedLine": false,
-          "targets": [{
+          "targets": [
+            {
               "datasource": {
                 "type": "prometheus",
                 "uid": "$ds"
@@ -4252,13 +4443,16 @@
             "show": true,
             "values": []
           },
-          "yaxes": [{
+          "yaxes": [
+            {
+              "$$hashKey": "object:889",
               "format": "bytes",
               "logBase": 1,
               "min": "0",
               "show": true
             },
             {
+              "$$hashKey": "object:890",
               "format": "short",
               "logBase": 1,
               "min": "0",
@@ -4317,19 +4511,21 @@
           "spaceLength": 10,
           "stack": false,
           "steppedLine": false,
-          "targets": [{
-            "datasource": {
-              "type": "prometheus",
-              "uid": "$ds"
-            },
-            "editorMode": "code",
-            "exemplar": true,
-            "expr": "sum(vm_cache_size_bytes{job=~\"$job\", instance=~\"$instance\"}) by(type) / \nsum(vm_cache_size_max_bytes{job=~\"$job\", instance=~\"$instance\"}) by(type)",
-            "interval": "",
-            "legendFormat": "{{ type }}",
-            "range": true,
-            "refId": "A"
-          }],
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$ds"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "sum(vm_cache_size_bytes{job=~\"$job\", instance=~\"$instance\"}) by(type) / \nsum(vm_cache_size_max_bytes{job=~\"$job\", instance=~\"$instance\"}) by(type)",
+              "interval": "",
+              "legendFormat": "{{ type }}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
           "thresholds": [],
           "timeRegions": [],
           "title": "Cache usage % ($instance)",
@@ -4344,7 +4540,8 @@
             "show": true,
             "values": []
           },
-          "yaxes": [{
+          "yaxes": [
+            {
               "$$hashKey": "object:107",
               "format": "percentunit",
               "logBase": 1,
@@ -4415,20 +4612,22 @@
           "spaceLength": 10,
           "stack": false,
           "steppedLine": false,
-          "targets": [{
-            "datasource": {
-              "type": "prometheus",
-              "uid": "$ds"
-            },
-            "exemplar": true,
-            "expr": "1 - (\n sum(rate(vm_cache_misses_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (type) /\n sum(rate(vm_cache_requests_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (type)\n)",
-            "format": "time_series",
-            "hide": false,
-            "interval": "",
-            "intervalFactor": 1,
-            "legendFormat": "{{type}}",
-            "refId": "A"
-          }],
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$ds"
+              },
+              "exemplar": true,
+              "expr": "1 - (\n sum(rate(vm_cache_misses_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (type) /\n sum(rate(vm_cache_requests_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (type)\n)",
+              "format": "time_series",
+              "hide": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{type}}",
+              "refId": "A"
+            }
+          ],
           "thresholds": [],
           "timeRegions": [],
           "title": "Cache hit ratio ($instance)",
@@ -4443,7 +4642,8 @@
             "show": true,
             "values": []
           },
-          "yaxes": [{
+          "yaxes": [
+            {
               "format": "percentunit",
               "logBase": 1,
               "max": "1",
@@ -4477,7 +4677,8 @@
         "y": 38
       },
       "id": 24,
-      "panels": [{
+      "panels": [
+        {
           "aliasColors": {},
           "bars": false,
           "dashLength": 10,
@@ -4522,7 +4723,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "9.0.3",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -4530,17 +4731,19 @@
           "spaceLength": 10,
           "stack": true,
           "steppedLine": false,
-          "targets": [{
-            "datasource": {
-              "type": "prometheus",
-              "uid": "$ds"
-            },
-            "expr": "sum(rate(vm_vminsert_metrics_read_total{job=~\"$job_storage\", instance=~\"$instance\"}[$__rate_interval])) by(instance)",
-            "format": "time_series",
-            "intervalFactor": 1,
-            "legendFormat": "{{instance}}",
-            "refId": "A"
-          }],
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$ds"
+              },
+              "expr": "sum(rate(vm_vminsert_metrics_read_total{job=~\"$job_storage\", instance=~\"$instance\"}[$__rate_interval])) by(instance)",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "{{instance}}",
+              "refId": "A"
+            }
+          ],
           "thresholds": [],
           "timeRegions": [],
           "title": "Ingestion rate ($instance)",
@@ -4555,7 +4758,8 @@
             "show": true,
             "values": []
           },
-          "yaxes": [{
+          "yaxes": [
+            {
               "format": "short",
               "logBase": 1,
               "min": "0",
@@ -4617,7 +4821,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "9.0.3",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -4625,18 +4829,20 @@
           "spaceLength": 10,
           "stack": false,
           "steppedLine": false,
-          "targets": [{
-            "datasource": {
-              "type": "prometheus",
-              "uid": "$ds"
-            },
-            "expr": "vm_free_disk_space_bytes{job=~\"$job_storage\", instance=~\"$instance\"} / ignoring(path) ((rate(vm_rows_added_to_storage_total{job=~\"$job_storage\", instance=~\"$instance\"}[1d]) - ignoring(type) rate(vm_deduplicated_samples_total{job=~\"$job_storage\", instance=~\"$instance\", type=\"merge\"}[1d])) * scalar(sum(vm_data_size_bytes{job=~\"$job_storage\", instance=~\"$instance\", type!=\"indexdb\"}) / sum(vm_rows{job=~\"$job_storage\", instance=~\"$instance\", type!=\"indexdb\"})))",
-            "format": "time_series",
-            "interval": "",
-            "intervalFactor": 1,
-            "legendFormat": "{{instance}}",
-            "refId": "A"
-          }],
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$ds"
+              },
+              "expr": "vm_free_disk_space_bytes{job=~\"$job_storage\", instance=~\"$instance\"} / ignoring(path) ((rate(vm_rows_added_to_storage_total{job=~\"$job_storage\", instance=~\"$instance\"}[1d]) - ignoring(type) rate(vm_deduplicated_samples_total{job=~\"$job_storage\", instance=~\"$instance\", type=\"merge\"}[1d])) * scalar(sum(vm_data_size_bytes{job=~\"$job_storage\", instance=~\"$instance\", type!=\"indexdb\"}) / sum(vm_rows{job=~\"$job_storage\", instance=~\"$instance\", type!=\"indexdb\"})))",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{instance}}",
+              "refId": "A"
+            }
+          ],
           "thresholds": [],
           "timeRegions": [],
           "title": "Storage full ETA ($instance)",
@@ -4651,7 +4857,8 @@
             "show": true,
             "values": []
           },
-          "yaxes": [{
+          "yaxes": [
+            {
               "$$hashKey": "object:87",
               "format": "s",
               "logBase": 1,
@@ -4714,7 +4921,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "9.0.3",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -4722,18 +4929,20 @@
           "spaceLength": 10,
           "stack": true,
           "steppedLine": false,
-          "targets": [{
-            "datasource": {
-              "type": "prometheus",
-              "uid": "$ds"
-            },
-            "expr": "sum(vm_rows{job=~\"$job_storage\", instance=~\"$instance\", type!=\"indexdb\"}) by(instance)",
-            "format": "time_series",
-            "interval": "",
-            "intervalFactor": 1,
-            "legendFormat": "{{instance}}",
-            "refId": "A"
-          }],
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$ds"
+              },
+              "expr": "sum(vm_rows{job=~\"$job_storage\", instance=~\"$instance\", type!=\"indexdb\"}) by(instance)",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{instance}}",
+              "refId": "A"
+            }
+          ],
           "thresholds": [],
           "timeRegions": [],
           "title": "Datapoints ($instance)",
@@ -4748,13 +4957,16 @@
             "show": true,
             "values": []
           },
-          "yaxes": [{
+          "yaxes": [
+            {
+              "$$hashKey": "object:1330",
               "format": "short",
               "logBase": 1,
               "min": "0",
               "show": true
             },
             {
+              "$$hashKey": "object:1331",
               "format": "short",
               "logBase": 1,
               "min": "0",
@@ -4780,7 +4992,7 @@
             },
             "overrides": []
           },
-          "fill": 1,
+          "fill": 0,
           "fillGradient": 0,
           "gridPos": {
             "h": 8,
@@ -4811,18 +5023,21 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "9.0.3",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
-          "seriesOverrides": [{
-            "alias": "pending index entries",
-            "yaxis": 2
-          }],
+          "seriesOverrides": [
+            {
+              "alias": "pending index entries",
+              "yaxis": 2
+            }
+          ],
           "spaceLength": 10,
           "stack": false,
           "steppedLine": false,
-          "targets": [{
+          "targets": [
+            {
               "datasource": {
                 "type": "prometheus",
                 "uid": "$ds"
@@ -4861,13 +5076,16 @@
             "show": true,
             "values": []
           },
-          "yaxes": [{
+          "yaxes": [
+            {
+              "$$hashKey": "object:1262",
               "format": "short",
               "logBase": 1,
               "min": "0",
               "show": true
             },
             {
+              "$$hashKey": "object:1263",
               "decimals": 3,
               "format": "none",
               "logBase": 1,
@@ -4924,7 +5142,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "9.0.3",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -4932,17 +5150,19 @@
           "spaceLength": 10,
           "stack": true,
           "steppedLine": false,
-          "targets": [{
-            "datasource": {
-              "type": "prometheus",
-              "uid": "$ds"
-            },
-            "expr": "sum(vm_data_size_bytes{job=~\"$job_storage\", instance=~\"$instance\", type!=\"indexdb\"}) by(instance)",
-            "format": "time_series",
-            "intervalFactor": 1,
-            "legendFormat": "{{instance}}",
-            "refId": "A"
-          }],
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$ds"
+              },
+              "expr": "sum(vm_data_size_bytes{job=~\"$job_storage\", instance=~\"$instance\", type!=\"indexdb\"}) by(instance)",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "{{instance}}",
+              "refId": "A"
+            }
+          ],
           "thresholds": [],
           "timeRegions": [],
           "title": "Disk space usage (datapoints) ($instance)",
@@ -4957,7 +5177,8 @@
             "show": true,
             "values": []
           },
-          "yaxes": [{
+          "yaxes": [
+            {
               "format": "bytes",
               "logBase": 1,
               "min": "0",
@@ -5019,7 +5240,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "9.0.3",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -5027,17 +5248,19 @@
           "spaceLength": 10,
           "stack": true,
           "steppedLine": false,
-          "targets": [{
-            "datasource": {
-              "type": "prometheus",
-              "uid": "$ds"
-            },
-            "expr": "sum(vm_data_size_bytes{job=~\"$job_storage\", instance=~\"$instance\", type=\"indexdb\"}) by(instance)",
-            "format": "time_series",
-            "intervalFactor": 1,
-            "legendFormat": "{{instance}}",
-            "refId": "A"
-          }],
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$ds"
+              },
+              "expr": "sum(vm_data_size_bytes{job=~\"$job_storage\", instance=~\"$instance\", type=\"indexdb\"}) by(instance)",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "{{instance}}",
+              "refId": "A"
+            }
+          ],
           "thresholds": [],
           "timeRegions": [],
           "title": "Disk space usage (index)  ($instance)",
@@ -5052,7 +5275,8 @@
             "show": true,
             "values": []
           },
-          "yaxes": [{
+          "yaxes": [
+            {
               "format": "bytes",
               "logBase": 1,
               "min": "0",
@@ -5084,7 +5308,7 @@
             },
             "overrides": []
           },
-          "fill": 1,
+          "fill": 0,
           "fillGradient": 0,
           "gridPos": {
             "h": 8,
@@ -5113,7 +5337,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "9.0.3",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -5121,21 +5345,23 @@
           "spaceLength": 10,
           "stack": false,
           "steppedLine": false,
-          "targets": [{
-            "datasource": {
-              "type": "prometheus",
-              "uid": "$ds"
-            },
-            "expr": "sum(vm_active_merges{job=~\"$job_storage\", instance=~\"$instance\"}) by(type)",
-            "legendFormat": "{{type}}",
-            "refId": "A"
-          }],
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$ds"
+              },
+              "expr": "sum(vm_active_merges{job=~\"$job_storage\", instance=~\"$instance\"}) by(type)",
+              "legendFormat": "{{type}}",
+              "refId": "A"
+            }
+          ],
           "thresholds": [],
           "timeRegions": [],
           "title": "Active merges ($instance)",
           "tooltip": {
             "shared": true,
-            "sort": 0,
+            "sort": 2,
             "value_type": "individual"
           },
           "type": "graph",
@@ -5144,7 +5370,9 @@
             "show": true,
             "values": []
           },
-          "yaxes": [{
+          "yaxes": [
+            {
+              "$$hashKey": "object:1399",
               "decimals": 0,
               "format": "short",
               "logBase": 1,
@@ -5152,6 +5380,7 @@
               "show": true
             },
             {
+              "$$hashKey": "object:1400",
               "format": "short",
               "logBase": 1,
               "min": "0",
@@ -5177,7 +5406,7 @@
             },
             "overrides": []
           },
-          "fill": 1,
+          "fill": 0,
           "fillGradient": 0,
           "gridPos": {
             "h": 8,
@@ -5206,7 +5435,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "9.0.3",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -5214,21 +5443,23 @@
           "spaceLength": 10,
           "stack": false,
           "steppedLine": false,
-          "targets": [{
-            "datasource": {
-              "type": "prometheus",
-              "uid": "$ds"
-            },
-            "expr": "sum(rate(vm_rows_merged_total{job=~\"$job_storage\", instance=~\"$instance\"}[$__rate_interval])) by(type)",
-            "legendFormat": "{{type}}",
-            "refId": "A"
-          }],
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$ds"
+              },
+              "expr": "sum(rate(vm_rows_merged_total{job=~\"$job_storage\", instance=~\"$instance\"}[$__rate_interval])) by(type)",
+              "legendFormat": "{{type}}",
+              "refId": "A"
+            }
+          ],
           "thresholds": [],
           "timeRegions": [],
           "title": "Merge speed",
           "tooltip": {
             "shared": true,
-            "sort": 0,
+            "sort": 2,
             "value_type": "individual"
           },
           "type": "graph",
@@ -5237,7 +5468,9 @@
             "show": true,
             "values": []
           },
-          "yaxes": [{
+          "yaxes": [
+            {
+              "$$hashKey": "object:1516",
               "decimals": 0,
               "format": "short",
               "logBase": 1,
@@ -5245,6 +5478,7 @@
               "show": true
             },
             {
+              "$$hashKey": "object:1517",
               "format": "short",
               "logBase": 1,
               "min": "0",
@@ -5264,7 +5498,7 @@
             "uid": "$ds"
           },
           "description": "Shows how many rows were ignored on insertion due to corrupted or out of retention timestamps.",
-          "fill": 1,
+          "fill": 0,
           "fillGradient": 0,
           "gridPos": {
             "h": 8,
@@ -5293,7 +5527,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "9.0.3",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -5301,17 +5535,19 @@
           "spaceLength": 10,
           "stack": false,
           "steppedLine": false,
-          "targets": [{
-            "datasource": {
-              "type": "prometheus",
-              "uid": "$ds"
-            },
-            "exemplar": true,
-            "expr": "sum(vm_rows_ignored_total{job=~\"$job_storage\", instance=~\"$instance\"}) by (reason)",
-            "interval": "",
-            "legendFormat": "{{reason}}",
-            "refId": "A"
-          }],
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$ds"
+              },
+              "exemplar": true,
+              "expr": "sum(vm_rows_ignored_total{job=~\"$job_storage\", instance=~\"$instance\"}) by (reason)",
+              "interval": "",
+              "legendFormat": "{{reason}}",
+              "refId": "A"
+            }
+          ],
           "thresholds": [],
           "timeRegions": [],
           "title": "Rows ignored ($instance)",
@@ -5326,12 +5562,15 @@
             "show": true,
             "values": []
           },
-          "yaxes": [{
+          "yaxes": [
+            {
+              "$$hashKey": "object:1584",
               "format": "short",
               "logBase": 1,
               "show": true
             },
             {
+              "$$hashKey": "object:1585",
               "format": "short",
               "logBase": 1,
               "show": true
@@ -5347,16 +5586,17 @@
           "dashLength": 10,
           "dashes": false,
           "datasource": {
+            "type": "prometheus",
             "uid": "$ds"
           },
-          "description": "Data parts of LSM tree.\nHigh number of parts could be an evidence of slow merge performance - check the resource utilization.\n* `indexdb` - inverted index\n* `storage/small` - recently added parts of data ingested into storage(hot data)\n* `storage/big` -  small parts gradually merged into big parts (cold data)",
+          "description": "The max number of data parts of LSM tree across all storage nodes.\nHigh number of parts (the hard limit is 512) is an evidence of slow merge performance - check the resource utilization.\n* `indexdb` - inverted index\n* `storage/small` - recently added parts of data ingested into storage (hot data)\n* `storage/big` -  small parts gradually merged into big parts (cold data)",
           "fieldConfig": {
             "defaults": {
               "links": []
             },
             "overrides": []
           },
-          "fill": 1,
+          "fill": 0,
           "fillGradient": 0,
           "gridPos": {
             "h": 8,
@@ -5386,7 +5626,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "9.0.3",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -5394,18 +5634,20 @@
           "spaceLength": 10,
           "stack": false,
           "steppedLine": false,
-          "targets": [{
-            "datasource": {
-              "type": "prometheus",
-              "uid": "$ds"
-            },
-            "expr": "sum(vm_parts{job=~\"$job_storage\", instance=~\"$instance\"}) by (type)",
-            "format": "time_series",
-            "interval": "",
-            "intervalFactor": 1,
-            "legendFormat": "{{type}}",
-            "refId": "A"
-          }],
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$ds"
+              },
+              "expr": "max(sum(vm_parts{job=~\"$job_storage\", instance=~\"$instance\"}) by (type, instance)) by(type)",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{type}}",
+              "refId": "A"
+            }
+          ],
           "thresholds": [],
           "timeRegions": [],
           "title": "LSM parts ($instance)",
@@ -5420,13 +5662,16 @@
             "show": true,
             "values": []
           },
-          "yaxes": [{
+          "yaxes": [
+            {
+              "$$hashKey": "object:1644",
               "format": "short",
               "logBase": 1,
               "min": "0",
               "show": true
             },
             {
+              "$$hashKey": "object:1645",
               "format": "short",
               "logBase": 1,
               "min": "0",
@@ -5468,17 +5713,19 @@
           },
           "lines": true,
           "linewidth": 1,
-          "links": [{
-            "targetBlank": true,
-            "title": "Readonly mode",
-            "url": "https://docs.victoriametrics.com/Cluster-VictoriaMetrics.html#readonly-mode"
-          }],
+          "links": [
+            {
+              "targetBlank": true,
+              "title": "Readonly mode",
+              "url": "https://docs.victoriametrics.com/Cluster-VictoriaMetrics.html#readonly-mode"
+            }
+          ],
           "nullPointMode": "null",
           "options": {
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "9.0.3",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -5486,17 +5733,19 @@
           "spaceLength": 10,
           "stack": false,
           "steppedLine": false,
-          "targets": [{
-            "datasource": {
-              "type": "prometheus",
-              "uid": "$ds"
-            },
-            "exemplar": true,
-            "expr": "vm_storage_is_read_only{job=~\"$job_storage\", instance=~\"$instance\"}",
-            "interval": "",
-            "legendFormat": "{{ instance }}",
-            "refId": "A"
-          }],
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$ds"
+              },
+              "exemplar": true,
+              "expr": "vm_storage_is_read_only{job=~\"$job_storage\", instance=~\"$instance\"}",
+              "interval": "",
+              "legendFormat": "{{ instance }}",
+              "refId": "A"
+            }
+          ],
           "thresholds": [],
           "timeRegions": [],
           "title": "Readonly mode",
@@ -5511,7 +5760,8 @@
             "show": true,
             "values": []
           },
-          "yaxes": [{
+          "yaxes": [
+            {
               "$$hashKey": "object:131",
               "format": "short",
               "logBase": 1,
@@ -5537,7 +5787,7 @@
             "type": "prometheus",
             "uid": "$ds"
           },
-          "description": "Shows how many ongoing insertions (not API /write calls) on disk are taking place, where:\n* `max` - equal to number of CPUs;\n* `current` - current number of goroutines busy with inserting rows into underlying storage.\n\nEvery successful API /write call results into flush on disk. The `max` is an internal limit and can't be changed. It is always equal to the number of CPUs. \n\nWhen `current` hits `max` constantly, it means storage is overloaded and requires more CPU.",
+          "description": "Shows how many ongoing insertions (not API /write calls) on disk are taking place, where:\n* `max` - equal to number of CPUs;\n* `current` - current number of goroutines busy with inserting rows into underlying storage.\n\nEvery successful API /write call results into flush on disk. The `max` is an internal limit and can't be changed. It is always equal to the number of CPUs. \n\nWhen `current` hits `max` constantly, it means storage is overloaded and requires more CPU or faster disk.",
           "fill": 0,
           "fillGradient": 0,
           "gridPos": {
@@ -5562,28 +5812,33 @@
           },
           "lines": true,
           "linewidth": 1,
-          "links": [{
-            "targetBlank": true,
-            "title": "Related discussion",
-            "url": "https://github.com/VictoriaMetrics/VictoriaMetrics/issues/632"
-          }],
+          "links": [
+            {
+              "targetBlank": true,
+              "title": "Related discussion",
+              "url": "https://github.com/VictoriaMetrics/VictoriaMetrics/issues/632"
+            }
+          ],
           "nullPointMode": "null",
           "options": {
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "9.0.3",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
-          "seriesOverrides": [{
-            "alias": "max",
-            "color": "#C4162A"
-          }],
+          "seriesOverrides": [
+            {
+              "alias": "max",
+              "color": "#C4162A"
+            }
+          ],
           "spaceLength": 10,
           "stack": false,
           "steppedLine": false,
-          "targets": [{
+          "targets": [
+            {
               "datasource": {
                 "type": "prometheus",
                 "uid": "$ds"
@@ -5621,12 +5876,15 @@
             "show": true,
             "values": []
           },
-          "yaxes": [{
+          "yaxes": [
+            {
+              "$$hashKey": "object:1768",
               "format": "short",
               "logBase": 1,
               "show": true
             },
             {
+              "$$hashKey": "object:1769",
               "format": "short",
               "logBase": 1,
               "show": true
@@ -5645,6 +5903,7 @@
             "type": "prometheus",
             "uid": "$ds"
           },
+          "description": "",
           "fieldConfig": {
             "defaults": {
               "links": []
@@ -5681,30 +5940,33 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "9.0.3",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
-          "seriesOverrides": [{
-            "$$hashKey": "object:186",
-            "alias": "max",
-            "color": "#C4162A"
-          }],
+          "seriesOverrides": [
+            {
+              "$$hashKey": "object:186",
+              "alias": "limit",
+              "color": "#C4162A"
+            }
+          ],
           "spaceLength": 10,
           "stack": false,
           "steppedLine": false,
-          "targets": [{
+          "targets": [
+            {
               "datasource": {
                 "type": "prometheus",
                 "uid": "$ds"
               },
               "editorMode": "code",
               "exemplar": true,
-              "expr": "sum(rate(process_cpu_seconds_total{job=~\"$job_storage\", instance=~\"$instance\"}[$__rate_interval]))",
+              "expr": "sum(rate(process_cpu_seconds_total{job=~\"$job_storage\", instance=~\"$instance\"}[$__rate_interval])) by(instance)",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "cores used",
+              "legendFormat": "{{instance}}",
               "range": true,
               "refId": "A"
             },
@@ -5714,9 +5976,9 @@
                 "uid": "$ds"
               },
               "editorMode": "code",
-              "expr": "sum(process_cpu_cores_available{job=~\"$job_storage\", instance=~\"$instance\"})",
+              "expr": "min(process_cpu_cores_available{job=~\"$job_storage\", instance=~\"$instance\"})",
               "hide": false,
-              "legendFormat": "max",
+              "legendFormat": "limit",
               "range": true,
               "refId": "B"
             }
@@ -5726,7 +5988,7 @@
           "title": "CPU ($instance)",
           "tooltip": {
             "shared": true,
-            "sort": 0,
+            "sort": 2,
             "value_type": "individual"
           },
           "type": "graph",
@@ -5735,13 +5997,16 @@
             "show": true,
             "values": []
           },
-          "yaxes": [{
+          "yaxes": [
+            {
+              "$$hashKey": "object:1827",
               "format": "short",
               "logBase": 1,
               "min": "0",
               "show": true
             },
             {
+              "$$hashKey": "object:1828",
               "format": "short",
               "logBase": 1,
               "show": true
@@ -5796,30 +6061,33 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "9.0.3",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
-          "seriesOverrides": [{
-            "$$hashKey": "object:186",
-            "alias": "max",
-            "color": "#C4162A"
-          }],
+          "seriesOverrides": [
+            {
+              "$$hashKey": "object:186",
+              "alias": "limit",
+              "color": "#C4162A"
+            }
+          ],
           "spaceLength": 10,
           "stack": false,
           "steppedLine": false,
-          "targets": [{
+          "targets": [
+            {
               "datasource": {
                 "type": "prometheus",
                 "uid": "$ds"
               },
               "editorMode": "code",
               "exemplar": true,
-              "expr": "sum(process_resident_memory_anon_bytes{job=~\"$job_storage\", instance=~\"$instance\"}) ",
+              "expr": "sum(process_resident_memory_anon_bytes{job=~\"$job_storage\", instance=~\"$instance\"}) by(instance) ",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "mem used",
+              "legendFormat": "{{instance}}",
               "range": true,
               "refId": "A"
             },
@@ -5829,9 +6097,9 @@
                 "uid": "$ds"
               },
               "editorMode": "code",
-              "expr": "sum(vm_available_memory_bytes{job=~\"$job_storage\", instance=~\"$instance\"})",
+              "expr": "min(vm_available_memory_bytes{job=~\"$job_storage\", instance=~\"$instance\"})",
               "hide": false,
-              "legendFormat": "max",
+              "legendFormat": "limit",
               "range": true,
               "refId": "B"
             }
@@ -5850,7 +6118,8 @@
             "show": true,
             "values": []
           },
-          "yaxes": [{
+          "yaxes": [
+            {
               "$$hashKey": "object:164",
               "format": "bytes",
               "logBase": 1,
@@ -5884,12 +6153,14 @@
         "y": 39
       },
       "id": 42,
-      "panels": [{
+      "panels": [
+        {
           "aliasColors": {},
           "bars": false,
           "dashLength": 10,
           "dashes": false,
           "datasource": {
+            "type": "prometheus",
             "uid": "$ds"
           },
           "description": "Request rate accepted by vmselect nodes",
@@ -5899,7 +6170,7 @@
             },
             "overrides": []
           },
-          "fill": 1,
+          "fill": 0,
           "fillGradient": 0,
           "gridPos": {
             "h": 8,
@@ -5929,7 +6200,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "9.0.3",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -5937,17 +6208,19 @@
           "spaceLength": 10,
           "stack": false,
           "steppedLine": false,
-          "targets": [{
-            "datasource": {
-              "type": "prometheus",
-              "uid": "$ds"
-            },
-            "expr": "sum(rate(vm_http_requests_total{job=~\"$job_select\", instance=~\"$instance.*\", path!~\"/favicon.ico\"}[$__rate_interval])) by (path) > 0",
-            "format": "time_series",
-            "intervalFactor": 1,
-            "legendFormat": "{{path}}",
-            "refId": "A"
-          }],
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$ds"
+              },
+              "expr": "sum(rate(vm_http_requests_total{job=~\"$job_select\", instance=~\"$instance.*\", path!~\"/favicon.ico|/metrics\"}[$__rate_interval])) by (path) > 0",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "{{path}}",
+              "refId": "A"
+            }
+          ],
           "thresholds": [],
           "timeRegions": [],
           "title": "Requests rate ($instance)",
@@ -5962,13 +6235,16 @@
             "show": true,
             "values": []
           },
-          "yaxes": [{
+          "yaxes": [
+            {
+              "$$hashKey": "object:2088",
               "format": "short",
               "logBase": 1,
               "min": "0",
               "show": true
             },
             {
+              "$$hashKey": "object:2089",
               "format": "short",
               "logBase": 1,
               "min": "0",
@@ -5985,16 +6261,17 @@
           "dashLength": 10,
           "dashes": false,
           "datasource": {
+            "type": "prometheus",
             "uid": "$ds"
           },
-          "description": "Shows how many ongoing insertions are taking place.\n* `max` - equal to number of CPU * 2 by default. May be configured with `search.maxConcurrentRequests` flag\n* `current` - current number of goroutines busy with processing requests\n\nWhen `current` hits `max` constantly, it means vmselect node is overloaded and require more CPU or higher limits.",
+          "description": "Shows the max number of concurrent selects across instances.\n* `max` - equal to number of CPU * 2 by default. May be configured with `search.maxConcurrentRequests` flag\n* `current` - current number of goroutines busy with processing requests\n\nWhen `current` hits `max` constantly, it means one or more vmselect nodes are overloaded and require more CPU or better load balancing. If CPU panel shows there are free resources - try increasing  `search.maxConcurrentRequests`.",
           "fieldConfig": {
             "defaults": {
               "links": []
             },
             "overrides": []
           },
-          "fill": 1,
+          "fill": 0,
           "fillGradient": 0,
           "gridPos": {
             "h": 8,
@@ -6026,24 +6303,28 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "9.0.3",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
-          "seriesOverrides": [{
-            "alias": "max",
-            "color": "#C4162A",
-            "fill": 0
-          }],
+          "seriesOverrides": [
+            {
+              "$$hashKey": "object:2150",
+              "alias": "max",
+              "color": "#C4162A",
+              "fill": 0
+            }
+          ],
           "spaceLength": 10,
           "stack": false,
           "steppedLine": false,
-          "targets": [{
+          "targets": [
+            {
               "datasource": {
                 "type": "prometheus",
                 "uid": "$ds"
               },
-              "expr": "sum(max_over_time(vm_concurrent_select_current{job=~\"$job_select\", instance=~\"$instance\"}[1m]))",
+              "expr": "max(max_over_time(vm_concurrent_select_current{job=~\"$job_select\", instance=~\"$instance\"}[1m])) ",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
@@ -6055,7 +6336,7 @@
                 "type": "prometheus",
                 "uid": "$ds"
               },
-              "expr": "sum(vm_concurrent_select_capacity{job=~\"$job_select\", instance=~\"$instance\"})",
+              "expr": "min(vm_concurrent_select_capacity{job=~\"$job_select\", instance=~\"$instance\"})",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "max",
@@ -6076,7 +6357,9 @@
             "show": true,
             "values": []
           },
-          "yaxes": [{
+          "yaxes": [
+            {
+              "$$hashKey": "object:2159",
               "decimals": 0,
               "format": "short",
               "logBase": 1,
@@ -6084,7 +6367,420 @@
               "show": true
             },
             {
+              "$$hashKey": "object:2160",
               "decimals": 0,
+              "format": "short",
+              "logBase": 1,
+              "min": "0",
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$ds"
+          },
+          "description": "99th percentile of number of series read per query.",
+          "fieldConfig": {
+            "defaults": {
+              "links": []
+            },
+            "overrides": []
+          },
+          "fill": 0,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 16
+          },
+          "hiddenSeries": false,
+          "id": 178,
+          "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "max": true,
+            "min": false,
+            "show": true,
+            "sort": "current",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null as zero",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "9.0.3",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$ds"
+              },
+              "expr": "histogram_quantile(0.99, sum(rate(vm_series_read_per_query_bucket{job=~\"$job_select\", instance=~\"$instance\"}[$__rate_interval])) by (instance, vmrange))",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{instance}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeRegions": [],
+          "title": "Series read per query ($instance)",
+          "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "$$hashKey": "object:2848",
+              "decimals": 2,
+              "format": "short",
+              "logBase": 1,
+              "min": "0",
+              "show": true
+            },
+            {
+              "$$hashKey": "object:2849",
+              "format": "short",
+              "logBase": 1,
+              "min": "0",
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$ds"
+          },
+          "description": "99th percentile of number of raw samples read per query.",
+          "fieldConfig": {
+            "defaults": {
+              "links": []
+            },
+            "overrides": []
+          },
+          "fill": 0,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 16
+          },
+          "hiddenSeries": false,
+          "id": 179,
+          "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "max": true,
+            "min": false,
+            "show": true,
+            "sort": "current",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null as zero",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "9.0.3",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$ds"
+              },
+              "expr": "histogram_quantile(0.99, sum(rate(vm_rows_read_per_query_bucket{job=~\"$job_select\", instance=~\"$instance\"}[$__rate_interval])) by (instance, vmrange))",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{instance}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeRegions": [],
+          "title": "Rows read per query ($instance)",
+          "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "$$hashKey": "object:2848",
+              "decimals": 2,
+              "format": "short",
+              "logBase": 1,
+              "min": "0",
+              "show": true
+            },
+            {
+              "$$hashKey": "object:2849",
+              "format": "short",
+              "logBase": 1,
+              "min": "0",
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$ds"
+          },
+          "description": "99th percentile of number of raw samples read per queried series.",
+          "fieldConfig": {
+            "defaults": {
+              "links": []
+            },
+            "overrides": []
+          },
+          "fill": 0,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 24
+          },
+          "hiddenSeries": false,
+          "id": 180,
+          "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "max": true,
+            "min": false,
+            "show": true,
+            "sort": "current",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null as zero",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "9.0.3",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$ds"
+              },
+              "expr": "histogram_quantile(0.99, sum(rate(vm_rows_read_per_series_bucket{job=~\"$job_select\", instance=~\"$instance\"}[$__rate_interval])) by (instance, vmrange))",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{instance}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeRegions": [],
+          "title": "Rows read per series ($instance)",
+          "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "$$hashKey": "object:2848",
+              "decimals": 2,
+              "format": "short",
+              "logBase": 1,
+              "min": "0",
+              "show": true
+            },
+            {
+              "$$hashKey": "object:2849",
+              "format": "short",
+              "logBase": 1,
+              "min": "0",
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$ds"
+          },
+          "description": "99th percentile of number of raw samples scanner per query.\n\nThis number can exceed number of RowsReadPerQuery if `step` query arg passed to [/api/v1/query_range](https://prometheus.io/docs/prometheus/latest/querying/api/#range-queries) is smaller than the lookbehind window set in square brackets of [rollup function](https://docs.victoriametrics.com/MetricsQL.html#rollup-functions). For example, if `increase(some_metric[1h])` is executed with the `step=5m`, then the same raw samples on a hour time range are scanned `1h/5m=12` times. See [this article](https://valyala.medium.com/how-to-optimize-promql-and-metricsql-queries-85a1b75bf986) for details.",
+          "fieldConfig": {
+            "defaults": {
+              "links": []
+            },
+            "overrides": []
+          },
+          "fill": 0,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 24
+          },
+          "hiddenSeries": false,
+          "id": 181,
+          "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "max": true,
+            "min": false,
+            "show": true,
+            "sort": "current",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null as zero",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "9.0.3",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$ds"
+              },
+              "expr": "histogram_quantile(0.99, sum(rate(vm_rows_scanned_per_query_bucket{job=~\"$job_select\", instance=~\"$instance\"}[$__rate_interval])) by (instance, vmrange))",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{instance}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeRegions": [],
+          "title": "Rows scanned per series ($instance)",
+          "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "$$hashKey": "object:2848",
+              "decimals": 2,
+              "format": "short",
+              "logBase": 1,
+              "min": "0",
+              "show": true
+            },
+            {
+              "$$hashKey": "object:2849",
               "format": "short",
               "logBase": 1,
               "min": "0",
@@ -6110,13 +6806,13 @@
             },
             "overrides": []
           },
-          "fill": 6,
+          "fill": 0,
           "fillGradient": 0,
           "gridPos": {
-            "h": 7,
+            "h": 8,
             "w": 24,
             "x": 0,
-            "y": 16
+            "y": 32
           },
           "hiddenSeries": false,
           "id": 93,
@@ -6140,18 +6836,22 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "9.0.3",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
-          "seriesOverrides": [{
-            "alias": "/read.*/",
-            "transform": "negative-Y"
-          }],
+          "seriesOverrides": [
+            {
+              "$$hashKey": "object:2229",
+              "alias": "/read.*/",
+              "transform": "negative-Y"
+            }
+          ],
           "spaceLength": 10,
           "stack": false,
           "steppedLine": false,
-          "targets": [{
+          "targets": [
+            {
               "datasource": {
                 "type": "prometheus",
                 "uid": "$ds"
@@ -6189,12 +6889,15 @@
             "show": true,
             "values": []
           },
-          "yaxes": [{
+          "yaxes": [
+            {
+              "$$hashKey": "object:2236",
               "format": "bps",
               "logBase": 1,
               "show": true
             },
             {
+              "$$hashKey": "object:2237",
               "format": "short",
               "logBase": 1,
               "show": true
@@ -6225,7 +6928,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 23
+            "y": 40
           },
           "hiddenSeries": false,
           "id": 163,
@@ -6249,30 +6952,33 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "9.0.3",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
-          "seriesOverrides": [{
-            "$$hashKey": "object:186",
-            "alias": "max",
-            "color": "#C4162A"
-          }],
+          "seriesOverrides": [
+            {
+              "$$hashKey": "object:186",
+              "alias": "limit",
+              "color": "#C4162A"
+            }
+          ],
           "spaceLength": 10,
           "stack": false,
           "steppedLine": false,
-          "targets": [{
+          "targets": [
+            {
               "datasource": {
                 "type": "prometheus",
                 "uid": "$ds"
               },
               "editorMode": "code",
               "exemplar": true,
-              "expr": "sum(rate(process_cpu_seconds_total{job=~\"$job_select\", instance=~\"$instance\"}[$__rate_interval]))",
+              "expr": "sum(rate(process_cpu_seconds_total{job=~\"$job_select\", instance=~\"$instance\"}[$__rate_interval])) by(instance)",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "cores used",
+              "legendFormat": "{{instance}}",
               "range": true,
               "refId": "A"
             },
@@ -6282,9 +6988,9 @@
                 "uid": "$ds"
               },
               "editorMode": "code",
-              "expr": "sum(process_cpu_cores_available{job=~\"$job_select\", instance=~\"$instance\"})",
+              "expr": "min(process_cpu_cores_available{job=~\"$job_select\", instance=~\"$instance\"})",
               "hide": false,
-              "legendFormat": "max",
+              "legendFormat": "limit",
               "range": true,
               "refId": "B"
             }
@@ -6303,13 +7009,16 @@
             "show": true,
             "values": []
           },
-          "yaxes": [{
+          "yaxes": [
+            {
+              "$$hashKey": "object:2303",
               "format": "short",
               "logBase": 1,
               "min": "0",
               "show": true
             },
             {
+              "$$hashKey": "object:2304",
               "format": "short",
               "logBase": 1,
               "show": true
@@ -6340,7 +7049,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 23
+            "y": 40
           },
           "hiddenSeries": false,
           "id": 165,
@@ -6364,30 +7073,33 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "9.0.3",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
-          "seriesOverrides": [{
-            "$$hashKey": "object:186",
-            "alias": "max",
-            "color": "#C4162A"
-          }],
+          "seriesOverrides": [
+            {
+              "$$hashKey": "object:186",
+              "alias": "limit",
+              "color": "#C4162A"
+            }
+          ],
           "spaceLength": 10,
           "stack": false,
           "steppedLine": false,
-          "targets": [{
+          "targets": [
+            {
               "datasource": {
                 "type": "prometheus",
                 "uid": "$ds"
               },
               "editorMode": "code",
               "exemplar": true,
-              "expr": "sum(process_resident_memory_anon_bytes{job=~\"$job_select\", instance=~\"$instance\"}) ",
+              "expr": "sum(process_resident_memory_anon_bytes{job=~\"$job_select\", instance=~\"$instance\"}) by(instance) ",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "mem used",
+              "legendFormat": "{{instance}}",
               "range": true,
               "refId": "A"
             },
@@ -6397,9 +7109,9 @@
                 "uid": "$ds"
               },
               "editorMode": "code",
-              "expr": "sum(vm_available_memory_bytes{job=~\"$job_select\", instance=~\"$instance\"})",
+              "expr": "min(vm_available_memory_bytes{job=~\"$job_select\", instance=~\"$instance\"})",
               "hide": false,
-              "legendFormat": "max",
+              "legendFormat": "limit",
               "range": true,
               "refId": "B"
             }
@@ -6418,7 +7130,8 @@
             "show": true,
             "values": []
           },
-          "yaxes": [{
+          "yaxes": [
+            {
               "$$hashKey": "object:164",
               "format": "bytes",
               "logBase": 1,
@@ -6452,7 +7165,8 @@
         "y": 40
       },
       "id": 40,
-      "panels": [{
+      "panels": [
+        {
           "aliasColors": {},
           "bars": false,
           "dashLength": 10,
@@ -6467,13 +7181,13 @@
             },
             "overrides": []
           },
-          "fill": 1,
+          "fill": 0,
           "fillGradient": 0,
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 160
+            "y": 41
           },
           "hiddenSeries": false,
           "id": 97,
@@ -6497,7 +7211,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "9.0.3",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -6505,17 +7219,19 @@
           "spaceLength": 10,
           "stack": false,
           "steppedLine": false,
-          "targets": [{
-            "datasource": {
-              "type": "prometheus",
-              "uid": "$ds"
-            },
-            "expr": "sum(rate(vm_http_requests_total{job=~\"$job_insert\", instance=~\"$instance.*\", path!~\"/favicon.ico\"}[$__rate_interval])) by (path) > 0",
-            "format": "time_series",
-            "intervalFactor": 1,
-            "legendFormat": "{{path}}",
-            "refId": "A"
-          }],
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$ds"
+              },
+              "expr": "sum(rate(vm_http_requests_total{job=~\"$job_insert\", instance=~\"$instance.*\", path!~\"/favicon.ico\"}[$__rate_interval])) by (path) > 0",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "{{path}}",
+              "refId": "A"
+            }
+          ],
           "thresholds": [],
           "timeRegions": [],
           "title": "Requests rate ($instance)",
@@ -6530,13 +7246,16 @@
             "show": true,
             "values": []
           },
-          "yaxes": [{
+          "yaxes": [
+            {
+              "$$hashKey": "object:2715",
               "format": "short",
               "logBase": 1,
               "min": "0",
               "show": true
             },
             {
+              "$$hashKey": "object:2716",
               "format": "short",
               "logBase": 1,
               "min": "0",
@@ -6553,6 +7272,7 @@
           "dashLength": 10,
           "dashes": false,
           "datasource": {
+            "type": "prometheus",
             "uid": "$ds"
           },
           "description": "Shows how many ongoing insertions are taking place.\n* `max` - equal to number of CPU * 4 by default. May be configured with `maxConcurrentInserts` flag;\n* `current` - current number of goroutines busy with processing requests.\n\n`-maxConcurrentInserts` limits the number of insert requests which may be actively processed at any given point in time. All the other insert requests are queued for up to `-insert.maxQueueDuration` in the hope they will get a chance to be processed. This queue is used mostly for absorbing spikes for incoming insert request rate.\n\nWhen `current` hits `max` constantly, it means vminsert node is overloaded and requires more CPU or higher limits.",
@@ -6568,7 +7288,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 160
+            "y": 41
           },
           "hiddenSeries": false,
           "id": 99,
@@ -6594,28 +7314,34 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "9.0.3",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
-          "seriesOverrides": [{
-            "alias": "max",
-            "color": "#C4162A",
-            "fill": 0
-          }],
+          "seriesOverrides": [
+            {
+              "$$hashKey": "object:2777",
+              "alias": "max",
+              "color": "#C4162A",
+              "fill": 0
+            }
+          ],
           "spaceLength": 10,
           "stack": false,
           "steppedLine": false,
-          "targets": [{
+          "targets": [
+            {
               "datasource": {
                 "type": "prometheus",
                 "uid": "$ds"
               },
-              "expr": "sum(vm_concurrent_insert_current{job=~\"$job_insert\", instance=~\"$instance\"})",
+              "editorMode": "code",
+              "expr": "max(vm_concurrent_insert_current{job=~\"$job_insert\", instance=~\"$instance\"}) by(instance)",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "current",
+              "legendFormat": "{{instance}}",
+              "range": true,
               "refId": "A"
             },
             {
@@ -6624,7 +7350,7 @@
                 "uid": "$ds"
               },
               "exemplar": true,
-              "expr": "sum(vm_concurrent_insert_capacity{job=~\"$job_insert\", instance=~\"$instance\"})",
+              "expr": "min(vm_concurrent_insert_capacity{job=~\"$job_insert\", instance=~\"$instance\"})",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
@@ -6646,7 +7372,9 @@
             "show": true,
             "values": []
           },
-          "yaxes": [{
+          "yaxes": [
+            {
+              "$$hashKey": "object:2786",
               "decimals": 0,
               "format": "short",
               "logBase": 1,
@@ -6654,6 +7382,7 @@
               "show": true
             },
             {
+              "$$hashKey": "object:2787",
               "decimals": 0,
               "format": "short",
               "logBase": 1,
@@ -6687,7 +7416,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 168
+            "y": 49
           },
           "hiddenSeries": false,
           "id": 90,
@@ -6711,7 +7440,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "9.0.3",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -6719,19 +7448,21 @@
           "spaceLength": 10,
           "stack": true,
           "steppedLine": false,
-          "targets": [{
-            "datasource": {
-              "type": "prometheus",
-              "uid": "$ds"
-            },
-            "exemplar": true,
-            "expr": "sum(rate(vm_tcplistener_read_bytes_total{job=~\"$job_insert\", instance=~\"$instance\"}[$__rate_interval])) by (instance) * 8 > 0",
-            "format": "time_series",
-            "interval": "",
-            "intervalFactor": 1,
-            "legendFormat": "{{instance}}",
-            "refId": "A"
-          }],
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$ds"
+              },
+              "exemplar": true,
+              "expr": "sum(rate(vm_tcplistener_read_bytes_total{job=~\"$job_insert\", instance=~\"$instance\"}[$__rate_interval])) by (instance) * 8 > 0",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{instance}}",
+              "refId": "A"
+            }
+          ],
           "thresholds": [],
           "timeRegions": [],
           "title": "Network usage ($instance)",
@@ -6746,7 +7477,8 @@
             "show": true,
             "values": []
           },
-          "yaxes": [{
+          "yaxes": [
+            {
               "format": "bps",
               "logBase": 1,
               "show": true
@@ -6777,13 +7509,13 @@
             },
             "overrides": []
           },
-          "fill": 1,
+          "fill": 0,
           "fillGradient": 0,
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 168
+            "y": 49
           },
           "hiddenSeries": false,
           "id": 88,
@@ -6807,7 +7539,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "9.0.3",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -6815,18 +7547,20 @@
           "spaceLength": 10,
           "stack": false,
           "steppedLine": false,
-          "targets": [{
-            "datasource": {
-              "type": "prometheus",
-              "uid": "$ds"
-            },
-            "expr": "histogram_quantile(0.99, sum(increase(vm_rows_per_insert_bucket{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (instance, vmrange))",
-            "format": "time_series",
-            "interval": "",
-            "intervalFactor": 1,
-            "legendFormat": "{{instance}}",
-            "refId": "A"
-          }],
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$ds"
+              },
+              "expr": "histogram_quantile(0.99, sum(increase(vm_rows_per_insert_bucket{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (instance, vmrange))",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{instance}}",
+              "refId": "A"
+            }
+          ],
           "thresholds": [],
           "timeRegions": [],
           "title": "Rows per insert ($instance)",
@@ -6841,7 +7575,9 @@
             "show": true,
             "values": []
           },
-          "yaxes": [{
+          "yaxes": [
+            {
+              "$$hashKey": "object:2848",
               "decimals": 2,
               "format": "short",
               "logBase": 1,
@@ -6849,6 +7585,7 @@
               "show": true
             },
             {
+              "$$hashKey": "object:2849",
               "format": "short",
               "logBase": 1,
               "min": "0",
@@ -6874,13 +7611,13 @@
             },
             "overrides": []
           },
-          "fill": 1,
+          "fill": 0,
           "fillGradient": 0,
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 176
+            "y": 57
           },
           "hiddenSeries": false,
           "id": 139,
@@ -6904,7 +7641,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "9.0.3",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -6912,28 +7649,32 @@
           "spaceLength": 10,
           "stack": false,
           "steppedLine": false,
-          "targets": [{
-            "datasource": {
-              "type": "prometheus",
-              "uid": "$ds"
-            },
-            "exemplar": true,
-            "expr": "rate(vm_rpc_send_duration_seconds_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])",
-            "format": "time_series",
-            "interval": "",
-            "intervalFactor": 1,
-            "legendFormat": "{{instance}} => {{addr}}",
-            "refId": "A"
-          }],
-          "thresholds": [{
-            "$$hashKey": "object:234",
-            "colorMode": "critical",
-            "fill": true,
-            "line": true,
-            "op": "gt",
-            "value": 0.9,
-            "yaxis": "left"
-          }],
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$ds"
+              },
+              "exemplar": true,
+              "expr": "rate(vm_rpc_send_duration_seconds_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{instance}} => {{addr}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [
+            {
+              "$$hashKey": "object:234",
+              "colorMode": "critical",
+              "fill": true,
+              "line": true,
+              "op": "gt",
+              "value": 0.9,
+              "yaxis": "left"
+            }
+          ],
           "timeRegions": [],
           "title": "Storage connection saturation ($instance)",
           "tooltip": {
@@ -6947,7 +7688,8 @@
             "show": true,
             "values": []
           },
-          "yaxes": [{
+          "yaxes": [
+            {
               "$$hashKey": "object:156",
               "decimals": 0,
               "format": "s",
@@ -6988,7 +7730,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 176
+            "y": 57
           },
           "hiddenSeries": false,
           "id": 114,
@@ -7012,7 +7754,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "9.0.3",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -7020,18 +7762,20 @@
           "spaceLength": 10,
           "stack": false,
           "steppedLine": false,
-          "targets": [{
-            "datasource": {
-              "type": "prometheus",
-              "uid": "$ds"
-            },
-            "expr": "vm_rpc_vmstorage_is_reachable{job=~\"$job\", instance=~\"$instance\"}",
-            "format": "time_series",
-            "interval": "",
-            "intervalFactor": 1,
-            "legendFormat": "{{instance}} => {{addr}}",
-            "refId": "A"
-          }],
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$ds"
+              },
+              "expr": "vm_rpc_vmstorage_is_reachable{job=~\"$job\", instance=~\"$instance\"}",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{instance}} => {{addr}}",
+              "refId": "A"
+            }
+          ],
           "thresholds": [],
           "timeRegions": [],
           "title": "Storage reachability ($instance)",
@@ -7046,7 +7790,8 @@
             "show": true,
             "values": []
           },
-          "yaxes": [{
+          "yaxes": [
+            {
               "$$hashKey": "object:1534",
               "decimals": 0,
               "format": "short",
@@ -7087,7 +7832,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 184
+            "y": 65
           },
           "hiddenSeries": false,
           "id": 164,
@@ -7111,30 +7856,33 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "9.0.3",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
-          "seriesOverrides": [{
-            "$$hashKey": "object:186",
-            "alias": "max",
-            "color": "#C4162A"
-          }],
+          "seriesOverrides": [
+            {
+              "$$hashKey": "object:186",
+              "alias": "limit",
+              "color": "#C4162A"
+            }
+          ],
           "spaceLength": 10,
           "stack": false,
           "steppedLine": false,
-          "targets": [{
+          "targets": [
+            {
               "datasource": {
                 "type": "prometheus",
                 "uid": "$ds"
               },
               "editorMode": "code",
               "exemplar": true,
-              "expr": "sum(rate(process_cpu_seconds_total{job=~\"$job_insert\", instance=~\"$instance\"}[$__rate_interval]))",
+              "expr": "sum(rate(process_cpu_seconds_total{job=~\"$job_insert\", instance=~\"$instance\"}[$__rate_interval])) by(instance)",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "cores used",
+              "legendFormat": "{{instance}}",
               "range": true,
               "refId": "A"
             },
@@ -7144,9 +7892,9 @@
                 "uid": "$ds"
               },
               "editorMode": "code",
-              "expr": "sum(process_cpu_cores_available{job=~\"$job_insert\", instance=~\"$instance\"})",
+              "expr": "min(process_cpu_cores_available{job=~\"$job_insert\", instance=~\"$instance\"})",
               "hide": false,
-              "legendFormat": "max",
+              "legendFormat": "limit",
               "range": true,
               "refId": "B"
             }
@@ -7165,7 +7913,8 @@
             "show": true,
             "values": []
           },
-          "yaxes": [{
+          "yaxes": [
+            {
               "$$hashKey": "object:887",
               "format": "short",
               "logBase": 1,
@@ -7204,7 +7953,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 184
+            "y": 65
           },
           "hiddenSeries": false,
           "id": 169,
@@ -7228,30 +7977,33 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "9.0.3",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
-          "seriesOverrides": [{
-            "$$hashKey": "object:186",
-            "alias": "max",
-            "color": "#C4162A"
-          }],
+          "seriesOverrides": [
+            {
+              "$$hashKey": "object:186",
+              "alias": "limit",
+              "color": "#C4162A"
+            }
+          ],
           "spaceLength": 10,
           "stack": false,
           "steppedLine": false,
-          "targets": [{
+          "targets": [
+            {
               "datasource": {
                 "type": "prometheus",
                 "uid": "$ds"
               },
               "editorMode": "code",
               "exemplar": true,
-              "expr": "sum(process_resident_memory_anon_bytes{job=~\"$job_insert\", instance=~\"$instance\"}) ",
+              "expr": "sum(process_resident_memory_anon_bytes{job=~\"$job_insert\", instance=~\"$instance\"}) by(instance)",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "mem used",
+              "legendFormat": "{{instance}}",
               "range": true,
               "refId": "A"
             },
@@ -7261,9 +8013,9 @@
                 "uid": "$ds"
               },
               "editorMode": "code",
-              "expr": "sum(vm_available_memory_bytes{job=~\"$job_insert\", instance=~\"$instance\"})",
+              "expr": "min(vm_available_memory_bytes{job=~\"$job_insert\", instance=~\"$instance\"})",
               "hide": false,
-              "legendFormat": "max",
+              "legendFormat": "limit",
               "range": true,
               "refId": "B"
             }
@@ -7282,7 +8034,8 @@
             "show": true,
             "values": []
           },
-          "yaxes": [{
+          "yaxes": [
+            {
               "$$hashKey": "object:164",
               "format": "bytes",
               "logBase": 1,
@@ -7305,11 +8058,13 @@
       "type": "row"
     }
   ],
+  "refresh": false,
   "schemaVersion": 36,
   "style": "dark",
   "tags": [],
   "templating": {
-    "list": [{
+    "list": [
+      {
         "current": {
           "selected": false,
           "text": "VictoriaMetrics",

--- a/dashboards/victoriametrics.json
+++ b/dashboards/victoriametrics.json
@@ -55,13 +55,13 @@
       }
     ]
   },
-  "description": "Overview for single node VictoriaMetrics v1.77.0 or higher",
+  "description": "Overview for single node VictoriaMetrics v1.79.0 or higher",
   "editable": true,
   "fiscalYearStartMonth": 0,
   "gnetId": 10229,
   "graphTooltip": 0,
   "id": null,
-  "iteration": 1659966607833,
+  "iteration": 1663338736864,
   "links": [
     {
       "icon": "doc",
@@ -281,6 +281,7 @@
     },
     {
       "datasource": {
+        "type": "prometheus",
         "uid": "$ds"
       },
       "description": "Average disk usage per datapoint.",
@@ -334,7 +335,7 @@
             "uid": "$ds"
           },
           "exemplar": true,
-          "expr": "sum(vm_data_size_bytes{job=~\"$job\", type!=\"indexdb\"}) / sum(vm_rows{job=~\"$job\", type!=\"indexdb\"})",
+          "expr": "sum(vm_data_size_bytes{job=~\"$job\"}) / sum(vm_rows{job=~\"$job\"})",
           "format": "time_series",
           "instant": true,
           "interval": "",
@@ -790,7 +791,7 @@
         },
         "overrides": []
       },
-      "fill": 1,
+      "fill": 0,
       "fillGradient": 0,
       "gridPos": {
         "h": 8,
@@ -857,12 +858,14 @@
       },
       "yaxes": [
         {
+          "$$hashKey": "object:758",
           "format": "short",
           "logBase": 1,
           "min": "0",
           "show": true
         },
         {
+          "$$hashKey": "object:759",
           "format": "short",
           "logBase": 1,
           "min": "0",
@@ -1187,7 +1190,7 @@
         },
         "overrides": []
       },
-      "fill": 1,
+      "fill": 0,
       "fillGradient": 0,
       "gridPos": {
         "h": 8,
@@ -1219,12 +1222,13 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.3.5",
+      "pluginVersion": "9.0.3",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
       "seriesOverrides": [
         {
+          "$$hashKey": "object:840",
           "alias": "max",
           "color": "#C4162A"
         }
@@ -1292,6 +1296,420 @@
       }
     },
     {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds"
+      },
+      "description": "99th percentile of number of raw samples read per query.",
+      "fieldConfig": {
+        "defaults": {
+          "links": []
+        },
+        "overrides": []
+      },
+      "fill": 0,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 22
+      },
+      "hiddenSeries": false,
+      "id": 101,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": true,
+        "max": true,
+        "min": false,
+        "show": true,
+        "sort": "current",
+        "sortDesc": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null as zero",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "9.0.3",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$ds"
+          },
+          "expr": "histogram_quantile(0.99, sum(rate(vm_rows_read_per_query_bucket{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (vmrange))",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "Rows read per query ($instance)",
+      "tooltip": {
+        "shared": true,
+        "sort": 2,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:2848",
+          "decimals": 2,
+          "format": "short",
+          "logBase": 1,
+          "min": "0",
+          "show": true
+        },
+        {
+          "$$hashKey": "object:2849",
+          "format": "short",
+          "logBase": 1,
+          "min": "0",
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds"
+      },
+      "description": "99th percentile of number of series read per query.",
+      "fieldConfig": {
+        "defaults": {
+          "links": []
+        },
+        "overrides": []
+      },
+      "fill": 0,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 30
+      },
+      "hiddenSeries": false,
+      "id": 99,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": true,
+        "max": true,
+        "min": false,
+        "show": true,
+        "sort": "current",
+        "sortDesc": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null as zero",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "9.0.3",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$ds"
+          },
+          "expr": "histogram_quantile(0.99, sum(rate(vm_series_read_per_query_bucket{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (vmrange))",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "Series read per query ($instance)",
+      "tooltip": {
+        "shared": true,
+        "sort": 2,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:2848",
+          "decimals": 2,
+          "format": "short",
+          "logBase": 1,
+          "min": "0",
+          "show": true
+        },
+        {
+          "$$hashKey": "object:2849",
+          "format": "short",
+          "logBase": 1,
+          "min": "0",
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds"
+      },
+      "description": "99th percentile of number of raw samples scanner per query.\n\nThis number can exceed number of RowsReadPerQuery if `step` query arg passed to [/api/v1/query_range](https://prometheus.io/docs/prometheus/latest/querying/api/#range-queries) is smaller than the lookbehind window set in square brackets of [rollup function](https://docs.victoriametrics.com/MetricsQL.html#rollup-functions). For example, if `increase(some_metric[1h])` is executed with the `step=5m`, then the same raw samples on a hour time range are scanned `1h/5m=12` times. See [this article](https://valyala.medium.com/how-to-optimize-promql-and-metricsql-queries-85a1b75bf986) for details.",
+      "fieldConfig": {
+        "defaults": {
+          "links": []
+        },
+        "overrides": []
+      },
+      "fill": 0,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 30
+      },
+      "hiddenSeries": false,
+      "id": 105,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": true,
+        "max": true,
+        "min": false,
+        "show": true,
+        "sort": "current",
+        "sortDesc": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null as zero",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "9.0.3",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$ds"
+          },
+          "expr": "histogram_quantile(0.99, sum(rate(vm_rows_scanned_per_query_bucket{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (vmrange))",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "Rows scanned per series ($instance)",
+      "tooltip": {
+        "shared": true,
+        "sort": 2,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:2848",
+          "decimals": 2,
+          "format": "short",
+          "logBase": 1,
+          "min": "0",
+          "show": true
+        },
+        {
+          "$$hashKey": "object:2849",
+          "format": "short",
+          "logBase": 1,
+          "min": "0",
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds"
+      },
+      "description": "99th percentile of number of raw samples read per queried series.",
+      "fieldConfig": {
+        "defaults": {
+          "links": []
+        },
+        "overrides": []
+      },
+      "fill": 0,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 38
+      },
+      "hiddenSeries": false,
+      "id": 103,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": true,
+        "max": true,
+        "min": false,
+        "show": true,
+        "sort": "current",
+        "sortDesc": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null as zero",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "9.0.3",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$ds"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum(rate(vm_rows_read_per_series_bucket{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (vmrange))",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{label_name}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "Rows read per series ($instance)",
+      "tooltip": {
+        "shared": true,
+        "sort": 2,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:2848",
+          "decimals": 2,
+          "format": "short",
+          "logBase": 1,
+          "min": "0",
+          "show": true
+        },
+        {
+          "$$hashKey": "object:2849",
+          "format": "short",
+          "logBase": 1,
+          "min": "0",
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
       "collapsed": true,
       "datasource": {
         "type": "prometheus",
@@ -1301,7 +1719,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 30
+        "y": 46
       },
       "id": 92,
       "panels": [
@@ -1321,7 +1739,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 7
+            "y": 31
           },
           "hiddenSeries": false,
           "id": 94,
@@ -1434,7 +1852,7 @@
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 15
+            "y": 39
           },
           "hiddenSeries": false,
           "id": 97,
@@ -1523,7 +1941,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 22
+            "y": 46
           },
           "hiddenSeries": false,
           "id": 95,
@@ -1630,7 +2048,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 31
+        "y": 47
       },
       "id": 14,
       "panels": [
@@ -1655,7 +2073,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 3
+            "y": 4
           },
           "hiddenSeries": false,
           "id": 10,
@@ -1680,7 +2098,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.3.2",
+          "pluginVersion": "9.0.3",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -1748,13 +2166,13 @@
             },
             "overrides": []
           },
-          "fill": 1,
+          "fill": 0,
           "fillGradient": 0,
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 3
+            "y": 4
           },
           "hiddenSeries": false,
           "id": 73,
@@ -1779,7 +2197,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.3.2",
+          "pluginVersion": "9.0.3",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -1817,12 +2235,14 @@
           },
           "yaxes": [
             {
+              "$$hashKey": "object:919",
               "format": "s",
               "logBase": 1,
               "min": "0",
               "show": true
             },
             {
+              "$$hashKey": "object:920",
               "format": "short",
               "logBase": 1,
               "min": "0",
@@ -1848,13 +2268,13 @@
             },
             "overrides": []
           },
-          "fill": 1,
+          "fill": 0,
           "fillGradient": 0,
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 11
+            "y": 12
           },
           "hiddenSeries": false,
           "id": 30,
@@ -1878,12 +2298,13 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.3.2",
+          "pluginVersion": "9.0.3",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
           "seriesOverrides": [
             {
+              "$$hashKey": "object:997",
               "alias": "bytes-per-datapoint",
               "yaxis": 2
             }
@@ -1931,12 +2352,14 @@
           },
           "yaxes": [
             {
+              "$$hashKey": "object:1004",
               "format": "short",
               "logBase": 1,
               "min": "0",
               "show": true
             },
             {
+              "$$hashKey": "object:1005",
               "decimals": 2,
               "format": "bytes",
               "logBase": 1,
@@ -1969,7 +2392,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 11
+            "y": 12
           },
           "hiddenSeries": false,
           "id": 34,
@@ -1993,7 +2416,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.3.2",
+          "pluginVersion": "9.0.3",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -2078,13 +2501,13 @@
             },
             "overrides": []
           },
-          "fill": 1,
+          "fill": 0,
           "fillGradient": 0,
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 19
+            "y": 20
           },
           "hiddenSeries": false,
           "id": 53,
@@ -2109,7 +2532,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.3.2",
+          "pluginVersion": "9.0.3",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -2157,12 +2580,14 @@
           },
           "yaxes": [
             {
+              "$$hashKey": "object:1136",
               "format": "bytes",
               "logBase": 1,
               "min": "0",
               "show": true
             },
             {
+              "$$hashKey": "object:1137",
               "format": "short",
               "logBase": 1,
               "min": "0",
@@ -2188,13 +2613,13 @@
             },
             "overrides": []
           },
-          "fill": 1,
+          "fill": 0,
           "fillGradient": 0,
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 19
+            "y": 20
           },
           "hiddenSeries": false,
           "id": 36,
@@ -2218,7 +2643,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.3.2",
+          "pluginVersion": "9.0.3",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -2254,12 +2679,14 @@
           },
           "yaxes": [
             {
+              "$$hashKey": "object:1066",
               "format": "short",
               "logBase": 1,
               "min": "0",
               "show": true
             },
             {
+              "$$hashKey": "object:1067",
               "format": "short",
               "logBase": 1,
               "min": "0",
@@ -2291,7 +2718,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 27
+            "y": 28
           },
           "hiddenSeries": false,
           "id": 55,
@@ -2315,7 +2742,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.3.2",
+          "pluginVersion": "9.0.3",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -2384,13 +2811,13 @@
             },
             "overrides": []
           },
-          "fill": 1,
+          "fill": 0,
           "fillGradient": 0,
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 27
+            "y": 28
           },
           "hiddenSeries": false,
           "id": 62,
@@ -2413,7 +2840,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.3.2",
+          "pluginVersion": "9.0.3",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -2447,6 +2874,7 @@
           },
           "yaxes": [
             {
+              "$$hashKey": "object:1262",
               "decimals": 0,
               "format": "short",
               "logBase": 1,
@@ -2454,6 +2882,7 @@
               "show": true
             },
             {
+              "$$hashKey": "object:1263",
               "format": "short",
               "logBase": 1,
               "min": "0",
@@ -2485,7 +2914,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 35
+            "y": 36
           },
           "hiddenSeries": false,
           "id": 58,
@@ -2509,7 +2938,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.3.2",
+          "pluginVersion": "9.0.3",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -2579,13 +3008,13 @@
             },
             "overrides": []
           },
-          "fill": 1,
+          "fill": 0,
           "fillGradient": 0,
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 35
+            "y": 36
           },
           "hiddenSeries": false,
           "id": 64,
@@ -2608,7 +3037,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.3.2",
+          "pluginVersion": "9.0.3",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -2682,7 +3111,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 43
+            "y": 44
           },
           "hiddenSeries": false,
           "id": 67,
@@ -2706,7 +3135,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.3.2",
+          "pluginVersion": "9.0.3",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -2780,7 +3209,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 32
+        "y": 48
       },
       "id": 71,
       "panels": [
@@ -2805,7 +3234,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 32
+            "y": 5
           },
           "hiddenSeries": false,
           "id": 66,
@@ -2915,7 +3344,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 32
+            "y": 5
           },
           "hiddenSeries": false,
           "id": 96,
@@ -3014,7 +3443,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 40
+            "y": 13
           },
           "hiddenSeries": false,
           "id": 68,
@@ -3124,7 +3553,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 40
+            "y": 13
           },
           "hiddenSeries": false,
           "id": 60,
@@ -3217,7 +3646,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 48
+            "y": 21
           },
           "hiddenSeries": false,
           "id": 90,
@@ -3311,7 +3740,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 48
+            "y": 21
           },
           "hiddenSeries": false,
           "id": 74,
@@ -3410,7 +3839,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 33
+        "y": 49
       },
       "id": 46,
       "panels": [
@@ -3429,13 +3858,13 @@
             },
             "overrides": []
           },
-          "fill": 1,
+          "fill": 0,
           "fillGradient": 0,
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 5
+            "y": 50
           },
           "hiddenSeries": false,
           "id": 44,
@@ -3459,7 +3888,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.3.5",
+          "pluginVersion": "9.0.3",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -3543,12 +3972,14 @@
           },
           "yaxes": [
             {
+              "$$hashKey": "object:1432",
               "format": "bytes",
               "logBase": 1,
               "min": "0",
               "show": true
             },
             {
+              "$$hashKey": "object:1433",
               "format": "short",
               "logBase": 1,
               "min": "0",
@@ -3575,13 +4006,13 @@
             },
             "overrides": []
           },
-          "fill": 1,
+          "fill": 0,
           "fillGradient": 0,
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 5
+            "y": 50
           },
           "hiddenSeries": false,
           "id": 57,
@@ -3605,7 +4036,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.3.5",
+          "pluginVersion": "9.0.3",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -3663,12 +4094,14 @@
           },
           "yaxes": [
             {
+              "$$hashKey": "object:1370",
               "format": "short",
               "logBase": 1,
               "min": "0",
               "show": true
             },
             {
+              "$$hashKey": "object:1371",
               "format": "short",
               "logBase": 1,
               "min": "0",
@@ -3694,13 +4127,13 @@
             },
             "overrides": []
           },
-          "fill": 1,
+          "fill": 0,
           "fillGradient": 0,
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 13
+            "y": 58
           },
           "hiddenSeries": false,
           "id": 75,
@@ -3724,12 +4157,13 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.3.5",
+          "pluginVersion": "9.0.3",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
           "seriesOverrides": [
             {
+              "$$hashKey": "object:1514",
               "alias": "max",
               "color": "#C4162A"
             }
@@ -3777,6 +4211,7 @@
           },
           "yaxes": [
             {
+              "$$hashKey": "object:1521",
               "decimals": 0,
               "format": "short",
               "logBase": 2,
@@ -3784,6 +4219,7 @@
               "show": true
             },
             {
+              "$$hashKey": "object:1522",
               "format": "short",
               "logBase": 1,
               "min": "0",
@@ -3815,7 +4251,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 13
+            "y": 58
           },
           "hiddenSeries": false,
           "id": 76,
@@ -3839,7 +4275,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.3.5",
+          "pluginVersion": "9.0.3",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -3929,7 +4365,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 21
+            "y": 66
           },
           "hiddenSeries": false,
           "id": 47,
@@ -3953,7 +4389,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.3.5",
+          "pluginVersion": "9.0.3",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -4027,7 +4463,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 21
+            "y": 66
           },
           "hiddenSeries": false,
           "id": 42,
@@ -4051,7 +4487,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.3.5",
+          "pluginVersion": "9.0.3",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -4123,7 +4559,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 29
+            "y": 74
           },
           "hiddenSeries": false,
           "id": 48,
@@ -4147,7 +4583,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.3.5",
+          "pluginVersion": "9.0.3",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -4221,7 +4657,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 29
+            "y": 74
           },
           "hiddenSeries": false,
           "id": 37,
@@ -4245,7 +4681,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.3.5",
+          "pluginVersion": "9.0.3",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -4319,7 +4755,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 37
+            "y": 82
           },
           "hiddenSeries": false,
           "id": 49,
@@ -4343,7 +4779,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.3.5",
+          "pluginVersion": "9.0.3",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",

--- a/dashboards/vmagent.json
+++ b/dashboards/vmagent.json
@@ -1,12 +1,12 @@
 {
   "__inputs": [],
-  "__elements": [],
+  "__elements": {},
   "__requires": [
     {
       "type": "grafana",
       "id": "grafana",
       "name": "Grafana",
-      "version": "8.4.4"
+      "version": "9.0.3"
     },
     {
       "type": "panel",
@@ -34,8 +34,8 @@
     },
     {
       "type": "panel",
-      "id": "table-old",
-      "name": "Table (old)",
+      "id": "table",
+      "name": "Table",
       "version": ""
     }
   ],
@@ -66,7 +66,7 @@
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
   "id": null,
-  "iteration": 1657810604530,
+  "iteration": 1663339589357,
   "links": [
     {
       "icon": "doc",
@@ -109,8 +109,148 @@
       },
       "id": 24,
       "panels": [],
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$ds"
+          },
+          "refId": "A"
+        }
+      ],
       "title": "Overview",
       "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds"
+      },
+      "description": "Shows the rate of samples scraped from configured targets.",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 0,
+        "y": 1
+      },
+      "id": 103,
+      "links": [
+        {
+          "title": "Troubleshooting",
+          "url": "https://docs.victoriametrics.com/vmagent.html#troubleshooting"
+        }
+      ],
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "last"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.0.3",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$ds"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(vm_promscrape_scraped_samples_sum{job=~\"$job\", instance=~\"$instance\", path!~\"/favicon.ico\"}[$__rate_interval]))",
+          "interval": "",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Samples scraped/s",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds"
+      },
+      "description": "Shows the rate of ingested samples",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 4,
+        "y": 1
+      },
+      "id": 102,
+      "links": [
+        {
+          "title": "Troubleshooting",
+          "url": "https://docs.victoriametrics.com/vmagent.html#troubleshooting"
+        }
+      ],
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "last"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.0.3",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$ds"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(vm_ingestserver_requests_total{job=~\"$job\", instance=~\"$instance\", path!~\"/favicon.ico\"}[$__rate_interval]))",
+          "interval": "",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Samples ingested/s",
+      "type": "stat"
     },
     {
       "datasource": {
@@ -135,7 +275,7 @@
       "gridPos": {
         "h": 3,
         "w": 4,
-        "x": 0,
+        "x": 8,
         "y": 1
       },
       "id": 9,
@@ -154,9 +294,12 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "8.4.4",
+      "pluginVersion": "9.0.3",
       "targets": [
         {
+          "datasource": {
+            "uid": "$ds"
+          },
           "expr": "sum(vm_promscrape_targets{job=~\"$job\", instance=~\"$instance\", status=\"up\"})",
           "interval": "",
           "legendFormat": "up",
@@ -193,7 +336,7 @@
       "gridPos": {
         "h": 3,
         "w": 4,
-        "x": 4,
+        "x": 12,
         "y": 1
       },
       "id": 72,
@@ -218,9 +361,12 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "8.4.4",
+      "pluginVersion": "9.0.3",
       "targets": [
         {
+          "datasource": {
+            "uid": "$ds"
+          },
           "expr": "sum(vm_promscrape_targets{job=~\"$job\", instance=~\"$instance\", status=\"down\"})",
           "interval": "",
           "legendFormat": "up",
@@ -259,7 +405,7 @@
       "gridPos": {
         "h": 3,
         "w": 4,
-        "x": 8,
+        "x": 16,
         "y": 1
       },
       "id": 16,
@@ -285,9 +431,12 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "8.4.4",
+      "pluginVersion": "9.0.3",
       "targets": [
         {
+          "datasource": {
+            "uid": "$ds"
+          },
           "expr": "sum(increase(vm_log_messages_total{job=~\"$job\", instance=~\"$instance\", level!=\"info\"}[30m]))",
           "interval": "",
           "legendFormat": "",
@@ -324,8 +473,8 @@
       },
       "gridPos": {
         "h": 3,
-        "w": 5,
-        "x": 12,
+        "w": 4,
+        "x": 20,
         "y": 1
       },
       "id": 56,
@@ -344,9 +493,12 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "8.4.4",
+      "pluginVersion": "9.0.3",
       "targets": [
         {
+          "datasource": {
+            "uid": "$ds"
+          },
           "expr": "sum(vm_persistentqueue_bytes_pending{job=~\"$job\", instance=~\"$instance\"})",
           "interval": "",
           "legendFormat": "",
@@ -357,92 +509,97 @@
       "type": "stat"
     },
     {
-      "columns": [],
       "datasource": {
+        "type": "prometheus",
         "uid": "$ds"
       },
-      "fontSize": "100%",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "displayMode": "auto",
+            "inspect": false,
+            "minWidth": 50
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Time"
+            },
+            "properties": [
+              {
+                "id": "custom.hidden",
+                "value": true
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Value"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Count"
+              }
+            ]
+          }
+        ]
+      },
       "gridPos": {
-        "h": 7,
-        "w": 7,
-        "x": 17,
-        "y": 1
+        "h": 5,
+        "w": 8,
+        "x": 0,
+        "y": 4
       },
-      "id": 11,
-      "scroll": true,
-      "showHeader": true,
-      "sort": {
-        "col": 4,
-        "desc": false
+      "id": 101,
+      "options": {
+        "footer": {
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true
       },
-      "styles": [
-        {
-          "alias": "uptime",
-          "align": "auto",
-          "colorMode": "cell",
-          "colors": [
-            "rgba(245, 54, 54, 0.9)",
-            "rgba(237, 129, 40, 0.89)",
-            "rgba(50, 172, 45, 0.97)"
-          ],
-          "dateFormat": "YYYY-MM-DD HH:mm:ss",
-          "decimals": 2,
-          "mappingType": 1,
-          "pattern": "Value",
-          "thresholds": [
-            "1800",
-            "3600"
-          ],
-          "type": "number",
-          "unit": "s"
-        },
-        {
-          "alias": "",
-          "align": "auto",
-          "colors": [
-            "rgba(245, 54, 54, 0.9)",
-            "rgba(237, 129, 40, 0.89)",
-            "rgba(50, 172, 45, 0.97)"
-          ],
-          "dateFormat": "YYYY-MM-DD HH:mm:ss",
-          "decimals": 2,
-          "mappingType": 1,
-          "pattern": "instance",
-          "thresholds": [],
-          "type": "string",
-          "unit": "short"
-        },
-        {
-          "alias": "",
-          "align": "auto",
-          "colors": [
-            "rgba(245, 54, 54, 0.9)",
-            "rgba(237, 129, 40, 0.89)",
-            "rgba(50, 172, 45, 0.97)"
-          ],
-          "dateFormat": "YYYY-MM-DD HH:mm:ss",
-          "decimals": 2,
-          "mappingType": 1,
-          "pattern": "/.*/",
-          "thresholds": [],
-          "type": "hidden",
-          "unit": "short"
-        }
-      ],
+      "pluginVersion": "9.0.3",
       "targets": [
         {
-          "expr": "sort((time() - vm_app_start_timestamp{job=~\"$job\", instance=~\"$instance\"}) or (up{job=~\"$job\", instance=~\"$instance\"}))",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$ds"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum(vm_app_version{job=~\"$job\", instance=~\"$instance\"}) by(job, short_version)",
           "format": "table",
-          "hide": false,
           "instant": true,
-          "interval": "",
-          "legendFormat": "{{instance}}",
+          "range": false,
           "refId": "A"
         }
       ],
-      "title": "Uptime",
-      "transform": "table",
-      "type": "table-old"
+      "type": "table"
     },
     {
       "aliasColors": {},
@@ -461,9 +618,9 @@
       "fill": 0,
       "fillGradient": 0,
       "gridPos": {
-        "h": 4,
-        "w": 17,
-        "x": 0,
+        "h": 5,
+        "w": 16,
+        "x": 8,
         "y": 4
       },
       "hiddenSeries": false,
@@ -490,7 +647,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.4.4",
+      "pluginVersion": "9.0.3",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -500,6 +657,9 @@
       "steppedLine": true,
       "targets": [
         {
+          "datasource": {
+            "uid": "$ds"
+          },
           "expr": "sort(sum(up{job=~\"$job\", instance=~\"$instance\"}) by (job, instance))",
           "format": "time_series",
           "instant": false,
@@ -566,7 +726,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 8
+        "y": 9
       },
       "hiddenSeries": false,
       "id": 5,
@@ -589,7 +749,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.4.4",
+      "pluginVersion": "9.0.3",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -642,11 +802,13 @@
       },
       "yaxes": [
         {
+          "$$hashKey": "object:537",
           "format": "short",
           "logBase": 1,
           "show": true
         },
         {
+          "$$hashKey": "object:538",
           "format": "bytes",
           "logBase": 1,
           "show": true
@@ -678,7 +840,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 8
+        "y": 9
       },
       "hiddenSeries": false,
       "id": 15,
@@ -702,7 +864,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.4.4",
+      "pluginVersion": "9.0.3",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -775,7 +937,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 16
+        "y": 17
       },
       "hiddenSeries": false,
       "id": 69,
@@ -805,7 +967,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.4.4",
+      "pluginVersion": "9.0.3",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -917,7 +1079,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 16
+        "y": 17
       },
       "hiddenSeries": false,
       "id": 17,
@@ -946,7 +1108,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.4.4",
+      "pluginVersion": "9.0.3",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -956,6 +1118,9 @@
       "steppedLine": false,
       "targets": [
         {
+          "datasource": {
+            "uid": "$ds"
+          },
           "exemplar": true,
           "expr": "sum(vmagent_remotewrite_pending_data_bytes{job=~\"$job\", instance=~\"$instance\", url=~\"$url\"}) by (url)",
           "interval": "",
@@ -1015,7 +1180,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 24
+        "y": 25
       },
       "hiddenSeries": false,
       "id": 79,
@@ -1039,7 +1204,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.4.4",
+      "pluginVersion": "9.0.3",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1049,6 +1214,9 @@
       "steppedLine": false,
       "targets": [
         {
+          "datasource": {
+            "uid": "$ds"
+          },
           "exemplar": true,
           "expr": "sum(rate(vmagent_remotewrite_packets_dropped_total{job=~\"$job\", instance=~\"$instance\", url=~\"$url\"}[$__interval])) by(url)",
           "interval": "",
@@ -1108,7 +1276,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 24
+        "y": 25
       },
       "hiddenSeries": false,
       "id": 49,
@@ -1138,7 +1306,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.4.4",
+      "pluginVersion": "9.0.3",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1148,6 +1316,9 @@
       "steppedLine": false,
       "targets": [
         {
+          "datasource": {
+            "uid": "$ds"
+          },
           "expr": "sum(increase(vm_persistentqueue_bytes_dropped_total{job=~\"$job\", instance=~\"$instance\"}[$__interval])) by (path)",
           "interval": "",
           "legendFormat": "{{ path }}",
@@ -1207,7 +1378,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 32
+        "y": 33
       },
       "hiddenSeries": false,
       "id": 18,
@@ -1237,7 +1408,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.4.4",
+      "pluginVersion": "9.0.3",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1320,7 +1491,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 32
+        "y": 33
       },
       "hiddenSeries": false,
       "id": 86,
@@ -1344,7 +1515,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.4.4",
+      "pluginVersion": "9.0.3",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1354,6 +1525,9 @@
       "steppedLine": false,
       "targets": [
         {
+          "datasource": {
+            "uid": "$ds"
+          },
           "exemplar": true,
           "expr": "sum(rate(vm_log_messages_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (level) ",
           "format": "time_series",
@@ -1405,7 +1579,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 40
+        "y": 41
       },
       "id": 28,
       "panels": [
@@ -1429,7 +1603,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 2
+            "y": 42
           },
           "hiddenSeries": false,
           "id": 48,
@@ -1452,7 +1626,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "9.0.3",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -1462,6 +1636,9 @@
           "steppedLine": false,
           "targets": [
             {
+              "datasource": {
+                "uid": "$ds"
+              },
               "exemplar": true,
               "expr": "sum(vm_promscrape_targets{job=~\"$job\", instance=~\"$instance\", status=\"up\"}) by(type) > 0",
               "format": "time_series",
@@ -1521,7 +1698,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 2
+            "y": 42
           },
           "hiddenSeries": false,
           "id": 76,
@@ -1544,7 +1721,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "9.0.3",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -1554,6 +1731,9 @@
           "steppedLine": false,
           "targets": [
             {
+              "datasource": {
+                "uid": "$ds"
+              },
               "exemplar": true,
               "expr": "sum(vm_promscrape_targets{job=~\"$job\", instance=~\"$instance\", status=\"down\"}) by(type) > 0",
               "format": "time_series",
@@ -1614,7 +1794,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 9
+            "y": 49
           },
           "hiddenSeries": false,
           "id": 20,
@@ -1637,7 +1817,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "9.0.3",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -1727,7 +1907,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 9
+            "y": 49
           },
           "hiddenSeries": false,
           "id": 31,
@@ -1750,7 +1930,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "9.0.3",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -1851,7 +2031,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 17
+            "y": 57
           },
           "hiddenSeries": false,
           "id": 46,
@@ -1874,7 +2054,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "9.0.3",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -1884,6 +2064,9 @@
           "steppedLine": false,
           "targets": [
             {
+              "datasource": {
+                "uid": "$ds"
+              },
               "expr": "histogram_quantile(0.95, sum(rate(vm_promscrape_scrape_response_size_bytes_bucket{job=~\"$job\", instance=~\"$instance\"}[$__interval])) by(vmrange))  ",
               "format": "time_series",
               "interval": "",
@@ -1891,6 +2074,9 @@
               "refId": "A"
             },
             {
+              "datasource": {
+                "uid": "$ds"
+              },
               "expr": "histogram_quantile(0.5, sum(rate(vm_promscrape_scrape_response_size_bytes_bucket{job=~\"$job\", instance=~\"$instance\"}[$__interval])) by(vmrange)) ",
               "interval": "",
               "legendFormat": "p0.5",
@@ -1947,7 +2133,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 17
+            "y": 57
           },
           "heatmap": {},
           "hideZeroBuckets": false,
@@ -1989,6 +2175,14 @@
           "yBucketBound": "auto"
         }
       ],
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$ds"
+          },
+          "refId": "A"
+        }
+      ],
       "title": "Scraping",
       "type": "row"
     },
@@ -2001,7 +2195,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 41
+        "y": 42
       },
       "id": 71,
       "panels": [
@@ -2027,7 +2221,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 3
+            "y": 66
           },
           "hiddenSeries": false,
           "id": 73,
@@ -2051,7 +2245,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "9.0.3",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -2099,12 +2293,14 @@
           },
           "yaxes": [
             {
+              "$$hashKey": "object:410",
               "format": "short",
               "logBase": 1,
               "min": "0",
               "show": true
             },
             {
+              "$$hashKey": "object:411",
               "format": "none",
               "logBase": 1,
               "show": true
@@ -2136,7 +2332,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 3
+            "y": 66
           },
           "hiddenSeries": false,
           "id": 77,
@@ -2160,7 +2356,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "9.0.3",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -2208,12 +2404,14 @@
           },
           "yaxes": [
             {
+              "$$hashKey": "object:272",
               "format": "short",
               "logBase": 1,
               "min": "0",
               "show": true
             },
             {
+              "$$hashKey": "object:273",
               "format": "none",
               "logBase": 1,
               "show": true
@@ -2245,7 +2443,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 11
+            "y": 74
           },
           "hiddenSeries": false,
           "id": 78,
@@ -2269,7 +2467,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "9.0.3",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -2306,12 +2504,14 @@
           },
           "yaxes": [
             {
+              "$$hashKey": "object:349",
               "format": "short",
               "logBase": 1,
               "min": "0",
               "show": true
             },
             {
+              "$$hashKey": "object:350",
               "format": "none",
               "logBase": 1,
               "show": true
@@ -2343,7 +2543,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 11
+            "y": 74
           },
           "hiddenSeries": false,
           "id": 50,
@@ -2366,7 +2566,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "9.0.3",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -2419,6 +2619,14 @@
           }
         }
       ],
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$ds"
+          },
+          "refId": "A"
+        }
+      ],
       "title": "Ingestion",
       "type": "row"
     },
@@ -2431,7 +2639,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 42
+        "y": 43
       },
       "id": 58,
       "panels": [
@@ -2457,7 +2665,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 43
+            "y": 83
           },
           "hiddenSeries": false,
           "id": 60,
@@ -2480,7 +2688,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.4.4",
+          "pluginVersion": "9.0.3",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -2506,7 +2714,7 @@
           "title": "Requests rate ($instance) to ($url)",
           "tooltip": {
             "shared": true,
-            "sort": 0,
+            "sort": 2,
             "value_type": "individual"
           },
           "type": "graph",
@@ -2517,6 +2725,7 @@
           },
           "yaxes": [
             {
+              "$$hashKey": "object:720",
               "decimals": 2,
               "format": "short",
               "logBase": 1,
@@ -2524,6 +2733,7 @@
               "show": true
             },
             {
+              "$$hashKey": "object:721",
               "format": "short",
               "logBase": 1,
               "show": true
@@ -2555,7 +2765,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 43
+            "y": 83
           },
           "hiddenSeries": false,
           "id": 66,
@@ -2578,7 +2788,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.4.4",
+          "pluginVersion": "9.0.3",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -2652,7 +2862,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 51
+            "y": 91
           },
           "hiddenSeries": false,
           "id": 61,
@@ -2675,7 +2885,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.4.4",
+          "pluginVersion": "9.0.3",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -2690,7 +2900,7 @@
                 "uid": "$ds"
               },
               "exemplar": true,
-              "expr": "sum(rate(vmagent_remotewrite_retries_count_total{job=~\"$job\", instance=~\"$instance\", url=~\"$url\"}[$__rate_interval])) by(url)",
+              "expr": "sum(rate(vmagent_remotewrite_retries_count_total{job=~\"$job\", instance=~\"$instance\", url=~\"$url\"}[$__rate_interval])) by(url) > 0",
               "interval": "",
               "legendFormat": "",
               "refId": "A"
@@ -2712,12 +2922,14 @@
           },
           "yaxes": [
             {
+              "$$hashKey": "object:789",
               "format": "short",
               "logBase": 1,
               "min": "0",
               "show": true
             },
             {
+              "$$hashKey": "object:790",
               "format": "short",
               "logBase": 1,
               "show": true
@@ -2748,7 +2960,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 51
+            "y": 91
           },
           "hiddenSeries": false,
           "id": 65,
@@ -2771,7 +2983,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.4.4",
+          "pluginVersion": "9.0.3",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -2781,6 +2993,9 @@
           "steppedLine": false,
           "targets": [
             {
+              "datasource": {
+                "uid": "$ds"
+              },
               "exemplar": true,
               "expr": "sum(vmagent_remotewrite_conns{job=~\"$job\", instance=~\"$instance\"}) by (instance)",
               "interval": "",
@@ -2837,7 +3052,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 59
+            "y": 99
           },
           "heatmap": {},
           "hideZeroBuckets": false,
@@ -2849,6 +3064,9 @@
           "reverseYBuckets": false,
           "targets": [
             {
+              "datasource": {
+                "uid": "$ds"
+              },
               "exemplar": true,
               "expr": "buckets_limit(12, prometheus_buckets(sum(rate(vmagent_remotewrite_duration_seconds_bucket{job=~\"$job\", instance=~\"$instance\", url=~\"$url\"}[$__interval])) by(vmrange)))",
               "format": "heatmap",
@@ -2897,7 +3115,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 59
+            "y": 99
           },
           "hiddenSeries": false,
           "id": 84,
@@ -2920,7 +3138,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.4.4",
+          "pluginVersion": "9.0.3",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -2930,6 +3148,10 @@
           "steppedLine": false,
           "targets": [
             {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$ds"
+              },
               "exemplar": true,
               "expr": "sum(rate(vmagent_remotewrite_send_duration_seconds_total{job=~\"$job\", instance=~\"$instance\", url=~\"$url\"}[$__rate_interval])) by (instance, url)\n/\nmax(vmagent_remotewrite_queues{job=~\"$job\", instance=~\"$instance\", url=~\"$url\"}) by(instance, url)",
               "interval": "",
@@ -2998,7 +3220,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 67
+            "y": 107
           },
           "heatmap": {},
           "hideZeroBuckets": false,
@@ -3010,6 +3232,9 @@
           "reverseYBuckets": false,
           "targets": [
             {
+              "datasource": {
+                "uid": "$ds"
+              },
               "exemplar": true,
               "expr": "buckets_limit(12, prometheus_buckets(sum(rate(vmagent_remotewrite_block_size_rows_bucket{job=~\"$job\", instance=~\"$instance\"}[$__interval])) by(vmrange)))",
               "format": "heatmap",
@@ -3054,7 +3279,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 67
+            "y": 107
           },
           "heatmap": {},
           "hideZeroBuckets": false,
@@ -3066,6 +3291,9 @@
           "reverseYBuckets": false,
           "targets": [
             {
+              "datasource": {
+                "uid": "$ds"
+              },
               "expr": "buckets_limit(12, prometheus_buckets(sum(rate(vmagent_remotewrite_block_size_bytes_bucket{job=~\"$job\", instance=~\"$instance\"}[$__interval])) by(vmrange)))",
               "format": "heatmap",
               "interval": "",
@@ -3105,7 +3333,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 75
+            "y": 115
           },
           "hiddenSeries": false,
           "id": 88,
@@ -3125,7 +3353,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.4.4",
+          "pluginVersion": "9.0.3",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -3135,6 +3363,9 @@
           "steppedLine": false,
           "targets": [
             {
+              "datasource": {
+                "uid": "$ds"
+              },
               "exemplar": true,
               "expr": "(vmagent_hourly_series_limit_current_series{job=~\"$job\", instance=~\"$instance\"} / vmagent_hourly_series_limit_max_series{job=~\"$job\", instance=~\"$instance\"}) * 100",
               "interval": "",
@@ -3142,6 +3373,9 @@
               "refId": "A"
             },
             {
+              "datasource": {
+                "uid": "$ds"
+              },
               "exemplar": true,
               "expr": "vmagent_daily_series_limit_max_series{job=~\"$job\", instance=~\"$instance\"}",
               "hide": true,
@@ -3208,7 +3442,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 75
+            "y": 115
           },
           "hiddenSeries": false,
           "id": 90,
@@ -3228,7 +3462,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.4.4",
+          "pluginVersion": "9.0.3",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -3238,6 +3472,9 @@
           "steppedLine": false,
           "targets": [
             {
+              "datasource": {
+                "uid": "$ds"
+              },
               "exemplar": true,
               "expr": "(vmagent_daily_series_limit_current_series{job=~\"$job\", instance=~\"$instance\"} / vmagent_daily_series_limit_max_series{job=~\"$job\", instance=~\"$instance\"}) * 100",
               "interval": "",
@@ -3245,6 +3482,9 @@
               "refId": "A"
             },
             {
+              "datasource": {
+                "uid": "$ds"
+              },
               "exemplar": true,
               "expr": "vmagent_daily_series_limit_max_series{job=~\"$job\", instance=~\"$instance\"}",
               "hide": true,
@@ -3297,6 +3537,14 @@
           }
         }
       ],
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$ds"
+          },
+          "refId": "A"
+        }
+      ],
       "title": "Remote write",
       "type": "row"
     },
@@ -3310,7 +3558,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 43
+        "y": 44
       },
       "id": 94,
       "panels": [
@@ -3330,7 +3578,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 5
+            "y": 124
           },
           "hiddenSeries": false,
           "id": 92,
@@ -3354,7 +3602,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "9.0.3",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -3420,7 +3668,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 5
+            "y": 124
           },
           "hiddenSeries": false,
           "id": 95,
@@ -3444,7 +3692,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "9.0.3",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -3516,7 +3764,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 13
+            "y": 132
           },
           "hiddenSeries": false,
           "id": 98,
@@ -3539,7 +3787,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "9.0.3",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -3625,7 +3873,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 13
+            "y": 132
           },
           "hiddenSeries": false,
           "id": 99,
@@ -3648,7 +3896,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "9.0.3",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -3713,6 +3961,15 @@
           }
         }
       ],
+      "targets": [
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "grafana"
+          },
+          "refId": "A"
+        }
+      ],
       "title": "Troubleshooting",
       "type": "row"
     },
@@ -3725,7 +3982,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 44
+        "y": 45
       },
       "id": 45,
       "panels": [
@@ -3738,7 +3995,7 @@
             "type": "prometheus",
             "uid": "$ds"
           },
-          "description": "Shows the CPU usage per vmagent instance. \nIf you think that usage is abnormal or unexpected pls file an issue and attach CPU profile if possible.",
+          "description": "Shows the CPU usage percentage per vmagent instance. \nIf you think that usage is abnormal or unexpected, pls file an issue and attach CPU profile if possible.",
           "fieldConfig": {
             "defaults": {
               "links": []
@@ -3751,7 +4008,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 62
+            "y": 141
           },
           "hiddenSeries": false,
           "id": 35,
@@ -3781,17 +4038,11 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "9.0.3",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
-          "seriesOverrides": [
-            {
-              "$$hashKey": "object:77",
-              "alias": "/Limit.*/",
-              "color": "#F2495C"
-            }
-          ],
+          "seriesOverrides": [],
           "spaceLength": 10,
           "stack": false,
           "steppedLine": false,
@@ -3802,26 +4053,12 @@
                 "uid": "$ds"
               },
               "exemplar": false,
-              "expr": "sum(rate(process_cpu_seconds_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by(instance)",
+              "expr": "sum(rate(process_cpu_seconds_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by(instance) / max(process_cpu_cores_available{job=~\"$job\", instance=~\"$instance\"}) by(instance)",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
               "legendFormat": "{{instance}}",
               "refId": "A"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "$ds"
-              },
-              "exemplar": false,
-              "expr": "process_cpu_cores_available{job=~\"$job\", instance=~\"$instance\"}",
-              "format": "time_series",
-              "hide": false,
-              "interval": "",
-              "intervalFactor": 1,
-              "legendFormat": "Limit ({{instance}})",
-              "refId": "B"
             }
           ],
           "thresholds": [],
@@ -3829,7 +4066,7 @@
           "title": "CPU ($instance)",
           "tooltip": {
             "shared": true,
-            "sort": 0,
+            "sort": 2,
             "value_type": "individual"
           },
           "type": "graph",
@@ -3840,12 +4077,14 @@
           },
           "yaxes": [
             {
-              "format": "short",
+              "$$hashKey": "object:912",
+              "format": "percentunit",
               "logBase": 1,
               "min": "0",
               "show": true
             },
             {
+              "$$hashKey": "object:913",
               "format": "short",
               "logBase": 1,
               "show": true
@@ -3876,7 +4115,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 62
+            "y": 141
           },
           "hiddenSeries": false,
           "id": 37,
@@ -3906,7 +4145,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "9.0.3",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -3916,6 +4155,9 @@
           "steppedLine": false,
           "targets": [
             {
+              "datasource": {
+                "uid": "$ds"
+              },
               "exemplar": true,
               "expr": "sum(process_resident_memory_bytes{job=~\"$job\", instance=~\"$instance\"}) by (instance)",
               "interval": "",
@@ -3923,6 +4165,9 @@
               "refId": "A"
             },
             {
+              "datasource": {
+                "uid": "$ds"
+              },
               "exemplar": true,
               "expr": "sum(process_resident_memory_anon_bytes{job=~\"$job\", instance=~\"$instance\"}) by (instance)",
               "hide": false,
@@ -3983,7 +4228,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 70
+            "y": 149
           },
           "hiddenSeries": false,
           "id": 81,
@@ -4007,12 +4252,13 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "9.0.3",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
           "seriesOverrides": [
             {
+              "$$hashKey": "object:1206",
               "alias": "read",
               "transform": "negative-Y"
             }
@@ -4022,6 +4268,9 @@
           "steppedLine": false,
           "targets": [
             {
+              "datasource": {
+                "uid": "$ds"
+              },
               "expr": "sum(rate(process_io_storage_read_bytes_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
               "format": "time_series",
               "hide": false,
@@ -4031,6 +4280,9 @@
               "refId": "A"
             },
             {
+              "datasource": {
+                "uid": "$ds"
+              },
               "expr": "sum(rate(process_io_storage_written_bytes_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
               "format": "time_series",
               "hide": false,
@@ -4056,11 +4308,13 @@
           },
           "yaxes": [
             {
+              "$$hashKey": "object:1213",
               "format": "bytes",
               "logBase": 1,
               "show": true
             },
             {
+              "$$hashKey": "object:1214",
               "format": "short",
               "logBase": 1,
               "min": "0",
@@ -4092,7 +4346,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 70
+            "y": 149
           },
           "hiddenSeries": false,
           "id": 7,
@@ -4116,7 +4370,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "9.0.3",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -4131,12 +4385,18 @@
           "steppedLine": false,
           "targets": [
             {
+              "datasource": {
+                "uid": "$ds"
+              },
               "expr": "sum(rate(vm_tcplistener_read_bytes_total{job=~\"$job\", instance=~\"$instance\"}[$__interval])) * 8\n+ sum(rate(vm_promscrape_conn_bytes_read_total{job=~\"$job\", instance=~\"$instance\"}[$__interval])) * 8",
               "interval": "",
               "legendFormat": "in",
               "refId": "A"
             },
             {
+              "datasource": {
+                "uid": "$ds"
+              },
               "expr": "sum(rate(vmagent_remotewrite_conn_bytes_written_total{job=~\"$job\", instance=~\"$instance\"}[$__interval])) * 8",
               "interval": "",
               "legendFormat": "out",
@@ -4179,9 +4439,10 @@
           "dashLength": 10,
           "dashes": false,
           "datasource": {
+            "type": "prometheus",
             "uid": "$ds"
           },
-          "description": "Panel shows the number of open file descriptors in the OS.\nReaching the limit of open files can cause various issues and must be prevented.\n\nSee how to change limits here https://medium.com/@muhammadtriwibowo/set-permanently-ulimit-n-open-files-in-ubuntu-4d61064429a",
+          "description": "Panel shows the percentage of open file descriptors in the OS per instance.\nReaching the limit of open files (100%) can cause various issues and must be prevented.\n\nSee how to change limits here https://medium.com/@muhammadtriwibowo/set-permanently-ulimit-n-open-files-in-ubuntu-4d61064429a",
           "fieldConfig": {
             "defaults": {
               "links": []
@@ -4194,7 +4455,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 78
+            "y": 157
           },
           "hiddenSeries": false,
           "id": 83,
@@ -4218,36 +4479,27 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "9.0.3",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
-          "seriesOverrides": [
-            {
-              "$$hashKey": "object:913",
-              "alias": "max",
-              "color": "#C4162A"
-            }
-          ],
+          "seriesOverrides": [],
           "spaceLength": 10,
           "stack": false,
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(process_open_fds{job=~\"$job\", instance=~\"$instance\"})",
+              "datasource": {
+                "uid": "$ds"
+              },
+              "editorMode": "code",
+              "expr": "max(process_open_fds{job=~\"$job\", instance=~\"$instance\"}) by(instance) \n/\nmin(process_max_fds{job=~\"$job\", instance=~\"$instance\"}) by(instance)",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 2,
-              "legendFormat": "open",
+              "legendFormat": "__auto",
+              "range": true,
               "refId": "A"
-            },
-            {
-              "expr": "min(process_max_fds{job=~\"$job\", instance=~\"$instance\"})",
-              "format": "time_series",
-              "interval": "",
-              "intervalFactor": 2,
-              "legendFormat": "max",
-              "refId": "B"
             }
           ],
           "thresholds": [],
@@ -4255,7 +4507,7 @@
           "title": "Open FDs ($instance)",
           "tooltip": {
             "shared": true,
-            "sort": 0,
+            "sort": 2,
             "value_type": "individual"
           },
           "type": "graph",
@@ -4266,13 +4518,15 @@
           },
           "yaxes": [
             {
-              "decimals": 0,
-              "format": "short",
-              "logBase": 2,
+              "$$hashKey": "object:987",
+              "decimals": 5,
+              "format": "percentunit",
+              "logBase": 1,
               "min": "0",
               "show": true
             },
             {
+              "$$hashKey": "object:988",
               "format": "short",
               "logBase": 1,
               "min": "0",
@@ -4303,7 +4557,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 78
+            "y": 157
           },
           "hiddenSeries": false,
           "id": 39,
@@ -4327,7 +4581,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "9.0.3",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -4337,6 +4591,9 @@
           "steppedLine": false,
           "targets": [
             {
+              "datasource": {
+                "uid": "$ds"
+              },
               "expr": "sum(go_goroutines{job=~\"$job\", instance=~\"$instance\"}) by(instance)",
               "format": "time_series",
               "interval": "",
@@ -4397,7 +4654,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 86
+            "y": 165
           },
           "hiddenSeries": false,
           "id": 43,
@@ -4421,7 +4678,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "9.0.3",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -4431,6 +4688,9 @@
           "steppedLine": false,
           "targets": [
             {
+              "datasource": {
+                "uid": "$ds"
+              },
               "expr": "max(go_gc_duration_seconds{job=~\"$job\", instance=~\"$instance\", quantile=\"1\"}) by(instance)",
               "format": "time_series",
               "intervalFactor": 2,
@@ -4489,7 +4749,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 86
+            "y": 165
           },
           "hiddenSeries": false,
           "id": 41,
@@ -4513,7 +4773,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "9.0.3",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -4523,6 +4783,9 @@
           "steppedLine": false,
           "targets": [
             {
+              "datasource": {
+                "uid": "$ds"
+              },
               "expr": "sum(process_num_threads{job=~\"$job\", instance=~\"$instance\"}) by(instance)",
               "format": "time_series",
               "intervalFactor": 2,
@@ -4563,12 +4826,20 @@
           }
         }
       ],
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$ds"
+          },
+          "refId": "A"
+        }
+      ],
       "title": "Resource usage",
       "type": "row"
     }
   ],
   "refresh": "",
-  "schemaVersion": 35,
+  "schemaVersion": 36,
   "style": "dark",
   "tags": [
     "vmagent",
@@ -4579,8 +4850,8 @@
       {
         "current": {
           "selected": true,
-          "text": "VM",
-          "value": "VM"
+          "text": "VictoriaMetrics",
+          "value": "VictoriaMetrics"
         },
         "hide": 0,
         "includeAll": false,
@@ -4595,14 +4866,14 @@
         "type": "datasource"
       },
       {
-        "allValue": "",
+        "allValue": ".*",
         "current": {},
         "datasource": {
           "uid": "$ds"
         },
         "definition": "label_values(vm_app_version{version=~\"^vmagent.*\"}, job)",
         "hide": 0,
-        "includeAll": false,
+        "includeAll": true,
         "multi": true,
         "name": "job",
         "options": [],
@@ -4666,6 +4937,17 @@
         "skipUrlSync": false,
         "sort": 0,
         "type": "query"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${ds}"
+        },
+        "filters": [],
+        "hide": 0,
+        "name": "adhoc",
+        "skipUrlSync": false,
+        "type": "adhoc"
       }
     ]
   },
@@ -4687,7 +4969,7 @@
     ]
   },
   "timezone": "",
-  "title": "vmagent",
+  "title": "VictoriaMetrics - vmagent",
   "uid": "G7Z9GzMGz",
   "version": 1,
   "weekStart": ""

--- a/dashboards/vmalert.json
+++ b/dashboards/vmalert.json
@@ -5,7 +5,7 @@
       "type": "grafana",
       "id": "grafana",
       "name": "Grafana",
-      "version": "8.3.5"
+      "version": "9.0.3"
     },
     {
       "type": "panel",
@@ -27,8 +27,8 @@
     },
     {
       "type": "panel",
-      "id": "table-old",
-      "name": "Table (old)",
+      "id": "table",
+      "name": "Table",
       "version": ""
     },
     {
@@ -42,7 +42,10 @@
     "list": [
       {
         "builtIn": 1,
-        "datasource": "-- Grafana --",
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
         "enable": true,
         "hide": true,
         "iconColor": "rgba(0, 211, 255, 1)",
@@ -62,7 +65,7 @@
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
   "id": null,
-  "iteration": 1644909221704,
+  "iteration": 1663341746917,
   "links": [
     {
       "asDropdown": false,
@@ -105,6 +108,10 @@
   "panels": [
     {
       "collapsed": false,
+      "datasource": {
+        "type": "datasource",
+        "uid": "grafana"
+      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -113,6 +120,15 @@
       },
       "id": 11,
       "panels": [],
+      "targets": [
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "grafana"
+          },
+          "refId": "A"
+        }
+      ],
       "title": "General ($instance)",
       "type": "row"
     },
@@ -181,9 +197,12 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "8.3.5",
+      "pluginVersion": "9.0.3",
       "targets": [
         {
+          "datasource": {
+            "uid": "$ds"
+          },
           "exemplar": false,
           "expr": "count(vmalert_config_last_reload_successful{job=~\"$job\", instance=~\"$instance\"} < 1 ) or 0",
           "interval": "",
@@ -220,7 +239,7 @@
       },
       "gridPos": {
         "h": 3,
-        "w": 5,
+        "w": 4,
         "x": 3,
         "y": 1
       },
@@ -240,9 +259,12 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "8.3.5",
+      "pluginVersion": "9.0.3",
       "targets": [
         {
+          "datasource": {
+            "uid": "$ds"
+          },
           "exemplar": false,
           "expr": "(sum(vmalert_alerting_rules_error{job=~\"$job\", instance=~\"$instance\", group=~\"$group\"}) or vector(0)) + \n(sum(vmalert_recording_rules_error{job=~\"$job\", instance=~\"$instance\", group=~\"$group\"}) or vector(0))",
           "interval": "",
@@ -275,8 +297,8 @@
       },
       "gridPos": {
         "h": 3,
-        "w": 5,
-        "x": 8,
+        "w": 4,
+        "x": 7,
         "y": 1
       },
       "id": 9,
@@ -295,9 +317,12 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "8.3.5",
+      "pluginVersion": "9.0.3",
       "targets": [
         {
+          "datasource": {
+            "uid": "$ds"
+          },
           "exemplar": false,
           "expr": "count(vmalert_alerting_rules_error{job=~\"$job\", instance=~\"$instance\", group=~\"$group\"})",
           "interval": "",
@@ -330,8 +355,8 @@
       },
       "gridPos": {
         "h": 3,
-        "w": 5,
-        "x": 13,
+        "w": 4,
+        "x": 11,
         "y": 1
       },
       "id": 7,
@@ -350,9 +375,12 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "8.3.5",
+      "pluginVersion": "9.0.3",
       "targets": [
         {
+          "datasource": {
+            "uid": "$ds"
+          },
           "exemplar": false,
           "expr": "count(vmalert_recording_rules_error{job=~\"$job\", instance=~\"$instance\", group=~\"$group\"})",
           "interval": "",
@@ -364,93 +392,97 @@
       "type": "stat"
     },
     {
-      "columns": [],
       "datasource": {
+        "type": "prometheus",
         "uid": "$ds"
       },
-      "fontSize": "100%",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "displayMode": "auto",
+            "inspect": false,
+            "minWidth": 50
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Time"
+            },
+            "properties": [
+              {
+                "id": "custom.hidden",
+                "value": true
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Value"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Count"
+              }
+            ]
+          }
+        ]
+      },
       "gridPos": {
-        "h": 7,
-        "w": 6,
-        "x": 18,
-        "y": 1
+        "h": 4,
+        "w": 9,
+        "x": 0,
+        "y": 4
       },
-      "id": 2,
-      "scroll": true,
-      "showHeader": true,
-      "sort": {
-        "col": 3,
-        "desc": false
+      "id": 45,
+      "options": {
+        "footer": {
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true
       },
-      "styles": [
-        {
-          "alias": "uptime",
-          "align": "auto",
-          "colorMode": "cell",
-          "colors": [
-            "rgba(245, 54, 54, 0.9)",
-            "rgba(237, 129, 40, 0.89)",
-            "rgba(50, 172, 45, 0.97)"
-          ],
-          "dateFormat": "YYYY-MM-DD HH:mm:ss",
-          "decimals": 2,
-          "mappingType": 1,
-          "pattern": "Value",
-          "thresholds": [
-            "1800",
-            "3600"
-          ],
-          "type": "number",
-          "unit": "s"
-        },
-        {
-          "alias": "",
-          "align": "auto",
-          "colors": [
-            "rgba(245, 54, 54, 0.9)",
-            "rgba(237, 129, 40, 0.89)",
-            "rgba(50, 172, 45, 0.97)"
-          ],
-          "dateFormat": "YYYY-MM-DD HH:mm:ss",
-          "decimals": 2,
-          "mappingType": 1,
-          "pattern": "instance",
-          "thresholds": [],
-          "type": "string",
-          "unit": "short"
-        },
-        {
-          "alias": "",
-          "align": "auto",
-          "colors": [
-            "rgba(245, 54, 54, 0.9)",
-            "rgba(237, 129, 40, 0.89)",
-            "rgba(50, 172, 45, 0.97)"
-          ],
-          "dateFormat": "YYYY-MM-DD HH:mm:ss",
-          "decimals": 2,
-          "mappingType": 1,
-          "pattern": "/.*/",
-          "thresholds": [],
-          "type": "hidden",
-          "unit": "short"
-        }
-      ],
+      "pluginVersion": "9.0.3",
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$ds"
+          },
+          "editorMode": "code",
           "exemplar": false,
-          "expr": "sort((time() - vm_app_start_timestamp{job=~\"$job\", instance=~\"$instance\"}) or (up{job=~\"$job\", instance=~\"$instance\"}))",
+          "expr": "sum(vm_app_version{job=~\"$job\", instance=~\"$instance\"}) by(job, short_version)",
           "format": "table",
-          "hide": false,
           "instant": true,
-          "interval": "",
-          "legendFormat": "{{instance}}",
+          "range": false,
           "refId": "A"
         }
       ],
-      "title": "Uptime",
-      "transform": "table",
-      "type": "table-old"
+      "type": "table"
     },
     {
       "aliasColors": {},
@@ -470,8 +502,8 @@
       "fillGradient": 0,
       "gridPos": {
         "h": 4,
-        "w": 18,
-        "x": 0,
+        "w": 15,
+        "x": 9,
         "y": 4
       },
       "hiddenSeries": false,
@@ -498,7 +530,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.3.5",
+      "pluginVersion": "9.0.3",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -508,6 +540,9 @@
       "steppedLine": true,
       "targets": [
         {
+          "datasource": {
+            "uid": "$ds"
+          },
           "exemplar": false,
           "expr": "sort(sum(up{job=~\"$job\", instance=~\"$instance\"}) by (job, instance))",
           "format": "time_series",
@@ -562,7 +597,7 @@
         "uid": "$ds"
       },
       "description": "Shows the number of fired alerts by instance.",
-      "fill": 1,
+      "fill": 0,
       "fillGradient": 0,
       "gridPos": {
         "h": 8,
@@ -591,7 +626,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.3.5",
+      "pluginVersion": "9.0.3",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -601,6 +636,9 @@
       "steppedLine": false,
       "targets": [
         {
+          "datasource": {
+            "uid": "$ds"
+          },
           "exemplar": false,
           "expr": "sum(increase(vmalert_alerts_fired_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by(instance)",
           "interval": "",
@@ -613,7 +651,7 @@
       "title": "Alerts fired total",
       "tooltip": {
         "shared": true,
-        "sort": 0,
+        "sort": 2,
         "value_type": "individual"
       },
       "type": "graph",
@@ -624,11 +662,13 @@
       },
       "yaxes": [
         {
+          "$$hashKey": "object:62",
           "format": "short",
           "logBase": 1,
           "show": true
         },
         {
+          "$$hashKey": "object:63",
           "format": "short",
           "logBase": 1,
           "show": true
@@ -682,7 +722,7 @@
         "alertThreshold": false
       },
       "percentage": false,
-      "pluginVersion": "8.3.5",
+      "pluginVersion": "9.0.3",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -692,6 +732,9 @@
       "steppedLine": false,
       "targets": [
         {
+          "datasource": {
+            "uid": "$ds"
+          },
           "exemplar": false,
           "expr": "sum(rate(vmalert_iteration_duration_seconds_sum{job=~\"$job\", instance=~\"$instance\", group=~\"$group\"}[$__rate_interval])) by(group) / \nsum(rate(vmalert_iteration_duration_seconds_count{job=~\"$job\", instance=~\"$instance\", group=~\"$group\"}[$__rate_interval])) by(group)",
           "interval": "",
@@ -767,7 +810,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.3.5",
+      "pluginVersion": "9.0.3",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -777,6 +820,9 @@
       "steppedLine": false,
       "targets": [
         {
+          "datasource": {
+            "uid": "$ds"
+          },
           "exemplar": false,
           "expr": "sum(rate(vmalert_execution_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (instance)",
           "interval": "",
@@ -800,11 +846,13 @@
       },
       "yaxes": [
         {
+          "$$hashKey": "object:182",
           "format": "short",
           "logBase": 1,
           "show": true
         },
         {
+          "$$hashKey": "object:183",
           "format": "short",
           "logBase": 1,
           "show": true
@@ -820,6 +868,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": {
+        "type": "prometheus",
         "uid": "$ds"
       },
       "description": "Shows the error rate while executing configured rules. Non-zero value means there are some issues with existing rules. Check the logs to get more details.",
@@ -852,7 +901,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.3.5",
+      "pluginVersion": "9.0.3",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -862,8 +911,11 @@
       "steppedLine": false,
       "targets": [
         {
+          "datasource": {
+            "uid": "$ds"
+          },
           "exemplar": false,
-          "expr": "sum(increase(vmalert_execution_errors_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by(instance)",
+          "expr": "sum(increase(vmalert_execution_errors_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by(instance) > 0",
           "interval": "",
           "legendFormat": "{{instance}}",
           "refId": "A"
@@ -885,11 +937,13 @@
       },
       "yaxes": [
         {
+          "$$hashKey": "object:244",
           "format": "short",
           "logBase": 1,
           "show": true
         },
         {
+          "$$hashKey": "object:245",
           "format": "short",
           "logBase": 1,
           "show": true
@@ -901,6 +955,10 @@
     },
     {
       "collapsed": true,
+      "datasource": {
+        "type": "datasource",
+        "uid": "grafana"
+      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -947,7 +1005,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.0.3",
+          "pluginVersion": "9.0.3",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -957,6 +1015,9 @@
           "steppedLine": false,
           "targets": [
             {
+              "datasource": {
+                "uid": "$ds"
+              },
               "exemplar": false,
               "expr": "sum(vmalert_alerts_firing{job=~\"$job\", instance=~\"$instance\", group=~\"$group\"}) by(group, alertname) > 0",
               "interval": "",
@@ -1032,7 +1093,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.0.3",
+          "pluginVersion": "9.0.3",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -1042,6 +1103,9 @@
           "steppedLine": false,
           "targets": [
             {
+              "datasource": {
+                "uid": "$ds"
+              },
               "exemplar": false,
               "expr": "sum(vmalert_alerting_rules_error{job=~\"$job\", instance=~\"$instance\", group=~\"$group\"}) by(group, alertname) > 0",
               "interval": "",
@@ -1117,7 +1181,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.0.3",
+          "pluginVersion": "9.0.3",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -1127,6 +1191,9 @@
           "steppedLine": false,
           "targets": [
             {
+              "datasource": {
+                "uid": "$ds"
+              },
               "exemplar": false,
               "expr": "sum(vmalert_alerts_pending{job=~\"$job\", instance=~\"$instance\", group=~\"$group\"}) by(group, alertname) > 0",
               "interval": "",
@@ -1170,6 +1237,7 @@
           "dashLength": 10,
           "dashes": false,
           "datasource": {
+            "type": "prometheus",
             "uid": "$ds"
           },
           "description": "Shows how many alerts are sent to Alertmanager per second. Only active alerts are sent.",
@@ -1202,7 +1270,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.0.3",
+          "pluginVersion": "9.0.3",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -1212,8 +1280,11 @@
           "steppedLine": false,
           "targets": [
             {
+              "datasource": {
+                "uid": "$ds"
+              },
               "exemplar": false,
-              "expr": "sum(rate(vmalert_alerts_sent_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by(instance, addr)",
+              "expr": "sum(rate(vmalert_alerts_sent_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by(instance, addr) > 0",
               "interval": "",
               "legendFormat": "{{instance}} => {{addr}}",
               "refId": "A"
@@ -1224,7 +1295,7 @@
           "title": "Requests rate to Alertmanager ($group)",
           "tooltip": {
             "shared": true,
-            "sort": 0,
+            "sort": 2,
             "value_type": "individual"
           },
           "type": "graph",
@@ -1259,6 +1330,7 @@
           "dashLength": 10,
           "dashes": false,
           "datasource": {
+            "type": "prometheus",
             "uid": "$ds"
           },
           "description": "Shows the error rate for the attempts to send alerts to Alertmanager. If not zero it means there issues on attempt to send notification to Alertmanager and some alerts may be not delivered properly. Check the logs for more details.",
@@ -1291,7 +1363,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.0.3",
+          "pluginVersion": "9.0.3",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -1301,8 +1373,11 @@
           "steppedLine": false,
           "targets": [
             {
+              "datasource": {
+                "uid": "$ds"
+              },
               "exemplar": false,
-              "expr": "sum(rate(vmalert_alerts_send_errors_total{job=~\"$job\", instance=~\"$instance\", group=~\"$group\"}[$__rate_interval])) by(instance, addr)",
+              "expr": "sum(rate(vmalert_alerts_send_errors_total{job=~\"$job\", instance=~\"$instance\", group=~\"$group\"}[$__rate_interval])) by(instance, addr) > 0",
               "interval": "",
               "legendFormat": "{{instance}} => {{addr}}",
               "refId": "A"
@@ -1343,11 +1418,24 @@
           }
         }
       ],
+      "targets": [
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "grafana"
+          },
+          "refId": "A"
+        }
+      ],
       "title": "Alerting rules ($instance)",
       "type": "row"
     },
     {
       "collapsed": true,
+      "datasource": {
+        "type": "datasource",
+        "uid": "grafana"
+      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -1371,7 +1459,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 26
+            "y": 50
           },
           "hiddenSeries": false,
           "id": 31,
@@ -1394,7 +1482,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.0.3",
+          "pluginVersion": "9.0.3",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -1404,6 +1492,9 @@
           "steppedLine": false,
           "targets": [
             {
+              "datasource": {
+                "uid": "$ds"
+              },
               "exemplar": false,
               "expr": "topk(10, sum(vmalert_recording_rules_last_evaluation_samples{job=~\"$job\", instance=~\"$instance\", group=~\"$group\"}) by(group, recording) > 0)",
               "interval": "",
@@ -1500,7 +1591,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 26
+            "y": 50
           },
           "id": 33,
           "options": {
@@ -1514,12 +1605,16 @@
               "placement": "bottom"
             },
             "tooltip": {
-              "mode": "single"
+              "mode": "single",
+              "sort": "none"
             }
           },
           "pluginVersion": "8.0.3",
           "targets": [
             {
+              "datasource": {
+                "uid": "$ds"
+              },
               "exemplar": false,
               "expr": "sum(vmalert_recording_rules_last_evaluation_samples{job=~\"$job\", instance=~\"$instance\", group=~\"$group\"}) by(group, recording) < 1",
               "interval": "",
@@ -1544,7 +1639,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 34
+            "y": 58
           },
           "hiddenSeries": false,
           "id": 30,
@@ -1567,7 +1662,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.0.3",
+          "pluginVersion": "9.0.3",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -1577,6 +1672,9 @@
           "steppedLine": false,
           "targets": [
             {
+              "datasource": {
+                "uid": "$ds"
+              },
               "exemplar": false,
               "expr": "sum(vmalert_recording_rules_error{job=~\"$job\", instance=~\"$instance\", group=~\"$group\"}) by(group, recording) > 0",
               "interval": "",
@@ -1615,11 +1713,24 @@
           }
         }
       ],
+      "targets": [
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "grafana"
+          },
+          "refId": "A"
+        }
+      ],
       "title": "Recording rules ($instance)",
       "type": "row"
     },
     {
       "collapsed": true,
+      "datasource": {
+        "type": "datasource",
+        "uid": "grafana"
+      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -1637,7 +1748,7 @@
             "type": "prometheus",
             "uid": "$ds"
           },
-          "description": "Shows the CPU usage per vmalert instance. \nIf you think that usage is abnormal or unexpected pls file an issue and attach CPU profile if possible.",
+          "description": "Shows the CPU usage percentage per vmalert instance. \nIf you think that usage is abnormal or unexpected pls file an issue and attach CPU profile if possible.",
           "fieldConfig": {
             "defaults": {
               "links": []
@@ -1650,7 +1761,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 27
+            "y": 67
           },
           "hiddenSeries": false,
           "id": 35,
@@ -1680,17 +1791,11 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.3.5",
+          "pluginVersion": "9.0.3",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
-          "seriesOverrides": [
-            {
-              "$$hashKey": "object:61",
-              "alias": "/Limit .*/",
-              "color": "#F2495C"
-            }
-          ],
+          "seriesOverrides": [],
           "spaceLength": 10,
           "stack": false,
           "steppedLine": false,
@@ -1701,26 +1806,12 @@
                 "uid": "$ds"
               },
               "exemplar": false,
-              "expr": "sum(rate(process_cpu_seconds_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by(instance)",
+              "expr": "sum(rate(process_cpu_seconds_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by(instance) / min(process_cpu_cores_available{job=~\"$job\", instance=~\"$instance\"}) by(instance)",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
               "legendFormat": "{{instance}}",
               "refId": "A"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "$ds"
-              },
-              "exemplar": false,
-              "expr": "process_cpu_cores_available{job=~\"$job\", instance=~\"$instance\"}",
-              "format": "time_series",
-              "hide": false,
-              "interval": "",
-              "intervalFactor": 1,
-              "legendFormat": "Limit ({{instance}})",
-              "refId": "B"
             }
           ],
           "thresholds": [],
@@ -1728,7 +1819,7 @@
           "title": "CPU ($instance)",
           "tooltip": {
             "shared": true,
-            "sort": 0,
+            "sort": 2,
             "value_type": "individual"
           },
           "type": "graph",
@@ -1739,12 +1830,14 @@
           },
           "yaxes": [
             {
-              "format": "short",
+              "$$hashKey": "object:473",
+              "format": "percentunit",
               "logBase": 1,
               "min": "0",
               "show": true
             },
             {
+              "$$hashKey": "object:474",
               "format": "short",
               "logBase": 1,
               "show": true
@@ -1775,7 +1868,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 27
+            "y": 67
           },
           "hiddenSeries": false,
           "id": 37,
@@ -1805,7 +1898,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.3.5",
+          "pluginVersion": "9.0.3",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -1815,6 +1908,9 @@
           "steppedLine": false,
           "targets": [
             {
+              "datasource": {
+                "uid": "$ds"
+              },
               "exemplar": false,
               "expr": "sum(process_resident_memory_bytes{job=~\"$job\", instance=~\"$instance\"}) by (instance)",
               "interval": "",
@@ -1822,6 +1918,9 @@
               "refId": "A"
             },
             {
+              "datasource": {
+                "uid": "$ds"
+              },
               "exemplar": false,
               "expr": "sum(process_resident_memory_anon_bytes{job=~\"$job\", instance=~\"$instance\"}) by (instance)",
               "hide": false,
@@ -1867,9 +1966,10 @@
           "dashLength": 10,
           "dashes": false,
           "datasource": {
+            "type": "prometheus",
             "uid": "$ds"
           },
-          "description": "Panel shows the number of open file descriptors in the OS.\nReaching the limit of open files can cause various issues and must be prevented.\n\nSee how to change limits here https://medium.com/@muhammadtriwibowo/set-permanently-ulimit-n-open-files-in-ubuntu-4d61064429a",
+          "description": "Panel shows the percentage of open file descriptors in the OS.\nReaching the limit of open files can cause various issues and must be prevented.\n\nSee how to change limits here https://medium.com/@muhammadtriwibowo/set-permanently-ulimit-n-open-files-in-ubuntu-4d61064429a",
           "fieldConfig": {
             "defaults": {
               "links": []
@@ -1882,7 +1982,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 35
+            "y": 75
           },
           "hiddenSeries": false,
           "id": 39,
@@ -1906,37 +2006,28 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.3.5",
+          "pluginVersion": "9.0.3",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
-          "seriesOverrides": [
-            {
-              "$$hashKey": "object:1161",
-              "alias": "max",
-              "color": "#C4162A"
-            }
-          ],
+          "seriesOverrides": [],
           "spaceLength": 10,
           "stack": false,
           "steppedLine": false,
           "targets": [
             {
+              "datasource": {
+                "uid": "$ds"
+              },
+              "editorMode": "code",
               "exemplar": false,
-              "expr": "sum(process_open_fds{job=~\"$job\", instance=~\"$instance\"}) by (instance)",
+              "expr": "sum(process_open_fds{job=~\"$job\", instance=~\"$instance\"}) by (instance) \n/\nmin(process_max_fds{job=~\"$job\", instance=~\"$instance\"}) by(instance)",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 2,
               "legendFormat": "open {{instance}}",
+              "range": true,
               "refId": "A"
-            },
-            {
-              "expr": "min(process_max_fds{job=~\"$job\", instance=~\"$instance\"})",
-              "format": "time_series",
-              "interval": "",
-              "intervalFactor": 2,
-              "legendFormat": "max",
-              "refId": "B"
             }
           ],
           "thresholds": [],
@@ -1955,13 +2046,15 @@
           },
           "yaxes": [
             {
-              "decimals": 0,
-              "format": "short",
-              "logBase": 2,
+              "$$hashKey": "object:540",
+              "decimals": 3,
+              "format": "percentunit",
+              "logBase": 1,
               "min": "0",
               "show": true
             },
             {
+              "$$hashKey": "object:541",
               "format": "short",
               "logBase": 1,
               "min": "0",
@@ -1992,7 +2085,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 35
+            "y": 75
           },
           "hiddenSeries": false,
           "id": 41,
@@ -2016,7 +2109,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.3.5",
+          "pluginVersion": "9.0.3",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -2026,6 +2119,9 @@
           "steppedLine": false,
           "targets": [
             {
+              "datasource": {
+                "uid": "$ds"
+              },
               "expr": "sum(go_goroutines{job=~\"$job\", instance=~\"$instance\"}) by(instance)",
               "format": "time_series",
               "interval": "",
@@ -2067,12 +2163,21 @@
           }
         }
       ],
+      "targets": [
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "grafana"
+          },
+          "refId": "A"
+        }
+      ],
       "title": "Resource usage",
       "type": "row"
     }
   ],
   "refresh": false,
-  "schemaVersion": 34,
+  "schemaVersion": 36,
   "style": "dark",
   "tags": [
     "victoriametrics",
@@ -2162,6 +2267,17 @@
         "skipUrlSync": false,
         "sort": 0,
         "type": "query"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${ds}"
+        },
+        "filters": [],
+        "hide": 0,
+        "name": "adhoc",
+        "skipUrlSync": false,
+        "type": "adhoc"
       }
     ]
   },
@@ -2171,7 +2287,7 @@
   },
   "timepicker": {},
   "timezone": "",
-  "title": "vmalert",
+  "title": "VictoriaMetrics - vmalert",
   "uid": "LzldHAVnz",
   "version": 1,
   "weekStart": ""


### PR DESCRIPTION
dashboards/vmalert: 

* apply consistent formatting across panels;
* adapt resource usage panels for multiple selected jobs/instances;
* show vmalert version in Stats section.

dashboards/vmagent: 

* apply consistent formatting across panels;
* add panels for showing number of samples ingested
or scraped;
* adapt resource usage panels for multiple selected jobs/instances;
* add adhoc variable;
* display vmagent's version in Stats.


dashboards/single:

* apply consistent formatting across panels;
* add extra panels to Performance for displaying
`vm_rows_read_per_query`, `vm_rows_scanned_per_query`,
`vm_rows_read_per_series` and `vm_series_read_per_query` metrics.

dashboards/cluster:

* apply consistent formatting across panels;
* make resource usage panels per component more detailed;
* add extra panels to vmselect for displaying
`vm_rows_read_per_query`, `vm_rows_scanned_per_query`,
`vm_rows_read_per_series` and `vm_series_read_per_query` metrics.
