### PR TITLE
vmalert: do not return nil `rules` for /api/v1/rules

### DIFF
--- a/app/vmalert/manager.go
+++ b/app/vmalert/manager.go
@@ -188,6 +188,7 @@ func (g *Group) toAPI() APIGroup {
 
 		Labels: g.Labels,
 	}
+	ag.Rules = make([]APIRule, 0)
 	for _, r := range g.Rules {
 		ag.Rules = append(ag.Rules, r.ToAPI())
 	}


### PR DESCRIPTION
The fix addresses a case when vmalert is configured with a group which has `name`, but doesn't have `rules` configured. In this case it still returns a `nil` instead of `[]` slice.

Fixing this via current commit.

See https://github.com/VictoriaMetrics/VictoriaMetrics/issues/4221