### PR TITLE
vmui: fix freeze when query regular with heatmap query

### DIFF
--- a/app/vmui/packages/vmui/src/pages/CustomPanel/index.tsx
+++ b/app/vmui/packages/vmui/src/pages/CustomPanel/index.tsx
@@ -44,7 +44,14 @@ const CustomPanel: FC = () => {
 
   const { queryOptions } = useFetchQueryOptions();
   const {
-    isLoading, liveData, graphData, error, queryErrors, warning, traces, isHistogram
+    isLoading,
+    liveData,
+    graphData,
+    error,
+    queryErrors,
+    warning,
+    traces,
+    isHistogram
   } = useFetchQuery({
     visible: true,
     customStep,
@@ -97,7 +104,7 @@ const CustomPanel: FC = () => {
 
   useEffect(() => {
     graphDispatch({ type: "SET_IS_HISTOGRAM", payload: isHistogram });
-  }, [isHistogram]);
+  }, [graphData]);
 
   return (
     <div

--- a/app/vmui/packages/vmui/src/utils/uplot/heatmap.ts
+++ b/app/vmui/packages/vmui/src/utils/uplot/heatmap.ts
@@ -137,7 +137,7 @@ export const convertPrometheusToVictoriaMetrics = (buckets: MetricResult[]): Met
 };
 
 const getUpperBound = (bucket: MetricResult) => {
-  const values = (bucket.metric.vmrange || bucket.metric.le).split("...");
+  const values = (bucket.metric.vmrange || bucket.metric.le || "").split("...");
   return promValueToNumber(values[values.length - 1]);
 };
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,8 @@ The following tip changes can be tested by building VictoriaMetrics components f
 
 ## tip
 
+* BUGFIX: [vmui](https://docs.victoriametrics.com/#vmui): fix issue where vmui would freeze when adding a query that returned regular rows alongside a heatmap query.
+
 ## [v1.90.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.90.0)
 
 Released at 2023-04-06


### PR DESCRIPTION
Fix issue where vmui would freeze when adding a query that returned regular rows alongside a heatmap query.