### PR TITLE
vmauth: rm ip filters from non-ent config example

### DIFF
--- a/app/vmauth/README.md
+++ b/app/vmauth/README.md
@@ -85,7 +85,7 @@ ip_filters:
   deny_list: [10.0.0.42]
 ```
 
-The following config allows requests for the user 'foobar' only from the ip `127.0.0.1`:
+The following config allows requests for the user 'foobar' only from the IP `127.0.0.1`:
 
 ```yml
 users:
@@ -95,6 +95,8 @@ users:
   ip_filters:
     allow_list: [127.0.0.1]
 ```
+
+See config example of using IP filters [here](https://github.com/VictoriaMetrics/VictoriaMetrics/blob/master/app/vmauth/example_config_ent.yml).
 
 ## Auth config
 

--- a/app/vmauth/example_config.yml
+++ b/app/vmauth/example_config.yml
@@ -89,8 +89,6 @@ users:
     url_prefix: "http://vminsert:8480/insert/42/prometheus"
     headers:
     - "X-Scope-OrgID: abc"
-    ip_filters:
-      deny_list: [127.0.0.1]
   default_url:
   - "http://default1:8888/unsupported_url_handler"
   - "http://default2:8888/unsupported_url_handler"
@@ -104,10 +102,3 @@ unauthorized_user:
     url_prefix:
     - http://vmselect1:8481/select/0/prometheus
     - http://vmselect2:8481/select/0/prometheus
-    ip_filters:
-      allow_list: [8.8.8.8]
-
-ip_filters:
-  allow_list: ["1.2.3.0/24", "127.0.0.1"]
-  deny_list:
-  - 10.1.0.1

--- a/app/vmauth/example_config_ent.yml
+++ b/app/vmauth/example_config_ent.yml
@@ -1,0 +1,57 @@
+# Arbitrary number of usernames may be put here.
+# It is possible to set multiple identical usernames with different passwords.
+# Such usernames can be differentiated by `name` option.
+
+users:
+  # A single user for querying and inserting data:
+  #
+  # - Requests to http://vmauth:8427/api/v1/query, http://vmauth:8427/api/v1/query_range
+  #   and http://vmauth:8427/api/v1/label/<label_name>/values are proxied to the following urls in a round-robin manner:
+  #     - http://vmselect1:8481/select/42/prometheus
+  #     - http://vmselect2:8481/select/42/prometheus
+  #   For example, http://vmauth:8427/api/v1/query is proxied to http://vmselect1:8480/select/42/prometheus/api/v1/query
+  #   or to http://vmselect2:8480/select/42/prometheus/api/v1/query .
+  #
+  # - Requests to http://vmauth:8427/api/v1/write are proxied to http://vminsert:8480/insert/42/prometheus/api/v1/write .
+  #   The "X-Scope-OrgID: abc" http header is added to these requests.
+  #
+  # Request which do not match `src_paths` from the `url_map` are proxied to the urls from `default_url`
+  # in a round-robin manner. The original request path is passed in `request_path` query arg.
+  # For example, request to http://vmauth:8427/non/existing/path are proxied:
+  #  - to http://default1:8888/unsupported_url_handler?request_path=/non/existing/path
+  #  - or http://default2:8888/unsupported_url_handler?request_path=/non/existing/path
+- username: "foobar"
+  url_map:
+  - src_paths:
+    - "/api/v1/query"
+    - "/api/v1/query_range"
+    - "/api/v1/label/[^/]+/values"
+    url_prefix:
+    - "http://vmselect1:8481/select/42/prometheus"
+    - "http://vmselect2:8481/select/42/prometheus"
+  - src_paths: ["/api/v1/write"]
+    url_prefix: "http://vminsert:8480/insert/42/prometheus"
+    headers:
+    - "X-Scope-OrgID: abc"
+    ip_filters:
+      deny_list: [127.0.0.1]
+  default_url:
+  - "http://default1:8888/unsupported_url_handler"
+  - "http://default2:8888/unsupported_url_handler"
+
+# Requests without Authorization header are routed according to `unauthorized_user` section.
+unauthorized_user:
+  url_map:
+  - src_paths:
+    - /api/v1/query
+    - /api/v1/query_range
+    url_prefix:
+    - http://vmselect1:8481/select/0/prometheus
+    - http://vmselect2:8481/select/0/prometheus
+    ip_filters:
+      allow_list: [8.8.8.8]
+
+ip_filters:
+  allow_list: ["1.2.3.0/24", "127.0.0.1"]
+  deny_list:
+  - 10.1.0.1

--- a/docs/vmauth.md
+++ b/docs/vmauth.md
@@ -96,7 +96,7 @@ ip_filters:
   deny_list: [10.0.0.42]
 ```
 
-The following config allows requests for the user 'foobar' only from the ip `127.0.0.1`:
+The following config allows requests for the user 'foobar' only from the IP `127.0.0.1`:
 
 ```yml
 users:
@@ -106,6 +106,8 @@ users:
   ip_filters:
     allow_list: [127.0.0.1]
 ```
+
+See config example of using IP filters [here](https://github.com/VictoriaMetrics/VictoriaMetrics/blob/master/app/vmauth/example_config_ent.yml).
 
 ## Auth config
 


### PR DESCRIPTION
It is impossible to run OS vmauth with the provided config. The example of using ip filters should be only a part of docs. All other examples should work seamlessly with OS version.