### PR TITLE
lib/{fs,mergeset,storage}: skip `.must-remove.` dirs when creating snapshot

### DIFF
--- a/lib/fs/fs.go
+++ b/lib/fs/fs.go
@@ -262,7 +262,7 @@ func MustRemoveTemporaryDirs(dir string) {
 			continue
 		}
 		dirName := fi.Name()
-		if strings.Contains(dirName, ".must-remove.") {
+		if IsScheduledForRemoval(dirName) {
 			fullPath := dir + "/" + dirName
 			MustRemoveAll(fullPath)
 		}
@@ -466,4 +466,8 @@ func isHTTPURL(targetURL string) bool {
 	parsed, err := url.Parse(targetURL)
 	return err == nil && (parsed.Scheme == "http" || parsed.Scheme == "https") && parsed.Host != ""
 
+}
+
+func IsScheduledForRemoval(name string) bool {
+	return strings.Contains(name, ".must-remove.")
 }

--- a/lib/mergeset/table.go
+++ b/lib/mergeset/table.go
@@ -1835,5 +1835,5 @@ func removeParts(pws []*partWrapper, partsToRemove map[*partWrapper]bool) ([]*pa
 func isSpecialDir(name string) bool {
 	// Snapshots and cache dirs aren't used anymore.
 	// Keep them here for backwards compatibility.
-	return name == "tmp" || name == "txn" || name == "snapshots" || name == "cache"
+	return name == "tmp" || name == "txn" || name == "snapshots" || name == "cache" || fs.IsScheduledForRemoval(name)
 }

--- a/lib/storage/partition.go
+++ b/lib/storage/partition.go
@@ -2022,7 +2022,7 @@ func (pt *partition) createSnapshot(srcDir, dstDir string) error {
 			// Skip non-directories.
 			continue
 		}
-		if fn == "tmp" || fn == "txn" {
+		if fn == "tmp" || fn == "txn" || fs.IsScheduledForRemoval(fn) {
 			// Skip special dirs.
 			continue
 		}


### PR DESCRIPTION
Dirs with `.must-remove.` marker are scheduled for deletion and will be removed.
Including those into snapshots could lead to sporadic errors during snapshot as file will be deleted shortly after `os.Readdir` was performed.

See  #3858