### PR TITLE
app/vmctl: Add insecure skip verify flag for remote read protocol

### DIFF
--- a/app/vmctl/flags.go
+++ b/app/vmctl/flags.go
@@ -410,19 +410,20 @@ var (
 )
 
 const (
-	remoteRead                 = "remote-read"
-	remoteReadUseStream        = "remote-read-use-stream"
-	remoteReadConcurrency      = "remote-read-concurrency"
-	remoteReadFilterTimeStart  = "remote-read-filter-time-start"
-	remoteReadFilterTimeEnd    = "remote-read-filter-time-end"
-	remoteReadFilterLabel      = "remote-read-filter-label"
-	remoteReadFilterLabelValue = "remote-read-filter-label-value"
-	remoteReadStepInterval     = "remote-read-step-interval"
-	remoteReadSrcAddr          = "remote-read-src-addr"
-	remoteReadUser             = "remote-read-user"
-	remoteReadPassword         = "remote-read-password"
-	remoteReadHTTPTimeout      = "remote-read-http-timeout"
-	remoteReadHeaders          = "remote-read-headers"
+	remoteRead                   = "remote-read"
+	remoteReadUseStream          = "remote-read-use-stream"
+	remoteReadConcurrency        = "remote-read-concurrency"
+	remoteReadFilterTimeStart    = "remote-read-filter-time-start"
+	remoteReadFilterTimeEnd      = "remote-read-filter-time-end"
+	remoteReadFilterLabel        = "remote-read-filter-label"
+	remoteReadFilterLabelValue   = "remote-read-filter-label-value"
+	remoteReadStepInterval       = "remote-read-step-interval"
+	remoteReadSrcAddr            = "remote-read-src-addr"
+	remoteReadUser               = "remote-read-user"
+	remoteReadPassword           = "remote-read-password"
+	remoteReadHTTPTimeout        = "remote-read-http-timeout"
+	remoteReadHeaders            = "remote-read-headers"
+	remoteReadInsecureSkipVerify = "remote-read-insecure-skip-verify"
 )
 
 var (
@@ -492,6 +493,11 @@ var (
 			Usage: "Optional HTTP headers to send with each request to the corresponding remote source storage \n" +
 				"For example, --remote-read-headers='My-Auth:foobar' would send 'My-Auth: foobar' HTTP header with every request to the corresponding remote source storage. \n" +
 				"Multiple headers must be delimited by '^^': --remote-read-headers='header1:value1^^header2:value2'",
+		},
+		&cli.BoolFlag{
+			Name:  remoteReadInsecureSkipVerify,
+			Usage: "Whether to skip tls verification when connecting to remote read address to perform read from",
+			Value: false,
 		},
 	}
 )

--- a/app/vmctl/flags.go
+++ b/app/vmctl/flags.go
@@ -496,7 +496,7 @@ var (
 		},
 		&cli.BoolFlag{
 			Name:  remoteReadInsecureSkipVerify,
-			Usage: "Whether to skip tls verification when connecting to remote read address to perform read from",
+			Usage: "Whether to skip TLS certificate verification when connecting to the remote read address",
 			Value: false,
 		},
 	}

--- a/app/vmctl/main.go
+++ b/app/vmctl/main.go
@@ -121,14 +121,15 @@ func main() {
 				Flags: mergeFlags(globalFlags, remoteReadFlags, vmFlags),
 				Action: func(c *cli.Context) error {
 					rr, err := remoteread.NewClient(remoteread.Config{
-						Addr:       c.String(remoteReadSrcAddr),
-						Username:   c.String(remoteReadUser),
-						Password:   c.String(remoteReadPassword),
-						Timeout:    c.Duration(remoteReadHTTPTimeout),
-						UseStream:  c.Bool(remoteReadUseStream),
-						Headers:    c.String(remoteReadHeaders),
-						LabelName:  c.String(remoteReadFilterLabel),
-						LabelValue: c.String(remoteReadFilterLabelValue),
+						Addr:               c.String(remoteReadSrcAddr),
+						Username:           c.String(remoteReadUser),
+						Password:           c.String(remoteReadPassword),
+						Timeout:            c.Duration(remoteReadHTTPTimeout),
+						UseStream:          c.Bool(remoteReadUseStream),
+						Headers:            c.String(remoteReadHeaders),
+						LabelName:          c.String(remoteReadFilterLabel),
+						LabelValue:         c.String(remoteReadFilterLabelValue),
+						InsecureSkipVerify: c.Bool(remoteReadInsecureSkipVerify),
 					})
 					if err != nil {
 						return fmt.Errorf("error create remote read client: %s", err)

--- a/app/vmctl/remoteread/remoteread.go
+++ b/app/vmctl/remoteread/remoteread.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/VictoriaMetrics/VictoriaMetrics/app/vmctl/utils"
 	"github.com/VictoriaMetrics/VictoriaMetrics/app/vmctl/vm"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/bytesutil"
 	"github.com/gogo/protobuf/proto"
@@ -60,6 +61,8 @@ type Config struct {
 	// LabelName, LabelValue stands for label=~value pair used for read requests.
 	// Is optional.
 	LabelName, LabelValue string
+	// TLSSkipVerify defines whether to skip tls verification when connecting to remote read address to perform read from
+	InsecureSkipVerify bool
 }
 
 // Filter defines a list of filters applied to requested data
@@ -100,7 +103,7 @@ func NewClient(cfg Config) (*Client, error) {
 	c := &Client{
 		c: &http.Client{
 			Timeout:   cfg.Timeout,
-			Transport: http.DefaultTransport.(*http.Transport).Clone(),
+			Transport: utils.Transport(cfg.Addr, cfg.InsecureSkipVerify),
 		},
 		addr:      strings.TrimSuffix(cfg.Addr, "/"),
 		user:      cfg.Username,

--- a/app/vmctl/remoteread/remoteread.go
+++ b/app/vmctl/remoteread/remoteread.go
@@ -61,7 +61,7 @@ type Config struct {
 	// LabelName, LabelValue stands for label=~value pair used for read requests.
 	// Is optional.
 	LabelName, LabelValue string
-	// TLSSkipVerify defines whether to skip tls verification when connecting to remote read address to perform read from
+	// TLSSkipVerify defines whether to skip TLS certificate verification when connecting to the remote read address.
 	InsecureSkipVerify bool
 }
 

--- a/app/vmctl/utils/tls.go
+++ b/app/vmctl/utils/tls.go
@@ -1,0 +1,25 @@
+package utils
+
+import (
+	"crypto/tls"
+	"net/http"
+	"strings"
+)
+
+// Transport creates http.Transport object based on provided URL.
+// Returns Transport with TLS configuration if URL contains `https` prefix
+func Transport(URL string, insecureSkipVerify bool) *http.Transport {
+	t := http.DefaultTransport.(*http.Transport).Clone()
+	if !strings.HasPrefix(URL, "https") {
+		return t
+	}
+	t.TLSClientConfig = TLSConfig(insecureSkipVerify)
+	return t
+}
+
+// TLSConfig creates tls.Config object from provided arguments
+func TLSConfig(insecureSkipVerify bool) *tls.Config {
+	return &tls.Config{
+		InsecureSkipVerify: insecureSkipVerify,
+	}
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -36,7 +36,7 @@ The following tip changes can be tested by building VictoriaMetrics components f
   - `vm_vmselect_concurrent_requests_current` - the current number of concurrently executed requests
   - `vm_vmselect_concurrent_requests_limit_reached_total` - the total number of requests, which were put in the wait queue when `-search.maxConcurrentRequests` concurrent requests are being executed
   - `vm_vmselect_concurrent_requests_limit_timeout_total` - the total number of canceled requests because they were sitting in the wait queue for more than `-search.maxQueueDuration`
-* FEATURE [vmctl](https://docs.victoriametrics.com/vmctl.html): add `-remote-read-insecure-skip-verify` command-line flag for remote read protocol. It can be used whether to skip tls verification when connecting to remote read address to perform read from.
+* FEATURE [vmctl](https://docs.victoriametrics.com/vmctl.html): add `-remote-read-insecure-skip-verify` command-line flag for remote read protocol. It can be used for skipping TLS certificate verification when connecting to the remote read address.
 
 * BUGFIX: [vmui](https://docs.victoriametrics.com/#vmui): properly update the `step` value in url after the `step` input field has been manually changed. This allows preserving the proper `step` when copy-n-pasting the url to another instance of web browser. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/3513).
 * BUGFIX: [vmui](https://docs.victoriametrics.com/#vmui): properly update tooltip when quickly hovering multiple lines on the graph. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/3530).

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -36,6 +36,7 @@ The following tip changes can be tested by building VictoriaMetrics components f
   - `vm_vmselect_concurrent_requests_current` - the current number of concurrently executed requests
   - `vm_vmselect_concurrent_requests_limit_reached_total` - the total number of requests, which were put in the wait queue when `-search.maxConcurrentRequests` concurrent requests are being executed
   - `vm_vmselect_concurrent_requests_limit_timeout_total` - the total number of canceled requests because they were sitting in the wait queue for more than `-search.maxQueueDuration`
+* FEATURE [vmctl](https://docs.victoriametrics.com/vmctl.html): add `-remote-read-insecure-skip-verify` command-line flag for remote read protocol. It can be used whether to skip tls verification when connecting to remote read address to perform read from.
 
 * BUGFIX: [vmui](https://docs.victoriametrics.com/#vmui): properly update the `step` value in url after the `step` input field has been manually changed. This allows preserving the proper `step` when copy-n-pasting the url to another instance of web browser. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/3513).
 * BUGFIX: [vmui](https://docs.victoriametrics.com/#vmui): properly update tooltip when quickly hovering multiple lines on the graph. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/3530).


### PR DESCRIPTION
Added flag to remote read protocol, which skip tls verification when connecting to remote read address to perform read from.

Related issue: https://github.com/VictoriaMetrics/VictoriaMetrics/issues/3590

Signed-off-by: dmitryk-dk [d.kozlov@victoriametrics.com](mailto:d.kozlov@victoriametrics.com)