### PR TITLE
Update base Alpine image to 3.18.2 to avoid security risks

### DIFF
--- a/app/vmui/Dockerfile-web
+++ b/app/vmui/Dockerfile-web
@@ -6,7 +6,7 @@ COPY web/ /build/
 RUN GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o web-amd64 github.com/VictoriMetrics/vmui/ && \
     GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go build -o web-windows github.com/VictoriMetrics/vmui/
 
-FROM alpine:3.18.0
+FROM alpine:3.18.2
 USER root
 
 COPY --from=build-web-stage /build/web-amd64 /app/web

--- a/deployment/docker/Makefile
+++ b/deployment/docker/Makefile
@@ -2,10 +2,10 @@
 
 DOCKER_NAMESPACE ?= victoriametrics
 
-ROOT_IMAGE ?= alpine:3.18.0
+ROOT_IMAGE ?= alpine:3.18.2
 
-# Use alpine:3.17.3 instead of 3.18.0 for CERTS_IMAGE
-# because alpine:3.18.0 is broken for cross-platform builds
+# Use alpine:3.17.3 instead of 3.18.2 for CERTS_IMAGE
+# because alpine:3.18.2 is broken for cross-platform builds
 # TODO: sync it with ROOT_IMAGE when it will be fixed in the new alpine releases
 CERTS_IMAGE := alpine:3.17.3
 


### PR DESCRIPTION
libcrypto3 and libssl3 in Alpine 3.18.0 have versions `3.1.0-r4` which contains CVE-2023-2650:
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-2650 Use ALpine image 3.18.2 which contains fixed versions of libssl3 and libcrypto3: 3.1.1-r0
NB: In Openshift these containers are marked as vulnerabilities because of these CVEs.