### PR TITLE
lib/mergeset: fix TestTableCreateSnapshotAt test when not all parts flushes to disk

### DIFF
--- a/lib/mergeset/table.go
+++ b/lib/mergeset/table.go
@@ -599,7 +599,7 @@ func (tb *Table) mergePartsOptimal(pws []*partWrapper) error {
 // This function is only for debugging and testing.
 func (tb *Table) DebugFlush() {
 	tb.flushPendingItems(nil, true)
-
+	tb.flushInmemoryItems()
 	// Wait for background flushers to finish.
 	tb.rawItemsPendingFlushesWG.Wait()
 }

--- a/lib/mergeset/table.go
+++ b/lib/mergeset/table.go
@@ -1435,10 +1435,10 @@ func (tb *Table) CreateSnapshotAt(dstDir string, deadline uint64) error {
 
 	// Make hardlinks for pws at dstDir
 	for _, pw := range pws {
-		if pw.mp != nil {
-			// Skip in-memory parts
-			continue
-		}
+		// if pw.mp != nil {
+		// 	// Skip in-memory parts
+		// 	continue
+		// }
 		if deadline > 0 && fasttime.UnixTimestamp() > deadline {
 			return fmt.Errorf("cannot create snapshot for %q: timeout exceeded", tb.path)
 		}

--- a/lib/mergeset/table.go
+++ b/lib/mergeset/table.go
@@ -599,8 +599,10 @@ func (tb *Table) mergePartsOptimal(pws []*partWrapper) error {
 // This function is only for debugging and testing.
 func (tb *Table) DebugFlush() {
 	tb.flushPendingItems(nil, true)
+
 	// Wait for background flushers to finish.
 	tb.rawItemsPendingFlushesWG.Wait()
+	tb.flushInmemoryParts(true)
 }
 
 func (tb *Table) startInmemoryPartsFlusher() {

--- a/lib/mergeset/table.go
+++ b/lib/mergeset/table.go
@@ -598,7 +598,7 @@ func (tb *Table) mergePartsOptimal(pws []*partWrapper) error {
 //
 // This function is only for debugging and testing.
 func (tb *Table) DebugFlush() {
-	tb.flushInmemoryItems()
+	tb.flushPendingItems(nil, true)
 	// Wait for background flushers to finish.
 	tb.rawItemsPendingFlushesWG.Wait()
 }

--- a/lib/mergeset/table.go
+++ b/lib/mergeset/table.go
@@ -602,7 +602,6 @@ func (tb *Table) DebugFlush() {
 
 	// Wait for background flushers to finish.
 	tb.rawItemsPendingFlushesWG.Wait()
-	tb.flushInmemoryParts(true)
 }
 
 func (tb *Table) startInmemoryPartsFlusher() {

--- a/lib/mergeset/table.go
+++ b/lib/mergeset/table.go
@@ -598,7 +598,6 @@ func (tb *Table) mergePartsOptimal(pws []*partWrapper) error {
 //
 // This function is only for debugging and testing.
 func (tb *Table) DebugFlush() {
-	tb.flushPendingItems(nil, true)
 	tb.flushInmemoryItems()
 	// Wait for background flushers to finish.
 	tb.rawItemsPendingFlushesWG.Wait()

--- a/lib/mergeset/table.go
+++ b/lib/mergeset/table.go
@@ -1435,10 +1435,10 @@ func (tb *Table) CreateSnapshotAt(dstDir string, deadline uint64) error {
 
 	// Make hardlinks for pws at dstDir
 	for _, pw := range pws {
-		// if pw.mp != nil {
-		// 	// Skip in-memory parts
-		// 	continue
-		// }
+		if pw.mp != nil {
+			// Skip in-memory parts
+			continue
+		}
 		if deadline > 0 && fasttime.UnixTimestamp() > deadline {
 			return fmt.Errorf("cannot create snapshot for %q: timeout exceeded", tb.path)
 		}

--- a/lib/mergeset/table_test.go
+++ b/lib/mergeset/table_test.go
@@ -101,6 +101,7 @@ func TestTableCreateSnapshotAt(t *testing.T) {
 
 	var isReadOnly uint32
 	tb := MustOpenTable(path, nil, nil, &isReadOnly)
+	defer tb.MustClose()
 
 	// Write a lot of items into the table, so background merges would start.
 	const itemsCount = 6e6
@@ -115,15 +116,6 @@ func TestTableCreateSnapshotAt(t *testing.T) {
 	if n := m.TotalItemsCount(); n != itemsCount {
 		t.Fatalf("unexpected itemsCount; got %d; want %v", n, itemsCount)
 	}
-
-	// We should release all resources and save whole data to the disk
-	// If we do not close the table merge workers can use in memory parts
-	// and snapshots will be with not full data
-	tb.MustClose()
-
-	// We must re-open table for create snapshot process
-	tb = MustOpenTable(path, nil, nil, &isReadOnly)
-	defer tb.MustClose()
 
 	// Create multiple snapshots.
 	snapshot1 := path + "-test-snapshot1"

--- a/lib/mergeset/table_test.go
+++ b/lib/mergeset/table_test.go
@@ -111,6 +111,12 @@ func TestTableCreateSnapshotAt(t *testing.T) {
 	}
 	tb.DebugFlush()
 
+	var m TableMetrics
+	tb.UpdateMetrics(&m)
+	if n := m.TotalItemsCount(); n != itemsCount {
+		t.Fatalf("unexpected itemsCount; got %d; want %v", n, itemsCount)
+	}
+
 	// Create multiple snapshots.
 	snapshot1 := path + "-test-snapshot1"
 	if err := tb.CreateSnapshotAt(snapshot1, 0); err != nil {
@@ -134,6 +140,7 @@ func TestTableCreateSnapshotAt(t *testing.T) {
 
 	var ts, ts1, ts2 TableSearch
 	ts.Init(tb)
+	defer ts.MustClose()
 	ts1.Init(tb1)
 	defer ts1.MustClose()
 	ts2.Init(tb2)

--- a/lib/mergeset/table_test.go
+++ b/lib/mergeset/table_test.go
@@ -109,7 +109,13 @@ func TestTableCreateSnapshotAt(t *testing.T) {
 		item := []byte(fmt.Sprintf("item %d", i))
 		tb.AddItems([][]byte{item})
 	}
-	tb.DebugFlush()
+
+	tb.flushPendingItems(nil, true)
+	// Wait for background flushers to finish.
+	tb.rawItemsPendingFlushesWG.Wait()
+	// call this function with true param initiate release parts
+	// to merge and flush a single in-memory part to disk.
+	tb.flushInmemoryParts(true)
 
 	var m TableMetrics
 	tb.UpdateMetrics(&m)

--- a/lib/mergeset/table_test.go
+++ b/lib/mergeset/table_test.go
@@ -104,7 +104,7 @@ func TestTableCreateSnapshotAt(t *testing.T) {
 	defer tb.MustClose()
 
 	// Write a lot of items into the table, so background merges would start.
-	const itemsCount = 3e5
+	const itemsCount = 6e6
 	for i := 0; i < itemsCount; i++ {
 		item := []byte(fmt.Sprintf("item %d", i))
 		tb.AddItems([][]byte{item})

--- a/lib/mergeset/table_test.go
+++ b/lib/mergeset/table_test.go
@@ -101,7 +101,6 @@ func TestTableCreateSnapshotAt(t *testing.T) {
 
 	var isReadOnly uint32
 	tb := MustOpenTable(path, nil, nil, &isReadOnly)
-	defer tb.MustClose()
 
 	// Write a lot of items into the table, so background merges would start.
 	const itemsCount = 6e6
@@ -116,6 +115,15 @@ func TestTableCreateSnapshotAt(t *testing.T) {
 	if n := m.TotalItemsCount(); n != itemsCount {
 		t.Fatalf("unexpected itemsCount; got %d; want %v", n, itemsCount)
 	}
+
+	// We should release all resources and save whole data to the disk
+	// If we do not close the table merge workers can use in memory parts
+	// and snapshots will be with not full data
+	tb.MustClose()
+
+	// We must re-open table for create snapshot process
+	tb = MustOpenTable(path, nil, nil, &isReadOnly)
+	defer tb.MustClose()
 
 	// Create multiple snapshots.
 	snapshot1 := path + "-test-snapshot1"


### PR DESCRIPTION
Fixed TestTableCreateSnapshotAt. The test fails because we do not close the table, and background merge workers start to use in-memory parts. When the process creates a snapshot, the last will not contain all data because of the merge process.

Related issue: https://github.com/VictoriaMetrics/VictoriaMetrics/issues/4272

Signed-off-by: dmitryk-dk [d.kozlov@victoriametrics.com](mailto:d.kozlov@victoriametrics.com)