### PR TITLE
fix(promscrape): check MaxScrapeSize after gzip decompression

### DIFF
--- a/lib/promscrape/client.go
+++ b/lib/promscrape/client.go
@@ -322,6 +322,11 @@ func (c *client) ReadData(dst []byte) ([]byte, error) {
 	} else if !swapResponseBodies {
 		dst = append(dst, resp.Body()...)
 	}
+	if len(dst) > c.hc.MaxResponseBodySize {
+		maxScrapeSizeExceeded.Inc()
+		return dst, fmt.Errorf("the response from %q exceeds -promscrape.maxScrapeSize=%d; "+
+			"either reduce the response size for the target or increase -promscrape.maxScrapeSize", c.scrapeURL, maxScrapeSize.N)
+	}
 	fasthttp.ReleaseResponse(resp)
 	if statusCode != fasthttp.StatusOK {
 		metrics.GetOrCreateCounter(fmt.Sprintf(`vm_promscrape_scrapes_total{status_code="%d"}`, statusCode)).Inc()


### PR DESCRIPTION
when scraping metrics in _normal_ mode (i.e. not in streamparse mode), the body response size is only checked before decompressing it, which, given the high compressibility of the prometheus metrics text-based representation, potentially permits to try parsing a `/metrics` endpoint 100x larger than the the configured `maxScrapeSize` (thereby potentially crashing `vmagent` for example)
This behaviour is inconsistent with the streamparse mode (details here https://github.com/VictoriaMetrics/VictoriaMetrics/pull/3527), where the `net.http/Client` correctly reports decompressed size
