### PR TITLE
lib/storage: fix reuse pendingMetricRow

### DIFF
--- a/lib/storage/storage.go
+++ b/lib/storage/storage.go
@@ -1959,7 +1959,8 @@ type pendingMetricRows struct {
 }
 
 func (pmrs *pendingMetricRows) reset() {
-	for _, pmr := range pmrs.pmrs {
+	for i := range pmrs.pmrs {
+		pmr := &pmrs.pmrs[i]
 		pmr.MetricName = nil
 		pmr.mr = nil
 	}
@@ -1983,10 +1984,14 @@ func (pmrs *pendingMetricRows) addRow(mr *MetricRow) error {
 		pmrs.lastMetricName = pmrs.metricNamesBuf[metricNamesBufLen:]
 		pmrs.lastMetricNameRaw = mr.MetricNameRaw
 	}
-	pmrs.pmrs = append(pmrs.pmrs, pendingMetricRow{
-		MetricName: pmrs.lastMetricName,
-		mr:         mr,
-	})
+	if cap(pmrs.pmrs) > len(pmrs.pmrs) {
+		pmrs.pmrs = pmrs.pmrs[:len(pmrs.pmrs)+1]
+	} else {
+		pmrs.pmrs = append(pmrs.pmrs, pendingMetricRow{})
+	}
+	pmr := &pmrs.pmrs[len(pmrs.pmrs)-1]
+	pmr.MetricName = pmrs.lastMetricName
+	pmr.mr = mr
 	return nil
 }
 


### PR DESCRIPTION
<img width="690" alt="image" src="https://user-images.githubusercontent.com/3659110/229309783-f911165b-a1ac-4734-9679-877a82977942.png">

I have enabled the [unusedwrite](https://github.com/golang/tools/blob/master/gopls/doc/analyzers.md#unusedwrite) check of golsp and it has alerted me that a `pmr` object was copied but the original `pmr` was not properly reset. However, since a new `pendingMetricRow` object was created directly when calling `pmrs` `append` below, it did not have any actual impact.

Based on this code logic, I suspect that the intention was to reuse the `pendingMetricRow` object, so I have made modifications to the code and submitted a pull request. Please inform me if my understanding is incorrect.