### PR TITLE
fix(golang): init fix append extralabels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ Gemfile.lock
 /_site
 _site
 *.tmp
+__debug_bin

--- a/lib/promscrape/scrapework.go
+++ b/lib/promscrape/scrapework.go
@@ -890,7 +890,7 @@ func appendExtraLabels(dst, extraLabels []prompbmarshal.Label, offset int, honor
 		return dst
 	}
 	for _, label := range extraLabels {
-		prevLabel := promrelabel.GetLabelByName(labels, label.Name)
+		prevLabel := promrelabel.GetLabelByName(dst, label.Name)
 		if prevLabel == nil {
 			// Fast path - the label doesn't exist in labels, so just add it to dst.
 			dst = append(dst, label)

--- a/lib/promscrape/scrapework.go
+++ b/lib/promscrape/scrapework.go
@@ -874,6 +874,8 @@ func appendLabels(dst []prompbmarshal.Label, metric string, src []parser.Tag, ex
 			Value: tag.Value,
 		})
 	}
+
+
 	return appendExtraLabels(dst, extraLabels, dstLen, honorLabels)
 }
 
@@ -883,12 +885,13 @@ func appendExtraLabels(dst, extraLabels []prompbmarshal.Label, offset int, honor
 	if len(dst) > offset && dst[offset].Name == "__name__" {
 		offset++
 	}
+	// I don't understand this, this case create a duplicate key labels :/ when we don't have tag in appendLabels
 	labels := dst[offset:]
-	if len(labels) == 0 {
-		// Fast path - add extraLabels to dst without the need to de-duplicate.
-		dst = append(dst, extraLabels...)
-		return dst
-	}
+	//if len(labels) == 0 {
+	//	// Fast path - add extraLabels to dst without the need to de-duplicate.
+	//	dst = append(dst, extraLabels...)
+	//	return dst
+	//}
 	for _, label := range extraLabels {
 		prevLabel := promrelabel.GetLabelByName(dst, label.Name)
 		if prevLabel == nil {


### PR DESCRIPTION
## Describe

This is a draf because i have many questions on this method. We cannot merge the PR in the state

This [PR](https://github.com/VictoriaMetrics/VictoriaMetrics/commit/4998402004a9bc400f2fe414d013a8fe3bab9703#diff-6b205cf6637d7b65a5c45d9417d08822d4efad94227268cb196f61aa2a0fc0f7) have modified function appendExtraLabels the behaviour is not same and I would like to know if the rendering in terms of trade is really what is expected 

I have start a test to understand my [issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/3278) for the function AppendLabels. When i send a labels  `{namespace="b"}` and a ExtraLabel {namespace="a"}, i don't a havei n result {exported_namespace="b",__name__="prescaling_metric",tagkey="tagvalue", namespace="a"}.

i have see this [function](https://github.com/VictoriaMetrics/VictoriaMetrics/commit/4998402004a9bc400f2fe414d013a8fe3bab9703#diff-6b205cf6637d7b65a5c45d9417d08822d4efad94227268cb196f61aa2a0fc0f7L889)  is not called with the same parameter before we send dst but now we sent labels contain only last labels in this case last Tag. This means that we no longer have a complete check of all the labels to see if we have duplicates.

When i change labels by dst, I get the expected result. But i this [line](https://github.com/VictoriaMetrics/VictoriaMetrics/blob/master/lib/promscrape/scrapework_test.go#L39) failed and i don't understand why we want to we want identical labels at the output with two different values over one series. 

 I understand that an exported_exported label is not desired, But Wouldn't this be a configuration error, and shouldn't it come up in exported_exported when you have an already named extra label exported that becomes a duplicate of a scrapped one? 

Thank you for your understanding :) 