### PR TITLE
lib/backup: set s3 default region to us-west-2

### DIFF
--- a/lib/backup/s3remote/s3.go
+++ b/lib/backup/s3remote/s3.go
@@ -61,7 +61,7 @@ func (fs *FS) Init() error {
 	}
 	configOpts := []func(*config.LoadOptions) error{
 		config.WithSharedConfigProfile(fs.ProfileName),
-		config.WithDefaultRegion("us-west-2"),
+		config.WithDefaultRegion("us-east-1"),
 	}
 
 	if len(fs.CredsFilePath) > 0 {

--- a/lib/backup/s3remote/s3.go
+++ b/lib/backup/s3remote/s3.go
@@ -61,6 +61,7 @@ func (fs *FS) Init() error {
 	}
 	configOpts := []func(*config.LoadOptions) error{
 		config.WithSharedConfigProfile(fs.ProfileName),
+		config.WithDefaultRegion("us-west-2"),
 	}
 
 	if len(fs.CredsFilePath) > 0 {


### PR DESCRIPTION
it should fix an error with region detection for bucket, if AWS_REGION env var is not set

```
VictoriaMetrics/app/vmbackupmanager/main.go:101 cannot create originFS: cannot initialize connection to s3: cannot determine region for bucket "qa-vmstorage-backups": operation error S3: HeadBucket, failed to resolve service endpoint, an AWS region is required, but was not found
```