### PR TITLE
Do not return username password in API response

### DIFF
--- a/app/vmauth/main.go
+++ b/app/vmauth/main.go
@@ -105,7 +105,7 @@ func requestHandler(w http.ResponseWriter, r *http.Request) bool {
 	ui := ac[authToken]
 	if ui == nil {
 		invalidAuthTokenRequests.Inc()
-		err := fmt.Errorf("cannot find the provided auth token %q in config", authToken)
+		err := fmt.Errorf("Incorrect username or password")
 		if *logInvalidAuthTokens {
 			err = &httpserver.ErrorWithStatusCode{
 				Err:        err,


### PR DESCRIPTION
When using API, if wrong username or password is provided as Basic Auth, the whole base64 auth token is returned in API response. This is not a good practice as the response might get logged by different systems sitting in between and result in credential leakage.

POC:
`curl -i -H "Authorization: Basic dm1hbGVydDpzamR5NzZ3ZHl1Z2Q3czdkeXM4Cg==" "https://<vmserver>/vm/select/0/prometheus/api/v1/query?query=suydhd"`
![image](https://user-images.githubusercontent.com/53171147/234010711-8a5caf17-b875-4f2e-965d-17cd9ccfef24.png)

Notes:
The credentials used in this POC are dummy credentials.