### PR TITLE
dashboard: add include all for instance variable

### DIFF
--- a/dashboards/victoriametrics.json
+++ b/dashboards/victoriametrics.json
@@ -5256,7 +5256,7 @@
         },
         "definition": "label_values(vm_app_version{job=~\"$job\"}, instance)",
         "hide": 0,
-        "includeAll": false,
+        "includeAll": true,
         "multi": false,
         "name": "instance",
         "options": [],


### PR DESCRIPTION
Allow include all for the instance variable for vmsingle dashboard.
This is useful if we want to use the adhoc function of the dashboard to filter across all instance for a specific label, such as `cluster`.
When we have many cluster, knowing all instance ip address space is hard so filtering with a label such as the cluster name is easier.