### PR TITLE
adds '-e' flag for echo in Makefile:copy-docs section

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -478,16 +478,18 @@ check-licenses: install-wwhrd
 	wwhrd check -f .wwhrd.yml
 
 copy-docs:
+# The 'printf' function is used instead of 'echo' or 'echo -e' to handle line breaks (e.g. '\n') in the same way on different operating systems (MacOS/Ubuntu Linux/Arch Linux) and their shells (bash/sh/zsh/fish).
+# For details, see https://github.com/VictoriaMetrics/VictoriaMetrics/pull/4548#issue-1782796419 and https://stackoverflow.com/questions/8467424/echo-newline-in-bash-prints-literal-n
 	echo "---" > ${DST}
 	@if [ ${ORDER} -ne 0 ]; then \
 		echo "sort: ${ORDER}" >> ${DST}; \
 		echo "weight: ${ORDER}" >> ${DST}; \
-		echo -e "menu:\n  docs:\n    parent: 'victoriametrics'\n    weight: ${ORDER}" >> ${DST}; \
+		printf "menu:\n  docs:\n    parent: 'victoriametrics'\n    weight: ${ORDER}\n" >> ${DST}; \
 	fi
 
 	echo "title: ${TITLE}" >> ${DST}
 	@if [ ${OLD_URL} ]; then \
-		echo -e "aliases:\n  - ${OLD_URL}" >> ${DST}; \
+		printf "aliases:\n  - ${OLD_URL}\n" >> ${DST}; \
 	fi
 	echo "---" >> ${DST}
 	cat ${SRC} >> ${DST}

--- a/Makefile
+++ b/Makefile
@@ -482,12 +482,12 @@ copy-docs:
 	@if [ ${ORDER} -ne 0 ]; then \
 		echo "sort: ${ORDER}" >> ${DST}; \
 		echo "weight: ${ORDER}" >> ${DST}; \
-		echo "menu:\n  docs:\n    parent: 'victoriametrics'\n    weight: ${ORDER}" >> ${DST}; \
+		echo -e "menu:\n  docs:\n    parent: 'victoriametrics'\n    weight: ${ORDER}" >> ${DST}; \
 	fi
 
 	echo "title: ${TITLE}" >> ${DST}
 	@if [ ${OLD_URL} ]; then \
-		echo "aliases:\n  - ${OLD_URL}" >> ${DST}; \
+		echo -e "aliases:\n  - ${OLD_URL}" >> ${DST}; \
 	fi
 	echo "---" >> ${DST}
 	cat ${SRC} >> ${DST}


### PR DESCRIPTION
Using this flag eliminates the wrong behavior of the copy-docs function in Arch Linux and its forks, which use https://fishshell.com by default.

Without using '-e' flag echo don't recognized "\n". See example:
```fish
on garuda@VictoriaMetrics on 🌱fix/wrong-copy-docs-behavior 📝 ×12via 🐹 v1.20.5 []
 🤍 19:08 󰈺  ❯ git status
On branch fix/wrong-copy-docs-behavior
Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
	modified:   Makefile
	modified:   README.md
	modified:   docs/README.md
	modified:   docs/Single-server-VictoriaMetrics.md
	modified:   docs/vmagent.md
	modified:   docs/vmalert.md
	modified:   docs/vmauth.md
	modified:   docs/vmbackup.md
	modified:   docs/vmbackupmanager.md
	modified:   docs/vmctl.md
	modified:   docs/vmgateway.md
	modified:   docs/vmrestore.md

no changes added to commit (use "git add" and/or "git commit -a")

on garuda@VictoriaMetrics on 🌱fix/wrong-copy-docs-behavior 📝 ×12via 🐹 v1.20.5 []
 🤍 19:09 󰈺  ❯ git diff docs/vmagent.md
diff --git a/docs/vmagent.md b/docs/vmagent.md
index 03404db69..fd16c4e54 100644
--- a/docs/vmagent.md
+++ b/docs/vmagent.md
@@ -1,13 +1,9 @@
 ---
 sort: 3
 weight: 3
-menu:
-  docs:
-    parent: 'victoriametrics'
-    weight: 3
+menu:\n  docs:\n    parent: 'victoriametrics'\n    weight: 3
 title: vmagent
-aliases:
-  - /vmagent.html
+aliases:\n  - /vmagent.html
 ---
 # vmagent
```