### PR TITLE
vminsert: fix unlimited reader when parsing opentsdb request

### DIFF
--- a/lib/protoparser/opentsdbhttp/stream/streamparser.go
+++ b/lib/protoparser/opentsdbhttp/stream/streamparser.go
@@ -33,7 +33,7 @@ var (
 func Parse(req *http.Request, callback func(rows []opentsdbhttp.Row) error) error {
 	wcr := writeconcurrencylimiter.GetReader(req.Body)
 	defer writeconcurrencylimiter.PutReader(wcr)
-	r := io.Reader(req.Body)
+	r := io.Reader(wcr)
 
 	readCalls.Inc()
 	if req.Header.Get("Content-Encoding") == "gzip" {


### PR DESCRIPTION
fix https://github.com/VictoriaMetrics/VictoriaMetrics/issues/4204