### PR TITLE
github: rm `plaintext` render

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -13,7 +13,6 @@ body:
     id: describe-the-bug
     attributes:
       label: Describe the bug
-      render: plain text
       description: |
         A clear and concise description of what the bug is.
       placeholder: |

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -6,7 +6,6 @@ body:
     id: describe-the-problem
     attributes:
       label: Is your feature request related to a problem? Please describe
-      render: plain text
       description: |
         A clear and concise description of what the problem is.
       placeholder: |


### PR DESCRIPTION
 `render: plain text` makes fields not formattable and prevents
 from pasting screenshots.

Signed-off-by: hagen1778 <roman@victoriametrics.com>