### PR TITLE
lib/storage: fix retention duration compute

### DIFF
--- a/lib/storage/storage.go
+++ b/lib/storage/storage.go
@@ -1093,14 +1093,14 @@ func nextRetentionDuration(retentionMsecs int64) time.Duration {
 	// Round retentionMsecs to days. This guarantees that per-day inverted index works as expected.
 	retentionMsecs = ((retentionMsecs + msecPerDay - 1) / msecPerDay) * msecPerDay
 	t := time.Now().UnixNano() / 1e6
-	deadline := ((t + retentionMsecs - 1) / retentionMsecs) * retentionMsecs
 	// Schedule the deadline to +4 hours from the next retention period start.
 	// This should prevent from possible double deletion of indexdb
 	// due to time drift - see https://github.com/VictoriaMetrics/VictoriaMetrics/issues/248 .
-	deadline += 4 * 3600 * 1000
 	// The effect of time zone on retention period is moved out.
 	// See https://github.com/VictoriaMetrics/VictoriaMetrics/pull/2574
-	deadline -= retentionTimezoneOffsetMsecs
+	retentionOffsetMscs := retentionTimezoneOffsetMsecs - int64(4*3600*1000)
+	deadline := ((t + retentionMsecs + retentionOffsetMscs - 1) / retentionMsecs) * retentionMsecs
+	deadline -= retentionOffsetMscs
 	return time.Duration(deadline-t) * time.Millisecond
 }
 


### PR DESCRIPTION
At the timestamp equal to 1682547055431, assuming the retentionTimezoneOffset is 8h, which is 28800000, and retentionMsecs is equal to 14d, which is 1209600000, at this time, the final calculated deadline is 1682539200000, which is less than the current time.

This problem may result in some infinite loops.