### PR TITLE
vmui: change graph legend label format

### DIFF
--- a/app/vmui/packages/vmui/src/components/Legend/Legend.tsx
+++ b/app/vmui/packages/vmui/src/components/Legend/Legend.tsx
@@ -48,7 +48,7 @@ const Legend: FC<LegendProps> = ({labels, query, onChange}) => {
                         e.stopPropagation();
                         handleClickFreeField(freeField, fieldId);
                       }}>
-                        {f}: {legendItem.freeFormFields[f]}
+                        {freeField}
                       </span>
                     </Tooltip>;
                   })}


### PR DESCRIPTION
Closes #3289

Changes graph label legend format from `label:value` to `label="value"`