### PR TITLE
fix: panic in nomad watcher because of nil map

### DIFF
--- a/lib/promscrape/discovery/nomad/watch.go
+++ b/lib/promscrape/discovery/nomad/watch.go
@@ -45,7 +45,7 @@ type serviceWatcher struct {
 
 // newNomadWatcher creates new watcher and starts background service discovery for Nomad.
 func newNomadWatcher(client *discoveryutils.Client, sdc *SDConfig, namespace, region string) *nomadWatcher {
-	var qa url.Values
+	qa := url.Values{}
 	if sdc.AllowStale == nil || *sdc.AllowStale {
 		qa.Set("stale", "")
 	}


### PR DESCRIPTION
url.Values is an uninitialized map.

Stack trace:

```
panic: assignment to entry in nil map
goroutine 102 [running]:
net/url.Values.Set(...)
	net/url/url.go:896
github.com/VictoriaMetrics/VictoriaMetrics/lib/promscrape/discovery/nomad.newNomadWatcher(0xc0001e6820, 0xc?, {0xc00019d7c8, 0x7}, {0xc00002a12d, 0x6})
	github.com/VictoriaMetrics/VictoriaMetrics/lib/promscrape/discovery/nomad/watch.go:50 +0x85
github.com/VictoriaMetrics/VictoriaMetrics/lib/promscrape/discovery/nomad.newAPIConfig(0xc000301000, {0x7ffcb7290c55, 0xf})
	github.com/VictoriaMetrics/VictoriaMetrics/lib/promscrape/discovery/nomad/api.go:93 +0x40f
github.com/VictoriaMetrics/VictoriaMetrics/lib/promscrape/discovery/nomad.getAPIConfig.func1()
	github.com/VictoriaMetrics/VictoriaMetrics/lib/promscrape/discovery/nomad/api.go:33 +0x25
github.com/VictoriaMetrics/VictoriaMetrics/lib/promscrape/discoveryutils.(*ConfigMap).Get(0xc000110cc0, {0x9b6660, 0xc000301000}, 0xc0003e8a58)
	github.com/VictoriaMetrics/VictoriaMetrics/lib/promscrape/discoveryutils/config_map.go:40 +0xfc
github.com/VictoriaMetrics/VictoriaMetrics/lib/promscrape/discovery/nomad.getAPIConfig(0x68b3e5?, {0x7ffcb7290c55?, 0xec16a0?})
	github.com/VictoriaMetrics/VictoriaMetrics/lib/promscrape/discovery/nomad/api.go:33 +0x65
github.com/VictoriaMetrics/VictoriaMetrics/lib/promscrape/discovery/nomad.(*SDConfig).GetLabels(0x0?, {0x7ffcb7290c55?, 0xc0003dc5af?})
	github.com/VictoriaMetrics/VictoriaMetrics/lib/promscrape/discovery/nomad/nomad.go:30 +0x1e
github.com/VictoriaMetrics/VictoriaMetrics/lib/promscrape.appendSDScrapeWork({0xec1a98, 0x0, 0x0}, {0xba9b80?, 0xc000301000?}, {0x7ffcb7290c55?, 0x40e599?}, 0xc00039a750, {0xa36558, 0xf})
	github.com/VictoriaMetrics/VictoriaMetrics/lib/promscrape/config.go:1042 +0x6d
github.com/VictoriaMetrics/VictoriaMetrics/lib/promscrape.(*Config).getNomadSDScrapeWork(0xc00008ade0, {0x0, 0x0, 0x48ced7?})
	github.com/VictoriaMetrics/VictoriaMetrics/lib/promscrape/config.go:825 +0x445
github.com/VictoriaMetrics/VictoriaMetrics/lib/promscrape.runScraper.func13(0x0?, {0x0?, 0xc000041680?, 0xc00010e9b8?})
	github.com/VictoriaMetrics/VictoriaMetrics/lib/promscrape/scraper.go:134 +0x1e
github.com/VictoriaMetrics/VictoriaMetrics/lib/promscrape.(*scrapeConfig).run.func1(0x6fc23ac00?)
	github.com/VictoriaMetrics/VictoriaMetrics/lib/promscrape/scraper.go:280 +0x86
github.com/VictoriaMetrics/VictoriaMetrics/lib/promscrape.(*scrapeConfig).run(0xc0001dc7c0, 0x0?)
	github.com/VictoriaMetrics/VictoriaMetrics/lib/promscrape/scraper.go:289 +0x187
github.com/VictoriaMetrics/VictoriaMetrics/lib/promscrape.(*scrapeConfigs).add.func1()
	github.com/VictoriaMetrics/VictoriaMetrics/lib/promscrape/scraper.go:237 +0x66
created by github.com/VictoriaMetrics/VictoriaMetrics/lib/promscrape.(*scrapeConfigs).add
	github.com/VictoriaMetrics/VictoriaMetrics/lib/promscrape/scraper.go:235 +0x219
```


vmagent config:

```yml
global:
    scrape_interval: 15s
  
  scrape_configs:
    - job_name: "vmagent"
      static_configs:
        - targets: ["localhost:8429"]
  
    - job_name: "app"
      nomad_sd_configs:
        - namespace: "app"
  ```
```