### PR TITLE
Adds sign of the assisted merge to the merge logs

### DIFF
--- a/lib/mergeset/table.go
+++ b/lib/mergeset/table.go
@@ -998,7 +998,7 @@ func (tb *Table) mergeWorker() {
 	isFinal := false
 	for {
 		// Limit the number of concurrent calls to mergeExistingParts, since the total number of merge workers
-		// across tables may exceed the the cap(mergeWorkersLimitCh).
+		// across tables may exceed the cap(mergeWorkersLimitCh).
 		mergeWorkersLimitCh <- struct{}{}
 		err := tb.mergeExistingParts(isFinal, false)
 		<-mergeWorkersLimitCh

--- a/lib/storage/partition.go
+++ b/lib/storage/partition.go
@@ -1054,7 +1054,7 @@ func (pt *partition) mergeWorker() {
 	isFinal := false
 	for {
 		// Limit the number of concurrent calls to mergeExistingParts, since the total number of merge workers
-		// across partitions may exceed the the cap(mergeWorkersLimitCh).
+		// across partitions may exceed the cap(mergeWorkersLimitCh).
 		mergeWorkersLimitCh <- struct{}{}
 		err := pt.mergeExistingParts(isFinal, false)
 		<-mergeWorkersLimitCh


### PR DESCRIPTION
This adds a sign of the assisted merge to the end of the message in merge logs, as requested in #2985.
The new messages will look like this:

```
merged (... parts, ... rows, ... blocks, ... bytes) into (... part, ... rows, ... blocks, ... bytes) in ... seconds at ... rows/sec to "..."; assisted: true
//or
merged (... parts, ... rows, ... blocks, ... bytes) into (... part, ... rows, ... blocks, ... bytes) in ... seconds at ... rows/sec to "..."; assisted: false
```