### PR TITLE
Adding pushgateway basic capabilities to vmagent

### DIFF
--- a/app/vmagent/main.go
+++ b/app/vmagent/main.go
@@ -259,6 +259,15 @@ func requestHandler(w http.ResponseWriter, r *http.Request) bool {
 		}
 		w.WriteHeader(http.StatusNoContent)
 		return true
+	case "/api/v1/pushgateway":
+		pushgatewayRequests.Inc()
+		if err := prometheusimport.InsertHandler(nil, r); err != nil {
+			pushgatewayErrors.Inc()
+			httpserver.Errorf(w, r, "%s", err)
+			return true
+		}
+		w.WriteHeader(http.StatusNoContent)
+		return true
 	case "/prometheus/api/v1/import/native", "/api/v1/import/native":
 		nativeimportRequests.Inc()
 		if err := native.InsertHandler(nil, r); err != nil {
@@ -525,6 +534,9 @@ var (
 
 	prometheusimportRequests = metrics.NewCounter(`vmagent_http_requests_total{path="/api/v1/import/prometheus", protocol="prometheusimport"}`)
 	prometheusimportErrors   = metrics.NewCounter(`vmagent_http_request_errors_total{path="/api/v1/import/prometheus", protocol="prometheusimport"}`)
+
+	pushgatewayRequests = metrics.NewCounter(`vmagent_http_requests_total{path="/api/v1/pushgateway", protocol="pushgateway"}`)
+	pushgatewayErrors   = metrics.NewCounter(`vmagent_http_request_errors_total{path="/api/v1/pushgateway", protocol="pushgateway"}`)
 
 	nativeimportRequests = metrics.NewCounter(`vmagent_http_requests_total{path="/api/v1/import/native", protocol="nativeimport"}`)
 	nativeimportErrors   = metrics.NewCounter(`vmagent_http_request_errors_total{path="/api/v1/import/native", protocol="nativeimport"}`)

--- a/app/vmagent/pushgateway/request_handler.go
+++ b/app/vmagent/pushgateway/request_handler.go
@@ -52,10 +52,10 @@ func extractLabelsFromPath(pushgatewayPath string) ([]prompbmarshal.Label, error
 	// With an arbitrary number of /<LABEL_NAME>/<LABEL_VALUE> pairs
 	// Source:https://github.com/prometheus/pushgateway#url
 	var result []prompbmarshal.Label
-	if !strings.HasPrefix(pushgatewayPath, "/metric/job/") {
+	if !strings.HasPrefix(pushgatewayPath, "/metrics/job/") {
 		return nil, fmt.Errorf("pushgateway endpoint format is incorrect. Expected /metrics/job/<JOB_NAME>{/<LABEL_NAME>/<LABEL_VALUE>}, got %q ", pushgatewayPath)
 	}
-	labelsString := strings.Replace(pushgatewayPath, "/metric/job/", "", 1)
+	labelsString := strings.Replace(pushgatewayPath, "/metrics/job/", "", 1)
 	labelsSlice := strings.Split(labelsString, "/")
 	if len(labelsSlice) == 1 && labelsSlice[0] == "" {
 		return nil, fmt.Errorf("pushgateway path has to contain a job name after /job/. Expected /metrics/job/<JOB_NAME>{/<LABEL_NAME>/<LABEL_VALUE>}, got %q ", pushgatewayPath)

--- a/app/vmagent/pushgateway/request_handler.go
+++ b/app/vmagent/pushgateway/request_handler.go
@@ -1,7 +1,9 @@
 package pushgateway
 
 import (
+	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/VictoriaMetrics/VictoriaMetrics/app/vmagent/common"
 	"github.com/VictoriaMetrics/VictoriaMetrics/app/vmagent/remotewrite"
@@ -22,7 +24,14 @@ var (
 
 // InsertHandler processes `/api/v1/pushgateway` request.
 func InsertHandler(at *auth.Token, req *http.Request) error {
-	pathLabels, err := parserCommon.GetExtraLabels(req)
+	// Pushgateway endpoint is of the style: /metrics/job/<JOB_NAME>{/<LABEL_NAME>/<LABEL_VALUE>}
+	// Source:https://github.com/prometheus/pushgateway#url
+	pushgatewayPath := strings.TrimSuffix(strings.Replace(req.URL.Path, "/api/v1/pushgateway", "", 1), "/")
+	pathLabels, err := extractLabelsFromPath(pushgatewayPath)
+	if err != nil {
+		return err
+	}
+	extraLabels, err := parserCommon.GetExtraLabels(req)
 	if err != nil {
 		return err
 	}
@@ -33,9 +42,45 @@ func InsertHandler(at *auth.Token, req *http.Request) error {
 	return writeconcurrencylimiter.Do(func() error {
 		isGzipped := req.Header.Get("Content-Encoding") == "gzip"
 		return parser.ParseStream(req.Body, defaultTimestamp, isGzipped, func(rows []parser.Row) error {
-			return insertRows(at, rows, pathLabels)
+			return insertRows(at, rows, append(pathLabels, extraLabels...))
 		}, nil)
 	})
+}
+
+func extractLabelsFromPath(pushgatewayPath string) ([]prompbmarshal.Label, error) {
+	// Parsing Pushgateway path which is of the style: /metrics/job/<JOB_NAME>{/<LABEL_NAME>/<LABEL_VALUE>}
+	// With an arbitrary number of /<LABEL_NAME>/<LABEL_VALUE> pairs
+	// Source:https://github.com/prometheus/pushgateway#url
+	var result []prompbmarshal.Label
+	if !strings.HasPrefix(pushgatewayPath, "/metric/job/") {
+		return nil, fmt.Errorf("pushgateway endpoint format is incorrect. Expected /metrics/job/<JOB_NAME>{/<LABEL_NAME>/<LABEL_VALUE>}, got %q ", pushgatewayPath)
+	}
+	labelsString := strings.Replace(pushgatewayPath, "/metric/job/", "", 1)
+	labelsSlice := strings.Split(labelsString, "/")
+	if len(labelsSlice) == 1 && labelsSlice[0] == "" {
+		return nil, fmt.Errorf("pushgateway path has to contain a job name after /job/. Expected /metrics/job/<JOB_NAME>{/<LABEL_NAME>/<LABEL_VALUE>}, got %q ", pushgatewayPath)
+	}
+
+	//The first value that comes after /metrics/job/JOB_NAME gives origin to a label with key "job" and value "JOB_NAME"
+	result = append(result, prompbmarshal.Label{
+		Name:  "job",
+		Value: labelsSlice[0],
+	})
+
+	// We expect the number of items to be odd.
+	// The first item is the job label and after that is key/value pairs
+	if len(labelsSlice)%2 == 0 {
+		return nil, fmt.Errorf("number of label key/pair passed via pushgateway endpoint format does not match")
+	}
+
+	// We start at 1, since index 0 was the job label value, and we jump every 2 - first item is the key, second is the value.
+	for i := 1; i < len(labelsSlice); i = i + 2 {
+		result = append(result, prompbmarshal.Label{
+			Name:  labelsSlice[i],
+			Value: labelsSlice[i+1],
+		})
+	}
+	return result, nil
 }
 
 func insertRows(at *auth.Token, rows []parser.Row, extraLabels []prompbmarshal.Label) error {

--- a/app/vmagent/pushgateway/request_handler.go
+++ b/app/vmagent/pushgateway/request_handler.go
@@ -1,0 +1,82 @@
+package pushgateway
+
+import (
+	"net/http"
+
+	"github.com/VictoriaMetrics/VictoriaMetrics/app/vmagent/common"
+	"github.com/VictoriaMetrics/VictoriaMetrics/app/vmagent/remotewrite"
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/auth"
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/prompbmarshal"
+	parserCommon "github.com/VictoriaMetrics/VictoriaMetrics/lib/protoparser/common"
+	parser "github.com/VictoriaMetrics/VictoriaMetrics/lib/protoparser/prometheus"
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/tenantmetrics"
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/writeconcurrencylimiter"
+	"github.com/VictoriaMetrics/metrics"
+)
+
+var (
+	rowsInserted       = metrics.NewCounter(`vmagent_rows_inserted_total{type="pushgateway"}`)
+	rowsTenantInserted = tenantmetrics.NewCounterMap(`vmagent_tenant_inserted_rows_total{type="pushgateway"}`)
+	rowsPerInsert      = metrics.NewHistogram(`vmagent_rows_per_insert{type="pushgateway"}`)
+)
+
+// InsertHandler processes `/api/v1/pushgateway` request.
+func InsertHandler(at *auth.Token, req *http.Request) error {
+	pathLabels, err := parserCommon.GetExtraLabels(req)
+	if err != nil {
+		return err
+	}
+	defaultTimestamp, err := parserCommon.GetTimestamp(req)
+	if err != nil {
+		return err
+	}
+	return writeconcurrencylimiter.Do(func() error {
+		isGzipped := req.Header.Get("Content-Encoding") == "gzip"
+		return parser.ParseStream(req.Body, defaultTimestamp, isGzipped, func(rows []parser.Row) error {
+			return insertRows(at, rows, pathLabels)
+		}, nil)
+	})
+}
+
+func insertRows(at *auth.Token, rows []parser.Row, extraLabels []prompbmarshal.Label) error {
+	ctx := common.GetPushCtx()
+	defer common.PutPushCtx(ctx)
+
+	tssDst := ctx.WriteRequest.Timeseries[:0]
+	labels := ctx.Labels[:0]
+	samples := ctx.Samples[:0]
+	for i := range rows {
+		r := &rows[i]
+		labelsLen := len(labels)
+		labels = append(labels, prompbmarshal.Label{
+			Name:  "__name__",
+			Value: r.Metric,
+		})
+		for j := range r.Tags {
+			tag := &r.Tags[j]
+			labels = append(labels, prompbmarshal.Label{
+				Name:  tag.Key,
+				Value: tag.Value,
+			})
+		}
+		labels = append(labels, extraLabels...)
+		samples = append(samples, prompbmarshal.Sample{
+			Value:     r.Value,
+			Timestamp: r.Timestamp,
+		})
+		tssDst = append(tssDst, prompbmarshal.TimeSeries{
+			Labels:  labels[labelsLen:],
+			Samples: samples[len(samples)-1:],
+		})
+	}
+	ctx.WriteRequest.Timeseries = tssDst
+	ctx.Labels = labels
+	ctx.Samples = samples
+	remotewrite.Push(at, &ctx.WriteRequest)
+	rowsInserted.Add(len(rows))
+	if at != nil {
+		rowsTenantInserted.Get(at).Add(len(rows))
+	}
+	rowsPerInsert.Update(float64(len(rows)))
+	return nil
+}


### PR DESCRIPTION
An initial implementation of the pushgateway protocol to vmagent.
The pushgateway protocol supports a few more things that are not covered in this PR (like adding [base64 label values](https://github.com/prometheus/pushgateway#url)) but this implementation adds the most basic features.

Maybe solves https://github.com/VictoriaMetrics/VictoriaMetrics/issues/1415?

It adds a new endpoint to `vmagent` (`/api/v1/pushgateway`) where prometheus time series can be posted following the [URL format](https://github.com/prometheus/pushgateway#url) of pushgateway.

Didn't expand the docs as I'm unsure this will be merged (I decided to give it a try nonetheless 😅 ), but I'll be happy to include this in the docs if you think there's a chance this will be merged.

Tested with the example provided in the `prometheus_client` [docs](https://github.com/prometheus/client_python#exporting-to-a-pushgateway):
```
from prometheus_client import CollectorRegistry, Gauge, push_to_gateway


registry = CollectorRegistry()
g = Gauge('job_last_success_unixtime', 'Last time a batch job successfully finished', registry=registry)
g.set_to_current_time()

g = Gauge('raid_status', '1 if raid array is okay', registry=registry)
g.set(1)

g = Gauge('my_inprogress_requests', 'Description of gauge', registry=registry)
g.inc()      # Increment by 1
g.dec(10)    # Decrement by given value
g.set(4.2)   # Set to a given value

push_to_gateway('http://localhost:8429/api/v1/pushgateway', job='batchA', registry=registry)
```

<img width="1200" alt="image" src="https://user-images.githubusercontent.com/725020/202566139-e458913e-e7a2-46ce-9faa-a1286fd86ee7.png">


Also tested using `curl`:
```
$ echo "pushgateway_time_series 1337" | curl --data-binary @- http://localhost:8429/api/v1/pushgateway/metrics/job/my_batch_job/label_key/label_value/key2/value2\?extra_label\=extra_key\=extra_value
```

<img width="1100" alt="image" src="https://user-images.githubusercontent.com/725020/202566853-69e61eb6-0d03-4a06-963c-1809ed4054ce.png">


The `insertRows` in `app/vmagent/pushgateway/request_handler.go` is fully copy paste from the `app/vmagent/prometheusimport/request_handler.go`.