### PR TITLE
[fix]fix vmalert maxResolveDuration flag note

### DIFF
--- a/app/vmalert/main.go
+++ b/app/vmalert/main.go
@@ -63,7 +63,7 @@ absolute path to all .tpl files in root.`)
 	validateTemplates   = flag.Bool("rule.validateTemplates", true, "Whether to validate annotation and label templates")
 	validateExpressions = flag.Bool("rule.validateExpressions", true, "Whether to validate rules expressions via MetricsQL engine")
 	maxResolveDuration  = flag.Duration("rule.maxResolveDuration", 0, "Limits the maximum duration for automatic alert expiration, "+
-		"which is by default equal to 3 evaluation intervals of the parent group.")
+		"which by default is 4 times evaluationInterval of the parent group.")
 	resendDelay            = flag.Duration("rule.resendDelay", 0, "Minimum amount of time to wait before resending an alert to notifier")
 	ruleUpdateEntriesLimit = flag.Int("rule.updateEntriesLimit", 20, "Defines the max number of rule's state updates stored in-memory. "+
 		"Rule's updates are available on rule's Details page and are used for debugging purposes. The number of stored updates can be overriden per rule via update_entries_limit param.")

--- a/docs/vmalert.md
+++ b/docs/vmalert.md
@@ -1165,7 +1165,7 @@ The shortlist of configuration flags is the following:
   -rule.configCheckInterval duration
      Interval for checking for changes in '-rule' files. By default the checking is disabled. Send SIGHUP signal in order to force config check for changes. DEPRECATED - see '-configCheckInterval' instead
   -rule.maxResolveDuration duration
-     Limits the maximum duration for automatic alert expiration, which is by default equal to 3 evaluation intervals of the parent group.
+     Limits the maximum duration for automatic alert expiration, which by default is 4 times evaluationInterval of the parent group.
   -rule.resendDelay duration
      Minimum amount of time to wait before resending an alert to notifier
   -rule.templates array


### PR DESCRIPTION
since this [commit](https://github.com/VictoriaMetrics/VictoriaMetrics/commit/11ae1ae92432731989bfe8af1bd7e4e7384719fc), maxResolveDuration should be 4 times of groupInterval by default instead of 3.
![image](https://user-images.githubusercontent.com/39937150/219304892-a138cbd2-8ecf-4ff3-a650-b2c3f4ef9b28.png)
![image](https://user-images.githubusercontent.com/39937150/219308042-be196747-31a2-42c7-9e66-42af1f09dd39.png)
