### PR TITLE
dashboards: fix typo in data link

### DIFF
--- a/dashboards/victoriametrics-cluster.json
+++ b/dashboards/victoriametrics-cluster.json
@@ -4436,7 +4436,7 @@
                 {
                   "targetBlank": true,
                   "title": "Drilldown",
-                  "url": "/d/oS7Bi_0Wz?viewPanel=196&${__url_time_range}${__all_variables}"
+                  "url": "/d/oS7Bi_0Wz?viewPanel=196&${__url_time_range}&${__all_variables}"
                 }
               ],
               "mappings": [],


### PR DESCRIPTION
Fixes a missing `&` char in data link for ETA panel on cluster dashboards. Without `&` char it generates wrong link when click on Drilldown menu.

Signed-off-by: hagen1778 <roman@victoriametrics.com>