### PR TITLE
remove leading url slashes on root page

### DIFF
--- a/app/vmalert/web.go
+++ b/app/vmalert/web.go
@@ -32,9 +32,9 @@ func initLinks() {
 		{fmt.Sprintf("api/v1/alert?%s=<int>&%s=<int>", paramGroupID, paramAlertID), "get alert status by group and alert ID"},
 
 		// system links
-		{"/flags", "command-line flags"},
-		{"/metrics", "list of application metrics"},
-		{"/-/reload", "reload configuration"},
+		{"flags", "command-line flags"},
+		{"metrics", "list of application metrics"},
+		{"-/reload", "reload configuration"},
 	}
 	navItems = []tpl.NavItem{
 		{Name: "vmalert", Url: "."},


### PR DESCRIPTION
These were breaking deployments that use deeper url paths like http://example.com/monitoring/vmalert/groups

(untested, but the current behavior is wrong for sure)