### PR TITLE
vmui: memory leak fix

### DIFF
--- a/app/vmui/packages/vmui/src/components/Chart/Heatmap/HeatmapChart/HeatmapChart.tsx
+++ b/app/vmui/packages/vmui/src/components/Chart/Heatmap/HeatmapChart/HeatmapChart.tsx
@@ -73,10 +73,9 @@ const HeatmapChart: FC<HeatmapChartProps> = ({
     });
   };
   const throttledSetScale = useCallback(throttle(setScale, 500), []);
-  const setPlotScale = ({ u, min, max }: { u: uPlot, min: number, max: number }) => {
+  const setPlotScale = ({ min, max }: { min: number, max: number }) => {
     const delta = (max - min) * 1000;
     if ((delta < limitsDurations.min) || (delta > limitsDurations.max)) return;
-    u.setScale("x", { min, max });
     setXRange({ min, max });
     throttledSetScale({ min, max });
   };
@@ -112,7 +111,7 @@ const HeatmapChart: FC<HeatmapChartProps> = ({
       const nxRange = e.deltaY < 0 ? oxRange * factor : oxRange / factor;
       const min = xVal - (zoomPos / width) * nxRange;
       const max = min + nxRange;
-      u.batch(() => setPlotScale({ u, min, max }));
+      u.batch(() => setPlotScale({ min, max }));
     });
   };
 
@@ -126,7 +125,6 @@ const HeatmapChart: FC<HeatmapChartProps> = ({
       e.preventDefault();
       const factor = (xRange.max - xRange.min) / 10 * (plus ? 1 : -1);
       setPlotScale({
-        u: uPlotInst,
         min: xRange.min + factor,
         max: xRange.max - factor
       });
@@ -241,7 +239,7 @@ const HeatmapChart: FC<HeatmapChartProps> = ({
         (u) => {
           const min = u.posToVal(u.select.left, "x");
           const max = u.posToVal(u.select.left + u.select.width, "x");
-          setPlotScale({ u, min, max });
+          setPlotScale({ min, max });
         }
       ]
     },
@@ -295,7 +293,6 @@ const HeatmapChart: FC<HeatmapChartProps> = ({
 
     const zoomFactor = dur / 50 * dir;
     uPlotInst.batch(() => setPlotScale({
-      u: uPlotInst,
       min: min + zoomFactor,
       max: max - zoomFactor
     }));

--- a/app/vmui/packages/vmui/src/components/Chart/Line/ChartTooltip/ChartTooltip.tsx
+++ b/app/vmui/packages/vmui/src/components/Chart/Line/ChartTooltip/ChartTooltip.tsx
@@ -17,11 +17,12 @@ import useEventListener from "../../../../hooks/useEventListener";
 export interface ChartTooltipProps {
   id: string,
   u: uPlot,
-  metrics: MetricResult[],
-  series: SeriesItem[],
+  metricItem: MetricResult,
+  seriesItem: SeriesItem,
   yRange: number[];
   unit?: string,
   isSticky?: boolean,
+  showQueryNum?: boolean,
   tooltipOffset: { left: number, top: number },
   tooltipIdx: { seriesIdx: number, dataIdx: number },
   onClose?: (id: string) => void
@@ -31,12 +32,13 @@ const ChartTooltip: FC<ChartTooltipProps> = ({
   u,
   id,
   unit = "",
-  metrics,
-  series,
+  metricItem,
+  seriesItem,
   yRange,
   tooltipIdx,
   tooltipOffset,
   isSticky,
+  showQueryNum,
   onClose
 }) => {
   const tooltipRef = useRef<HTMLDivElement>(null);
@@ -53,17 +55,13 @@ const ChartTooltip: FC<ChartTooltipProps> = ({
   const dataTime = u.data[0][dataIdx];
   const date = dayjs(dataTime * 1000).tz().format(DATE_FULL_TIMEZONE_FORMAT);
 
-  const color = series[seriesIdx]?.stroke+"";
-
-  const calculations = series[seriesIdx]?.calculations || {};
-
-  const groups = new Set(metrics.map(m => m.group));
-  const showQueryNum = groups.size > 1;
-  const group = metrics[seriesIdx-1]?.group || 0;
+  const color = `${seriesItem?.stroke}`;
+  const calculations = seriesItem?.calculations || {};
+  const group = metricItem?.group || 0;
 
 
   const fullMetricName = useMemo(() => {
-    const metric = metrics[seriesIdx-1]?.metric || {};
+    const metric = metricItem?.metric || {};
     const labelNames = Object.keys(metric).filter(x => x != "__name__");
     const labels = labelNames.map(key => `${key}=${JSON.stringify(metric[key])}`);
     let metricName = metric["__name__"] || "";
@@ -71,7 +69,7 @@ const ChartTooltip: FC<ChartTooltipProps> = ({
       metricName += "{" + labels.join(",") + "}";
     }
     return metricName;
-  }, [metrics, seriesIdx]);
+  }, [metricItem]);
 
   const handleClose = () => {
     onClose && onClose(id);
@@ -97,7 +95,7 @@ const ChartTooltip: FC<ChartTooltipProps> = ({
   const calcPosition = () => {
     if (!tooltipRef.current) return;
 
-    const topOnChart = u.valToPos((value || 0), series[seriesIdx]?.scale || "1");
+    const topOnChart = u.valToPos((value || 0), seriesItem?.scale || "1");
     const leftOnChart = u.valToPos(dataTime, "x");
     const { width: tooltipWidth, height: tooltipHeight } = tooltipRef.current.getBoundingClientRect();
     const { width, height } = u.over.getBoundingClientRect();
@@ -142,9 +140,7 @@ const ChartTooltip: FC<ChartTooltipProps> = ({
     >
       <div className="vm-chart-tooltip-header">
         <div className="vm-chart-tooltip-header__date">
-          {showQueryNum && (
-            <div>Query {group}</div>
-          )}
+          {showQueryNum && (<div>Query {group}</div>)}
           {date}
         </div>
         {isSticky && (

--- a/app/vmui/packages/vmui/src/components/Chart/Line/ChartTooltip/ChartTooltip.tsx
+++ b/app/vmui/packages/vmui/src/components/Chart/Line/ChartTooltip/ChartTooltip.tsx
@@ -19,7 +19,6 @@ export interface ChartTooltipProps {
   u: uPlot,
   metricItem: MetricResult,
   seriesItem: SeriesItem,
-  yRange: number[];
   unit?: string,
   isSticky?: boolean,
   showQueryNum?: boolean,
@@ -34,7 +33,6 @@ const ChartTooltip: FC<ChartTooltipProps> = ({
   unit = "",
   metricItem,
   seriesItem,
-  yRange,
   tooltipIdx,
   tooltipOffset,
   isSticky,
@@ -51,7 +49,7 @@ const ChartTooltip: FC<ChartTooltipProps> = ({
   const [dataIdx, setDataIdx] = useState(tooltipIdx.dataIdx);
 
   const value = get(u, ["data", seriesIdx, dataIdx], 0);
-  const valueFormat = formatPrettyNumber(value, get(yRange, [0]), get(yRange, [1]));
+  const valueFormat = formatPrettyNumber(value, get(u, ["scales", "1", "min"], 0), get(u, ["scales", "1", "max"], 1));
   const dataTime = u.data[0][dataIdx];
   const date = dayjs(dataTime * 1000).tz().format(DATE_FULL_TIMEZONE_FORMAT);
 

--- a/app/vmui/packages/vmui/src/components/Chart/Line/Legend/LegendItem/LegendItem.tsx
+++ b/app/vmui/packages/vmui/src/components/Chart/Line/Legend/LegendItem/LegendItem.tsx
@@ -1,9 +1,8 @@
-import React, { FC, useState, useMemo } from "preact/compat";
+import React, { FC, useMemo } from "preact/compat";
 import { MouseEvent } from "react";
 import { LegendItemType } from "../../../../../utils/uplot/types";
 import "./style.scss";
 import classNames from "classnames";
-import Tooltip from "../../../../Main/Tooltip/Tooltip";
 import { getFreeFields } from "./helpers";
 import useCopyToClipboard from "../../../../../hooks/useCopyToClipboard";
 
@@ -15,7 +14,6 @@ interface LegendItemProps {
 
 const LegendItem: FC<LegendItemProps> = ({ legend, onChange, isHeatmap }) => {
   const copyToClipboard = useCopyToClipboard();
-  const [copiedValue, setCopiedValue] = useState("");
 
   const freeFormFields = useMemo(() => {
     const result = getFreeFields(legend);
@@ -25,20 +23,17 @@ const LegendItem: FC<LegendItemProps> = ({ legend, onChange, isHeatmap }) => {
   const calculations = legend.calculations;
   const showCalculations = Object.values(calculations).some(v => v);
 
-  const handleClickFreeField = async (val: string, id: string) => {
-    const copied = await copyToClipboard(val);
-    if (!copied) return;
-    setCopiedValue(id);
-    setTimeout(() => setCopiedValue(""), 2000);
+  const handleClickFreeField = async (val: string) => {
+    await copyToClipboard(val, `${val} has been copied`);
   };
 
   const createHandlerClick = (legend: LegendItemType) => (e: MouseEvent<HTMLDivElement>) => {
     onChange && onChange(legend, e.ctrlKey || e.metaKey);
   };
 
-  const createHandlerCopy = (freeField: string, id: string) => (e: MouseEvent<HTMLDivElement>) => {
+  const createHandlerCopy = (freeField: string) => (e: MouseEvent<HTMLDivElement>) => {
     e.stopPropagation();
-    handleClickFreeField(freeField, id);
+    handleClickFreeField(freeField);
   };
 
   return (
@@ -62,21 +57,14 @@ const LegendItem: FC<LegendItemProps> = ({ legend, onChange, isHeatmap }) => {
           {legend.freeFormFields["__name__"]}
           {!!freeFormFields.length && <>&#123;</>}
           {freeFormFields.map((f, i) => (
-            <Tooltip
-              key={f.id}
-              open={copiedValue === f.id}
-              title={"copied!"}
-              placement="top-center"
+            <span
+              className="vm-legend-item-info__free-fields"
+              key={f.key}
+              onClick={createHandlerCopy(f.freeField)}
+              title="copy to clipboard"
             >
-              <span
-                className="vm-legend-item-info__free-fields"
-                key={f.key}
-                onClick={createHandlerCopy(f.freeField, f.id)}
-                title="copy to clipboard"
-              >
-                {f.freeField}{i + 1 < freeFormFields.length && ","}
-              </span>
-            </Tooltip>
+              {f.freeField}{i + 1 < freeFormFields.length && ","}
+            </span>
           ))}
           {!!freeFormFields.length && <>&#125;</>}
         </span>

--- a/app/vmui/packages/vmui/src/components/Chart/Line/LineChart/LineChart.tsx
+++ b/app/vmui/packages/vmui/src/components/Chart/Line/LineChart/LineChart.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useCallback, useEffect, useMemo, useRef, useState } from "preact/compat";
+import React, { FC, useCallback, useEffect, useRef, useState } from "preact/compat";
 import uPlot, {
   AlignedData as uPlotData,
   Options as uPlotOptions,
@@ -37,8 +37,6 @@ export interface LineChartProps {
   height?: number;
 }
 
-enum typeChartUpdate {xRange = "xRange", yRange = "yRange"}
-
 const LineChart: FC<LineChartProps> = ({
   data,
   series,
@@ -63,15 +61,14 @@ const LineChart: FC<LineChartProps> = ({
   const [tooltipIdx, setTooltipIdx] = useState({ seriesIdx: -1, dataIdx: -1 });
   const [tooltipOffset, setTooltipOffset] = useState({ left: 0, top: 0 });
   const [stickyTooltips, setStickyToolTips] = useState<ChartTooltipProps[]>([]);
-  const tooltipId = useMemo(() => `${tooltipIdx.seriesIdx}_${tooltipIdx.dataIdx}`, [tooltipIdx]);
 
-  const setScale = ({ min, max }: { min: number, max: number }): void => {
+  const throttledSetScale = useCallback(throttle(({ min, max }: { min: number, max: number }) => {
     setPeriod({
       from: dayjs(min * 1000).toDate(),
       to: dayjs(max * 1000).toDate()
     });
-  };
-  const throttledSetScale = useCallback(throttle(setScale, 500), []);
+  }, 500), []);
+
   const setPlotScale = ({ u, min, max }: { u: uPlot, min: number, max: number }) => {
     const delta = (max - min) * 1000;
     if ((delta < limitsDurations.min) || (delta > limitsDurations.max)) return;
@@ -132,26 +129,36 @@ const LineChart: FC<LineChartProps> = ({
     }
   }, [uPlotInst, xRange]);
 
-  const handleClick = useCallback(() => {
-    if (!showTooltip) return;
-    const id = `${tooltipIdx.seriesIdx}_${tooltipIdx.dataIdx}`;
-    const props = {
+  const getChartProps = useCallback(() => {
+    const { seriesIdx, dataIdx } = tooltipIdx;
+    const id = `${seriesIdx}_${dataIdx}`;
+    const metricItem = metrics[seriesIdx-1];
+    const seriesItem = series[seriesIdx] as SeriesItem;
+
+    const groups = new Set(metrics.map(m => m.group));
+    const showQueryNum = groups.size > 1;
+
+    return {
       id,
       unit,
-      series,
-      metrics,
+      seriesItem,
+      metricItem,
       yRange,
       tooltipIdx,
       tooltipOffset,
+      showQueryNum,
     };
+  }, [metrics, series, tooltipIdx, tooltipOffset, unit, yRange]);
 
-    if (!stickyTooltips.find(t => t.id === id)) {
-      const tooltipProps = JSON.parse(JSON.stringify(props));
-      setStickyToolTips(prev => [...prev, tooltipProps]);
+  const handleClick = useCallback(() => {
+    if (!showTooltip) return;
+    const props = getChartProps();
+    if (!stickyTooltips.find(t => t.id === props.id)) {
+      setStickyToolTips(prev => [...prev, props as ChartTooltipProps]);
     }
-  }, [metrics, series, stickyTooltips, tooltipIdx, tooltipOffset, showTooltip, unit, yRange]);
+  }, [getChartProps, stickyTooltips, showTooltip]);
 
-  const handleUnStick = (id:string) => {
+  const handleUnStick = (id: string) => {
     setStickyToolTips(prev => prev.filter(t => t.id !== id));
   };
 
@@ -189,7 +196,7 @@ const LineChart: FC<LineChartProps> = ({
     tzDate: ts => dayjs(formatDateForNativeInput(dateFromSeconds(ts))).local().toDate(),
     series,
     axes: getAxes( [{}, { scale: "1" }], unit),
-    scales: { ...getScales() },
+    scales: getScales(),
     width: layoutSize.width || 400,
     height: height || 500,
     plugins: [{ hooks: { ready: onReadyChart, setCursor, setSeries: seriesFocus } }],
@@ -203,34 +210,6 @@ const LineChart: FC<LineChartProps> = ({
       ]
     }
   };
-
-  const updateChart = (type: typeChartUpdate): void => {
-    if (!uPlotInst) return;
-    switch (type) {
-      case typeChartUpdate.xRange:
-        uPlotInst.scales.x.range = getRangeX;
-        break;
-      case typeChartUpdate.yRange:
-        Object.keys(yaxis.limits.range).forEach(axis => {
-          if (!uPlotInst.scales[axis]) return;
-          uPlotInst.scales[axis].range = (u: uPlot, min = 0, max = 1) => getRangeY(u, min, max, axis);
-        });
-        break;
-    }
-    if (!isPanning) uPlotInst.redraw();
-  };
-
-  useEffect(() => setXRange({ min: period.start, max: period.end }), [period]);
-
-  useEffect(() => {
-    setStickyToolTips([]);
-    setTooltipIdx({ seriesIdx: -1, dataIdx: -1 });
-    if (!uPlotRef.current) return;
-    const u = new uPlot(options, data, uPlotRef.current);
-    setUPlotInst(u);
-    setXRange({ min: period.start, max: period.end });
-    return u.destroy;
-  }, [uPlotRef.current, series, layoutSize, height, isDarkTheme]);
 
   const handleTouchStart = (e: TouchEvent) => {
     if (e.touches.length !== 2) return;
@@ -263,13 +242,39 @@ const LineChart: FC<LineChartProps> = ({
     }));
   }, [uPlotInst, startTouchDistance, xRange]);
 
-  useEffect(() => updateChart(typeChartUpdate.xRange), [xRange]);
-  useEffect(() => updateChart(typeChartUpdate.yRange), [yaxis]);
+  useEffect(() => setXRange({ min: period.start, max: period.end }), [period]);
 
   useEffect(() => {
-    const show = tooltipIdx.dataIdx !== -1 && tooltipIdx.seriesIdx !== -1;
-    setShowTooltip(show);
-  }, [tooltipIdx, stickyTooltips]);
+    setStickyToolTips([]);
+    setTooltipIdx({ seriesIdx: -1, dataIdx: -1 });
+    if (!uPlotRef.current) return;
+    const u = new uPlot(options, data, uPlotRef.current);
+    setUPlotInst(u);
+    setXRange({ min: period.start, max: period.end });
+    return u.destroy;
+  }, [uPlotRef, series, isDarkTheme]);
+
+  useEffect(() => {
+    if (!uPlotInst) return;
+    uPlotInst.scales.x.range = getRangeX;
+  }, [xRange]);
+
+  useEffect(() => {
+    if (!uPlotInst) return;
+    Object.keys(yaxis.limits.range).forEach(axis => {
+      if (!uPlotInst.scales[axis]) return;
+      uPlotInst.scales[axis].range = (u: uPlot, min = 0, max = 1) => getRangeY(u, min, max, axis);
+    });
+  }, [yaxis]);
+
+  useEffect(() => {
+    if (!uPlotInst) return;
+    uPlotInst.setSize({  width: layoutSize.width || 400, height: height || 500 });
+  }, [height, layoutSize]);
+
+  useEffect(() => {
+    setShowTooltip(tooltipIdx.dataIdx !== -1 && tooltipIdx.seriesIdx !== -1);
+  }, [tooltipIdx]);
 
   useEventListener("click", handleClick);
   useEventListener("keydown", handleKeyDown);
@@ -293,14 +298,8 @@ const LineChart: FC<LineChartProps> = ({
       />
       {uPlotInst && showTooltip && (
         <ChartTooltip
-          unit={unit}
+          {...getChartProps()}
           u={uPlotInst}
-          series={series as SeriesItem[]}
-          metrics={metrics}
-          yRange={yRange}
-          tooltipIdx={tooltipIdx}
-          tooltipOffset={tooltipOffset}
-          id={tooltipId}
         />
       )}
 

--- a/app/vmui/packages/vmui/src/components/Main/Tooltip/Tooltip.tsx
+++ b/app/vmui/packages/vmui/src/components/Main/Tooltip/Tooltip.tsx
@@ -4,7 +4,6 @@ import "./style.scss";
 import { ReactNode } from "react";
 import { ExoticComponent } from "react";
 import useDeviceDetect from "../../../hooks/useDeviceDetect";
-import useEventListener from "../../../hooks/useEventListener";
 
 interface TooltipProps {
   children: ReactNode
@@ -30,7 +29,6 @@ const Tooltip: FC<TooltipProps> = ({
   const popperRef = useRef<HTMLDivElement>(null);
 
   const onScrollWindow = () => setIsOpen(false);
-  useEventListener("scroll", onScrollWindow);
 
   useEffect(() => {
     if (!popperRef.current || !isOpen) return;
@@ -38,6 +36,11 @@ const Tooltip: FC<TooltipProps> = ({
       width: popperRef.current.clientWidth,
       height: popperRef.current.clientHeight
     });
+    window.addEventListener("scroll", onScrollWindow);
+
+    return () => {
+      window.removeEventListener("scroll", onScrollWindow);
+    };
   }, [isOpen]);
 
   const popperStyle = useMemo(() => {

--- a/app/vmui/packages/vmui/src/styles/components/table.scss
+++ b/app/vmui/packages/vmui/src/styles/components/table.scss
@@ -51,6 +51,7 @@
       font-weight: bold;
       text-transform: capitalize;
       text-align: left;
+      overflow-wrap: normal;
     }
 
     &_gray {

--- a/app/vmui/packages/vmui/src/utils/uplot/events.ts
+++ b/app/vmui/packages/vmui/src/utils/uplot/events.ts
@@ -17,7 +17,7 @@ export const dragChart = ({ e, factor = 0.85, u, setPanning, setPlotScale }: Dra
 
     const clientX = isMouseEvent ? e.clientX : e.touches[0].clientX;
     const dx = xUnitsPerPx * ((clientX - leftStart) * factor);
-    setPlotScale({ u, min: scXMin - dx, max: scXMax - dx });
+    setPlotScale({ min: scXMin - dx, max: scXMax - dx });
   };
   const mouseUp = () => {
     setPanning(false);

--- a/app/vmui/packages/vmui/src/utils/uplot/scales.ts
+++ b/app/vmui/packages/vmui/src/utils/uplot/scales.ts
@@ -1,0 +1,26 @@
+import uPlot, { Range, Scale, Scales } from "uplot";
+import { getMinMaxBuffer } from "./axes";
+import { YaxisState } from "../../state/graph/reducer";
+
+interface XRangeType {
+  min: number,
+  max: number
+}
+
+export const getRangeX = (xRange: XRangeType): Range.MinMax => {
+  return [xRange.min, xRange.max];
+};
+
+export const getRangeY = (u: uPlot, min = 0, max = 1, axis: string, yaxis: YaxisState): Range.MinMax => {
+  if (yaxis.limits.enable) return yaxis.limits.range[axis];
+  return getMinMaxBuffer(min, max);
+};
+
+export const getScales = (yaxis: YaxisState, xRange: XRangeType): Scales => {
+  const scales: { [key: string]: { range: Scale.Range } } = { x: { range: () => getRangeX(xRange) } };
+  const ranges = Object.keys(yaxis.limits.range);
+  (ranges.length ? ranges : ["1"]).forEach(axis => {
+    scales[axis] = { range: (u: uPlot, min = 0, max = 1) => getRangeY(u, min, max, axis, yaxis) };
+  });
+  return scales;
+};

--- a/app/vmui/packages/vmui/src/utils/uplot/types.ts
+++ b/app/vmui/packages/vmui/src/utils/uplot/types.ts
@@ -12,7 +12,7 @@ export interface DragArgs {
     u: uPlot,
     factor: number,
     setPanning: (enable: boolean) => void,
-    setPlotScale: ({ u, min, max }: { u: uPlot, min: number, max: number }) => void
+    setPlotScale: ({ min, max }: { min: number, max: number }) => void
 }
 
 export interface LegendItemType {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -33,6 +33,7 @@ The following tip changes can be tested by building VictoriaMetrics components f
   Remove redundant limit from [Prometheus api/v1/series](https://docs.victoriametrics.com/Single-server-VictoriaMetrics.html#prometheus-querying-api-usage). See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/4339).
 * BUGFIX: [vmagent](https://docs.victoriametrics.com/vmagent.html): fix panic on vmagent shutdown which could lead to loosing aggregation results which were not flushed to remote yet. See [this](https://github.com/VictoriaMetrics/VictoriaMetrics/pull/4407) for details.
 * BUGFIX: [vmbackupmanager](https://docs.victoriametrics.com/vmbackupmanager.html): fix an issue with `vmbackupmanager` not being able to restore data from a backup stored in GCS. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/4420) for details.
+* BUGFIX: [vmui](https://docs.victoriametrics.com/#vmui): fix a memory leak issue associated with chart updates. See [this pull request](https://github.com/VictoriaMetrics/VictoriaMetrics/pull/4455).
 
 ## [v1.91.2](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.91.2)
 


### PR DESCRIPTION
### Description:
In the current chart refresh implementation, a memory leak problem has been detected. With each new chart update, memory usage increases even though the chart data remains unchanged. This can lead to degraded performance and, ultimately, application failure.

### Changes:
- Fixed a memory leak associated with chart updates.
- Memory consumption for the chart's legend and tooltips has been optimized.

### Evidence of Results:
The comparison shows a noticeable improvement in memory usage. Heap snapshots have been provided, with the current logic shown on the left and the corrected logic on the right.

#### Testing was conducted with the following parameters:
- query: `flag`
- timerange: `30m`
- limit: `1000` series (for more noticeable growth)

Link to example: [Chart Example](https://play.victoriametrics.com/select/accounting/1/6a716b0f-38bc-4856-90ce-448fd713e3fe/prometheus/graph/#/?g0.expr=flag&g0.range_input=30m&g0.end_input=2023-06-15T09%3A18%3A29&g0.relative_time=last_30_minutes). Please note that the `limit` parameter needs to be set manually in the `Settings` section.

<img src="https://github.com/VictoriaMetrics/VictoriaMetrics/assets/29711459/a1be98cd-ac1d-4278-abb8-808fff74c39c" width="600"/>