### PR TITLE
dashboards: respect $job var in sub-vars for cluster dash

### DIFF
--- a/dashboards/victoriametrics-cluster.json
+++ b/dashboards/victoriametrics-cluster.json
@@ -8652,81 +8652,6 @@
           "type": "prometheus",
           "uid": "$ds"
         },
-        "definition": "label_values(vm_app_version{version=~\"^vminsert.*\"}, job)",
-        "hide": 2,
-        "includeAll": false,
-        "multi": false,
-        "name": "job_insert",
-        "options": [],
-        "query": {
-          "query": "label_values(vm_app_version{version=~\"^vminsert.*\"}, job)",
-          "refId": "VictoriaMetrics-job_insert-Variable-Query"
-        },
-        "refresh": 1,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 0,
-        "tagValuesQuery": "",
-        "tagsQuery": "",
-        "type": "query",
-        "useTags": false
-      },
-      {
-        "current": {},
-        "datasource": {
-          "type": "prometheus",
-          "uid": "$ds"
-        },
-        "definition": "label_values(vm_app_version{version=~\"^vmselect.*\"}, job)",
-        "hide": 2,
-        "includeAll": false,
-        "multi": false,
-        "name": "job_select",
-        "options": [],
-        "query": {
-          "query": "label_values(vm_app_version{version=~\"^vmselect.*\"}, job)",
-          "refId": "VictoriaMetrics-job_select-Variable-Query"
-        },
-        "refresh": 1,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 0,
-        "tagValuesQuery": "",
-        "tagsQuery": "",
-        "type": "query",
-        "useTags": false
-      },
-      {
-        "current": {},
-        "datasource": {
-          "type": "prometheus",
-          "uid": "$ds"
-        },
-        "definition": "label_values(vm_app_version{version=~\"^vmstorage.*\"}, job)",
-        "hide": 2,
-        "includeAll": false,
-        "multi": false,
-        "name": "job_storage",
-        "options": [],
-        "query": {
-          "query": "label_values(vm_app_version{version=~\"^vmstorage.*\"}, job)",
-          "refId": "VictoriaMetrics-job_storage-Variable-Query"
-        },
-        "refresh": 1,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 0,
-        "tagValuesQuery": "",
-        "tagsQuery": "",
-        "type": "query",
-        "useTags": false
-      },
-      {
-        "current": {},
-        "datasource": {
-          "type": "prometheus",
-          "uid": "$ds"
-        },
         "definition": "label_values(vm_app_version{version=~\"^vm(insert|select|storage).*\"}, job)",
         "hide": 0,
         "includeAll": true,
@@ -8736,6 +8661,81 @@
         "query": {
           "query": "label_values(vm_app_version{version=~\"^vm(insert|select|storage).*\"}, job)",
           "refId": "VictoriaMetrics-job-Variable-Query"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "$ds"
+        },
+        "definition": "label_values(vm_app_version{job=~\"$job\", version=~\"^vminsert.*\"}, job)",
+        "hide": 2,
+        "includeAll": false,
+        "multi": false,
+        "name": "job_insert",
+        "options": [],
+        "query": {
+          "query": "label_values(vm_app_version{job=~\"$job\", version=~\"^vminsert.*\"}, job)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "$ds"
+        },
+        "definition": "label_values(vm_app_version{job=~\"$job\", version=~\"^vmselect.*\"}, job)",
+        "hide": 2,
+        "includeAll": false,
+        "multi": false,
+        "name": "job_select",
+        "options": [],
+        "query": {
+          "query": "label_values(vm_app_version{job=~\"$job\", version=~\"^vmselect.*\"}, job)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "$ds"
+        },
+        "definition": "label_values(vm_app_version{job=~\"$job\", version=~\"^vmstorage.*\"}, job)",
+        "hide": 2,
+        "includeAll": false,
+        "multi": false,
+        "name": "job_storage",
+        "options": [],
+        "query": {
+          "query": "label_values(vm_app_version{job=~\"$job\", version=~\"^vmstorage.*\"}, job)",
+          "refId": "StandardVariableQuery"
         },
         "refresh": 1,
         "regex": "",


### PR DESCRIPTION
Previously, $job_select, $job_storage and $job_insert didn't respect the $job filter. This change updates the variable queries to account for set $job variable.

<img width="690" alt="image" src="https://user-images.githubusercontent.com/2902918/208057271-fef36a94-5c5d-4650-a693-a3d1452840a4.png">


Signed-off-by: hagen1778 <roman@victoriametrics.com>