### PR TITLE
k8s-monitoring-via-vm-cluster.md: removed extra spaces

### DIFF
--- a/docs/guides/k8s-monitoring-via-vm-cluster.md
+++ b/docs/guides/k8s-monitoring-via-vm-cluster.md
@@ -89,7 +89,7 @@ vmstorage:
   podAnnotations:
       prometheus.io/scrape: "true"
       prometheus.io/port: "8482"
-EOF     
+EOF
 ```
 </div>
 


### PR DESCRIPTION
Fix will remove not needed extra spaces in helm command.