### PR TITLE
vmselect: report requested memory in slow log

### DIFF
--- a/app/vmselect/promql/exec_test.go
+++ b/app/vmselect/promql/exec_test.go
@@ -67,7 +67,7 @@ func TestExecSuccess(t *testing.T) {
 			RoundDigits:        100,
 		}
 		for i := 0; i < 5; i++ {
-			result, err := Exec(nil, ec, q, false)
+			result, _, err := Exec(nil, ec, q, false)
 			if err != nil {
 				t.Fatalf(`unexpected error when executing %q: %s`, q, err)
 			}
@@ -8098,14 +8098,14 @@ func TestExecError(t *testing.T) {
 			RoundDigits:        100,
 		}
 		for i := 0; i < 4; i++ {
-			rv, err := Exec(nil, ec, q, false)
+			rv, _, err := Exec(nil, ec, q, false)
 			if err == nil {
 				t.Fatalf(`expecting non-nil error on %q`, q)
 			}
 			if rv != nil {
 				t.Fatalf(`expecting nil rv`)
 			}
-			rv, err = Exec(nil, ec, q, true)
+			rv, _, err = Exec(nil, ec, q, true)
 			if err == nil {
 				t.Fatalf(`expecting non-nil error on %q`, q)
 			}


### PR DESCRIPTION
Closes #3405

Reports requested memory in the slow log.

```
2022-12-02T10:21:07.326Z	warn	app/vmselect/main.go:140	slow query according to -search.logSlowQueryDuration=1ms: remoteAddr="127.0.0.1:40978", duration=0.008 seconds; requestedMemory=30504 bytes; requestURI: "/prometheus/api/v1/query_range?query=vm_active_merges&start=1669974666.508&end=1669976466.508&step=3.145"
```
