### PR TITLE
app/vmalert: add series fetched for alerting rule

### DIFF
--- a/app/vmalert/datasource/datasource.go
+++ b/app/vmalert/datasource/datasource.go
@@ -13,7 +13,7 @@ type Querier interface {
 	// It returns list of Metric in response, the http.Request used for sending query
 	// and error if any. Returned http.Request can't be reused and its body is already read.
 	// Query should stop once ctx is cancelled.
-	Query(ctx context.Context, query string, ts time.Time) ([]Metric, *http.Request, error)
+	Query(ctx context.Context, query string, ts time.Time) (int, []Metric, *http.Request, error)
 	// QueryRange executes range request with the given query on the given time range.
 	// It returns list of Metric in response and error if any.
 	// QueryRange should stop once ctx is cancelled.

--- a/app/vmalert/datasource/datasource.go
+++ b/app/vmalert/datasource/datasource.go
@@ -13,7 +13,7 @@ type Querier interface {
 	// It returns list of Metric in response, the http.Request used for sending query
 	// and error if any. Returned http.Request can't be reused and its body is already read.
 	// Query should stop once ctx is cancelled.
-	Query(ctx context.Context, query string, ts time.Time) (int, []Metric, *http.Request, error)
+	Query(ctx context.Context, query string, ts time.Time) (int64, []Metric, *http.Request, error)
 	// QueryRange executes range request with the given query on the given time range.
 	// It returns list of Metric in response and error if any.
 	// QueryRange should stop once ctx is cancelled.

--- a/app/vmalert/datasource/vm.go
+++ b/app/vmalert/datasource/vm.go
@@ -98,7 +98,7 @@ func NewVMStorage(baseURL string, authCfg *promauth.Config, lookBack time.Durati
 }
 
 // Query executes the given query and returns parsed response
-func (s *VMStorage) Query(ctx context.Context, query string, ts time.Time) (int, []Metric, *http.Request, error) {
+func (s *VMStorage) Query(ctx context.Context, query string, ts time.Time) (int64, []Metric, *http.Request, error) {
 	req, err := s.newRequestPOST()
 	if err != nil {
 		return 0, nil, nil, err

--- a/app/vmalert/datasource/vm_graphite_api.go
+++ b/app/vmalert/datasource/vm_graphite_api.go
@@ -35,7 +35,7 @@ func (r graphiteResponse) metrics() []Metric {
 	return ms
 }
 
-func parseGraphiteResponse(req *http.Request, resp *http.Response) (int, []Metric, error) {
+func parseGraphiteResponse(req *http.Request, resp *http.Response) (int64, []Metric, error) {
 	r := &graphiteResponse{}
 	if err := json.NewDecoder(resp.Body).Decode(r); err != nil {
 		return 0, nil, fmt.Errorf("error parsing graphite metrics for %s: %w", req.URL.Redacted(), err)

--- a/app/vmalert/datasource/vm_graphite_api.go
+++ b/app/vmalert/datasource/vm_graphite_api.go
@@ -35,12 +35,12 @@ func (r graphiteResponse) metrics() []Metric {
 	return ms
 }
 
-func parseGraphiteResponse(req *http.Request, resp *http.Response) ([]Metric, error) {
+func parseGraphiteResponse(req *http.Request, resp *http.Response) (int, []Metric, error) {
 	r := &graphiteResponse{}
 	if err := json.NewDecoder(resp.Body).Decode(r); err != nil {
-		return nil, fmt.Errorf("error parsing graphite metrics for %s: %w", req.URL.Redacted(), err)
+		return 0, nil, fmt.Errorf("error parsing graphite metrics for %s: %w", req.URL.Redacted(), err)
 	}
-	return r.metrics(), nil
+	return 0, r.metrics(), nil
 }
 
 const (

--- a/app/vmalert/datasource/vm_prom_api.go
+++ b/app/vmalert/datasource/vm_prom_api.go
@@ -13,23 +13,29 @@ var disablePathAppend = flag.Bool("remoteRead.disablePathAppend", false, "Whethe
 	"to the configured -datasource.url and -remoteRead.url")
 
 type promResponse struct {
-	Status    string `json:"status"`
-	ErrorType string `json:"errorType"`
-	Error     string `json:"error"`
-	Data      struct {
-		ResultType string          `json:"resultType"`
-		Result     json.RawMessage `json:"result"`
-	} `json:"data"`
-	Stats struct {
-		SeriesFetched int64 `json:"seriesFetched,omitempty"`
-	} `json:"stats,omitempty"`
+	Status    string            `json:"status"`
+	ErrorType string            `json:"errorType"`
+	Error     string            `json:"error"`
+	Data      promResponseData  `json:"data"`
+	Stats     promResponseStats `json:"stats,omitempty"`
+}
+
+type promResponseData struct {
+	ResultType string          `json:"resultType"`
+	Result     json.RawMessage `json:"result"`
+}
+
+type promResponseStats struct {
+	SeriesFetched int64 `json:"seriesFetched,omitempty"`
 }
 
 type promInstant struct {
-	Result []struct {
-		Labels map[string]string `json:"metric"`
-		TV     [2]interface{}    `json:"value"`
-	} `json:"result"`
+	Result []promInstantResult `json:"result"`
+}
+
+type promInstantResult struct {
+	Labels map[string]string `json:"metric"`
+	TV     [2]interface{}    `json:"value"`
 }
 
 func (r promInstant) metrics() ([]Metric, error) {

--- a/app/vmalert/datasource/vm_test.go
+++ b/app/vmalert/datasource/vm_test.go
@@ -155,7 +155,7 @@ func TestVMInstantQuery(t *testing.T) {
 		t.Fatalf("unexpected %s", err)
 	}
 	expectedSeriesFetched := 2
-	if seriesFetched != expectedSeriesFetched {
+	if seriesFetched != int64(expectedSeriesFetched) {
 		t.Fatalf("unexpected series fetched %d want %d", seriesFetched, expectedSeriesFetched)
 	}
 

--- a/app/vmalert/datasource/vm_test.go
+++ b/app/vmalert/datasource/vm_test.go
@@ -150,7 +150,7 @@ func TestVMInstantQuery(t *testing.T) {
 		t.Fatalf("unexpected metric %+v want %+v", m, expected)
 	}
 
-	seriesFetched, _, _, err := pq.Query(ctx, query, ts) // 8 - scalar with series fetched
+	seriesFetched, _, _, err := pq.Query(ctx, query, ts) // 8 - result with seriesFetched filed
 	if err != nil {
 		t.Fatalf("unexpected %s", err)
 	}

--- a/app/vmalert/datasource/vm_test.go
+++ b/app/vmalert/datasource/vm_test.go
@@ -79,7 +79,7 @@ func TestVMInstantQuery(t *testing.T) {
 		case 7:
 			w.Write([]byte(`{"status":"success","data":{"resultType":"scalar","result":[1583786142, "1"]}}`))
 		case 8:
-			w.Write([]byte(`{"status":"success","data":{"resultType":"scalar","result":[1583786142, "1"]},"stats":{"seriesFetched":2}}`))
+			w.Write([]byte(`{"status":"success","data":{"resultType":"scalar","result":[1583786142, "1"]},"stats":{"seriesFetched":1}}`))
 		}
 	})
 
@@ -154,7 +154,7 @@ func TestVMInstantQuery(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected %s", err)
 	}
-	expectedSeriesFetched := 2
+	expectedSeriesFetched := 1
 	if seriesFetched != int64(expectedSeriesFetched) {
 		t.Fatalf("unexpected series fetched %d want %d", seriesFetched, expectedSeriesFetched)
 	}

--- a/app/vmalert/helpers_test.go
+++ b/app/vmalert/helpers_test.go
@@ -49,7 +49,7 @@ func (fq *fakeQuerier) QueryRange(ctx context.Context, q string, _, _ time.Time)
 	return req, err
 }
 
-func (fq *fakeQuerier) Query(_ context.Context, _ string, _ time.Time) (int, []datasource.Metric, *http.Request, error) {
+func (fq *fakeQuerier) Query(_ context.Context, _ string, _ time.Time) (int64, []datasource.Metric, *http.Request, error) {
 	fq.Lock()
 	defer fq.Unlock()
 	if fq.err != nil {
@@ -90,7 +90,7 @@ func (fqr *fakeQuerierWithRegistry) QueryRange(ctx context.Context, q string, _,
 	return req, err
 }
 
-func (fqr *fakeQuerierWithRegistry) Query(_ context.Context, expr string, _ time.Time) (int, []datasource.Metric, *http.Request, error) {
+func (fqr *fakeQuerierWithRegistry) Query(_ context.Context, expr string, _ time.Time) (int64, []datasource.Metric, *http.Request, error) {
 	fqr.Lock()
 	defer fqr.Unlock()
 
@@ -109,7 +109,7 @@ type fakeQuerierWithDelay struct {
 	delay time.Duration
 }
 
-func (fqd *fakeQuerierWithDelay) Query(ctx context.Context, expr string, ts time.Time) (int, []datasource.Metric, *http.Request, error) {
+func (fqd *fakeQuerierWithDelay) Query(ctx context.Context, expr string, ts time.Time) (int64, []datasource.Metric, *http.Request, error) {
 	timer := time.NewTimer(fqd.delay)
 	select {
 	case <-ctx.Done():

--- a/app/vmalert/recording.go
+++ b/app/vmalert/recording.go
@@ -120,7 +120,7 @@ func (rr *RecordingRule) ExecRange(ctx context.Context, start, end time.Time) ([
 // Exec executes RecordingRule expression via the given Querier.
 func (rr *RecordingRule) Exec(ctx context.Context, ts time.Time, limit int) ([]prompbmarshal.TimeSeries, error) {
 	start := time.Now()
-	qMetrics, req, err := rr.q.Query(ctx, rr.Expr, ts)
+	_, qMetrics, req, err := rr.q.Query(ctx, rr.Expr, ts)
 	curState := ruleStateEntry{
 		time:     start,
 		at:       ts,

--- a/app/vmalert/rule.go
+++ b/app/vmalert/rule.go
@@ -55,9 +55,9 @@ type ruleStateEntry struct {
 	samples int
 	// stores the curl command reflecting the HTTP request used during rule.Exec
 	curl string
-	// store how much series fetched from storage during the query evaluation.
+	// stores how much series fetched from storage during the query evaluation.
 	// 0 means do not match any series.
-	seriesFetched int
+	seriesFetched int64
 }
 
 func newRuleState(size int) *ruleState {

--- a/app/vmalert/rule.go
+++ b/app/vmalert/rule.go
@@ -55,8 +55,8 @@ type ruleStateEntry struct {
 	samples int
 	// stores the curl command reflecting the HTTP request used during rule.Exec
 	curl string
-	// stores how much series fetched from storage during the query evaluation.
-	// 0 means do not match any series.
+	// stores the number of series fetched during the last evaluation
+	// 0 means no matching series or field is missing with Prometheus or older versions of VM.
 	seriesFetched int64
 }
 

--- a/app/vmalert/rule.go
+++ b/app/vmalert/rule.go
@@ -55,6 +55,9 @@ type ruleStateEntry struct {
 	samples int
 	// stores the curl command reflecting the HTTP request used during rule.Exec
 	curl string
+	// store how much series fetched from storage during the query evaluation.
+	// 0 means do not match any series.
+	seriesFetched int
 }
 
 func newRuleState(size int) *ruleState {


### PR DESCRIPTION
part of https://github.com/VictoriaMetrics/VictoriaMetrics/issues/4039

get seriesFetched data when query alerting rule if datasource support and expose `vmalert_alerting_rules_last_evaluation_series_fetched`
![image](https://user-images.githubusercontent.com/39937150/229531923-bb564af0-2de7-4198-ade6-803ad8b9dacc.png)
![image](https://user-images.githubusercontent.com/39937150/229532049-1b718fd9-3bcb-4ac3-807e-d5ef938cfd87.png)
