### PR TITLE
discover/ec2: bump API version

### DIFF
--- a/lib/awsapi/config.go
+++ b/lib/awsapi/config.go
@@ -109,7 +109,7 @@ func (cfg *Config) GetEC2APIResponse(action, filtersQueryString, nextPageToken s
 	if len(nextPageToken) > 0 {
 		apiURL += fmt.Sprintf("&NextToken=%s", url.QueryEscape(nextPageToken))
 	}
-	apiURL += "&Version=2013-10-15"
+	apiURL += "&Version=2016-11-15"
 	req, err := newSignedGetRequest(apiURL, "ec2", cfg.region, ac)
 	if err != nil {
 		return nil, fmt.Errorf("cannot create signed request: %w", err)


### PR DESCRIPTION
Switch to the actual API version `2016-11-15`,
since the old version doesn't provide access to all the fields which implementation expects.
For example, old API missing `zone_id` field
in `DescribeAvailabilityZonesResponse` response.

See https://github.com/VictoriaMetrics/VictoriaMetrics/issues/3700

Signed-off-by: hagen1778 <roman@victoriametrics.com>