### PR TITLE
vmui: fix title in the graph tooltip

### DIFF
--- a/app/vmui/packages/vmui/src/components/Chart/ChartTooltip/ChartTooltip.tsx
+++ b/app/vmui/packages/vmui/src/components/Chart/ChartTooltip/ChartTooltip.tsx
@@ -56,7 +56,7 @@ const ChartTooltip: FC<ChartTooltipProps> = ({
   const name = useMemo(() => {
     const metricName = (series[seriesIdx]?.label || "").replace(/{.+}/gmi, "").trim();
     return getLegendLabel(metricName);
-  }, []);
+  }, [series, seriesIdx]);
 
   const fields = useMemo(() => {
     const metric = metrics[seriesIdx - 1]?.metric || {};


### PR DESCRIPTION
Fixed title be improperly updated in the tooltip when hovering graph lines. 
- #3530