### PR TITLE
lib/storage: log original labels set when label value is truncated

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,8 @@ The following tip changes can be tested by building VictoriaMetrics components f
 
 ## tip
 
+* FEATURE: log metrics with truncated labels if the length of label value in the ingested metric exceeds `-maxLabelValueLen`. This should simplify debugging for this case.
+
 ## [v1.89.1](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.89.1)
 
 Released at 2023-03-12

--- a/lib/storage/metric_name.go
+++ b/lib/storage/metric_name.go
@@ -480,10 +480,7 @@ func MarshalMetricNameRaw(dst []byte, labels []prompb.Label) []byte {
 			label.Name = label.Name[:maxLabelNameLen]
 		}
 		if len(label.Value) > maxLabelValueLen {
-			atomic.AddUint64(&TooLongLabelValues, 1)
-			logger.Warnf("truncated label value as it exceeds configured maximal label value length: max %d, actual %d;"+
-				" truncated label: %s; original labels: %s; either reduce the label value length or increase -maxLabelValueLen=%d;",
-				maxLabelValueLen, len(label.Value), label.Name, labelsToString(labels), maxLabelValueLen)
+			trackTruncatedLabels(labels, label)
 			label.Value = label.Value[:maxLabelValueLen]
 		}
 		if len(label.Value) == 0 {
@@ -531,7 +528,7 @@ func trackDroppedLabels(labels, droppedLabels []prompb.Label) {
 	select {
 	case <-droppedLabelsLogTicker.C:
 		// Do not call logger.WithThrottler() here, since this will result in increased CPU usage
-		// because labelsToString() will be called with each trackDroppedLAbels call.
+		// because labelsToString() will be called with each trackDroppedLabels call.
 		logger.Warnf("dropping %d labels for %s; dropped labels: %s; either reduce the number of labels for this metric "+
 			"or increase -maxLabelsPerTimeseries=%d command-line flag value",
 			len(droppedLabels), labelsToString(labels), labelsToString(droppedLabels), maxLabelsPerTimeseries)
@@ -539,7 +536,21 @@ func trackDroppedLabels(labels, droppedLabels []prompb.Label) {
 	}
 }
 
+func trackTruncatedLabels(labels []prompb.Label, truncated *prompb.Label) {
+	atomic.AddUint64(&TooLongLabelValues, 1)
+	select {
+	case <-truncatedLabelsLogTicker.C:
+		// Do not call logger.WithThrottler() here, since this will result in increased CPU usage
+		// because labelsToString() will be called with each trackTruncatedLabels call.
+		logger.Warnf("truncated label value as it exceeds configured maximal label value length: max %d, actual %d;"+
+			" truncated label: %s; original labels: %s; either reduce the label value length or increase -maxLabelValueLen=%d;",
+			maxLabelValueLen, len(truncated.Value), truncated.Name, labelsToString(labels), maxLabelValueLen)
+	default:
+	}
+}
+
 var droppedLabelsLogTicker = time.NewTicker(5 * time.Second)
+var truncatedLabelsLogTicker = time.NewTicker(5 * time.Second)
 
 func labelsToString(labels []prompb.Label) string {
 	labelsCopy := append([]prompb.Label{}, labels...)

--- a/lib/storage/metric_name.go
+++ b/lib/storage/metric_name.go
@@ -481,6 +481,9 @@ func MarshalMetricNameRaw(dst []byte, labels []prompb.Label) []byte {
 		}
 		if len(label.Value) > maxLabelValueLen {
 			atomic.AddUint64(&TooLongLabelValues, 1)
+			logger.Warnf("truncated label value as it exceeds configured maximal label value length: max %d, actual %d;"+
+				" truncated label: %s; original labels: %s; either reduce the label value length or increase -maxLabelValueLen=%d;",
+				maxLabelValueLen, len(label.Value), label.Name, labelsToString(labels), maxLabelValueLen)
 			label.Value = label.Value[:maxLabelValueLen]
 		}
 		if len(label.Value) == 0 {


### PR DESCRIPTION
Currently, too long value can be discovered by using `vm_too_long_label_values_total` metric, but it does not provide a way to find exact metric and label which was truncated.  This makes it hard to debug and properly fix source of too long label values.

Log message example:
```
2023-03-13T17:20:44.416Z        warn    VictoriaMetrics/lib/storage/metric_name.go:484     truncated label value as it exceeds configured maximal label value length: max 3, actual 22;truncated label: __name__; original labels: {__name__="scrape_timeout_seconds",instance="localhost:8429",job="sel"}; either reduce the label value length or increase -maxLabelValueLen=3;
```