### PR TITLE
.github/workflows/codeql-analysis.yml: specifically setting the Go version

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -40,6 +40,12 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v3
 
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.19
+      if: ${{ matrix.language == 'go' }}
+
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2


### PR DESCRIPTION
This PR adds to setup specific Go version and should fix [failed builds](https://github.com/VictoriaMetrics/VictoriaMetrics/actions/runs/3329416205/jobs/5506603245) 

see https://github.com/github/codeql-action/issues/1059