### PR TITLE
make: make openssl output parsing symbol number agnostic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ PKG_PREFIX := github.com/VictoriaMetrics/VictoriaMetrics
 
 DATEINFO_TAG ?= $(shell date -u +'%Y%m%d-%H%M%S')
 BUILDINFO_TAG ?= $(shell echo $$(git describe --long --all | tr '/' '-')$$( \
-	      git diff-index --quiet HEAD -- || echo '-dirty-'$$(git diff-index -u HEAD | openssl sha1 | cut -c 10-17)))
+	      git diff-index --quiet HEAD -- || echo '-dirty-'$$(git diff-index -u HEAD | openssl sha1 | cut -d' ' -f2 | cut -c 1-8)))
 
 PKG_TAG ?= $(shell git tag -l --points-at HEAD)
 ifeq ($(PKG_TAG),)


### PR DESCRIPTION
Newer version of openssl changed output format which breaks symbol number based parsing.
Previous version output(`OpenSSL 1.1.1n  15 Mar 2022`):
```
(stdin)= 790da16b24f4f8e1cc1389defa3ee51a6602473b
```
Newer version(`OpenSSL 3.0.7 1 Nov 2022`):
```
SHA1(stdin)= 7db3104e62c38b114da52f41a7d7f00c1d46b6e9
```
Splitting space by resolves this for both versions.