### PR TITLE
Add endpoint labels for pod targets

### DIFF
--- a/lib/promscrape/discovery/kubernetes/endpointslice.go
+++ b/lib/promscrape/discovery/kubernetes/endpointslice.go
@@ -84,6 +84,11 @@ func (eps *EndpointSlice) getTargetLabels(gw *groupWatcher) []*promutils.Labels 
 				m.Add("__address__", addr)
 				p.appendCommonLabels(m, gw)
 				p.appendContainerLabels(m, c, &cp)
+
+				// Prometheus sets endpoints_name and namespace labels for all endpoints
+				// Even if port is not matching service port.
+				// See https://github.com/VictoriaMetrics/VictoriaMetrics/issues/4154
+				p.appendEndpointSliceLabels(m, eps)
 				if svc != nil {
 					svc.appendCommonLabels(m)
 				}

--- a/lib/promscrape/discovery/kubernetes/pod.go
+++ b/lib/promscrape/discovery/kubernetes/pod.go
@@ -178,6 +178,16 @@ func (p *Pod) appendContainerLabels(m *promutils.Labels, c Container, cp *Contai
 	}
 }
 
+func (p *Pod) appendEndpointLabels(m *promutils.Labels, eps *Endpoints) {
+	m.Add("__meta_kubernetes_endpoints_name", eps.Metadata.Name)
+	eps.Metadata.registerLabelsAndAnnotations("__meta_kubernetes_endpoints", m)
+}
+
+func (p *Pod) appendEndpointSliceLabels(m *promutils.Labels, eps *EndpointSlice) {
+	m.Add("__meta_kubernetes_endpointslice_name", eps.Metadata.Name)
+	eps.Metadata.registerLabelsAndAnnotations("__meta_kubernetes_endpointslice", m)
+}
+
 func (p *Pod) appendCommonLabels(m *promutils.Labels, gw *groupWatcher) {
 	if gw.attachNodeMetadata {
 		m.Add("__meta_kubernetes_node_name", p.Spec.NodeName)


### PR DESCRIPTION
Add `__meta_kubernetes_endpoints_name`, `__meta_kubernetes_endpoints_label_<labelname>` and `__meta_kubernetes_endpoints_labelpresent_<labelname>`  labels for all targets discovered from ports not assigned to endpoint. Previously, ports not matched by `Service` did not have this label. See [[this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/4154)]