### PR TITLE
Vmalert/add log for failed alert creation

### DIFF
--- a/app/vmalert/alerting.go
+++ b/app/vmalert/alerting.go
@@ -245,6 +245,7 @@ func (ar *AlertingRule) ExecRange(ctx context.Context, start, end time.Time) ([]
 	for _, s := range series {
 		a, err := ar.newAlert(s, nil, time.Time{}, qFn) // initial alert
 		if err != nil {
+		    logger.Errorf("failed to create alert: %s", err)
 			return nil, fmt.Errorf("failed to create alert: %s", err)
 		}
 		if ar.For == 0 { // if alert is instant
@@ -352,6 +353,7 @@ func (ar *AlertingRule) Exec(ctx context.Context, ts time.Time, limit int) ([]pr
 		}
 		a, err := ar.newAlert(m, ls, start, qFn)
 		if err != nil {
+		    logger.Errorf("failed to create alert: %w", err)
 			curState.err = fmt.Errorf("failed to create alert: %w", err)
 			return nil, curState.err
 		}

--- a/app/vmalert/alerting.go
+++ b/app/vmalert/alerting.go
@@ -245,7 +245,7 @@ func (ar *AlertingRule) ExecRange(ctx context.Context, start, end time.Time) ([]
 	for _, s := range series {
 		a, err := ar.newAlert(s, nil, time.Time{}, qFn) // initial alert
 		if err != nil {
-		    logger.Errorf("failed to create alert: %s", err)
+			logger.Errorf("failed to create alert: %s", err)
 			return nil, fmt.Errorf("failed to create alert: %s", err)
 		}
 		if ar.For == 0 { // if alert is instant
@@ -353,7 +353,7 @@ func (ar *AlertingRule) Exec(ctx context.Context, ts time.Time, limit int) ([]pr
 		}
 		a, err := ar.newAlert(m, ls, start, qFn)
 		if err != nil {
-		    logger.Errorf("failed to create alert: %w", err)
+			logger.Errorf("failed to create alert: %w", err)
 			curState.err = fmt.Errorf("failed to create alert: %w", err)
 			return nil, curState.err
 		}


### PR DESCRIPTION
## Problem

I'm trying to use the metric `vmalert_alerting_rules_error` to follow and act when we get some error in evaluation step.
However, I can only find the error in `lastError` field, when accessing `/api/v1/rules` of a VictoriaMetrics/alert instance which isn't a good approach (we are using kubernetes, so I need to find the POD, apply a `port-forward` download the result of this API and then try to find what is the error).

## Solution

Log the error, which turn easy to find what is the error and when it's happened