### PR TITLE
vmalert: correctly update seriesFetched metric for const exprs

### DIFF
--- a/app/vmalert/alerting.go
+++ b/app/vmalert/alerting.go
@@ -129,7 +129,13 @@ func newAlertingRule(qb datasource.QuerierBuilder, group *Group, cfg config.Rule
 				// means seriesFetched is unsupported
 				return -1
 			}
-			return float64(*e.seriesFetched)
+			seriesFetched := float64(*e.seriesFetched)
+			if seriesFetched == 0 && e.samples > 0 {
+				// `alert: 0.95` will fetch no series
+				// but will get one time series in response.
+				seriesFetched = float64(e.samples)
+			}
+			return seriesFetched
 		})
 	return ar
 }


### PR DESCRIPTION
Previously, metric `vmalert_alerting_rules_last_evaluation_series_fetched` would be set to 0 for const expressions, because const expression do not match any series. This may result into a confusion: no series were matched but response isn't empty. The change updates the logic behind metric: if no series were matched but there are samples in response - use amount of samples as number of series.