### PR TITLE
lib/promscrape: fix cancelling in-flight scrape requests during configuration reload

### DIFF
--- a/lib/promscrape/client.go
+++ b/lib/promscrape/client.go
@@ -266,7 +266,7 @@ func (c *client) ReadData(dst []byte) ([]byte, error) {
 	ctx, cancel := context.WithDeadline(c.ctx, deadline)
 	defer cancel()
 
-	err := doRequestWithPossibleRetry(c.hc, req, resp, ctx)
+	err := doRequestWithPossibleRetry(ctx, c.hc, req, resp)
 	statusCode := resp.StatusCode()
 	redirectsCount := 0
 	for err == nil && isStatusRedirect(statusCode) {
@@ -286,7 +286,7 @@ func (c *client) ReadData(dst []byte) ([]byte, error) {
 			break
 		}
 		req.URI().UpdateBytes(location)
-		err = doRequestWithPossibleRetry(c.hc, req, resp, ctx)
+		err = doRequestWithPossibleRetry(ctx, c.hc, req, resp)
 		statusCode = resp.StatusCode()
 		redirectsCount++
 	}
@@ -353,7 +353,7 @@ var (
 	scrapeRetries         = metrics.NewCounter(`vm_promscrape_scrape_retries_total`)
 )
 
-func doRequestWithPossibleRetry(hc *fasthttp.HostClient, req *fasthttp.Request, resp *fasthttp.Response, ctx context.Context) error {
+func doRequestWithPossibleRetry(ctx context.Context, hc *fasthttp.HostClient, req *fasthttp.Request, resp *fasthttp.Response) error {
 	sleepTime := time.Second
 	scrapeRequests.Inc()
 	deadline, hasDeadline := ctx.Deadline()

--- a/lib/promscrape/client.go
+++ b/lib/promscrape/client.go
@@ -262,7 +262,11 @@ func (c *client) ReadData(dst []byte) ([]byte, error) {
 		// This should reduce memory uage when scraping big targets.
 		dst = resp.SwapBody(dst)
 	}
-	err := doRequestWithPossibleRetry(c.hc, req, resp, deadline)
+
+	ctx, cancel := context.WithDeadline(c.ctx, deadline)
+	defer cancel()
+
+	err := doRequestWithPossibleRetry(c.hc, req, resp, ctx)
 	statusCode := resp.StatusCode()
 	redirectsCount := 0
 	for err == nil && isStatusRedirect(statusCode) {
@@ -282,7 +286,7 @@ func (c *client) ReadData(dst []byte) ([]byte, error) {
 			break
 		}
 		req.URI().UpdateBytes(location)
-		err = doRequestWithPossibleRetry(c.hc, req, resp, deadline)
+		err = doRequestWithPossibleRetry(c.hc, req, resp, ctx)
 		statusCode = resp.StatusCode()
 		redirectsCount++
 	}
@@ -349,13 +353,14 @@ var (
 	scrapeRetries         = metrics.NewCounter(`vm_promscrape_scrape_retries_total`)
 )
 
-func doRequestWithPossibleRetry(hc *fasthttp.HostClient, req *fasthttp.Request, resp *fasthttp.Response, deadline time.Time) error {
+func doRequestWithPossibleRetry(hc *fasthttp.HostClient, req *fasthttp.Request, resp *fasthttp.Response, ctx context.Context) error {
 	sleepTime := time.Second
 	scrapeRequests.Inc()
+	deadline, hasDeadline := ctx.Deadline()
 	for {
 		// Use DoDeadline instead of Do even if hc.ReadTimeout is already set in order to guarantee the given deadline
 		// across multiple retries.
-		err := hc.DoDeadline(req, resp, deadline)
+		err := hc.DoCtx(ctx, req, resp)
 		if err == nil {
 			statusCode := resp.StatusCode()
 			if statusCode != fasthttp.StatusTooManyRequests {
@@ -364,6 +369,11 @@ func doRequestWithPossibleRetry(hc *fasthttp.HostClient, req *fasthttp.Request, 
 		} else if err != fasthttp.ErrConnectionClosed && !strings.Contains(err.Error(), "broken pipe") {
 			return err
 		}
+
+		if !hasDeadline {
+			return err
+		}
+
 		// Retry request after exponentially increased sleep.
 		maxSleepTime := time.Until(deadline)
 		if sleepTime > maxSleepTime {


### PR DESCRIPTION
Implements cancelling in-flight requests for `fasthttp.HostClient`.

Related #3747