### PR TITLE
vmui: add compact table view

### DIFF
--- a/app/vmui/packages/vmui/src/styles/components/table.scss
+++ b/app/vmui/packages/vmui/src/styles/components/table.scss
@@ -7,6 +7,10 @@
   margin-top: -$padding-medium;
   background-color: $color-background-block;
 
+  &-additional-settings {
+    margin-bottom: $padding-medium*1.5;
+  }
+
   &__row {
     background-color: $color-background-block;
     transition: background-color 200ms ease;

--- a/app/vmui/packages/vmui/src/utils/metric.ts
+++ b/app/vmui/packages/vmui/src/utils/metric.ts
@@ -1,6 +1,6 @@
 import { MetricBase } from "../api/types";
 
-export const getNameForMetric = (result: MetricBase, alias?: string): string => {
+export const getNameForMetric = (result: MetricBase, alias?: string, connector = ": ", quoteValue = false): string => {
   const { __name__, ...freeFormFields } = result.metric;
   const name = alias || __name__ || "";
 
@@ -8,5 +8,7 @@ export const getNameForMetric = (result: MetricBase, alias?: string): string => 
     return name || `Result ${result.group}`; // a bit better than just {} for case of aggregation functions
   }
 
-  return `${name} {${Object.entries(freeFormFields).map(e => `${e[0]}: ${e[1]}`).join(", ")}}`;
+  return `${name} {${Object.entries(freeFormFields).map(e => 
+    `${e[0]}${connector}${(quoteValue ? `"${e[1]}"` : e[1])}`
+  ).join(", ")}}`;
 };


### PR DESCRIPTION
Closes #3241

Adds support for a compact table view showing labels in a single cell instead of split by columns.