### PR TITLE
vmalert: fix nil map assignment

### DIFF
--- a/app/vmalert/datasource/vm.go
+++ b/app/vmalert/datasource/vm.go
@@ -69,6 +69,7 @@ func (s *VMStorage) Clone() *VMStorage {
 		debug: s.debug,
 	}
 	if s.extraHeaders != nil {
+		ns.extraHeaders = make([]keyValue, len(s.extraHeaders))
 		copy(ns.extraHeaders, s.extraHeaders)
 	}
 	if s.extraParams != nil {

--- a/app/vmalert/datasource/vm.go
+++ b/app/vmalert/datasource/vm.go
@@ -55,7 +55,7 @@ type keyValue struct {
 
 // Clone makes clone of VMStorage, shares http client.
 func (s *VMStorage) Clone() *VMStorage {
-	return &VMStorage{
+	ns := &VMStorage{
 		c:                s.c,
 		authCfg:          s.authCfg,
 		datasourceURL:    s.datasourceURL,
@@ -65,11 +65,22 @@ func (s *VMStorage) Clone() *VMStorage {
 
 		dataSourceType:     s.dataSourceType,
 		evaluationInterval: s.evaluationInterval,
-		extraParams:        s.extraParams,
-		extraHeaders:       s.extraHeaders,
 
 		debug: s.debug,
 	}
+	if s.extraHeaders != nil {
+		copy(ns.extraHeaders, s.extraHeaders)
+	}
+	if s.extraParams != nil {
+		if ns.extraParams == nil {
+			ns.extraParams = url.Values{}
+		}
+		for k, v := range s.extraParams {
+			ns.extraParams[k] = v
+		}
+	}
+
+	return ns
 }
 
 // ApplyParams - changes given querier params.

--- a/app/vmalert/datasource/vm.go
+++ b/app/vmalert/datasource/vm.go
@@ -66,19 +66,17 @@ func (s *VMStorage) Clone() *VMStorage {
 		dataSourceType:     s.dataSourceType,
 		evaluationInterval: s.evaluationInterval,
 
+		// init map so it can be populated below
+		extraParams: url.Values{},
+
 		debug: s.debug,
 	}
-	if s.extraHeaders != nil {
+	if len(s.extraHeaders) > 0 {
 		ns.extraHeaders = make([]keyValue, len(s.extraHeaders))
 		copy(ns.extraHeaders, s.extraHeaders)
 	}
-	if s.extraParams != nil {
-		if ns.extraParams == nil {
-			ns.extraParams = url.Values{}
-		}
-		for k, v := range s.extraParams {
-			ns.extraParams[k] = v
-		}
+	for k, v := range s.extraParams {
+		ns.extraParams[k] = v
 	}
 
 	return ns

--- a/app/vmalert/datasource/vm.go
+++ b/app/vmalert/datasource/vm.go
@@ -76,9 +76,14 @@ func (s *VMStorage) Clone() *VMStorage {
 func (s *VMStorage) ApplyParams(params QuerierParams) *VMStorage {
 	s.dataSourceType = toDatasourceType(params.DataSourceType)
 	s.evaluationInterval = params.EvaluationInterval
-	for k, vl := range params.QueryParams {
-		for _, v := range vl { // custom query params are prior to default ones
-			s.extraParams.Set(k, v)
+	if params.QueryParams != nil {
+		if s.extraParams == nil {
+			s.extraParams = url.Values{}
+		}
+		for k, vl := range params.QueryParams {
+			for _, v := range vl { // custom query params are prior to default ones
+				s.extraParams.Set(k, v)
+			}
 		}
 	}
 	if params.Headers != nil {
@@ -106,6 +111,7 @@ func NewVMStorage(baseURL string, authCfg *promauth.Config, lookBack time.Durati
 		lookBack:         lookBack,
 		queryStep:        queryStep,
 		dataSourceType:   datasourcePrometheus,
+		extraParams:      url.Values{},
 	}
 }
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -24,6 +24,9 @@ The following tip changes can be tested by building VictoriaMetrics components f
 
 ## tip
 
+* BUGFIX: [vmalert](https://docs.victoriametrics.com/vmalert.html): fix nil map assignment panic in runtime introduced in this [change](https://github.com/VictoriaMetrics/VictoriaMetrics/pull/4341).
+
+
 ## [v1.91.1](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.91.1)
 
 Released at 2023-06-01


### PR DESCRIPTION
The storage instance with nil map params was created for remote-read purposes. And before change https://github.com/VictoriaMetrics/VictoriaMetrics/pull/4341/commits/7a9ae9de0d2221cf7759e49ebcde0a06508b0f68 this map was ignored in ApplyParams. Now, it started to be used and vmalert panics in runtime.

The fix properly inits map for at `NewVMStorage` and verifies it is not nil on assignment in `ApplyParams`.