### PR TITLE
enhance relabel debug

### DIFF
--- a/lib/promrelabel/relabel.go
+++ b/lib/promrelabel/relabel.go
@@ -48,10 +48,8 @@ func (prc *parsedRelabelConfig) String() string {
 }
 
 // Apply applies pcs to labels starting from the labelsOffset.
-//
-// If isFinalize is set, then FinalizeLabels is called on the labels[labelsOffset:].
 func (pcs *ParsedConfigs) Apply(labels []prompbmarshal.Label, labelsOffset int) []prompbmarshal.Label {
-	var inStr string
+	var inStr, outStr string
 	relabelDebug := false
 	if pcs != nil {
 		relabelDebug = pcs.relabelDebug
@@ -70,14 +68,15 @@ func (pcs *ParsedConfigs) Apply(labels []prompbmarshal.Label, labelsOffset int) 
 			labels = tmp
 		}
 	}
+	if relabelDebug {
+		outStr = labelsToString(labels[labelsOffset:])
+	}
 	labels = removeEmptyLabels(labels, labelsOffset)
 	if relabelDebug {
 		if len(labels) == labelsOffset {
-			logger.Infof("\nRelabel  In: %s\nRelabel Out: DROPPED - all labels removed", inStr)
+			logger.Infof("\nRelabel  In: %s\nRelabeled to DROP: %s", inStr, outStr)
 			return labels
-		}
-		outStr := labelsToString(labels[labelsOffset:])
-		if inStr == outStr {
+		} else if inStr == outStr {
 			logger.Infof("\nRelabel  In: %s\nRelabel Out: KEPT AS IS - no change", inStr)
 		} else {
 			logger.Infof("\nRelabel  In: %s\nRelabel Out: %s", inStr, outStr)


### PR DESCRIPTION
- `FinalizeLabels()` removes all labels with `__` prefix. But they might have been modified as well wrt. to its initial value and thus this information gets lost. Expert knows, that finally all `__*` labels get removed -> No problem to deduce the final value.  So out gets now constructed before `FinalizeLabels()`.
- When labels are shown in the output, they should have the same order, as used to record the initial set. So `SortLabels()` gets now done _after_ debug output construction.
- Skipping debug output for `len(labels) == labelsOffset` is not ok for the same reason as with `FinalizeLabels()`: possibly modified `__*` labels get lost (but might be import for relabeling). That's why this mini optimization got removed.