### PR TITLE
Fix issue-3309 - currHourMetricIDs shouldn't contain metrics from prev hour

### DIFF
--- a/lib/storage/storage.go
+++ b/lib/storage/storage.go
@@ -2362,7 +2362,11 @@ func (s *Storage) updateCurrHourMetricIDs(hour uint64) {
 	}
 	s.currHourMetricIDs.Store(hmNew)
 	if hm.hour != hour {
-		hm.m.Union(newMetricIDs.At(hm.hour))
+		if hm.m != nil {
+			hm.m.Union(newMetricIDs.At(hm.hour))
+		} else {
+			hm.m = newMetricIDs.At(hm.hour)
+		}
 		s.prevHourMetricIDs.Store(hm)
 	}
 }

--- a/lib/storage/storage.go
+++ b/lib/storage/storage.go
@@ -98,7 +98,7 @@ type Storage struct {
 
 	// Pending MetricID values to be added to currHourMetricIDs.
 	pendingHourEntriesLock sync.Mutex
-	pendingHourEntries     *uint64set.Set
+	pendingHourEntries     pendingHourEntries
 
 	// Pending MetricIDs to be added to nextDayMetricIDs.
 	pendingNextDayMetricIDsLock sync.Mutex
@@ -213,7 +213,7 @@ func OpenStorage(path string, retentionMsecs int64, maxHourlySeries, maxDailySer
 	hmPrev := s.mustLoadHourMetricIDs(hour-1, "prev_hour_metric_ids")
 	s.currHourMetricIDs.Store(hmCurr)
 	s.prevHourMetricIDs.Store(hmPrev)
-	s.pendingHourEntries = &uint64set.Set{}
+	s.pendingHourEntries = pendingHourEntries{{}, {}}
 
 	date := fasttime.UnixDate()
 	nextDayMetricIDs := s.mustLoadNextDayMetricIDs(date)
@@ -700,10 +700,12 @@ func (s *Storage) currHourMetricIDsUpdater() {
 	for {
 		select {
 		case <-s.stop:
-			s.updateCurrHourMetricIDs()
+			hour := fasttime.UnixHour()
+			s.updateCurrHourMetricIDs(hour)
 			return
 		case <-ticker.C:
-			s.updateCurrHourMetricIDs()
+			hour := fasttime.UnixHour()
+			s.updateCurrHourMetricIDs(hour)
 		}
 	}
 }
@@ -768,7 +770,7 @@ func (s *Storage) mustRotateIndexDB() {
 	//    So queries for the last 24 hours stop returning samples added at step 3.
 	// See https://github.com/VictoriaMetrics/VictoriaMetrics/issues/2698
 	s.pendingHourEntriesLock.Lock()
-	s.pendingHourEntries = &uint64set.Set{}
+	s.pendingHourEntries = pendingHourEntries{{}, {}}
 	s.pendingHourEntriesLock.Unlock()
 	s.currHourMetricIDs.Store(&hourMetricIDs{})
 	s.prevHourMetricIDs.Store(&hourMetricIDs{})
@@ -2027,7 +2029,7 @@ func (s *Storage) updatePerDateData(rows []rawRow, mrs []*MetricRow) error {
 	}
 	if len(pendingHourEntries) > 0 {
 		s.pendingHourEntriesLock.Lock()
-		s.pendingHourEntries.AddMulti(pendingHourEntries)
+		s.pendingHourEntries.At(hm.hour).AddMulti(pendingHourEntries)
 		s.pendingHourEntriesLock.Unlock()
 	}
 	if len(pendingDateMetricIDs) == 0 {
@@ -2321,15 +2323,24 @@ func (s *Storage) updateNextDayMetricIDs() {
 	s.nextDayMetricIDs.Store(eNew)
 }
 
-func (s *Storage) updateCurrHourMetricIDs() {
+type pendingHourEntries [2]*uint64set.Set
+
+func (p pendingHourEntries) At(hour uint64) *uint64set.Set {
+	return p[hour%2]
+}
+
+func (p pendingHourEntries) Len() int {
+	return p[0].Len() + p[1].Len()
+}
+
+func (s *Storage) updateCurrHourMetricIDs(hour uint64) {
 	hm := s.currHourMetricIDs.Load().(*hourMetricIDs)
 	s.pendingHourEntriesLock.Lock()
 	newMetricIDs := s.pendingHourEntries
-	s.pendingHourEntries = &uint64set.Set{}
+	s.pendingHourEntries = pendingHourEntries{{}, {}}
 	s.pendingHourEntriesLock.Unlock()
 
-	hour := fasttime.UnixHour()
-	if newMetricIDs.Len() == 0 && hm.hour == hour {
+	if newMetricIDs.At(hour).Len() == 0 && hm.hour == hour {
 		// Fast path: nothing to update.
 		return
 	}
@@ -2343,7 +2354,7 @@ func (s *Storage) updateCurrHourMetricIDs() {
 		m = &uint64set.Set{}
 		isFull = true
 	}
-	m.Union(newMetricIDs)
+	m.Union(newMetricIDs.At(hour))
 	hmNew := &hourMetricIDs{
 		m:      m,
 		hour:   hour,
@@ -2351,6 +2362,7 @@ func (s *Storage) updateCurrHourMetricIDs() {
 	}
 	s.currHourMetricIDs.Store(hmNew)
 	if hm.hour != hour {
+		hm.m.Union(newMetricIDs.At(hm.hour))
 		s.prevHourMetricIDs.Store(hm)
 	}
 }


### PR DESCRIPTION
This is to fix https://github.com/VictoriaMetrics/VictoriaMetrics/issues/3309

It might happen that `updateCurrHourMetricIDs` stores metric from previous hour (previous day) in `s.currHourMetricIDs`. This happens when `s.pendingHourEntries` has any entries on the first run in the hour. This (as described in the issue) may have catastrophic consequences on per-day index creation.

This change splits `s.pendingHourEntries` into two sets - one for odd hours, one for even (since we only need two for buckets when hour changes). Then, in case of `s.currHourMetricIDs` rotation, it adds entries from `(hour-1)%2` bucket to `s.prevHourMetricIDs` and entries from `hour%2` bucket to new `s.currHourMetricIDs`. Under all other cases it works the same.

One more change is to parametrise `updateCurrHourMetricIDs` with current hour - this makes unit testing so much easier.