### PR TITLE
app/vmctl: update importing tips when migrating data with overlapping time range

### DIFF
--- a/app/vmctl/README.md
+++ b/app/vmctl/README.md
@@ -790,6 +790,9 @@ to allocated CPU resources of your VictoriaMetrics installation.
 to the corresponding source address.
 9. `vmctl` supports `--vm-native-disable-http-keep-alive` to allow `vmctl` to use non-persistent HTTP connections to avoid
 error `use of closed network connection` when run a longer export.
+10. Migrating data with overlapping time range for destination data can produce duplicates series at destination. 
+To avoid duplicates on the destination set `-dedup.minScrapeInterval=1ms`  for `vmselect` and `vmstorage`. 
+It will instruct `vmselect` and `vmstorage` to ignore duplicates with match exactly by the timestamp (ms is the highest timestamp precision in VictoriaMetrics)     
 
 In this mode `vmctl` acts as a proxy between two VM instances, where time series filtering is done by "source" (`src`)
 and processing is done by "destination" (`dst`). So no extra memory or CPU resources required on `vmctl` side. Only

--- a/app/vmctl/README.md
+++ b/app/vmctl/README.md
@@ -790,9 +790,9 @@ to allocated CPU resources of your VictoriaMetrics installation.
 to the corresponding source address.
 9. `vmctl` supports `--vm-native-disable-http-keep-alive` to allow `vmctl` to use non-persistent HTTP connections to avoid
 error `use of closed network connection` when run a longer export.
-10. Migrating data with overlapping time range for destination data can produce duplicates series at destination. 
-To avoid duplicates on the destination set `-dedup.minScrapeInterval=1ms`  for `vmselect` and `vmstorage`. 
-It will instruct `vmselect` and `vmstorage` to ignore duplicates with match exactly by the timestamp (ms is the highest timestamp precision in VictoriaMetrics)     
+10. Migrating data with overlapping time range for destination data can produce duplicates series at destination.
+To avoid duplicates on the destination set `-dedup.minScrapeInterval=1ms` for `vmselect` and `vmstorage`.
+This will instruct `vmselect` and `vmstorage` to ignore duplicates with match timestamps.     
 
 In this mode `vmctl` acts as a proxy between two VM instances, where time series filtering is done by "source" (`src`)
 and processing is done by "destination" (`dst`). So no extra memory or CPU resources required on `vmctl` side. Only

--- a/docs/vmctl.md
+++ b/docs/vmctl.md
@@ -795,8 +795,8 @@ to the corresponding source address.
 9. `vmctl` supports `--vm-native-disable-http-keep-alive` to allow `vmctl` to use non-persistent HTTP connections to avoid
 error `use of closed network connection` when run a longer export.
 10. Migrating data with overlapping time range for destination data can produce duplicates series at destination.
-To avoid duplicates on the destination set `-dedup.minScrapeInterval=1ms`  for `vmselect` and `vmstorage`.
-It will instruct `vmselect` and `vmstorage` to ignore duplicates with match exactly by the timestamp (ms is the highest timestamp precision in VictoriaMetrics)
+To avoid duplicates on the destination set `-dedup.minScrapeInterval=1ms` for `vmselect` and `vmstorage`.
+This will instruct `vmselect` and `vmstorage` to ignore duplicates with match timestamps.
 
 In this mode `vmctl` acts as a proxy between two VM instances, where time series filtering is done by "source" (`src`)
 and processing is done by "destination" (`dst`). So no extra memory or CPU resources required on `vmctl` side. Only

--- a/docs/vmctl.md
+++ b/docs/vmctl.md
@@ -794,6 +794,9 @@ to allocated CPU resources of your VictoriaMetrics installation.
 to the corresponding source address.
 9. `vmctl` supports `--vm-native-disable-http-keep-alive` to allow `vmctl` to use non-persistent HTTP connections to avoid
 error `use of closed network connection` when run a longer export.
+10. Migrating data with overlapping time range for destination data can produce duplicates series at destination.
+To avoid duplicates on the destination set `-dedup.minScrapeInterval=1ms`  for `vmselect` and `vmstorage`.
+It will instruct `vmselect` and `vmstorage` to ignore duplicates with match exactly by the timestamp (ms is the highest timestamp precision in VictoriaMetrics)
 
 In this mode `vmctl` acts as a proxy between two VM instances, where time series filtering is done by "source" (`src`)
 and processing is done by "destination" (`dst`). So no extra memory or CPU resources required on `vmctl` side. Only


### PR DESCRIPTION
Added recommendation when users try to backfill data with overlapping time ranges for destination storage.

Signed-off-by: dmitryk-dk [d.kozlov@victoriametrics.com](mailto:d.kozlov@victoriametrics.com)