### PR TITLE
fix: vmselect multi-level setup panic

### DIFF
--- a/app/vmselect/netstorage/netstorage.go
+++ b/app/vmselect/netstorage/netstorage.go
@@ -2014,7 +2014,7 @@ func (sn *storageNode) execOnConnWithPossibleRetry(qt *querytracer.Tracer, funcN
 	}
 	// Repeat the query in the hope the error was temporary.
 	qtRetry := qtChild.NewChild("retry rpc call %s() after error", funcName)
-	err = sn.execOnConn(qtChild, funcName, f, deadline)
+	err = sn.execOnConn(qtRetry, funcName, f, deadline)
 	qtRetry.Done()
 	return err
 }

--- a/app/vmselect/netstorage/netstorage.go
+++ b/app/vmselect/netstorage/netstorage.go
@@ -2002,7 +2002,7 @@ func (sn *storageNode) processSearchQuery(qt *querytracer.Tracer, requestData []
 func (sn *storageNode) execOnConnWithPossibleRetry(qt *querytracer.Tracer, funcName string, f func(bc *handshake.BufferedConn) error, deadline searchutils.Deadline) error {
 	qtChild := qt.NewChild("rpc call %s()", funcName)
 	err := sn.execOnConn(qtChild, funcName, f, deadline)
-	qtChild.Done()
+	defer qtChild.Done()
 	if err == nil {
 		return nil
 	}
@@ -2013,9 +2013,9 @@ func (sn *storageNode) execOnConnWithPossibleRetry(qt *querytracer.Tracer, funcN
 		return err
 	}
 	// Repeat the query in the hope the error was temporary.
-	qtChild = qt.NewChild("retry rpc call %s() after error", funcName)
+	qtRetry := qtChild.NewChild("retry rpc call %s() after error", funcName)
 	err = sn.execOnConn(qtChild, funcName, f, deadline)
-	qtChild.Done()
+	qtRetry.Done()
 	return err
 }
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -35,6 +35,7 @@ The following tip changes can be tested by building VictoriaMetrics components f
 * BUGFIX: [vmagent](https://docs.victoriametrics.com/vmagent.html): properly return `200 OK` HTTP status code when importing data via [Pushgateway protocol](https://docs.victoriametrics.com/#how-to-import-data-in-prometheus-exposition-format). See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/3636).
 * BUGFIX: [vmauth](https://docs.victoriametrics.com/vmauth.html): allow re-entering authorization info in the web browser if the entered info was incorrect. Previously it was non-trivial to do via the web browser, since `vmauth` was returning `400 Bad Request` instead of `401 Unauthorized` http response code.
 * BUGFIX: [vmauth](https://docs.victoriametrics.com/vmauth.html): always log the client address and the requested URL on proxying errors. Previously some errors could miss this information.
+* BUGFIX: [VictoriaMetrics cluster](https://docs.victoriametrics.com/Cluster-VictoriaMetrics.html): fix panic on top-level vmselect nodes of [multi-level setup](https://docs.victoriametrics.com/Cluster-VictoriaMetrics.html#multi-level-cluster-setup) when the `-replicationFactor` flag is set and request contains `trace` query parameter. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/3734).
 
 ## [v1.86.2](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.86.2)
 


### PR DESCRIPTION
In case of multi-level setup with `replicationFactor` set to value higher than 1 responses from some nodes would be dropped. Dropping response will also close `Tracer` before netstorage will retry request causing `NewChild` being called on closed `Tracer`.

This PR changes usage of `qt` to create retry `Tracer` based on `Tracer` which was created locally, this helps to ensure `Tracer` cannot  be closed outside of function execution flow.

Related  #3734