### PR TITLE
lib/storage: creates parts.json on start-up if it not exists.

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -40,6 +40,7 @@ The following tip changes can be tested by building VictoriaMetrics components f
 * BUGFIX: [vmagent](https://docs.victoriametrics.com/vmagent.html): fix panic on vmagent shutdown which could lead to loosing aggregation results which were not flushed to remote yet. See [this](https://github.com/VictoriaMetrics/VictoriaMetrics/pull/4407) for details.
 * BUGFIX: [vmagent](https://docs.victoriametrics.com/vmagent.html): fixed service name detection for [consulagent service discovery](https://docs.victoriametrics.com/sd_configs.html?highlight=consulagent#consulagent_sd_configs) in case of a difference in service name and service id. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/4390) for details.
 * BUGFIX: [vmbackupmanager](https://docs.victoriametrics.com/vmbackupmanager.html): fix an issue with `vmbackupmanager` not being able to restore data from a backup stored in GCS. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/4420) for details.
+* BUGFIX: [storage](https://docs.victoriametrics.com/Single-server-VictoriaMetrics.html): Properly creates `parts.json` after migration from versions below `v1.90.0. It must fix errors on start-up after unclean shutdown. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/4336) for details.
 
 ## [v1.91.2](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.91.2)
 

--- a/lib/mergeset/table.go
+++ b/lib/mergeset/table.go
@@ -1383,6 +1383,11 @@ func mustOpenParts(path string) []*partWrapper {
 		}
 		pws = append(pws, pw)
 	}
+	partNamesPath := filepath.Join(path, partsFilename)
+	if !fs.IsPathExist(partNamesPath) {
+		// create parts.json file on migration from previous versions before v1.90.0
+		mustWritePartNames(pws, partNamesPath)
+	}
 
 	return pws
 }

--- a/lib/mergeset/table.go
+++ b/lib/mergeset/table.go
@@ -1386,7 +1386,7 @@ func mustOpenParts(path string) []*partWrapper {
 	partNamesPath := filepath.Join(path, partsFilename)
 	if !fs.IsPathExist(partNamesPath) {
 		// create parts.json file on migration from previous versions before v1.90.0
-		mustWritePartNames(pws, partNamesPath)
+		mustWritePartNames(pws, path)
 	}
 
 	return pws

--- a/lib/storage/partition.go
+++ b/lib/storage/partition.go
@@ -268,7 +268,7 @@ func mustOpenPartition(smallPartsPath, bigPartsPath string, s *Storage) *partiti
 	partNamesPath := filepath.Join(smallPartsPath, partsFilename)
 	if !fs.IsPathExist(partNamesPath) {
 		// create parts.json file on migration from previous versions before v1.90.0
-		mustWritePartNames(smallParts, bigParts, path)
+		mustWritePartNames(smallParts, bigParts, smallPartsPath)
 	}
 
 	pt := newPartition(name, smallPartsPath, bigPartsPath, s)

--- a/lib/storage/partition.go
+++ b/lib/storage/partition.go
@@ -268,7 +268,7 @@ func mustOpenPartition(smallPartsPath, bigPartsPath string, s *Storage) *partiti
 	partNamesPath := filepath.Join(smallPartsPath, partsFilename)
 	if !fs.IsPathExist(partNamesPath) {
 		// create parts.json file on migration from previous versions before v1.90.0
-		mustWritePartNames(smallParts, bigParts, partNamesPath)
+		mustWritePartNames(smallParts, bigParts, path)
 	}
 
 	pt := newPartition(name, smallPartsPath, bigPartsPath, s)

--- a/lib/storage/partition.go
+++ b/lib/storage/partition.go
@@ -265,6 +265,12 @@ func mustOpenPartition(smallPartsPath, bigPartsPath string, s *Storage) *partiti
 	smallParts := mustOpenParts(smallPartsPath, partNamesSmall)
 	bigParts := mustOpenParts(bigPartsPath, partNamesBig)
 
+	partNamesPath := filepath.Join(smallPartsPath, partsFilename)
+	if !fs.IsPathExist(partNamesPath) {
+		// create parts.json file on migration from previous versions before v1.90.0
+		mustWritePartNames(smallParts, bigParts, partNamesPath)
+	}
+
 	pt := newPartition(name, smallPartsPath, bigPartsPath, s)
 	pt.smallParts = smallParts
 	pt.bigParts = bigParts


### PR DESCRIPTION
It fixes migrations from versions below v1.90.0.
Previously parts.json was created only after successful merge. But if merge was interruped for some reason (OOM or shutdown), parts.json wasn't created and partitions left after interruped merge weren't properly deleted. Since VM cannot check if it must be removed or not. https://github.com/VictoriaMetrics/VictoriaMetrics/issues/4336