### PR TITLE
lib/promscrape/discovery/kubernetes: correctly wrap error

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -54,7 +54,7 @@ Released at 14-10-2022
 * BUGFIX: [vmbackupmanager](https://docs.victoriametrics.com/vmbackupmanager.html): fix deletion of old backups at [Azure blob storage](https://azure.microsoft.com/en-us/products/storage/blobs/).
 * BUGFIX: [MetricsQL](https://docs.victoriametrics.com/MetricsQL.html): properly apply regex filters when searching for time series. Previously unexpected time series could be returned from regex filter. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/3227). The issue was introduced in [v1.82.0](https://docs.victoriametrics.com/CHANGELOG.html#v1820).
 * BUGFIX: [vmagent](https://docs.victoriametrics.com/vmbagent.html): properly apply `if` section with regex filters. Previously unexpected metrics could be returned from `if` section. The issue was introduced in [v1.82.0](https://docs.victoriametrics.com/CHANGELOG.html#v1820).
-
+* BUGFIX: [vmagent](https://docs.victoriametrics.com/vmbagent.html): properly wrap handle timeout error for kubernetes service discovery watch response.
 
 ## [v1.82.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.82.0)
 

--- a/lib/promscrape/discovery/kubernetes/api_watcher.go
+++ b/lib/promscrape/discovery/kubernetes/api_watcher.go
@@ -702,7 +702,7 @@ func (uw *urlWatcher) readObjectUpdateStream(r io.Reader) error {
 	var we WatchEvent
 	for {
 		if err := d.Decode(&we); err != nil {
-			return fmt.Errorf("cannot parse WatchEvent json response: %s", err)
+			return fmt.Errorf("cannot parse WatchEvent json response: %w", err)
 		}
 		switch we.Type {
 		case "ADDED", "MODIFIED":


### PR DESCRIPTION
follow-up after 1304824201bd8bb52907431f2b22981cd11e3930