### PR TITLE
dashboards: add VersionChange annotation

### DIFF
--- a/dashboards/victoriametrics-cluster.json
+++ b/dashboards/victoriametrics-cluster.json
@@ -69,6 +69,19 @@
         "iconColor": "red",
         "name": "alerts",
         "titleFormat": "{{alertname}}"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "$ds"
+        },
+        "enable": true,
+        "expr": "sum(vm_app_version{job=~\"$job\"}) by(short_version) unless (sum(vm_app_version{job=~\"$job\"} offset 20m) by(short_version))",
+        "hide": true,
+        "iconColor": "dark-blue",
+        "name": "version change",
+        "textFormat": "{{short_version}}",
+        "titleFormat": "Version change"
       }
     ]
   },

--- a/dashboards/victoriametrics.json
+++ b/dashboards/victoriametrics.json
@@ -69,6 +69,19 @@
         "iconColor": "red",
         "name": "alerts",
         "titleFormat": "{{alertname}}"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "$ds"
+        },
+        "enable": true,
+        "expr": "sum(vm_app_version{job=~\"$job\"}) by(short_version) unless (sum(vm_app_version{job=~\"$job\"} offset 20m) by(short_version))",
+        "hide": true,
+        "iconColor": "dark-blue",
+        "name": "version",
+        "textFormat": "{{short_version}}",
+        "titleFormat": "Version change"
       }
     ]
   },

--- a/dashboards/vmalert.json
+++ b/dashboards/vmalert.json
@@ -52,6 +52,19 @@
           "type": "dashboard"
         },
         "type": "dashboard"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "$ds"
+        },
+        "enable": true,
+        "expr": "sum(vm_app_version{job=~\"$job\"}) by(short_version) unless (sum(vm_app_version{job=~\"$job\"} offset 20m) by(short_version))",
+        "hide": true,
+        "iconColor": "dark-blue",
+        "name": "version",
+        "textFormat": "{{short_version}}",
+        "titleFormat": "Version change"
       }
     ]
   },


### PR DESCRIPTION
The new annotation is hidden by default and suppose to show component `short_version` label change on the panels.
<img width="647" alt="image" src="https://user-images.githubusercontent.com/2902918/207085431-dae72f9d-9a52-4add-b7fc-c52e5821f14c.png">


Signed-off-by: hagen1778 <roman@victoriametrics.com>