### PR TITLE
vmselect/netstorage: remove merge optimisation for identical timestamps

### DIFF
--- a/app/vmselect/netstorage/netstorage.go
+++ b/app/vmselect/netstorage/netstorage.go
@@ -510,15 +510,12 @@ func mergeSortBlocks(dst *Result, sbh sortBlocksHeap, dedupInterval int64) {
 		tsNext := sbNext.Timestamps[sbNext.NextIdx]
 		topTimestamps := top.Timestamps
 		topNextIdx := top.NextIdx
-		if n := equalTimestampsPrefix(topTimestamps[topNextIdx:], sbNext.Timestamps[sbNext.NextIdx:]); n > 0 && dedupInterval > 0 {
-			// Skip n replicated samples at top if deduplication is enabled.
-			top.NextIdx = topNextIdx + n
-		} else {
-			// Copy samples from top to dst with timestamps not exceeding tsNext.
-			top.NextIdx = topNextIdx + binarySearchTimestamps(topTimestamps[topNextIdx:], tsNext)
-			dst.Timestamps = append(dst.Timestamps, topTimestamps[topNextIdx:top.NextIdx]...)
-			dst.Values = append(dst.Values, top.Values[topNextIdx:top.NextIdx]...)
-		}
+
+		// Copy samples from top to dst with timestamps not exceeding tsNext.
+		top.NextIdx = topNextIdx + binarySearchTimestamps(topTimestamps[topNextIdx:], tsNext)
+		dst.Timestamps = append(dst.Timestamps, topTimestamps[topNextIdx:top.NextIdx]...)
+		dst.Values = append(dst.Values, top.Values[topNextIdx:top.NextIdx]...)
+
 		if top.NextIdx < len(topTimestamps) {
 			heap.Fix(&sbh, 0)
 		} else {
@@ -534,15 +531,6 @@ func mergeSortBlocks(dst *Result, sbh sortBlocksHeap, dedupInterval int64) {
 }
 
 var dedupsDuringSelect = metrics.NewCounter(`vm_deduplicated_samples_total{type="select"}`)
-
-func equalTimestampsPrefix(a, b []int64) int {
-	for i, v := range a {
-		if i >= len(b) || v != b[i] {
-			return i
-		}
-	}
-	return len(a)
-}
 
 func binarySearchTimestamps(timestamps []int64, ts int64) int {
 	// The code has been adapted from sort.Search.

--- a/app/vmselect/netstorage/netstorage_test.go
+++ b/app/vmselect/netstorage/netstorage_test.go
@@ -102,21 +102,6 @@ func TestMergeSortBlocks(t *testing.T) {
 		Values:     []float64{9, 4.2, 2.1, 5.2, 42, 6.1},
 	})
 
-	// Multiple blocks with identical timestamps.
-	f([]*sortBlock{
-		{
-			Timestamps: []int64{1, 2, 4},
-			Values:     []float64{9, 5.2, 6.1},
-		},
-		{
-			Timestamps: []int64{1, 2, 4},
-			Values:     []float64{4.2, 2.1, 42},
-		},
-	}, 1, &Result{
-		Timestamps: []int64{1, 2, 4},
-		Values:     []float64{4.2, 2.1, 42},
-	})
-
 	// Multiple blocks with identical timestamps, disabled deduplication.
 	f([]*sortBlock{
 		{
@@ -130,6 +115,21 @@ func TestMergeSortBlocks(t *testing.T) {
 	}, 0, &Result{
 		Timestamps: []int64{1, 1, 2, 2, 4, 4},
 		Values:     []float64{9, 4.2, 2.1, 5.2, 6.1, 42},
+	})
+
+	// Multiple blocks with identical timestamps, enabled deduplication.
+	f([]*sortBlock{
+		{
+			Timestamps: []int64{1, 1, 1},
+			Values:     []float64{1, 5, 10},
+		},
+		{
+			Timestamps: []int64{1, 1, 1},
+			Values:     []float64{2, 4, 6},
+		},
+	}, 1, &Result{
+		Timestamps: []int64{1},
+		Values:     []float64{10},
 	})
 
 	// Multiple blocks with identical timestamp ranges.


### PR DESCRIPTION
Optimization was used to skip data blocks with identical timestamps. But for https://github.com/VictoriaMetrics/VictoriaMetrics/issues/3333 it breaks the logic, since values aren't checked anymore. Hence, it can be that vmselect will skip data blocks which could contain bigger values with identical timestamps.

Signed-off-by: hagen1778 <roman@victoriametrics.com>