### PR TITLE
alerts: remove `show_at` label for RequestErrorsToAPI alert

### DIFF
--- a/deployment/docker/alerts.yml
+++ b/deployment/docker/alerts.yml
@@ -54,7 +54,6 @@ groups:
         for: 15m
         labels:
           severity: warning
-          show_at: dashboard
         annotations:
           dashboard: "http://localhost:3000/d/wNf0q_kZk?viewPanel=35&var-instance={{ $labels.instance }}"
           summary: "Too many errors served for path {{ $labels.path }} (instance {{ $labels.instance }})"


### PR DESCRIPTION
Alert `RequestErrorsToAPI` could be permanently triggered due to mistakes in clients configuration. However, such requests are unlikely to cause VM health state change. So there is no need in displaying this alert because there will be no correlation caused by it.

Signed-off-by: hagen1778 <roman@victoriametrics.com>