### PR TITLE
vmctl: fix panic on start

### DIFF
--- a/app/vmctl/main.go
+++ b/app/vmctl/main.go
@@ -34,6 +34,9 @@ func main() {
 		Name:    "vmctl",
 		Usage:   "VictoriaMetrics command-line tool",
 		Version: buildinfo.Version,
+		// Disable `-version` flag to avoid conflict with lib/buildinfo flags
+		// see https://github.com/urfave/cli/issues/1560
+		HideVersion: true,
 		Commands: []*cli.Command{
 			{
 				Name:  "opentsdb",


### PR DESCRIPTION
The change disables initing the `-version` flag in new `urfave/cli/v2` update. The `-version` flag conflicts with the identical flag from `lib/buildinfo` and causes panic.

See https://github.com/VictoriaMetrics/VictoriaMetrics/pull/3299

Signed-off-by: hagen1778 <roman@victoriametrics.com>