### PR TITLE
app/vmctl: skip series if measurement not found

### DIFF
--- a/app/vmctl/influx/influx.go
+++ b/app/vmctl/influx/influx.go
@@ -162,7 +162,8 @@ func (c *Client) Explore() ([]*Series, error) {
 	for _, s := range series {
 		fields, ok := mFields[s.Measurement]
 		if !ok {
-			return nil, fmt.Errorf("can't find field keys for measurement %q", s.Measurement)
+			log.Printf("can't find field keys for measurement %q", s.Measurement)
+			continue
 		}
 		for _, field := range fields {
 			is := &Series{

--- a/app/vmctl/influx/influx.go
+++ b/app/vmctl/influx/influx.go
@@ -162,7 +162,7 @@ func (c *Client) Explore() ([]*Series, error) {
 	for _, s := range series {
 		fields, ok := mFields[s.Measurement]
 		if !ok {
-			log.Printf("skip field keys for measurement %q", s.Measurement)
+			log.Printf("skip measurement %q since it has no fields", s.Measurement)
 			continue
 		}
 		for _, field := range fields {

--- a/app/vmctl/influx/influx.go
+++ b/app/vmctl/influx/influx.go
@@ -162,7 +162,7 @@ func (c *Client) Explore() ([]*Series, error) {
 	for _, s := range series {
 		fields, ok := mFields[s.Measurement]
 		if !ok {
-			log.Printf("can't find field keys for measurement %q", s.Measurement)
+			log.Printf("skip field keys for measurement %q", s.Measurement)
 			continue
 		}
 		for _, field := range fields {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,8 @@ The following tip changes can be tested by building VictoriaMetrics components f
 
 ## tip
 
+* BUGFIX: [vmctl](https://docs.victoriametrics.com/vmctl.html): skip series with no data when a retention policy autogen can have no data in the measurement and and don't stop migration process. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/3837).
+
 ## [v1.88.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.88.0)
 
 Released at 2023-02-24

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,7 +15,7 @@ The following tip changes can be tested by building VictoriaMetrics components f
 
 ## tip
 
-* BUGFIX: [vmctl](https://docs.victoriametrics.com/vmctl.html): skip series with no data when a retention policy autogen can have no data in the measurement and and don't stop migration process. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/3837).
+* BUGFIX: [vmctl](https://docs.victoriametrics.com/vmctl.html): skip field keys for measurement when a measurement has no data in the retention policy. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/3837).
 
 ## [v1.88.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.88.0)
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,7 +16,7 @@ The following tip changes can be tested by building VictoriaMetrics components f
 ## tip
 
 * BUGFIX: [vmagent](https://docs.victoriametrics.com/vmagent.html): use the provided `-remoteWrite.*` auth options when determining whether the remote storage supports [VictoriaMetrics remote write protocol](https://docs.victoriametrics.com/vmagent.html#victoriametrics-remote-write-protocol). Previously the auth options were ignored. This was preventing from automatic switch to VictoriaMetrics remote write protocol.
-* BUGFIX: [vmctl](https://docs.victoriametrics.com/vmctl.html): skip field keys for measurement when a measurement has no data in the retention policy. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/3837).
+* BUGFIX: [vmctl](https://docs.victoriametrics.com/vmctl.html): skip measurements with no fields when migrating data from influxdb. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/3837).
 
 ## [v1.88.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.88.0)
 


### PR DESCRIPTION
When we try to import data from influx db a retention policy autogen can have no data in the measurement and at this moment vmctl struggles to import the data.
skip field keys for measurement when a measurement has no data in the retention policy

Related issue: https://github.com/VictoriaMetrics/VictoriaMetrics/issues/3837

Signed-off-by: dmitryk-dk [d.kozlov@victoriametrics.com](mailto:d.kozlov@victoriametrics.com)