### PR TITLE
Add ability to customize `/api/v1/import/prometheus` response code

### DIFF
--- a/README.md
+++ b/README.md
@@ -904,6 +904,8 @@ Below is the output for `/path/to/vminsert -help`:
      Auth key for /debug/pprof/* endpoints. It must be passed via authKey query arg. It overrides httpAuth.* settings
   -prevCacheRemovalPercent float
      Items in the previous caches are removed when the percent of requests it serves becomes lower than this value. Higher values reduce memory usage at the cost of higher CPU usage. See also -cacheExpireDuration (default 0.1)
+  -prometheusImportResponseCode int
+     HTTP response code for /api/v1/import/prometheus requests. (default 204)
   -pushmetrics.extraLabel array
      Optional labels to add to metrics pushed to -pushmetrics.url . For example, -pushmetrics.extraLabel='instance="foo"' adds instance="foo" label to all the metrics pushed to -pushmetrics.url
      Supports an array of values separated by comma or specified via multiple flags.

--- a/app/vmagent/README.md
+++ b/app/vmagent/README.md
@@ -1275,6 +1275,8 @@ See the docs at https://docs.victoriametrics.com/vmagent.html .
      Auth key for /debug/pprof/* endpoints. It must be passed via authKey query arg. It overrides httpAuth.* settings
   -prevCacheRemovalPercent float
      Items in the previous caches are removed when the percent of requests it serves becomes lower than this value. Higher values reduce memory usage at the cost of higher CPU usage. See also -cacheExpireDuration (default 0.1)
+  -prometheusImportResponseCode int
+     HTTP response code for /api/v1/import/prometheus requests. (default 204)
   -promscrape.azureSDCheckInterval duration
      Interval for checking for changes in Azure. This works only if azure_sd_configs is configured in '-promscrape.config' file. See https://docs.victoriametrics.com/sd_configs.html#azure_sd_configs for details (default 1m0s)
   -promscrape.cluster.memberNum string

--- a/app/vmagent/main.go
+++ b/app/vmagent/main.go
@@ -56,6 +56,7 @@ var (
 	dryRun                 = flag.Bool("dryRun", false, "Whether to check only config files without running vmagent. The following files are checked: "+
 		"-promscrape.config, -remoteWrite.relabelConfig, -remoteWrite.urlRelabelConfig . "+
 		"Unknown config entries aren't allowed in -promscrape.config by default. This can be changed by passing -promscrape.config.strictParse=false command-line flag")
+	prometheusImportResponseCode = flag.Int("prometheusImportResponseCode", http.StatusNoContent, "HTTP response code for /api/v1/import/prometheus requests.")
 )
 
 var (
@@ -223,7 +224,7 @@ func requestHandler(w http.ResponseWriter, r *http.Request) bool {
 			httpserver.Errorf(w, r, "%s", err)
 			return true
 		}
-		w.WriteHeader(http.StatusNoContent)
+		w.WriteHeader(*prometheusImportResponseCode)
 		return true
 	}
 	if strings.HasPrefix(path, "datadog/") {

--- a/app/vminsert/main.go
+++ b/app/vminsert/main.go
@@ -60,6 +60,7 @@ var (
 	storageNodes           = flagutil.NewArrayString("storageNode", "Comma-separated addresses of vmstorage nodes; usage: -storageNode=vmstorage-host1,...,vmstorage-hostN . "+
 		"Enterprise version of VictoriaMetrics supports automatic discovery of vmstorage addresses via dns+srv records. For example, -storageNode=dns+srv:vmstorage.addrs . "+
 		"See https://docs.victoriametrics.com/Cluster-VictoriaMetrics.html#automatic-vmstorage-discovery")
+	prometheusImportResponseCode = flag.Int("prometheusImportResponseCode", http.StatusNoContent, "HTTP response code for /api/v1/import/prometheus requests.")
 )
 
 var (
@@ -202,7 +203,7 @@ func requestHandler(w http.ResponseWriter, r *http.Request) bool {
 			httpserver.Errorf(w, r, "%s", err)
 			return true
 		}
-		w.WriteHeader(http.StatusNoContent)
+		w.WriteHeader(*prometheusImportResponseCode)
 		return true
 	}
 	if strings.HasPrefix(p.Suffix, "datadog/") {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,7 @@ The following tip changes can be tested by building VictoriaMetrics components f
 ## tip
 
 * FEATURE: [vmui](https://docs.victoriametrics.com/#vmui): add ability to show custom dashboards at vmui by specifying a path to a directory with dashboard config files via `-vmui.customDashboardsPath` command-line flag. See [this feature request](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/3322) and [these docs](https://github.com/VictoriaMetrics/VictoriaMetrics/tree/master/app/vmui/packages/vmui/public/dashboards).
+* FEATURE: add `-prometheusImportResponseCode` command-line flag to [vmagent](https://docs.victoriametrics.com/vmagent.html) and to `vminsert` component of [VictoriaMetrics cluster](https://docs.victoriametrics.com/Cluster-VictoriaMetrics.html). Flag allows to configure HTTP response code for `api/v1/import/prometheus/` request. This is needed when client library does not accept default `204 No content` response code. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/3636).
 
 * BUGFIX: [vmagent](https://docs.victoriametrics.com/vmagent.html): [dockerswarm_sd_configs](https://docs.victoriametrics.com/sd_configs.html#dockerswarm_sd_configs): apply `filters` only to objects of the specified `role`. Previously filters were applied to all the objects, which could cause errors when different types of objects were used with filters that were not compatible with them. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/3579).
 

--- a/docs/Cluster-VictoriaMetrics.md
+++ b/docs/Cluster-VictoriaMetrics.md
@@ -908,6 +908,8 @@ Below is the output for `/path/to/vminsert -help`:
      Auth key for /debug/pprof/* endpoints. It must be passed via authKey query arg. It overrides httpAuth.* settings
   -prevCacheRemovalPercent float
      Items in the previous caches are removed when the percent of requests it serves becomes lower than this value. Higher values reduce memory usage at the cost of higher CPU usage. See also -cacheExpireDuration (default 0.1)
+  -prometheusImportResponseCode int
+     HTTP response code for /api/v1/import/prometheus requests. (default 204)
   -pushmetrics.extraLabel array
      Optional labels to add to metrics pushed to -pushmetrics.url . For example, -pushmetrics.extraLabel='instance="foo"' adds instance="foo" label to all the metrics pushed to -pushmetrics.url
      Supports an array of values separated by comma or specified via multiple flags.

--- a/docs/Single-server-VictoriaMetrics.md
+++ b/docs/Single-server-VictoriaMetrics.md
@@ -1269,6 +1269,10 @@ VictoriaMetrics accepts arbitrary number of lines in a single request to `/api/v
 
 Note that it could be required to flush response cache after importing historical data. See [these docs](#backfilling) for detail.
 
+Note that `api/v1/import/prometheus` returns `204 No content` response by default. Some client libraries require different response code for successful response.
+It is possible to use `-prometheusImportResponseCode` command-line flag to change the default response code for `/api/v1/import/prometheus` endpoint.
+For example, `-prometheusImportResponseCode=200` must be used for [prometheus/client_golang](https://github.com/prometheus/client_golang) library.
+
 VictoriaMetrics also may scrape Prometheus targets - see [these docs](#how-to-scrape-prometheus-exporters-such-as-node-exporter).
 
 ## Relabeling

--- a/docs/vmagent.md
+++ b/docs/vmagent.md
@@ -1279,6 +1279,8 @@ See the docs at https://docs.victoriametrics.com/vmagent.html .
      Auth key for /debug/pprof/* endpoints. It must be passed via authKey query arg. It overrides httpAuth.* settings
   -prevCacheRemovalPercent float
      Items in the previous caches are removed when the percent of requests it serves becomes lower than this value. Higher values reduce memory usage at the cost of higher CPU usage. See also -cacheExpireDuration (default 0.1)
+  -prometheusImportResponseCode int
+     HTTP response code for /api/v1/import/prometheus requests. (default 204)
   -promscrape.azureSDCheckInterval duration
      Interval for checking for changes in Azure. This works only if azure_sd_configs is configured in '-promscrape.config' file. See https://docs.victoriametrics.com/sd_configs.html#azure_sd_configs for details (default 1m0s)
   -promscrape.cluster.memberNum string


### PR DESCRIPTION
This PR adds flag to `vmagent` and `vminsert` in order to add ability to customize `/api/v1/import/prometheus` response code.
Currently, it returns `204 No content` code which is not compatible with [prometheus golang client](https://github.com/prometheus/client_golang/blob/main/prometheus/push/push.go#L299).
Other client libraries might have their own validation logic, so it will be better to provide an ability to use some specific code which will suit user needs for specific libraries.

Fixes https://github.com/VictoriaMetrics/VictoriaMetrics/issues/3636