### PR TITLE
docker-compose: bump version of container tags for VictoriaMetrics components

### DIFF
--- a/deployment/docker/docker-compose-cluster.yml
+++ b/deployment/docker/docker-compose-cluster.yml
@@ -2,7 +2,7 @@ version: '3.5'
 services:
   vmagent:
     container_name: vmagent
-    image: victoriametrics/vmagent:v1.81.2
+    image: victoriametrics/vmagent:v1.83.0
     depends_on:
       - "vminsert"
     ports:
@@ -32,7 +32,7 @@ services:
 
   vmstorage-1:
     container_name: vmstorage-1
-    image: victoriametrics/vmstorage:v1.81.2-cluster
+    image: victoriametrics/vmstorage:v1.83.0-cluster
     ports:
       - 8482
       - 8400
@@ -44,7 +44,7 @@ services:
     restart: always
   vmstorage-2:
     container_name: vmstorage-2
-    image: victoriametrics/vmstorage:v1.81.2-cluster
+    image: victoriametrics/vmstorage:v1.83.0-cluster
     ports:
       - 8482
       - 8400
@@ -56,7 +56,7 @@ services:
     restart: always
   vminsert:
     container_name: vminsert
-    image: victoriametrics/vminsert:v1.81.2-cluster
+    image: victoriametrics/vminsert:v1.83.0-cluster
     depends_on:
       - "vmstorage-1"
       - "vmstorage-2"
@@ -68,7 +68,7 @@ services:
     restart: always
   vmselect:
     container_name: vmselect
-    image: victoriametrics/vmselect:v1.81.2-cluster
+    image: victoriametrics/vmselect:v1.83.0-cluster
     depends_on:
       - "vmstorage-1"
       - "vmstorage-2"
@@ -82,7 +82,7 @@ services:
 
   vmalert:
     container_name: vmalert
-    image: victoriametrics/vmalert:v1.81.2
+    image: victoriametrics/vmalert:v1.83.0
     depends_on:
       - "vmselect"
     ports:

--- a/deployment/docker/docker-compose.yml
+++ b/deployment/docker/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.5"
 services:
   vmagent:
     container_name: vmagent
-    image: victoriametrics/vmagent:v1.81.2
+    image: victoriametrics/vmagent:v1.83.0
     depends_on:
       - "victoriametrics"
     ports:
@@ -18,7 +18,7 @@ services:
     restart: always
   victoriametrics:
     container_name: victoriametrics
-    image: victoriametrics/victoria-metrics:v1.81.2
+    image: victoriametrics/victoria-metrics:v1.83.0
     ports:
       - 8428:8428
       - 8089:8089
@@ -56,7 +56,7 @@ services:
     restart: always
   vmalert:
     container_name: vmalert
-    image: victoriametrics/vmalert:v1.81.2
+    image: victoriametrics/vmalert:v1.83.0
     depends_on:
       - "victoriametrics"
       - "alertmanager"


### PR DESCRIPTION
This PR will update version of VictoriaMetrics components in docker-compose files for Cluster and Single node