### PR TITLE
docs: scroll to center of the view port

### DIFF
--- a/docs/_includes/extra/script.js
+++ b/docs/_includes/extra/script.js
@@ -17,7 +17,7 @@ window.addEventListener("load", function () {
         element = document.querySelector(selector(href));
     }
     if (element) {
-        element.scrollIntoView({ behavior: "smooth" });
+        element.scrollIntoView({ behavior: "smooth", block: "center", inline: "nearest" });
     }
 });
 


### PR DESCRIPTION
Added two scroll params where the `block` is vertical alignment. It will scroll to the element but create and offset to center this element into the viewport

Scroll to the bottom of the page
<img width="1084" alt="Screenshot 2023-06-23 at 15 13 53" src="https://github.com/VictoriaMetrics/VictoriaMetrics/assets/12189570/9041f4a2-eaf1-4a75-86a5-a358a5a9fee7">

Scroll to the center of the page.
<img width="1666" alt="Screenshot 2023-06-23 at 15 14 43" src="https://github.com/VictoriaMetrics/VictoriaMetrics/assets/12189570/97b61a57-a366-4065-b834-da78848c1819">

Scroll to the start of the page.

<img width="1628" alt="Screenshot 2023-06-23 at 15 15 51" src="https://github.com/VictoriaMetrics/VictoriaMetrics/assets/12189570/3d9ceff0-eaf6-46bc-831a-752196ac5fd6">

Signed-off-by: dmitryk-dk [d.kozlov@victoriametrics.com](mailto:d.kozlov@victoriametrics.com)