### PR TITLE
CI: checkout correct branch for build step

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Code checkout
         uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.workflow_run.head_branch }}
 
       - name: Setup Go
         uses: actions/setup-go@v3


### PR DESCRIPTION
so with my change introduced in https://github.com/VictoriaMetrics/VictoriaMetrics/pull/3670 we now trigger build only if after tests are successful. However github actions for such job uses default branch.
This changes fixes this so that build job will use same commit as the test job that triggered build

see here for more details
https://blog.pother.ca/github-actions-workflow_run-event/