### PR TITLE
deployment/docker: bump Grafana version to v9.2.7

### DIFF
--- a/deployment/docker/docker-compose-cluster.yml
+++ b/deployment/docker/docker-compose-cluster.yml
@@ -17,7 +17,7 @@ services:
 
   grafana:
     container_name: grafana
-    image: grafana/grafana:9.2.6
+    image: grafana/grafana:9.2.7
     depends_on:
       - "vmselect"
     ports:

--- a/deployment/docker/docker-compose.yml
+++ b/deployment/docker/docker-compose.yml
@@ -40,7 +40,7 @@ services:
     restart: always
   grafana:
     container_name: grafana
-    image: grafana/grafana:9.2.6
+    image: grafana/grafana:9.2.7
     depends_on:
       - "victoriametrics"
     ports:


### PR DESCRIPTION
see https://grafana.com/blog/2022/11/29/grafana-security-release-new-versions-with-high-severity-security-fix-for-cve-2022-31097/