### PR TITLE
Datadog - Add device as a tag if it's present as a field in the series object

### DIFF
--- a/app/vmagent/datadog/request_handler.go
+++ b/app/vmagent/datadog/request_handler.go
@@ -56,7 +56,7 @@ func insertRows(at *auth.Token, series []parser.Series, extraLabels []prompbmars
 			Name:  "host",
 			Value: ss.Host,
 		})
-		if len(ss.Device) > 0 {
+		if ss.Device != "" {
 			labels = append(labels, prompbmarshal.Label{
 				Name:  "device",
 				Value: ss.Device,

--- a/app/vmagent/datadog/request_handler.go
+++ b/app/vmagent/datadog/request_handler.go
@@ -56,6 +56,12 @@ func insertRows(at *auth.Token, series []parser.Series, extraLabels []prompbmars
 			Name:  "host",
 			Value: ss.Host,
 		})
+		if len(ss.Device) > 0 {
+			labels = append(labels, prompbmarshal.Label{
+				Name:  "device",
+				Value: ss.Device,
+			})
+		}
 		for _, tag := range ss.Tags {
 			name, value := parser.SplitTag(tag)
 			if name == "host" {

--- a/app/vminsert/datadog/request_handler.go
+++ b/app/vminsert/datadog/request_handler.go
@@ -55,7 +55,7 @@ func insertRows(series []parser.Series, extraLabels []prompbmarshal.Label) error
 		ctx.Labels = ctx.Labels[:0]
 		ctx.AddLabel("", ss.Metric)
 		ctx.AddLabel("host", ss.Host)
-		if len(ss.Device) > 0 {
+		if ss.Device != "" {
 			ctx.AddLabel("device", ss.Device)
 		}
 		for _, tag := range ss.Tags {

--- a/app/vminsert/datadog/request_handler.go
+++ b/app/vminsert/datadog/request_handler.go
@@ -55,6 +55,9 @@ func insertRows(series []parser.Series, extraLabels []prompbmarshal.Label) error
 		ctx.Labels = ctx.Labels[:0]
 		ctx.AddLabel("", ss.Metric)
 		ctx.AddLabel("host", ss.Host)
+		if len(ss.Device) > 0 {
+			ctx.AddLabel("device", ss.Device)
+		}
 		for _, tag := range ss.Tags {
 			name, value := parser.SplitTag(tag)
 			if name == "host" {

--- a/lib/protoparser/datadog/parser.go
+++ b/lib/protoparser/datadog/parser.go
@@ -67,6 +67,10 @@ type Series struct {
 	Metric string   `json:"metric"`
 	Points []Point  `json:"points"`
 	Tags   []string `json:"tags"`
+	// The device field does not appear in the datadog docs, but datadog-agent does use it.
+	// Datadog agent (v7 at least), removes the tag "device" and adds it as its own field. Why? That I don't know!
+	// https://github.com/DataDog/datadog-agent/blob/0ada7a97fed6727838a6f4d9c87123d2aafde735/pkg/metrics/series.go#L84-L105
+	Device string `json:"device"`
 
 	// Do not decode Type, since it isn't used by VictoriaMetrics
 	// Type string `json:"type"`

--- a/lib/protoparser/datadog/parser_test.go
+++ b/lib/protoparser/datadog/parser_test.go
@@ -56,6 +56,7 @@ func TestRequestUnmarshalSuccess(t *testing.T) {
       "host": "test.example.com",
       "interval": 20,
       "metric": "system.load.1",
+      "device": "/dev/sda",
       "points": [[
         1575317847,
         0.5
@@ -71,6 +72,7 @@ func TestRequestUnmarshalSuccess(t *testing.T) {
 		Series: []Series{{
 			Host:   "test.example.com",
 			Metric: "system.load.1",
+			Device: "/dev/sda",
 			Points: []Point{{
 				1575317847,
 				0.5,


### PR DESCRIPTION
For some reason that I don't understand, the `datadog-agent` (at least v7) removes the `device` tag from the `Tags` field and adds it as it's own field in the Series object - as far as I can tell, this is not mentioned in the [datadog documentation to submit metrics (check v1)](https://docs.datadoghq.com/api/latest/metrics/#submit-metrics).

In the `datadog-agent` code, you can see the `device` tag being removed from the `Tags` field [in here](https://github.com/DataDog/datadog-agent/blob/0ada7a97fed6727838a6f4d9c87123d2aafde735/pkg/metrics/series.go#L84-L105).

What this PR does is to add what is in the device field value as a label.