### PR TITLE
dashboards: fix operator datasource variable

### DIFF
--- a/dashboards/backupmanager.json
+++ b/dashboards/backupmanager.json
@@ -1664,9 +1664,9 @@
     "list": [
       {
         "current": {
-          "selected": false,
-          "text": "cluster-monitoring",
-          "value": "cluster-monitoring"
+          "selected": true,
+          "text": "VictoriaMetrics",
+          "value": "VictoriaMetrics"
         },
         "hide": 0,
         "includeAll": false,

--- a/dashboards/clusterbytenant.json
+++ b/dashboards/clusterbytenant.json
@@ -559,7 +559,7 @@
     "list": [
       {
         "current": {
-          "selected": false,
+          "selected": true,
           "text": "VictoriaMetrics",
           "value": "VictoriaMetrics"
         },

--- a/dashboards/operator.json
+++ b/dashboards/operator.json
@@ -1179,14 +1179,14 @@
     "list": [
       {
         "current": {
-          "selected": false,
-          "text": "cloud-test-13",
-          "value": "cloud-test-13"
+          "selected": true,
+          "text": "VictoriaMetrics",
+          "value": "VictoriaMetrics"
         },
         "hide": 0,
         "includeAll": false,
         "multi": false,
-        "name": "datasource",
+        "name": "ds",
         "options": [],
         "query": "prometheus",
         "queryValue": "",

--- a/dashboards/victoriametrics-cluster.json
+++ b/dashboards/victoriametrics-cluster.json
@@ -8630,9 +8630,9 @@
     "list": [
       {
         "current": {
-          "selected": false,
-          "text": "VictoriaMetrics - cluster",
-          "value": "VictoriaMetrics - cluster"
+          "selected": true,
+          "text": "VictoriaMetrics",
+          "value": "VictoriaMetrics"
         },
         "hide": 0,
         "includeAll": false,

--- a/dashboards/victoriametrics.json
+++ b/dashboards/victoriametrics.json
@@ -5182,7 +5182,7 @@
     "list": [
       {
         "current": {
-          "selected": false,
+          "selected": true,
           "text": "VictoriaMetrics",
           "value": "VictoriaMetrics"
         },

--- a/dashboards/vmalert.json
+++ b/dashboards/vmalert.json
@@ -2765,8 +2765,8 @@
       {
         "current": {
           "selected": true,
-          "text": "VictoriaMetrics - cluster",
-          "value": "VictoriaMetrics - cluster"
+          "text": "VictoriaMetrics",
+          "value": "VictoriaMetrics"
         },
         "hide": 0,
         "includeAll": false,


### PR DESCRIPTION
I got "Failed to upgrade legacy queries Datasource $ds was not found" in Grafana on operator dashboard.
It's datasource variable was incorrectly named `datasource`.

I also took the liberty and made the rest of the dashboards have homogeneous datasource-variable names and selections, matching vmagent dashboard - which have worked fine for me.