### PR TITLE
Azure Service Discovery - Fix token fetch for Container Apps/App Services

### DIFF
--- a/lib/promscrape/discovery/azure/api.go
+++ b/lib/promscrape/discovery/azure/api.go
@@ -262,13 +262,13 @@ func parseTokenExpiry(tr tokenResponse) (int64, error) {
 		var expiresOnSeconds int64
 		expiresOnSeconds, err = strconv.ParseInt(tr.ExpiresOn, 10, 64)
 		if err != nil {
-			return 0, fmt.Errorf("cannot parse token auth response %q: %w", tr.ExpiresOn, err)
+			return 0, fmt.Errorf("cannot parse expiresOn=%q in auth token response: %w", tr.ExpiresOn, err)
 		}
 		expiresInSeconds = expiresOnSeconds - time.Now().Unix()
 	} else {
 		expiresInSeconds, err = strconv.ParseInt(tr.ExpiresIn, 10, 64)
 		if err != nil {
-			return 0, fmt.Errorf("cannot parse token auth response %q: %w", tr.ExpiresIn, err)
+			return 0, fmt.Errorf("cannot parse expiresIn=%q auth token response: %w", tr.ExpiresIn, err)
 		}
 	}
 

--- a/lib/promscrape/discovery/azure/api.go
+++ b/lib/promscrape/discovery/azure/api.go
@@ -199,11 +199,15 @@ func getRefreshTokenFunc(sdc *SDConfig, ac, proxyAC *promauth.Config, env *cloud
 		q := endpointURL.Query()
 
 		msiSecret := os.Getenv("MSI_SECRET")
+		identityHeader := os.Getenv("IDENTITY_HEADER")
 		clientIDParam := "client_id"
 		apiVersion := "2018-02-01"
 		if msiSecret != "" {
 			clientIDParam = "clientid"
 			apiVersion = "2017-09-01"
+		}
+		if identityHeader != "" {
+			apiVersion = "2019-08-01"
 		}
 		q.Set("api-version", apiVersion)
 		q.Set(clientIDParam, sdc.ClientID)
@@ -214,6 +218,9 @@ func getRefreshTokenFunc(sdc *SDConfig, ac, proxyAC *promauth.Config, env *cloud
 		modifyRequest = func(request *http.Request) {
 			if msiSecret != "" {
 				request.Header.Set("secret", msiSecret)
+				if identityHeader != "" {
+					request.Header.Set("X-IDENTITY-HEADER", msiSecret)
+				}
 			} else {
 				request.Header.Set("Metadata", "true")
 			}

--- a/lib/promscrape/discovery/azure/api.go
+++ b/lib/promscrape/discovery/azure/api.go
@@ -207,6 +207,7 @@ func getRefreshTokenFunc(sdc *SDConfig, ac, proxyAC *promauth.Config, env *cloud
 			apiVersion = "2017-09-01"
 		}
 		if identityHeader != "" {
+			clientIDParam = "client_id"
 			apiVersion = "2019-08-01"
 		}
 		q.Set("api-version", apiVersion)


### PR DESCRIPTION
Fixes #3830.

While testing VMAgent inside [Azure Container Apps](https://learn.microsoft.com/en-us/azure/container-apps/overview) together with Azure service discovery using Managed Identity I noticed I was not able to get a token from the [IMDS](https://learn.microsoft.com/en-us/azure/virtual-machines/linux/instance-metadata-service?tabs=windows) endpoint.

During investigation I noticed a few issues.
- The endpoint used in these resources requires a newer API version and a different auth header.
  - Solution I used is the same as [Azure Go SDK utilizes](https://github.com/Azure/azure-sdk-for-go/blob/main/sdk/azidentity/managed_identity_client.go#L120) which is checking for the environment variable `IDENTITY_HEADER`, and adding the correct API version and header if it is set.
  - If using User Assigned Identity, the query parameter needs to be `client_id`.
- The token response from the endpoint only contains a `expires_on` in addition to the `access_token`.
