### PR TITLE
docs/vmagent.md: fix typo

### DIFF
--- a/docs/vmagent.md
+++ b/docs/vmagent.md
@@ -80,7 +80,7 @@ Pass `-help` to `vmagent` in order to see [the full list of supported command-li
 
 `vmagent` supports multiple approaches for reloading configs from updated config files such as `-promscrape.config`, `-remoteWrite.relabelConfig` and `-remoteWrite.urlRelabelConfig`:
 
-* Sending `SUGHUP` signal to `vmagent` process:
+* Sending `SIGHUP` signal to `vmagent` process:
 
   ```console
   kill -SIGHUP `pidof vmagent`


### PR DESCRIPTION
fix typo: 'SUGHUP'