### PR TITLE
Type parameters for resize functions

### DIFF
--- a/lib/bytesutil/bytesutil.go
+++ b/lib/bytesutil/bytesutil.go
@@ -6,51 +6,51 @@ import (
 	"unsafe"
 )
 
-// ResizeWithCopyMayOverallocate resizes b to minimum n bytes and returns the resized buffer (which may be newly allocated).
+// ResizeWithCopyMayOverallocate resizes b to minimum n elements and returns the resized buffer (which may be newly allocated).
 //
 // If newly allocated buffer is returned then b contents is copied to it.
-func ResizeWithCopyMayOverallocate(b []byte, n int) []byte {
+func ResizeWithCopyMayOverallocate[T any](b []T, n int) []T {
 	if n <= cap(b) {
 		return b[:n]
 	}
 	nNew := roundToNearestPow2(n)
-	bNew := make([]byte, nNew)
+	bNew := make([]T, nNew)
 	copy(bNew, b)
 	return bNew[:n]
 }
 
-// ResizeWithCopyNoOverallocate resizes b to exactly n bytes and returns the resized buffer (which may be newly allocated).
+// ResizeWithCopyNoOverallocate resizes b to exactly n elements and returns the resized buffer (which may be newly allocated).
 //
 // If newly allocated buffer is returned then b contents is copied to it.
-func ResizeWithCopyNoOverallocate(b []byte, n int) []byte {
+func ResizeWithCopyNoOverallocate[T any](b []T, n int) []T {
 	if n <= cap(b) {
 		return b[:n]
 	}
-	bNew := make([]byte, n)
+	bNew := make([]T, n)
 	copy(bNew, b)
 	return bNew
 }
 
-// ResizeNoCopyMayOverallocate resizes b to minimum n bytes and returns the resized buffer (which may be newly allocated).
+// ResizeNoCopyMayOverallocate resizes b to minimum n elements and returns the resized buffer (which may be newly allocated).
 //
 // If newly allocated buffer is returned then b contents isn't copied to it.
-func ResizeNoCopyMayOverallocate(b []byte, n int) []byte {
+func ResizeNoCopyMayOverallocate[T any](b []T, n int) []T {
 	if n <= cap(b) {
 		return b[:n]
 	}
 	nNew := roundToNearestPow2(n)
-	bNew := make([]byte, nNew)
+	bNew := make([]T, nNew)
 	return bNew[:n]
 }
 
-// ResizeNoCopyNoOverallocate resizes b to exactly n bytes and returns the resized buffer (which may be newly allocated).
+// ResizeNoCopyNoOverallocate resizes b to exactly n elements and returns the resized buffer (which may be newly allocated).
 //
 // If newly allocated buffer is returned then b contents isn't copied to it.
-func ResizeNoCopyNoOverallocate(b []byte, n int) []byte {
+func ResizeNoCopyNoOverallocate[T any](b []T, n int) []T {
 	if n <= cap(b) {
 		return b[:n]
 	}
-	return make([]byte, n)
+	return make([]T, n)
 }
 
 // roundToNearestPow2 rounds n to the nearest power of 2

--- a/lib/bytesutil/bytesutil_test.go
+++ b/lib/bytesutil/bytesutil_test.go
@@ -32,7 +32,7 @@ func TestRoundToNearestPow2(t *testing.T) {
 
 func TestResizeNoCopyNoOverallocate(t *testing.T) {
 	for i := 0; i < 1000; i++ {
-		b := ResizeNoCopyNoOverallocate(nil, i)
+		b := ResizeNoCopyNoOverallocate[byte](nil, i)
 		if len(b) != i {
 			t.Fatalf("invalid b size; got %d; want %d", len(b), i)
 		}
@@ -74,7 +74,7 @@ func TestResizeNoCopyNoOverallocate(t *testing.T) {
 
 func TestResizeNoCopyMayOverallocate(t *testing.T) {
 	for i := 0; i < 1000; i++ {
-		b := ResizeNoCopyMayOverallocate(nil, i)
+		b := ResizeNoCopyMayOverallocate[byte](nil, i)
 		if len(b) != i {
 			t.Fatalf("invalid b size; got %d; want %d", len(b), i)
 		}
@@ -111,7 +111,7 @@ func TestResizeNoCopyMayOverallocate(t *testing.T) {
 
 func TestResizeWithCopyNoOverallocate(t *testing.T) {
 	for i := 0; i < 1000; i++ {
-		b := ResizeWithCopyNoOverallocate(nil, i)
+		b := ResizeWithCopyNoOverallocate[byte](nil, i)
 		if len(b) != i {
 			t.Fatalf("invalid b size; got %d; want %d", len(b), i)
 		}
@@ -153,7 +153,7 @@ func TestResizeWithCopyNoOverallocate(t *testing.T) {
 
 func TestResizeWithCopyMayOverallocate(t *testing.T) {
 	for i := 0; i < 1000; i++ {
-		b := ResizeWithCopyMayOverallocate(nil, i)
+		b := ResizeWithCopyMayOverallocate[byte](nil, i)
 		if len(b) != i {
 			t.Fatalf("invalid b size; got %d; want %d", len(b), i)
 		}


### PR DESCRIPTION
Resize functions are useful for slices in general, not just slices of bytes. Add a type parameter to each function.

Usage for these will be in a forthcoming PR. Submitting this separately because it's contained and hopefully uncontroversial.