### PR TITLE
CI: speedup build by 2.4x. restore nightly build

### DIFF
--- a/.github/workflows/codeql-analysis-js.yml
+++ b/.github/workflows/codeql-analysis-js.yml
@@ -13,6 +13,10 @@ on:
   schedule:
     - cron: "30 18 * * 2"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+  
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -30,6 +30,10 @@ on:
   schedule:
     - cron: "30 18 * * 2"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,6 +17,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     name: lint

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -74,11 +74,17 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup Go
+        id: go
         uses: actions/setup-go@v3
         with:
           go-version: 1.19.5
           check-latest: true
           cache: true
+
+      - uses: actions/cache@v3
+        with:
+          path: gocache-for-docker
+          key:  gocache-docker-${{ runner.os }}-${{ steps.go.outputs.go-version }}-${{ hashFiles('go.mod') }}
 
       - name: Build
         run: |

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -26,23 +26,23 @@ jobs:
           go-version: 1.19.5
         id: go
 
-      - uses: actions/cache@v3
-        with:
-          path: gocache-for-docker
-          key: ${{ runner.os }}-${{ steps.go.outputs.go-version }}-dockerbuild-${{ hashFiles('go.mod') }}
-
       - name: Setup docker scan
         run: |
           mkdir -p ~/.docker/cli-plugins && \
           curl https://github.com/docker/scan-cli-plugin/releases/latest/download/docker-scan_linux_amd64 -L -s -S -o ~/.docker/cli-plugins/docker-scan &&\
           chmod +x ~/.docker/cli-plugins/docker-scan
 
-      - name: Code checkout
-        uses: actions/checkout@master
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       
+      - name: Code checkout
+        uses: actions/checkout@master
+
+      - uses: actions/cache@v3
+        with:
+          path: gocache-for-docker
+          key: gocache-docker-${{ runner.os }}-${{ steps.go.outputs.go-version }}-${{ hashFiles('go.mod') }}
+
       - name: Publish
         run: |
           docker scan --login --token "$SNYK_TOKEN" --accept-license

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -39,8 +39,6 @@ jobs:
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-        with:
-          use: linux/amd64,linux/arm,linux/arm64,linux/ppc64le,linux/386
       -
         name: Publish
         run: |

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -42,4 +42,7 @@ jobs:
       -
         name: Publish
         run: |
+          docker scan --login --token "$SNYK_TOKEN"
           LATEST_TAG=nightly PKG_TAG=nightly make publish
+        env: 
+          SNYK_TOKEN: ${{ secrets.SNYK_AUTH_TOKEN }}

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -3,9 +3,6 @@ on:
   schedule:
     # Daily at 2:48am
     - cron: '48 2 * * *'
-  push:
-    branches:
-      - nightly-build
 
 permissions:
   contents: read

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -3,6 +3,9 @@ on:
   schedule:
     # Daily at 2:48am
     - cron: '48 2 * * *'
+  push:
+    branches:
+      - nightly-build
 
 permissions:
   contents: read
@@ -33,6 +36,11 @@ jobs:
       -
         name: Code checkout
         uses: actions/checkout@master
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+        with:
+          use: linux/amd64,linux/arm,linux/arm64,linux/ppc64le,linux/386
       -
         name: Publish
         run: |

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -43,7 +43,7 @@ jobs:
           path: gocache-for-docker
           key: gocache-docker-${{ runner.os }}-${{ steps.go.outputs.go-version }}-${{ hashFiles('go.mod') }}
 
-      - name: Publish
+      - name: build & publish
         run: |
           docker scan --login --token "$SNYK_TOKEN" --accept-license
           LATEST_TAG=nightly PKG_TAG=nightly make publish

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -15,32 +15,35 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      -
-        name: Login to Docker Hub
+      - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      -
-        name: Setup Go
+      - name: Setup Go
         uses: actions/setup-go@main
         with:
           go-version: 1.19.5
         id: go
-      -
-        name: Setup docker scan
+
+      - uses: actions/cache@v3
+        with:
+          path: gocache-for-docker
+          key: ${{ runner.os }}-${{ steps.go.outputs.go-version }}-dockerbuild-${{ hashFiles('go.mod') }}
+
+      - name: Setup docker scan
         run: |
           mkdir -p ~/.docker/cli-plugins && \
           curl https://github.com/docker/scan-cli-plugin/releases/latest/download/docker-scan_linux_amd64 -L -s -S -o ~/.docker/cli-plugins/docker-scan &&\
           chmod +x ~/.docker/cli-plugins/docker-scan
-      -
-        name: Code checkout
+
+      - name: Code checkout
         uses: actions/checkout@master
-      -
-        name: Set up Docker Buildx
+
+      - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-      -
-        name: Publish
+      
+      - name: Publish
         run: |
           docker scan --login --token "$SNYK_TOKEN" --accept-license
           LATEST_TAG=nightly PKG_TAG=nightly make publish

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -42,7 +42,7 @@ jobs:
       -
         name: Publish
         run: |
-          docker scan --login --token "$SNYK_TOKEN"
+          docker scan --login --token "$SNYK_TOKEN" --accept-license
           LATEST_TAG=nightly PKG_TAG=nightly make publish
         env: 
           SNYK_TOKEN: ${{ secrets.SNYK_AUTH_TOKEN }}

--- a/deployment/docker/builder/Dockerfile
+++ b/deployment/docker/builder/Dockerfile
@@ -3,7 +3,7 @@ FROM $go_builder_image
 STOPSIGNAL SIGINT
 RUN apk add git gcc musl-dev make wget --no-cache && \
     mkdir /opt/cross-builder && \
-    wget https://musl.cc/aarch64-linux-musl-cross.tgz -O /opt/cross-builder/aarch64-musl.tgz && \
+    wget https://musl.cc/aarch64-linux-musl-cross.tgz -O /opt/cross-builder/aarch64-musl.tgz --no-verbose && \
     cd /opt/cross-builder && \
     tar zxf aarch64-musl.tgz -C ./  && \
     rm /opt/cross-builder/aarch64-musl.tgz


### PR DESCRIPTION
- fix nightly build (docker scan allows only 10 for free, but with auth in Snyk opensource scan is free)
- enable fast cancel for jobs if there are new commits into same branch or PR, to avoid unnecessary builds
- enabled caching for `/gocache-for-docker` which lead to build speedup 
<img width="923" alt="CleanShot 2023-02-06 at 19 30 37@2x" src="https://user-images.githubusercontent.com/7897050/216961375-873a9d62-95b8-4296-b03a-e436936b0cc2.png">
