### PR TITLE
Add /api/v2/write endpoint for influx vminsert

### DIFF
--- a/app/vminsert/main.go
+++ b/app/vminsert/main.go
@@ -274,7 +274,7 @@ func requestHandler(w http.ResponseWriter, r *http.Request) bool {
 		}
 		w.WriteHeader(http.StatusNoContent)
 		return true
-	case "influx/write", "influx/api/v2/write":
+	case "influx/write", "influx/api/v2/write", "api/v2/write":
 		influxWriteRequests.Inc()
 		addInfluxResponseHeaders(w)
 		if err := influx.InsertHandlerForHTTP(at, r); err != nil {


### PR DESCRIPTION
Faced a lack of this endpoint after migrating from single-node version to cluster. 
Looks like in current API structure it fits well, so as it'd help smooth migration from single-node to cluster in further versions.