### PR TITLE
lib/logger: support for renaming json fields

### DIFF
--- a/lib/logger/json-fields.go
+++ b/lib/logger/json-fields.go
@@ -1,0 +1,32 @@
+package logger
+
+import "strings"
+
+var (
+	fieldTs     = "ts"
+	fieldLevel  = "level"
+	fieldCaller = "caller"
+	fieldMsg    = "msg"
+)
+
+func setLoggerJSONFields() {
+	fields := strings.Split(*loggerJSONFields, ",")
+	for _, f := range fields {
+		v := strings.Split(strings.TrimSpace(f), ":")
+		if len(v) != 2 {
+			continue
+		}
+
+		old, new := v[0], v[1]
+		switch old {
+		case "ts":
+			fieldTs = new
+		case "level":
+			fieldLevel = new
+		case "caller":
+			fieldCaller = new
+		case "msg":
+			fieldMsg = new
+		}
+	}
+}


### PR DESCRIPTION
Closes #2348

Adds support for renaming json fields in logs through `--loggerJsonFields` such as:

```
--loggerJsonFields ts:time,level:lvl,msg:message
```