### PR TITLE
lib/promscrape/discoveryutils: use correct timeout for blocking requests

### DIFF
--- a/lib/promscrape/discoveryutils/client.go
+++ b/lib/promscrape/discoveryutils/client.go
@@ -207,7 +207,7 @@ func (c *Client) getAPIResponseWithParamsAndClient(client *HTTPClient, path stri
 		return nil, fmt.Errorf("cannot parse %q: %w", requestURL, err)
 	}
 
-	deadline := time.Now().Add(client.WriteTimeout)
+	deadline := time.Now().Add(client.ReadTimeout)
 	ctx, cancel := context.WithDeadline(c.clientCtx, deadline)
 	defer cancel()
 	req, err := http.NewRequestWithContext(ctx, "GET", u.String(), nil)


### PR DESCRIPTION
Fixes timeout usage to use Read timeout since context sets limit for the whole request lifecycle.