### PR TITLE
lib/fs: use `unix.Statfs()` / `unix.Statvfs()` when using a path

### DIFF
--- a/lib/fs/fs_solaris.go
+++ b/lib/fs/fs_solaris.go
@@ -49,15 +49,8 @@ func createFlockFile(flockFile string) (*os.File, error) {
 }
 
 func mustGetFreeSpace(path string) uint64 {
-	d, err := os.Open(path)
-	if err != nil {
-		logger.Panicf("FATAL: cannot open dir for determining free disk space: %s", err)
-	}
-	defer MustClose(d)
-
-	fd := d.Fd()
 	var stat unix.Statvfs_t
-	if err := unix.Fstatvfs(int(fd), &stat); err != nil {
+	if err := unix.Statvfs(path, &stat); err != nil {
 		logger.Panicf("FATAL: cannot determine free disk space on %q: %s", path, err)
 	}
 	return freeSpace(stat)

--- a/lib/fs/fs_unix.go
+++ b/lib/fs/fs_unix.go
@@ -45,15 +45,8 @@ func createFlockFile(flockFile string) (*os.File, error) {
 }
 
 func mustGetFreeSpace(path string) uint64 {
-	d, err := os.Open(path)
-	if err != nil {
-		logger.Panicf("FATAL: cannot open dir for determining free disk space: %s", err)
-	}
-	defer MustClose(d)
-
-	fd := d.Fd()
 	var stat unix.Statfs_t
-	if err := unix.Fstatfs(int(fd), &stat); err != nil {
+	if err := unix.Statfs(path, &stat); err != nil {
 		logger.Panicf("FATAL: cannot determine free disk space on %q: %s", path, err)
 	}
 	return freeSpace(stat)


### PR DESCRIPTION
Since `fs.mustGetFreeSpace()` requires a path anyway, this PR changes it from `unix.Fstatfs()` to `unix.Statfs()` (Solaris: `unix.Fstatvfs()` => `unix.Statvfs()`).

Measured around 3.5x faster, and from 3 allocs down to 1 alloc, which seems reasonable going from 3 syscalls down to 1 syscall.