### PR TITLE
deployment/docker: add examples for victoria-logs deployment

### DIFF
--- a/deployment/docker/docker-compose-vlogs-filebeat.yml
+++ b/deployment/docker/docker-compose-vlogs-filebeat.yml
@@ -1,0 +1,28 @@
+version: "3"
+
+services:
+  filebeat-vlogs:
+    image: docker.elastic.co/beats/filebeat:8.8.0
+    user: root
+    command:
+      - "--strict.perms=false"
+    volumes:
+      - ./filebeat/filebeat.yml:/usr/share/filebeat/filebeat.yml:ro
+      - /var/run/docker.sock:/var/run/docker.sock
+      - /var/lib/docker:/var/lib/docker
+    depends_on: [vlogs]
+    ports:
+      - "5140:5140"
+
+  # Run `make package-victoria-logs` to build victoria-logs image
+  vlogs:
+    image: docker.io/victoriametrics/victoria-logs:heads-logs-examples-0-g66b42a677-dirty-b95f1d4b
+    volumes:
+      - vlogs:/vlogs
+    ports:
+      - "9428:9428"
+    command:
+      - -storageDataPath=/vlogs
+
+volumes:
+  vlogs:

--- a/deployment/docker/docker-compose-vlogs-fluentbit.yml
+++ b/deployment/docker/docker-compose-vlogs-fluentbit.yml
@@ -1,0 +1,24 @@
+version: "3"
+
+services:
+  fluentbit:
+    image: cr.fluentbit.io/fluent/fluent-bit:2.1.4
+    volumes:
+      - /var/lib/docker/containers:/var/lib/docker/containers:ro
+      - ./fluentbit/fluent-bit.conf:/fluent-bit/etc/fluent-bit.conf
+    depends_on: [vlogs]
+    ports:
+      - "5140:5140"
+
+  # Run `make package-victoria-logs` to build victoria-logs image
+  vlogs:
+    image: docker.io/victoriametrics/victoria-logs:heads-logs-examples-0-g66b42a677-dirty-b95f1d4b
+    volumes:
+      - vlogs:/vlogs
+    ports:
+      - "9428:9428"
+    command:
+      - -storageDataPath=/vlogs
+
+volumes:
+  vlogs:

--- a/deployment/docker/docker-compose-vlogs-logstash.yml
+++ b/deployment/docker/docker-compose-vlogs-logstash.yml
@@ -1,0 +1,27 @@
+version: '3'
+
+services:
+  logstash:
+    build:
+      context: ./logstash/
+      dockerfile: Dockerfile
+    restart: on-failure
+    volumes:
+      - ./logstash/pipeline.conf:/usr/share/logstash/pipeline/logstash.conf:ro
+      - ./logstash/logstash.yml:/usr/share/logstash/config/logstash.yml:ro
+    depends_on: [vlogs]
+    ports:
+      - "5140:5140"
+
+  # Run `make package-victoria-logs` to build victoria-logs image
+  vlogs:
+    image: docker.io/victoriametrics/victoria-logs:heads-logs-examples-0-g66b42a677-dirty-b95f1d4b
+    volumes:
+      - vlogs:/vlogs
+    ports:
+      - "9428:9428"
+    command:
+      - -storageDataPath=/vlogs
+
+volumes:
+  vlogs:

--- a/deployment/docker/filebeat/filebeat.yml
+++ b/deployment/docker/filebeat/filebeat.yml
@@ -1,0 +1,22 @@
+filebeat.inputs:
+  - type: syslog
+    format: rfc3164
+    protocol.tcp:
+      host: "0.0.0.0:5140"
+
+filebeat.autodiscover:
+  providers:
+    - type: docker
+      hints.enabled: true
+
+processors:
+  - add_docker_metadata: ~
+
+output.elasticsearch:
+  hosts: [ "http://vlogs:9428/insert/elasticsearch/" ]
+  worker: 5
+  bulk_max_size: 1000
+  parameters:
+    _msg_field: "message"
+    _time_field: "@timestamp"
+    _stream_fields: "host.name,process.program,process.pid,container.name"

--- a/deployment/docker/fluentbit/fluent-bit.conf
+++ b/deployment/docker/fluentbit/fluent-bit.conf
@@ -1,0 +1,29 @@
+[INPUT]
+    name              tail
+    path              /var/lib/docker/containers/**/*.log
+    multiline.parser  docker, cri
+    Parser docker
+    Docker_Mode  On
+
+[INPUT]
+    Name     syslog
+    Listen   0.0.0.0
+    Port     5140
+    Parser   syslog-rfc3164
+    Mode     tcp
+
+[SERVICE]
+    Flush        1
+    Parsers_File parsers.conf
+
+[Output]
+    Name http
+    Match *
+    host vlogs
+    port 9428
+    compress gzip
+    uri /insert/jsonline/?_stream_fields=stream&_msg_field=log&_time_field=date
+    format json_lines
+    json_date_format iso8601
+    header AccountID 0
+    header ProjectID 0

--- a/deployment/docker/logstash/Dockerfile
+++ b/deployment/docker/logstash/Dockerfile
@@ -1,0 +1,3 @@
+FROM docker.elastic.co/logstash/logstash:8.8.0
+
+RUN bin/logstash-plugin install logstash-output-opensearch

--- a/deployment/docker/logstash/logstash.yml
+++ b/deployment/docker/logstash/logstash.yml
@@ -1,0 +1,2 @@
+http.host: 0.0.0.0
+xpack.monitoring.enabled: false

--- a/deployment/docker/logstash/pipeline.conf
+++ b/deployment/docker/logstash/pipeline.conf
@@ -1,0 +1,20 @@
+input {
+  syslog {
+    port => 5140
+  }
+}
+
+output {
+  opensearch {
+    hosts => ["http://vlogs:9428/insert/elasticsearch"]
+    custom_headers => {
+        "AccountID" => "0"
+        "ProjectID" => "0"
+    }
+    parameters => {
+        "_stream_fields" => "host.ip,process.name"
+        "_msg_field" => "message"
+        "_time_field" => "@timestamp"
+    }
+  }
+}

--- a/deployment/docker/logstash/readme.md
+++ b/deployment/docker/logstash/readme.md
@@ -1,0 +1,27 @@
+# How to set up sending logs to VictoriaLogs from logstash
+
+It is required to use [OpenSearch plugin](https://github.com/opensearch-project/logstash-output-opensearch) for output configuration.
+Plugin can be installed by using the following command:
+```
+bin/logstash-plugin install logstash-output-opensearch
+```
+OpenSearch plugin is required because elasticsearch output plugin performs various checks for Elasticsearch version and license which are not applicable for VictoriaLogs.
+
+Here is an example of logstash configuration:
+
+```
+  opensearch {
+    hosts => ["http://vlogs:9428/insert/elasticsearch"]
+    custom_headers => {
+        "AccountID" => "0"
+        "ProjectID" => "0"
+    }
+    parameters => {
+        "_stream_fields" => "host.ip,process.name"
+        "_msg_field" => "message"
+        "_time_field" => "@timestamp"
+    }
+  }
+```
+
+Please, note that `_stream_fields` parameter must follow recommended [best practices](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#stream-fields) to achieve better performance.


### PR DESCRIPTION
Adds examples for different logs shipment solutions:
- fluentbit
- filebeat
- logstash

Configuration uses:
- syslog at port 5140
- docker logs from host for filebeat/fluent-bit