### PR TITLE
Fix vmctl command hint for vm-native-step-interval

### DIFF
--- a/app/vmctl/flags.go
+++ b/app/vmctl/flags.go
@@ -353,7 +353,7 @@ var (
 		},
 		&cli.StringFlag{
 			Name:  vmNativeStepInterval,
-			Usage: fmt.Sprintf("Split export data into chunks. Requires setting --%s. Valid values are '%s','%s','%s'.", vmNativeFilterTimeStart, stepper.StepMonth, stepper.StepDay, stepper.StepHour),
+			Usage: fmt.Sprintf("Split export data into chunks. Requires setting --%s. Valid values are '%s','%s','%s','%s'.", vmNativeFilterTimeStart, stepper.StepMonth, stepper.StepDay, stepper.StepHour, stepper.StepMinute),
 		},
 		&cli.StringFlag{
 			Name: vmNativeSrcAddr,


### PR DESCRIPTION
Signed-off-by: yanggang <gang.yang@daocloud.io>

/kind cleanup

supplement the omission flag hint for the ```Step Const```
```
app/vmctl/stepper/split.go
```