### PR TITLE
Decrease severity to info for RecordingRulesNoData

### DIFF
--- a/deployment/docker/alerts-vmalert.yml
+++ b/deployment/docker/alerts-vmalert.yml
@@ -43,7 +43,7 @@ groups:
         expr: sum(vmalert_recording_rules_last_evaluation_samples) by(job, group, recording) < 1
         for: 30m
         labels:
-          severity: warning
+          severity: info
         annotations:
           dashboard: "http://localhost:3000/d/LzldHAVnz?viewPanel=33&var-group={{ $labels.group }}"
           summary: "Recording rule {{ $labels.recording }} ({ $labels.group }}) produces no data"


### PR DESCRIPTION
RecordingRulesNoData could be firing for some very normal reasons - like no metrics source are being scraped at this time but rules are preloaded.

Therefore, it better to mark such alert as 'info', as suggest by some guides, as there could be likely no point to notify regarding this alert.

https://monitoring.mixins.dev/

```
info for alerts that do not require any action by itself but mark something as “out of the ordinary”. Those alerts aren’t usually routed anywhere, but can be inspected during troubleshooting.
```