### PR TITLE
ci: disable JS codeQL check

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'go', 'javascript' ]
+        language: [ 'go' ]
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
         # Learn more about CodeQL language support at https://git.io/codeql-language-support
 


### PR DESCRIPTION
We have limited amount of time used by Github CI runners and JS analysis accounts for a half of it.
Since JS represents only a small fraction of the codebase and is solely maintained by one person - I suggest disabling the CodeQL check in order to save CI runners time.

Signed-off-by: hagen1778 <roman@victoriametrics.com>