### PR TITLE
Fix flag help message for the backups types.

### DIFF
--- a/app/vmbackup/main.go
+++ b/app/vmbackup/main.go
@@ -118,7 +118,7 @@ func main() {
 
 func usage() {
 	const s = `
-vmbackup performs backups for VictoriaMetrics data from instant snapshots to gcs, s3
+vmbackup performs backups for VictoriaMetrics data from instant snapshots to gcs, s3 , azblob 
 or local filesystem. Backed up data can be restored with vmrestore.
 
 See the docs at https://docs.victoriametrics.com/vmbackup.html .


### PR DESCRIPTION
Signed-off-by: yanggang <gang.yang@daocloud.io>

/kind cleanup

There is type ```azblob``` missing.
