### PR TITLE
lib/snapshot: fix error message format for failed HTTP request

### DIFF
--- a/lib/snapshot/snapshot.go
+++ b/lib/snapshot/snapshot.go
@@ -39,7 +39,7 @@ func Create(createSnapshotURL string) (string, error) {
 		return "", err
 	}
 	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("unexpected status code returned from %q; expecting %d; got %d; response body: %q", createSnapshotURL, resp.StatusCode, http.StatusOK, body)
+		return "", fmt.Errorf("unexpected status code returned from %q; expecting %d; got %d; response body: %q", createSnapshotURL, http.StatusOK, resp.StatusCode, body)
 	}
 
 	snap := snapshot{}


### PR DESCRIPTION
Currently, in case 401 error will be returned error message will be:
```
unexpected status code returned from ""; expecting 401; got 200;
```