### PR TITLE
vmui: step

### DIFF
--- a/app/vmui/packages/vmui/src/components/Configurators/StepConfigurator/StepConfigurator.tsx
+++ b/app/vmui/packages/vmui/src/components/Configurators/StepConfigurator/StepConfigurator.tsx
@@ -1,5 +1,4 @@
-import React, { FC, useCallback, useState } from "preact/compat";
-import { useEffect } from "react";
+import React, { FC, useCallback, useEffect, useState } from "preact/compat";
 import debounce from "lodash.debounce";
 import { RestartIcon } from "../../Main/Icons";
 import TextField from "../../Main/TextField/TextField";
@@ -8,16 +7,17 @@ import Tooltip from "../../Main/Tooltip/Tooltip";
 
 interface StepConfiguratorProps {
   defaultStep?: number,
+  value?: number,
   setStep: (step: number) => void,
 }
 
-const StepConfigurator: FC<StepConfiguratorProps> = ({ defaultStep, setStep }) => {
+const StepConfigurator: FC<StepConfiguratorProps> = ({ value, defaultStep, setStep }) => {
 
-  const [customStep, setCustomStep] = useState(defaultStep);
+  const [customStep, setCustomStep] = useState(value || defaultStep);
   const [error, setError] = useState("");
 
   const handleApply = (step: number) => setStep(step || 1);
-  const debouncedHandleApply = useCallback(debounce(handleApply, 700), []);
+  const debouncedHandleApply = useCallback(debounce(handleApply, 500), []);
 
   const onChangeStep = (val: string) => {
     const value = +val;
@@ -40,12 +40,12 @@ const StepConfigurator: FC<StepConfiguratorProps> = ({ defaultStep, setStep }) =
   };
 
   useEffect(() => {
-    if (defaultStep) handleSetStep(defaultStep);
-  }, [defaultStep]);
+    if (value) handleSetStep(value);
+  }, [value]);
 
   return (
     <TextField
-      label="Step value"
+      label="Step value of seconds"
       type="number"
       value={customStep}
       error={error}

--- a/app/vmui/packages/vmui/src/pages/CustomPanel/hooks/useSetQueryParams.ts
+++ b/app/vmui/packages/vmui/src/pages/CustomPanel/hooks/useSetQueryParams.ts
@@ -6,12 +6,14 @@ import { useQueryState } from "../../../state/query/QueryStateContext";
 import { displayTypeTabs } from "../DisplayTypeSwitch";
 import { setQueryStringWithoutPageReload } from "../../../utils/query-string";
 import { compactObject } from "../../../utils/object";
+import { useGraphState } from "../../../state/graph/GraphStateContext";
 
 export const useSetQueryParams = () => {
   const { tenantId } = useAppState();
   const { displayType } = useCustomPanelState();
   const { query } = useQueryState();
   const { duration, relativeTime, period: { date, step } } = useTimeState();
+  const { customStep } = useGraphState();
 
   const setSearchParamsFromState = () => {
     const params: Record<string, unknown> = {};
@@ -20,15 +22,16 @@ export const useSetQueryParams = () => {
       params[`${group}.expr`] = q;
       params[`${group}.range_input`] = duration;
       params[`${group}.end_input`] = date;
-      params[`${group}.step_input`] = step;
       params[`${group}.tab`] = displayTypeTabs.find(t => t.value === displayType)?.prometheusCode || 0;
       params[`${group}.relative_time`] = relativeTime;
       params[`${group}.tenantID`] = tenantId;
+
+      if ((step !== customStep) && customStep) params[`${group}.step_input`] = customStep;
     });
 
     setQueryStringWithoutPageReload(compactObject(params));
   };
 
-  useEffect(setSearchParamsFromState, [tenantId, displayType, query, duration, relativeTime, date, step]);
+  useEffect(setSearchParamsFromState, [tenantId, displayType, query, duration, relativeTime, date, step, customStep]);
   useEffect(setSearchParamsFromState, []);
 };

--- a/app/vmui/packages/vmui/src/utils/time.ts
+++ b/app/vmui/packages/vmui/src/utils/time.ts
@@ -26,6 +26,22 @@ const shortDurations = supportedDurations.map(d => d.short);
 
 export const roundToMilliseconds = (num: number): number => Math.round(num*1000)/1000;
 
+const roundStep = (step: number) => {
+  if (step >= 100) {
+    return Math.round(step) - (Math.round(step)%10); // step 10
+  }
+  if (step < 100 && step >= 10) {
+    return Math.round(step) - (Math.round(step)%5); // step 5
+  }
+  if (step < 10 && step >= 1) {
+    return Math.round(step); // step 1
+  }
+  if (step < 1 && step > 0.01) {
+    return Math.round(step * 40) / 40; // step 0.025
+  }
+  return roundToMilliseconds(step);
+};
+
 export const isSupportedDuration = (str: string): Partial<Record<UnitTypeShort, string>> | undefined => {
 
   const digits = str.match(/\d+/g);
@@ -57,7 +73,8 @@ export const getTimeperiodForDuration = (dur: string, date?: Date): TimeParams =
   }, {});
 
   const delta = dayjs.duration(durObject).asSeconds();
-  const step = roundToMilliseconds(delta / MAX_ITEMS_PER_CHART) || 0.001;
+  const rawStep = delta / MAX_ITEMS_PER_CHART;
+  const step = roundStep(rawStep) || 0.001;
 
   return {
     start: n - delta,

--- a/app/vmui/packages/vmui/src/utils/time.ts
+++ b/app/vmui/packages/vmui/src/utils/time.ts
@@ -27,17 +27,18 @@ const shortDurations = supportedDurations.map(d => d.short);
 export const roundToMilliseconds = (num: number): number => Math.round(num*1000)/1000;
 
 const roundStep = (step: number) => {
+  const integerStep = Math.round(step);
   if (step >= 100) {
-    return Math.round(step) - (Math.round(step)%10); // step 10
+    return integerStep - (integerStep%10); // integer multiple of 10
   }
   if (step < 100 && step >= 10) {
-    return Math.round(step) - (Math.round(step)%5); // step 5
+    return integerStep - (integerStep%5); // integer multiple of 5
   }
   if (step < 10 && step >= 1) {
-    return Math.round(step); // step 1
+    return integerStep; // integer
   }
   if (step < 1 && step > 0.01) {
-    return Math.round(step * 40) / 40; // step 0.025
+    return Math.round(step * 40) / 40; // float to thousandths multiple of 5
   }
   return roundToMilliseconds(step);
 };


### PR DESCRIPTION
- Save step to URL params only when overriding step
- By default, the step is set from the URL, if it is not there, then it is calculated automatically
- Step resets when changing duration (zoom in/out or  change time range)
- Change step rounding: 
  * if `step > 100` then rounds up to an integer multiple of 10
  * if `step between 10 and 100` then rounds up to an integer multiple of 5
  * if `step between 0.01 and 1`  then rounds up to a float to thousandths multiple of 5
  * if `step < 0.01` then rounds up to a float to thousandths

<br/>

- #3510
- #3513