### PR TITLE
doc: vmctl vm-native-step-interval supported values

### DIFF
--- a/docs/vmctl.md
+++ b/docs/vmctl.md
@@ -801,7 +801,7 @@ It is possible split migration process into set of smaller batches based on time
 migrating large volumes of data as this adds indication of progress and ability to restore process from certain point 
 in case of failure.
 
-To use this you need to specify `--vm-native-step-interval` flag. Supported values are: `month`, `day`, `hour`.
+To use this you need to specify `--vm-native-step-interval` flag. Supported values are: `month`, `day`, `hour`, `minute`.
 Note that in order to use this it is required `--vm-native-filter-time-start` to be set to calculate time ranges for 
 export process.
 


### PR DESCRIPTION
Small fix for vmctl docs to add missing supported value for vm-native-step-interval