### PR TITLE
lib/backup/s3remote: fix error checking for alternative S3 providers

### DIFF
--- a/lib/backup/s3remote/s3.go
+++ b/lib/backup/s3remote/s3.go
@@ -3,7 +3,6 @@ package s3remote
 import (
 	"bytes"
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -12,7 +11,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/feature/s3/manager"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
-	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/backup/common"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/backup/fscommon"
@@ -307,7 +305,7 @@ func (fs *FS) HasFile(filePath string) (bool, error) {
 	}
 	o, err := fs.s3.GetObject(context.Background(), input)
 	if err != nil {
-		if errors.Is(err, &types.NoSuchKey{}) {
+		if strings.Contains(err.Error(), "NoSuchKey") {
 			return false, nil
 		}
 		return false, fmt.Errorf("cannot open %q at %s (remote path %q): %w", filePath, fs, path, err)


### PR DESCRIPTION
Changes error checking to fix support of alternative S3 providers (tested with Minio)
404 error returned by Minio is wrapped into generic `smithy.OperatonError` instead of AWS `types.NoSuchKey`
The only way to check for this specific error is to check error message.
Since this error message is also present in default AWS message this PR changes validation to only check error message to unify error checking. 