### PR TITLE
lib/vmselectapi: extend error handling to ignore "reset by peer"

### DIFF
--- a/lib/vmselectapi/server.go
+++ b/lib/vmselectapi/server.go
@@ -257,7 +257,9 @@ func (s *Server) processConn(bc *handshake.BufferedConn) error {
 				// Remote client gracefully closed the connection.
 				return nil
 			}
-			if errors.Is(err, net.ErrClosed) || strings.Contains(err.Error(), "broken pipe") {
+			if errors.Is(err, net.ErrClosed) ||
+				strings.Contains(err.Error(), "broken pipe") ||
+				strings.Contains(err.Error(), "connection reset by peer") {
 				// The connection has been interrupted abruptly.
 				// It could happen due to unexpected network glitch or because connection was
 				// interrupted by remote client. In both cases, remote client will notice


### PR DESCRIPTION
This is a followup for https://github.com/VictoriaMetrics/VictoriaMetrics/pull/4418 to also handle "connection reset by peer" errors in connection handling logic. 
This error can be triggered just the same as described in original PR: when query was closed on vmselect side and connection has been interrupted.