### PR TITLE
protoparser/opentsdb: allow lines without tags

### DIFF
--- a/lib/protoparser/opentsdb/parser_test.go
+++ b/lib/protoparser/opentsdb/parser_test.go
@@ -37,9 +37,6 @@ func TestRowsUnmarshalFailure(t *testing.T) {
 	f("put aaa timestamp")
 	f("put foobar 3df4 -123456 a=b")
 
-	// Missing first tag
-	f("put aaa 123 43")
-
 	// Invalid value
 	f("put aaa 123 invalid-value")
 	f("put foobar 789 -123foo456 a=b")
@@ -102,6 +99,14 @@ func TestRowsUnmarshalSuccess(t *testing.T) {
 					Value: "c",
 				},
 			},
+		}},
+	})
+	// No tags
+	f("put foobar 789 -123.456", &Rows{
+		Rows: []Row{{
+			Metric:    "foobar",
+			Value:     -123.456,
+			Timestamp: 789,
 		}},
 	})
 	// Fractional timestamp that is supported by Akumuli.


### PR DESCRIPTION
According to http://opentsdb.net/docs/build/html/api_telnet/put.html "At least one tag pair must be present".
However, in VictoriaMetrics datamodel tags aren't required. This could be confusing for users. Allowing accept lines without tags seems to do no harm.

https://github.com/VictoriaMetrics/VictoriaMetrics/issues/3290
Signed-off-by: hagen1778 <roman@victoriametrics.com>