### PR TITLE
app/vmctl: enable version flag

### DIFF
--- a/app/vmctl/main.go
+++ b/app/vmctl/main.go
@@ -35,9 +35,6 @@ func main() {
 		Name:    "vmctl",
 		Usage:   "VictoriaMetrics command-line tool",
 		Version: buildinfo.Version,
-		// Disable `-version` flag to avoid conflict with lib/buildinfo flags
-		// see https://github.com/urfave/cli/issues/1560
-		HideVersion: true,
 		Commands: []*cli.Command{
 			{
 				Name:  "opentsdb",


### PR DESCRIPTION
Enabled version flag, because the [issue](https://github.com/urfave/cli/issues/1560) was fixed 

Signed-off-by: dmitryk-dk [d.kozlov@victoriametrics.com](mailto:d.kozlov@victoriametrics.com)