### PR TITLE
app/vmctl: Increase http request timeout made by remote read client, add importing tips

### DIFF
--- a/app/vmctl/README.md
+++ b/app/vmctl/README.md
@@ -483,6 +483,11 @@ Processing ranges: 8798 / 8798 [████████████████
 2022/10/19 16:45:37 Total time: 1m19.406283424s
 ```
 
+Importing tips:
+
+1. Migrating big volumes of data may result in reaching the timeout by remote read client.
+Please verify that `--remote-read-http-timeout` were set with correct timeout. By default, that value set to 5 minute.
+
 ### Filtering
 
 The filtering consists of two parts: by labels and time.

--- a/app/vmctl/README.md
+++ b/app/vmctl/README.md
@@ -483,10 +483,9 @@ Processing ranges: 8798 / 8798 [████████████████
 2022/10/19 16:45:37 Total time: 1m19.406283424s
 ```
 
-Importing tips:
-
-1. Migrating big volumes of data may result in reaching the timeout by remote read client.
-Please verify that `--remote-read-http-timeout` were set with correct timeout. By default, that value set to 5 minute.
+Migrating big volumes of data may result in remote read client reaching the timeout.
+Consider increasing the value of `--remote-read-http-timeout` (default `5m`) command-line flag when seeing
+timeouts or `context canceled` errors.
 
 ### Filtering
 

--- a/app/vmctl/flags.go
+++ b/app/vmctl/flags.go
@@ -485,7 +485,7 @@ var (
 		},
 		&cli.DurationFlag{
 			Name:  remoteReadHTTPTimeout,
-			Usage: "Timeout defines timeout for HTTP write request to remote storage",
+			Usage: "Timeout defines timeout for HTTP requests made by remote read client",
 		},
 		&cli.StringFlag{
 			Name:  remoteReadHeaders,

--- a/app/vmctl/remoteread/remoteread.go
+++ b/app/vmctl/remoteread/remoteread.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	defaultReadTimeout = 30 * time.Second
+	defaultReadTimeout = 300 * time.Second
 	remoteReadPath     = "/api/v1/read"
 	healthPath         = "/-/healthy"
 )

--- a/app/vmctl/remoteread/remoteread.go
+++ b/app/vmctl/remoteread/remoteread.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	defaultReadTimeout = 300 * time.Second
+	defaultReadTimeout = 5 * time.Minute
 	remoteReadPath     = "/api/v1/read"
 	healthPath         = "/-/healthy"
 )

--- a/docs/vmctl.md
+++ b/docs/vmctl.md
@@ -487,10 +487,9 @@ Processing ranges: 8798 / 8798 [████████████████
 2022/10/19 16:45:37 Total time: 1m19.406283424s
 ```
 
-Importing tips:
-
-1. Migrating big volumes of data may result in reaching the timeout by remote read client.
-Please verify that `--remote-read-http-timeout` were set with correct timeout. By default, that value set to 5 minute.
+Migrating big volumes of data may result in remote read client reaching the timeout.
+Consider increasing the value of `--remote-read-http-timeout` (default `5m`) command-line flag when seeing
+timeouts or `context canceled` errors.
 
 ### Filtering
 

--- a/docs/vmctl.md
+++ b/docs/vmctl.md
@@ -487,6 +487,11 @@ Processing ranges: 8798 / 8798 [████████████████
 2022/10/19 16:45:37 Total time: 1m19.406283424s
 ```
 
+Importing tips:
+
+1. Migrating big volumes of data may result in reaching the timeout by remote read client.
+Please verify that `--remote-read-http-timeout` were set with correct timeout. By default, that value set to 5 minute.
+
 ### Filtering
 
 The filtering consists of two parts: by labels and time.


### PR DESCRIPTION
When a user tries to migrate a huge amount of data via remote read protocol, he can experience context timeout because the server does not respond in time.
To prevent this situation increased the default timeout from the 30s to 5min.
Added importing tips, fixed typo

Signed-off-by: dmitryk-dk [d.kozlov@victoriametrics.com](mailto:d.kozlov@victoriametrics.com)