### PR TITLE
BUGFIX: properly calculate histogram_quantile with the same value and different string le

### DIFF
--- a/app/vmselect/promql/transform.go
+++ b/app/vmselect/promql/transform.go
@@ -942,6 +942,7 @@ func transformHistogramQuantile(tfa *transformFuncArg) ([]*timeseries, error) {
 	}
 	rvs := make([]*timeseries, 0, len(m))
 	for _, xss := range m {
+		xss = mergeSameLE(xss)
 		sort.Slice(xss, func(i, j int) bool {
 			return xss[i].le < xss[j].le
 		})
@@ -1032,6 +1033,37 @@ func fixBrokenBuckets(i int, xss []leTimeseries) {
 			vNext = v
 		}
 	}
+}
+
+func mergeSameLE(xss []leTimeseries) []leTimeseries {
+	hit := false
+	m := make(map[float64]leTimeseries)
+	for _, xs := range xss {
+		i, ok := m[xs.le]
+		if ok {
+			ts := &timeseries{}
+			ts.CopyFromShallowTimestamps(i.ts)
+			for k := range ts.Values {
+				ts.Values[k] += xs.ts.Values[k]
+			}
+			m[xs.le] = leTimeseries{
+				le: xs.le,
+				ts: ts,
+			}
+			hit = true
+			continue
+		}
+		m[xs.le] = xs
+	}
+	if (!hit) {
+		return xss
+	}
+
+	r := make([]leTimeseries, 0, len(m))
+	for _, v := range m {
+		r = append(r, v)
+	}
+	return r
 }
 
 func transformHour(t time.Time) int {


### PR DESCRIPTION
With v1.81.2-cluster
If two target have the same `le` value but different string, like this:
target_01: `test_metric{le="1"}` and `test_metric{le="5"}`
target_02: `test_metric{le="1.0"}` and `test_metric{le="5.0"}`

It will not properly calculate `histogram_quantile(0.95, sum(rate(test_metric)) by (le))`.

ql1: `sum(rate(test_metric)) by (target_name, le)`

```json
{
    "status": "success",
    "isPartial": false,
    "data": {
        "resultType": "vector",
        "result": [
            {
                "metric": {
                    "target_name": "target_01",
                    "le": "1"
                },
                "value": [
                    1665523482,
                    "10.103333333333333"
                ]
            },
            {
                "metric": {
                    "target_name": "target_01",
                    "le": "5"
                },
                "value": [
                    1665523482,
                    "10.103333333333335"
                ]
            },
            {
                "metric": {
                    "target_name": "target_01",
                    "le": "0.1"
                },
                "value": [
                    1665523482,
                    "10.103333333333335"
                ]
            },
            {
                "metric": {
                    "target_name": "target_01",
                    "le": "0.5"
                },
                "value": [
                    1665523482,
                    "10.103333333333335"
                ]
            },
            {
                "metric": {
                    "target_name": "target_01",
                    "le": "2.5"
                },
                "value": [
                    1665523482,
                    "10.103333333333333"
                ]
            },
            {
                "metric": {
                    "target_name": "target_01",
                    "le": "+Inf"
                },
                "value": [
                    1665523482,
                    "10.103333333333333"
                ]
            },
            {
                "metric": {
                    "target_name": "target_01",
                    "le": "0.01"
                },
                "value": [
                    1665523482,
                    "4.47"
                ]
            },
            {
                "metric": {
                    "target_name": "target_01",
                    "le": "0.05"
                },
                "value": [
                    1665523482,
                    "10.08"
                ]
            },
            {
                "metric": {
                    "target_name": "target_01",
                    "le": "0.25"
                },
                "value": [
                    1665523482,
                    "10.103333333333335"
                ]
            },
            {
                "metric": {
                    "target_name": "target_01",
                    "le": "0.75"
                },
                "value": [
                    1665523482,
                    "10.103333333333333"
                ]
            },
            {
                "metric": {
                    "target_name": "target_01",
                    "le": "0.005"
                },
                "value": [
                    1665523482,
                    "0"
                ]
            },
            {
                "metric": {
                    "target_name": "target_01",
                    "le": "0.025"
                },
                "value": [
                    1665523482,
                    "10.033333333333335"
                ]
            },
            {
                "metric": {
                    "target_name": "target_01",
                    "le": "0.075"
                },
                "value": [
                    1665523482,
                    "10.103333333333335"
                ]
            },
            {
                "metric": {
                    "target_name": "target_02",
                    "le": "0.1"
                },
                "value": [
                    1665523482,
                    "0"
                ]
            },
            {
                "metric": {
                    "target_name": "target_02",
                    "le": "0.5"
                },
                "value": [
                    1665523482,
                    "0"
                ]
            },
            {
                "metric": {
                    "target_name": "target_02",
                    "le": "1.0"
                },
                "value": [
                    1665523482,
                    "0"
                ]
            },
            {
                "metric": {
                    "target_name": "target_02",
                    "le": "2.5"
                },
                "value": [
                    1665523482,
                    "0"
                ]
            },
            {
                "metric": {
                    "target_name": "target_02",
                    "le": "5.0"
                },
                "value": [
                    1665523482,
                    "0"
                ]
            },
            {
                "metric": {
                    "target_name": "target_02",
                    "le": "+Inf"
                },
                "value": [
                    1665523482,
                    "0"
                ]
            },
            {
                "metric": {
                    "target_name": "target_02",
                    "le": "0.01"
                },
                "value": [
                    1665523482,
                    "0"
                ]
            },
            {
                "metric": {
                    "target_name": "target_02",
                    "le": "0.05"
                },
                "value": [
                    1665523482,
                    "0"
                ]
            },
            {
                "metric": {
                    "target_name": "target_02",
                    "le": "0.25"
                },
                "value": [
                    1665523482,
                    "0"
                ]
            },
            {
                "metric": {
                    "target_name": "target_02",
                    "le": "0.75"
                },
                "value": [
                    1665523482,
                    "0"
                ]
            },
            {
                "metric": {
                    "target_name": "target_02",
                    "le": "0.005"
                },
                "value": [
                    1665523482,
                    "0"
                ]
            },
            {
                "metric": {
                    "target_name": "target_02",
                    "le": "0.025"
                },
                "value": [
                    1665523482,
                    "0"
                ]
            },
            {
                "metric": {
                    "target_name": "target_02",
                    "le": "0.075"
                },
                "value": [
                    1665523482,
                    "0"
                ]
            }
        ]
    }
}
```

ql2: `sum(rate(test_metric)) by (le)`
``` json
{
    "status": "success",
    "isPartial": false,
    "data": {
        "resultType": "vector",
        "result": [
            {
                "metric": {
                    "le": "1"
                },
                "value": [
                    1665523482,
                    "10.103333333333333"
                ]
            },
            {
                "metric": {
                    "le": "5"
                },
                "value": [
                    1665523482,
                    "10.103333333333333"
                ]
            },
            {
                "metric": {
                    "le": "0.1"
                },
                "value": [
                    1665523482,
                    "10.103333333333335"
                ]
            },
            {
                "metric": {
                    "le": "0.5"
                },
                "value": [
                    1665523482,
                    "10.103333333333335"
                ]
            },
            {
                "metric": {
                    "le": "1.0"
                },
                "value": [
                    1665523482,
                    "0"
                ]
            },
            {
                "metric": {
                    "le": "2.5"
                },
                "value": [
                    1665523482,
                    "10.103333333333333"
                ]
            },
            {
                "metric": {
                    "le": "5.0"
                },
                "value": [
                    1665523482,
                    "0"
                ]
            },
            {
                "metric": {
                    "le": "+Inf"
                },
                "value": [
                    1665523482,
                    "10.103333333333333"
                ]
            },
            {
                "metric": {
                    "le": "0.01"
                },
                "value": [
                    1665523482,
                    "4.470000000000001"
                ]
            },
            {
                "metric": {
                    "le": "0.05"
                },
                "value": [
                    1665523482,
                    "10.08"
                ]
            },
            {
                "metric": {
                    "le": "0.25"
                },
                "value": [
                    1665523482,
                    "10.103333333333333"
                ]
            },
            {
                "metric": {
                    "le": "0.75"
                },
                "value": [
                    1665523482,
                    "10.103333333333333"
                ]
            },
            {
                "metric": {
                    "le": "0.005"
                },
                "value": [
                    1665523482,
                    "0"
                ]
            },
            {
                "metric": {
                    "le": "0.025"
                },
                "value": [
                    1665523482,
                    "10.033333333333333"
                ]
            },
            {
                "metric": {
                    "le": "0.075"
                },
                "value": [
                    1665523482,
                    "10.103333333333333"
                ]
            }
        ]
    }
}
```

ql3: `histogram_quantile(0.95, sum(rate(test_metric)) by (le))`
``` json
{
    "status": "success",
    "isPartial": false,
    "data": {
        "resultType": "vector",
        "result": [
            {
                "metric": {},
                "value": [
                    1665523482,
                    "5"
                ]
            }
        ]
    }
}
```