### PR TITLE
vmalert: do not hold pointer to http.Request

### DIFF
--- a/app/vmalert/alerting.go
+++ b/app/vmalert/alerting.go
@@ -284,7 +284,7 @@ func (ar *AlertingRule) Exec(ctx context.Context, ts time.Time, limit int) ([]pr
 		duration: time.Since(start),
 		samples:  len(qMetrics),
 		err:      err,
-		req:      req,
+		curl:     requestToCurl(req),
 	}
 
 	defer func() {

--- a/app/vmalert/recording.go
+++ b/app/vmalert/recording.go
@@ -121,7 +121,7 @@ func (rr *RecordingRule) Exec(ctx context.Context, ts time.Time, limit int) ([]p
 		at:       ts,
 		duration: time.Since(start),
 		samples:  len(qMetrics),
-		req:      req,
+		curl:     requestToCurl(req),
 	}
 
 	defer func() {

--- a/app/vmalert/rule.go
+++ b/app/vmalert/rule.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"errors"
-	"net/http"
 	"sync"
 	"time"
 
@@ -54,8 +53,8 @@ type ruleStateEntry struct {
 	// stores the number of samples returned during
 	// the last evaluation
 	samples int
-	// stores the HTTP request used by datasource during rule.Exec
-	req *http.Request
+	// stores the curl command reflecting the HTTP request used during rule.Exec
+	curl string
 }
 
 const defaultStateEntriesLimit = 20

--- a/app/vmalert/web.qtpl
+++ b/app/vmalert/web.qtpl
@@ -457,7 +457,7 @@
                  <td class="text-center">{%f.3 u.duration.Seconds() %}s</td>
                  <td class="text-center">{%s u.at.Format(time.RFC3339) %}</td>
                  <td>
-                    <textarea class="curl-area" rows="1" onclick="this.focus();this.select()">{%s requestToCurl(u.req) %}</textarea>
+                    <textarea class="curl-area" rows="1" onclick="this.focus();this.select()">{%s u.curl %}</textarea>
                 </td>
              </tr>
           </li>

--- a/app/vmalert/web.qtpl.go
+++ b/app/vmalert/web.qtpl.go
@@ -1358,7 +1358,7 @@ func StreamRuleDetails(qw422016 *qt422016.Writer, r *http.Request, rule APIRule)
                  <td>
                     <textarea class="curl-area" rows="1" onclick="this.focus();this.select()">`)
 //line app/vmalert/web.qtpl:460
-		qw422016.E().S(requestToCurl(u.req))
+		qw422016.E().S(u.curl)
 //line app/vmalert/web.qtpl:460
 		qw422016.N().S(`</textarea>
                 </td>


### PR DESCRIPTION
http.Request was used as a part of state struct
for generating the curl command when viewing the rule's state changes.
It appears, that holding a reference is far more expensive than generating the curl command immediately.
On the test with 40k rules, this change reduces memory and CPU usage by 50%.

Signed-off-by: hagen1778 <roman@victoriametrics.com>