### PR TITLE
set X-Idempotency-Key header on VMAgent client requests

### DIFF
--- a/app/vmagent/remotewrite/client.go
+++ b/app/vmagent/remotewrite/client.go
@@ -331,6 +331,7 @@ func (c *client) doRequest(url string, body []byte) (*http.Response, error) {
 	h := req.Header
 	h.Set("User-Agent", "vmagent")
 	h.Set("Content-Type", "application/x-protobuf")
+	h["X-Idempotency-Key"] = []string{}
 	if c.useVMProto {
 		h.Set("Content-Encoding", "zstd")
 		h.Set("X-VictoriaMetrics-Remote-Write-Version", "1")


### PR DESCRIPTION
The `X-Idempotency-Key` header allows [`http.Transport`](https://pkg.go.dev/net/http@master#Transport) to treat a POST request as idempotent, so it will retry on a network error:

> Transport only retries a request upon encountering a network error if the connection has been already been used successfully and if the request is idempotent and either has no body or has its Request.GetBody defined. HTTP requests are considered idempotent if they have HTTP methods GET, HEAD, OPTIONS, or TRACE; or if their Header map contains an "Idempotency-Key" or "X-Idempotency-Key" entry. If the idempotency key value is a zero-length slice, the request is treated as idempotent but the header is not sent on the wire.

This prevents application errors when the client attempts to reuse an idle connection closed by the server, which may occur if the server's timeout is less than or equal to the client's.

Fixes #4139.