### PR TITLE
Fix/snap build

### DIFF
--- a/deployment/docker/.#docker-compose-cluster.yml
+++ b/deployment/docker/.#docker-compose-cluster.yml
@@ -1,0 +1,1 @@
+dengolius@ryzen.36379

--- a/snap/local/Makefile
+++ b/snap/local/Makefile
@@ -18,7 +18,7 @@ build-snap: snap-builder-image
 		-w /builder \
 		--env PKG_TAG=$(SNAP_TAG) \
 		$(SNAP_BUILDER_IMAGE) \
-		bash -c 'snapcraft clean && snapcraft snap -o bin/'
+		bash -c 'snapcraft clean && snapcraft snap -o "bin/victoriametrics_$(SNAP_TAG)_multi.snap"'
 
 release-snap: snap-builder-image build-snap
 	docker run --rm \

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -51,7 +51,7 @@ confinement: strict # use 'strict' once you have the right plugs and slots
 parts:
   build:
     plugin: go
-    go-channel: 1.17/stable
+    go-channel: 1.20/stable
     go-importpath: github.com/VictoriaMetrics/VictoriaMetrics
     source: .
     source-type: local


### PR DESCRIPTION
PR contains:
- fix for snap build when snap produce only file `bin` instead of `victoriametrics_$(SNAP_TAG)_multi.snap` 
- update for go version to latest latest 1.20/stable
