### PR TITLE
app/vmagent/remotewrite: fix vmagent panic on shutdown

### DIFF
--- a/app/vmagent/remotewrite/remotewrite.go
+++ b/app/vmagent/remotewrite/remotewrite.go
@@ -587,6 +587,9 @@ func newRemoteWriteCtx(argIdx int, at *auth.Token, remoteWriteURL *url.URL, maxI
 }
 
 func (rwctx *remoteWriteCtx) MustStop() {
+	sas := rwctx.sas.Swap(nil)
+	sas.MustStop()
+
 	for _, ps := range rwctx.pss {
 		ps.MustStop()
 	}
@@ -595,9 +598,6 @@ func (rwctx *remoteWriteCtx) MustStop() {
 	rwctx.fq.UnblockAllReaders()
 	rwctx.c.MustStop()
 	rwctx.c = nil
-
-	sas := rwctx.sas.Swap(nil)
-	sas.MustStop()
 
 	rwctx.fq.MustClose()
 	rwctx.fq = nil


### PR DESCRIPTION
Currently, when vmagent is stopping it first flushes pending series in remote write context and proceeds to stop streaming aggregation. This leads to streaming aggregation being unable to write results into pending timeseries (since it is already nil) and panic. This can lead to loosing some aggregation results being lost almost silently.

Fix is reordering flow to first stop streaming aggregation and flush all pending timeseries after that.