### PR TITLE
vmselect: exit early from queue on context cancel

### DIFF
--- a/app/vmselect/main.go
+++ b/app/vmselect/main.go
@@ -116,10 +116,11 @@ func RequestHandler(w http.ResponseWriter, r *http.Request) bool {
 			qt.Printf("wait in queue because -search.maxConcurrentRequests=%d concurrent requests are executed", *maxConcurrentRequests)
 			defer func() { <-concurrencyLimitCh }()
 		case <-r.Context().Done():
+			timerpool.Put(t)
 			remoteAddr := httpserver.GetQuotedRemoteAddr(r)
 			requestURI := httpserver.GetRequestURI(r)
-			logger.Infof("client has cancelled the request: remoteAddr=%s, requestURI: %q",
-				remoteAddr, requestURI)
+			logger.Infof("client has cancelled the request after %.3f seconds: remoteAddr=%s, requestURI: %q",
+				d.Seconds(), remoteAddr, requestURI)
 			return true
 		case <-t.C:
 			timerpool.Put(t)

--- a/app/vmselect/main.go
+++ b/app/vmselect/main.go
@@ -115,6 +115,12 @@ func RequestHandler(w http.ResponseWriter, r *http.Request) bool {
 			timerpool.Put(t)
 			qt.Printf("wait in queue because -search.maxConcurrentRequests=%d concurrent requests are executed", *maxConcurrentRequests)
 			defer func() { <-concurrencyLimitCh }()
+		case <-r.Context().Done():
+			remoteAddr := httpserver.GetQuotedRemoteAddr(r)
+			requestURI := httpserver.GetRequestURI(r)
+			logger.Infof("client has cancelled the request: remoteAddr=%s, requestURI: %q",
+				remoteAddr, requestURI)
+			return true
 		case <-t.C:
 			timerpool.Put(t)
 			concurrencyLimitTimeout.Inc()


### PR DESCRIPTION
When `-search.maxConcurrentRequests` is reached, vmselect puts request in the queue. It is expected, that requests in the queue will be processed as soon as it would be enough capacity to do so.

However, it could happen that while request was waiting its turn, the client could have already cancel it (close the connection, or just close the tab with UI). In this case, we should de-queue such requests to avoid spending extra resources on them.