### PR TITLE
fix parse for invalid partial RFC3339 format

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -42,7 +42,7 @@ The following tip changes can be tested by building VictoriaMetrics components f
   `--search.maxGraphiteTagValues` for limiting the number of tag values returned Graphite `/tags/<tag_name>` API. 
   Remove redundant limit from [Prometheus api/v1/series](https://docs.victoriametrics.com/Single-server-VictoriaMetrics.html#prometheus-querying-api-usage). See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/4339).
 * BUGFIX: [vmui](https://docs.victoriametrics.com/#vmui): fix application routing issues and problems with manual URL changes. See [this pull request](https://github.com/VictoriaMetrics/VictoriaMetrics/pull/4408).
-* BUGFIX: fix invalid [timestamp formats](https://docs.victoriametrics.com/Single-server-VictoriaMetrics.html#timestamp-formats) in query APIs and in export APIs.
+* BUGFIX: add validation for invalid [partial RFC3339 timestamp formats](https://docs.victoriametrics.com/Single-server-VictoriaMetrics.html#timestamp-formats) in query APIs and in export APIs.
 
 ## [v1.91.3](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.91.3)
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -42,7 +42,7 @@ The following tip changes can be tested by building VictoriaMetrics components f
   `--search.maxGraphiteTagValues` for limiting the number of tag values returned Graphite `/tags/<tag_name>` API. 
   Remove redundant limit from [Prometheus api/v1/series](https://docs.victoriametrics.com/Single-server-VictoriaMetrics.html#prometheus-querying-api-usage). See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/4339).
 * BUGFIX: [vmui](https://docs.victoriametrics.com/#vmui): fix application routing issues and problems with manual URL changes. See [this pull request](https://github.com/VictoriaMetrics/VictoriaMetrics/pull/4408).
-
+* BUGFIX: fix invalid [timestamp formats](https://docs.victoriametrics.com/Single-server-VictoriaMetrics.html#timestamp-formats) in query APIs and in export APIs.
 
 ## [v1.91.3](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.91.3)
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -42,7 +42,7 @@ The following tip changes can be tested by building VictoriaMetrics components f
   `--search.maxGraphiteTagValues` for limiting the number of tag values returned Graphite `/tags/<tag_name>` API. 
   Remove redundant limit from [Prometheus api/v1/series](https://docs.victoriametrics.com/Single-server-VictoriaMetrics.html#prometheus-querying-api-usage). See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/4339).
 * BUGFIX: [vmui](https://docs.victoriametrics.com/#vmui): fix application routing issues and problems with manual URL changes. See [this pull request](https://github.com/VictoriaMetrics/VictoriaMetrics/pull/4408).
-* BUGFIX: add validation for invalid [partial RFC3339 timestamp formats](https://docs.victoriametrics.com/Single-server-VictoriaMetrics.html#timestamp-formats) in query APIs and in export APIs.
+* BUGFIX: add validation for invalid [partial RFC3339 timestamp formats](https://docs.victoriametrics.com/Single-server-VictoriaMetrics.html#timestamp-formats) in query and export APIs.
 
 ## [v1.91.3](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.91.3)
 

--- a/lib/promutils/time.go
+++ b/lib/promutils/time.go
@@ -75,7 +75,7 @@ func ParseTimeAt(s string, currentTimestamp float64) (float64, error) {
 			return 0, err
 		}
 		if y, _ := strconv.Atoi(s); y > maxValidYear || y < minValidYear {
-			return 0, fmt.Errorf("got invalid year %s, must between [%d, %d]", s, minValidYear, maxValidYear)
+			return 0, fmt.Errorf("got invalid partial RFC3339 time: %s, year must between [%d, %d]", s, minValidYear, maxValidYear)
 		}
 		return tzOffset + float64(t.UnixNano())/1e9, nil
 	}

--- a/lib/promutils/time.go
+++ b/lib/promutils/time.go
@@ -2,16 +2,9 @@ package promutils
 
 import (
 	"fmt"
-	"math"
 	"strconv"
 	"strings"
 	"time"
-)
-
-var (
-	// Time.UnixNano can only store maxInt64, which is 2262
-	maxValidYear, _ = strconv.Atoi(time.Unix(0, int64(math.MaxInt64)).Format("2006"))
-	minValidYear, _ = strconv.Atoi(time.Unix(0, 0).Format("2006"))
 )
 
 // ParseTime parses time s in different formats.
@@ -23,6 +16,12 @@ func ParseTime(s string) (float64, error) {
 	currentTimestamp := float64(time.Now().UnixNano()) / 1e9
 	return ParseTimeAt(s, currentTimestamp)
 }
+
+const (
+	// time.UnixNano can only store maxInt64, which is 2262
+	maxValidYear = 2262
+	minValidYear = 1970
+)
 
 // ParseTimeAt parses time s in different formats, assuming the given currentTimestamp.
 //
@@ -74,8 +73,9 @@ func ParseTimeAt(s string, currentTimestamp float64) (float64, error) {
 		if err != nil {
 			return 0, err
 		}
-		if y, _ := strconv.Atoi(s); y > maxValidYear || y < minValidYear {
-			return 0, fmt.Errorf("got invalid partial RFC3339 time: %s, year must between [%d, %d]", s, minValidYear, maxValidYear)
+		y := t.Year()
+		if y > maxValidYear || y < minValidYear {
+			return 0, fmt.Errorf("cannot parse year from %q: year must in range [%d, %d]", s, minValidYear, maxValidYear)
 		}
 		return tzOffset + float64(t.UnixNano())/1e9, nil
 	}

--- a/lib/promutils/time.go
+++ b/lib/promutils/time.go
@@ -2,9 +2,16 @@ package promutils
 
 import (
 	"fmt"
+	"math"
 	"strconv"
 	"strings"
 	"time"
+)
+
+var (
+	// Time.UnixNano can only store maxInt64, which is 2262
+	maxValidYear, _ = strconv.Atoi(time.Unix(0, int64(math.MaxInt64)).Format("2006"))
+	minValidYear, _ = strconv.Atoi(time.Unix(0, 0).Format("2006"))
 )
 
 // ParseTime parses time s in different formats.
@@ -66,6 +73,9 @@ func ParseTimeAt(s string, currentTimestamp float64) (float64, error) {
 		t, err := time.Parse("2006", s)
 		if err != nil {
 			return 0, err
+		}
+		if y, _ := strconv.Atoi(s); y > maxValidYear || y < minValidYear {
+			return 0, fmt.Errorf("got invalid year %s, must between [%d, %d]", s, minValidYear, maxValidYear)
 		}
 		return tzOffset + float64(t.UnixNano())/1e9, nil
 	}

--- a/lib/promutils/time_test.go
+++ b/lib/promutils/time_test.go
@@ -91,6 +91,7 @@ func TestParseTimeFailure(t *testing.T) {
 	}
 
 	f("")
+	f("2263")
 	f("23-45:50")
 	f("1223-fo:ba")
 	f("1223-12:ba")


### PR DESCRIPTION
Unlike prometheus, VictoriaMetrics accepts [format timestamp with four letter as year](https://docs.victoriametrics.com/Single-server-VictoriaMetrics.html#timestamp-formats) in [query APIs](https://docs.victoriametrics.com/#prometheus-querying-api-usage) and in [export APIs](https://docs.victoriametrics.com/#how-to-export-time-series).
We parse time using time.UnixNano which can only store maxInt64, so the valid year is between [1970,2262]

tip: User can't query data by passing timestamp "6000" as "1970-10-01 00:10:00" like prometheus, they should use something like 1970-01-01T10:00:00.
