### PR TITLE
docs: when modifying docs in place allow storing backups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@
 Gemfile.lock
 /_site
 _site
+*.tmp

--- a/Makefile
+++ b/Makefile
@@ -402,7 +402,7 @@ copy-docs:
 		echo "---\nsort: ${ORDER}\n---\n" > ${DST}; \
 	fi
 	cat ${SRC} >> ${DST}
-	sed -i 's/<img src=\"docs\//<img src=\"/' ${DST}
+	sed -i '.tmp' 's/<img src=\"docs\//<img src=\"/' ${DST}
 
 # Copies docs for all components and adds the order tag.
 # For ORDER=0 it adds no order tag.


### PR DESCRIPTION
The stored backups would help to identify docs corruption but aren't needed for commiting. So `.tmp` backup files are also git-ignored.

Signed-off-by: hagen1778 <roman@victoriametrics.com>