### PR TITLE
Retry writes for partial writes

### DIFF
--- a/lib/fs/fs.go
+++ b/lib/fs/fs.go
@@ -363,15 +363,15 @@ func ReadFullData(r io.Reader, data []byte) error {
 
 // MustWriteData writes data to w.
 func MustWriteData(w io.Writer, data []byte) {
-	if len(data) == 0 {
-		return
-	}
-	n, err := w.Write(data)
-	if err != nil {
-		logger.Panicf("FATAL: cannot write %d bytes: %s", len(data), err)
-	}
-	if n != len(data) {
-		logger.Panicf("BUG: writer wrote %d bytes instead of %d bytes", n, len(data))
+	for len(data) != 0 {
+		n, err := w.Write(data)
+		if err != nil {
+			logger.Panicf("FATAL: cannot write %d bytes: %s", len(data), err)
+		}
+		if n == 0 {
+			logger.Panicf("BUG: wrote 0 bytes, but %d was sent", len(data))
+		}
+		data = data[n:]
 	}
 }
 


### PR DESCRIPTION
That may happen in particular in NFS. POSIX:2008-conforming kernel implementations can return partial writes for writes of more than 512 bytes.

This fix takes inspiration of PostgreSQL fixes for NFS: https://www.postgresql.org/message-id/20110909174405.GC25219%40tornado.leadboat.com

This draft PR only fixes this in one place only, for review. If accepted, we need to add in other places and review again.
