### PR TITLE
vmui: fix multi-line query

### DIFF
--- a/app/vmui/packages/vmui/src/components/Main/Autocomplete/Autocomplete.tsx
+++ b/app/vmui/packages/vmui/src/components/Main/Autocomplete/Autocomplete.tsx
@@ -56,13 +56,14 @@ const Autocomplete: FC<AutocompleteProps> = ({
   const handleKeyDown = (e: KeyboardEvent) => {
     const { key, ctrlKey, metaKey, shiftKey } = e;
     const modifiers = ctrlKey || metaKey || shiftKey;
+    const hasOptions = foundOptions.length;
 
-    if (key === "ArrowUp" && !modifiers) {
+    if (key === "ArrowUp" && !modifiers && hasOptions) {
       e.preventDefault();
       setFocusOption((prev) => prev <= 0 ? 0 : prev - 1);
     }
 
-    if (key === "ArrowDown" && !modifiers) {
+    if (key === "ArrowDown" && !modifiers && hasOptions) {
       e.preventDefault();
       const lastIndex = foundOptions.length - 1;
       setFocusOption((prev) => prev >= lastIndex ? lastIndex : prev + 1);

--- a/app/vmui/packages/vmui/src/utils/query-string.ts
+++ b/app/vmui/packages/vmui/src/utils/query-string.ts
@@ -5,7 +5,7 @@ import { MAX_QUERY_FIELDS } from "../constants/graph";
 export const setQueryStringWithoutPageReload = (params: Record<string, unknown>): void => {
   const w = window;
   if (w) {
-    const qsValue = Object.entries(params).map(([k, v]) => `${k}=${v}`).join("&");
+    const qsValue = Object.entries(params).map(([k, v]) => `${k}=${encodeURIComponent(String(v))}`).join("&");
     const qs = qsValue ? `?${qsValue}` : "";
     const newurl = `${w.location.protocol}//${w.location.host}${w.location.pathname}${qs}${w.location.hash}`;
     w.history.pushState({ path: newurl }, "", newurl);


### PR DESCRIPTION
- correct encode query in URL (#3444)
- remove prevent nav by up/down keys for multi-line query (#3445)
- multi-line queries are left as is when sent and put into the URL.