### PR TITLE
deployment/docker: allow overriding docker namespace

### DIFF
--- a/deployment/docker/Makefile
+++ b/deployment/docker/Makefile
@@ -1,6 +1,6 @@
 # All these commands must run from repository root.
 
-DOCKER_NAMESPACE := victoriametrics
+DOCKER_NAMESPACE ?= victoriametrics
 
 ROOT_IMAGE ?= alpine:3.17.3
 CERTS_IMAGE := alpine:3.17.3


### PR DESCRIPTION
It makes it easier for users who build and self-host images to publish their images without changing tags manually.