### PR TITLE
lib/vmselectapi: fixes regression for disable compression setting

### DIFF
--- a/lib/vmselectapi/server.go
+++ b/lib/vmselectapi/server.go
@@ -114,9 +114,10 @@ func NewServer(addr string, api API, limits Limits, disableResponseCompression b
 		return float64(len(concurrencyLimitCh))
 	})
 	s := &Server{
-		api:    api,
-		limits: limits,
-		ln:     ln,
+		api:                        api,
+		limits:                     limits,
+		disableResponseCompression: disableResponseCompression,
+		ln:                         ln,
 
 		concurrencyLimitCh: concurrencyLimitCh,
 


### PR DESCRIPTION
after vmselect api refactoring it wasn't possible to disable response cache. This patch restores correct behavior for rpc.disableCompression flag