### PR TITLE
lib/storage: correctly handle io.EOF error for pre-fetched metrics

### DIFF
--- a/lib/storage/storage.go
+++ b/lib/storage/storage.go
@@ -1184,7 +1184,7 @@ func (s *Storage) prefetchMetricNames(qt *querytracer.Tracer, srcMetricIDs []uin
 			}
 		}
 	})
-	if err != nil {
+	if err != nil && err != io.EOF {
 		return err
 	}
 	qt.Printf("pre-fetch metric names for %d metric ids", len(metricIDs))


### PR DESCRIPTION
io.EOF shouldn't be returned from this function. It breaks all search API logic and may result in empty query results.