### PR TITLE
Lint and errcheck using golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,15 @@
+run:
+  timeout: 2m
+
+enable:
+  - revive
+
+issues:
+  exclude-rules:
+    - linters:
+      - staticcheck
+      text: "SA(4003|1019|5011):"
+
+linters-settings:
+  errcheck:
+    exclude: ./errcheck_excludes.txt

--- a/Makefile
+++ b/Makefile
@@ -315,21 +315,7 @@ vet:
 	go vet ./lib/...
 	go vet ./app/...
 
-lint: install-golint
-	golint lib/...
-	golint app/...
-
-install-golint:
-	which golint || go install golang.org/x/lint/golint@latest
-
-errcheck: install-errcheck
-	errcheck -exclude=errcheck_excludes.txt ./lib/...
-	errcheck -exclude=errcheck_excludes.txt ./app/...
-
-install-errcheck:
-	which errcheck || go install github.com/kisielk/errcheck@latest
-
-check-all: fmt vet lint errcheck golangci-lint govulncheck
+check-all: fmt vet golangci-lint govulncheck
 
 test:
 	go test ./lib/... ./app/...
@@ -380,7 +366,7 @@ install-qtc:
 
 
 golangci-lint: install-golangci-lint
-	golangci-lint run --exclude '(SA4003|SA1019|SA5011):' -D errcheck -D structcheck --timeout 2m
+	golangci-lint run 
 
 install-golangci-lint:
 	which golangci-lint || curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(shell go env GOPATH)/bin v1.50.1


### PR DESCRIPTION
Lint via golangci-lint using revive. This replaces golint, which is now deprecated and archived.

Delegate errcheck to golangci-lint as well. This allows better control over errcheck as opposed to direct invocation, particularly when excluding a package or directory from checking (not done in this PR but coming).