### PR TITLE
number of replicationFactor should less than number of storageNode. (#3805)

### DIFF
--- a/app/vmselect/main.go
+++ b/app/vmselect/main.go
@@ -124,6 +124,11 @@ func main() {
 		if err != nil {
 			logger.Fatalf("cannot initialize vmselectapi server: %s", err)
 		}
+
+		if len(*storageNodes) < netstorage.GetReplicationFactor() {
+			logger.Warnf("number of replicationFactor should less than number of storageNode.")			
+		}
+
 		vmselectapiServer = s
 		logger.Infof("started vmselectapi server at %q", *clusternativeListenAddr)
 	}

--- a/app/vmselect/netstorage/netstorage.go
+++ b/app/vmselect/netstorage/netstorage.go
@@ -2818,3 +2818,7 @@ func (pnc *perNodeCounter) GetTotal() uint64 {
 	}
 	return total
 }
+
+func GetReplicationFactor() Int{
+	return *replicationFactor
+}


### PR DESCRIPTION
- Run vmselect with multi-level cluster mode, option is `-replicationFactor=2`, but `-storageNode=vmstorage-1` (not `-storageNode=vmstorage-1,vmstorage-2`) situatation, WARN log that `number of replicationFactor should less than number of storageNode.`
- related issue : https://github.com/VictoriaMetrics/VictoriaMetrics/issues/3805