### PR TITLE
app/vmagent: mention `enable_http2` in changelog

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -24,6 +24,8 @@ The following tip changes can be tested by building VictoriaMetrics components f
 
 ## tip
 
+
+* FEATURE: [vmagent](https://docs.victoriametrics.com/vmagent.html): Adds `enable_http2` on scrape configuration level. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/4283). Thanks to @Haleygo for [the pull request](https://github.com/VictoriaMetrics/VictoriaMetrics/pull/4295).
 * FEATURE: [vmctl](https://docs.victoriametrics.com/vmctl.html): add verbose output for docker installations or when TTY isn't available. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/4081).
 * BUGFIX: add the following command-line flags, which can be used for limiting Graphite API calls: 
   `--search.maxGraphiteTagKeys` for limiting the number of tag keys returned from Graphite `/tags`, `/tags/autoComplete/*`, `/tags/findSeries` API. 

--- a/lib/promscrape/client.go
+++ b/lib/promscrape/client.go
@@ -168,12 +168,12 @@ func newClient(ctx context.Context, sw *ScrapeWork) *client {
 			logger.Errorf("failed to configure HTTP/2 transport: %s", err)
 		}
 	}
-
 	if sw.DenyRedirects {
 		sc.CheckRedirect = func(req *http.Request, via []*http.Request) error {
 			return http.ErrUseLastResponse
 		}
 	}
+
 	return &client{
 		hc:                      hc,
 		ctx:                     ctx,


### PR DESCRIPTION
Follow-up after
https://github.com/VictoriaMetrics/VictoriaMetrics/commit/72c3cd47eb1120037ceffb2400e54b11c8a0e414