### PR TITLE
lib/promscrape/targetstatus: fix crash during droppedTarget registration

### DIFF
--- a/lib/promscrape/config.go
+++ b/lib/promscrape/config.go
@@ -1186,7 +1186,9 @@ func (swc *scrapeWorkConfig) getScrapeWork(target string, extraLabels, metaLabel
 	}
 	if labels.Len() == 0 {
 		// Drop target without labels.
-		droppedTargetsMap.Register(originalLabels, swc.relabelConfigs)
+		if !*dropOriginalLabels {
+			droppedTargetsMap.Register(originalLabels, swc.relabelConfigs)
+		}
 		return nil, nil
 	}
 	// See https://www.robustperception.io/life-of-a-label
@@ -1201,7 +1203,9 @@ func (swc *scrapeWorkConfig) getScrapeWork(target string, extraLabels, metaLabel
 	address := labels.Get("__address__")
 	if len(address) == 0 {
 		// Drop target without scrape address.
-		droppedTargetsMap.Register(originalLabels, swc.relabelConfigs)
+		if !*dropOriginalLabels {
+			droppedTargetsMap.Register(originalLabels, swc.relabelConfigs)
+		}
 		return nil, nil
 	}
 	// Usability extension to Prometheus behavior: extract optional scheme and metricsPath from __address__.

--- a/lib/promscrape/targetstatus.go
+++ b/lib/promscrape/targetstatus.go
@@ -300,6 +300,10 @@ func (dt *droppedTargets) Register(originalLabels *promutils.Labels, relabelConf
 }
 
 func labelsHash(labels *promutils.Labels) uint64 {
+	if labels == nil {
+		return 0
+	}
+
 	d := xxhashPool.Get().(*xxhash.Digest)
 	for _, label := range labels.Labels {
 		_, _ = d.WriteString(label.Name)

--- a/lib/promscrape/targetstatus.go
+++ b/lib/promscrape/targetstatus.go
@@ -300,10 +300,6 @@ func (dt *droppedTargets) Register(originalLabels *promutils.Labels, relabelConf
 }
 
 func labelsHash(labels *promutils.Labels) uint64 {
-	if labels == nil {
-		return 0
-	}
-
 	d := xxhashPool.Get().(*xxhash.Digest)
 	for _, label := range labels.Labels {
 		_, _ = d.WriteString(label.Name)


### PR DESCRIPTION
In case there is a flag `--promscrape.dropOriginalLabels` set to `true` and either:
- resulting labels are empty:
   ```go
	if labels.Len() == 0 {
		// Drop target without labels.
		droppedTargetsMap.Register(originalLabels, swc.relabelConfigs)
		return nil, nil
	}
   ```
-  `__address__` label is empty:
   ```go
	if len(address) == 0 {
		// Drop target without scrape address.
		droppedTargetsMap.Register(originalLabels, swc.relabelConfigs)
		return nil, nil
	}
   ```
`Register` will be called with `nil` argument which will lead to panic during hashing.

Fixes  #3580