### PR TITLE
lib/promscrape: correctly register `vm_promscrape_config_*` metrics

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,7 @@ The following tip changes can be tested by building VictoriaMetrics components f
 ## tip
 
 * BUGFIX: [vmagent](https://docs.victoriametrics.com/vmagent.html): use the provided `-remoteWrite.*` auth options when determining whether the remote storage supports [VictoriaMetrics remote write protocol](https://docs.victoriametrics.com/vmagent.html#victoriametrics-remote-write-protocol). Previously the auth options were ignored. This was preventing from automatic switch to VictoriaMetrics remote write protocol.
+* BUGFIX: [vmagent](https://docs.victoriametrics.com/vmagent.html): set `vm_promscrape_config_last_reload_successful` to 1 when there is no scrape config provided via `-promscrape.config` command-line flag. Previously `vm_promscrape_config_last_reload_successful` was set to 0 in this case, which was confusing and could trigger false-positive alert.
 
 ## [v1.88.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.88.0)
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,7 +16,7 @@ The following tip changes can be tested by building VictoriaMetrics components f
 ## tip
 
 * BUGFIX: [vmagent](https://docs.victoriametrics.com/vmagent.html): use the provided `-remoteWrite.*` auth options when determining whether the remote storage supports [VictoriaMetrics remote write protocol](https://docs.victoriametrics.com/vmagent.html#victoriametrics-remote-write-protocol). Previously the auth options were ignored. This was preventing from automatic switch to VictoriaMetrics remote write protocol.
-* BUGFIX: [vmagent](https://docs.victoriametrics.com/vmagent.html): set `vm_promscrape_config_last_reload_successful` to 1 when there is no scrape config provided via `-promscrape.config` command-line flag. Previously `vm_promscrape_config_last_reload_successful` was set to 0 in this case, which was confusing and could trigger false-positive alert.
+* BUGFIX: [vmagent](https://docs.victoriametrics.com/vmagent.html): do not register `vm_promscrape_config_*` metrics if `-promscrape.config` flag is not used. Previously those metrics were registered and never updated, which was confusing and could trigger false-positive alerts.
 
 ## [v1.88.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.88.0)
 

--- a/lib/promscrape/scraper.go
+++ b/lib/promscrape/scraper.go
@@ -99,10 +99,11 @@ func WriteConfigData(w io.Writer) {
 
 func runScraper(configFile string, pushData func(at *auth.Token, wr *prompbmarshal.WriteRequest), globalStopCh <-chan struct{}) {
 	if configFile == "" {
-		// Nothing to scrape, set configSuccess to 1 in order to avoid false-positive alerts about failed config reloads.
-		configSuccess.Set(1)
+		// Nothing to scrape.
 		return
 	}
+
+	metrics.RegisterSet(configMetricsSet)
 
 	// Register SIGHUP handler for config reload before loadConfig.
 	// This guarantees that the config will be re-read if the signal arrives just after loadConfig.
@@ -201,10 +202,11 @@ func runScraper(configFile string, pushData func(at *auth.Token, wr *prompbmarsh
 }
 
 var (
-	configReloads      = metrics.NewCounter(`vm_promscrape_config_reloads_total`)
-	configReloadErrors = metrics.NewCounter(`vm_promscrape_config_reloads_errors_total`)
-	configSuccess      = metrics.NewCounter(`vm_promscrape_config_last_reload_successful`)
-	configTimestamp    = metrics.NewCounter(`vm_promscrape_config_last_reload_success_timestamp_seconds`)
+	configMetricsSet   = metrics.NewSet()
+	configReloads      = configMetricsSet.NewCounter(`vm_promscrape_config_reloads_total`)
+	configReloadErrors = configMetricsSet.NewCounter(`vm_promscrape_config_reloads_errors_total`)
+	configSuccess      = configMetricsSet.NewCounter(`vm_promscrape_config_last_reload_successful`)
+	configTimestamp    = configMetricsSet.NewCounter(`vm_promscrape_config_last_reload_success_timestamp_seconds`)
 )
 
 type scrapeConfigs struct {

--- a/lib/promscrape/scraper.go
+++ b/lib/promscrape/scraper.go
@@ -99,7 +99,8 @@ func WriteConfigData(w io.Writer) {
 
 func runScraper(configFile string, pushData func(at *auth.Token, wr *prompbmarshal.WriteRequest), globalStopCh <-chan struct{}) {
 	if configFile == "" {
-		// Nothing to scrape.
+		// Nothing to scrape, set configSuccess to 1 in order to avoid false-positive alerts about failed config reloads.
+		configSuccess.Set(1)
 		return
 	}
 


### PR DESCRIPTION
Previously, metrics were initialized but never updated which leaded to false-positive alerts and could confuse users.