### PR TITLE
make: add goimports task

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -409,7 +409,7 @@ vet:
 	go vet ./lib/...
 	go vet ./app/...
 
-goimports:
+goimports: install-goimports
 	goimports -local github.com/VictoriaMetrics/VictoriaMetrics -w ./lib
 	goimports -local github.com/VictoriaMetrics/VictoriaMetrics -w ./app
 
@@ -477,6 +477,9 @@ install-govulncheck:
 
 install-wwhrd:
 	which wwhrd || go install github.com/frapposelli/wwhrd@latest
+
+install-goimports:
+	which goimports || go install golang.org/x/tools/cmd/goimports@latest
 
 check-licenses: install-wwhrd
 	wwhrd check -f .wwhrd.yml

--- a/Makefile
+++ b/Makefile
@@ -409,7 +409,11 @@ vet:
 	go vet ./lib/...
 	go vet ./app/...
 
-check-all: fmt vet golangci-lint govulncheck
+goimports:
+	goimports -local github.com/VictoriaMetrics/VictoriaMetrics -w ./lib
+	goimports -local github.com/VictoriaMetrics/VictoriaMetrics -w ./app
+
+check-all: fmt goimports vet golangci-lint govulncheck
 
 test:
 	go test ./lib/... ./app/...

--- a/Makefile
+++ b/Makefile
@@ -409,9 +409,15 @@ vet:
 	go vet ./lib/...
 	go vet ./app/...
 
+# Set variables by using target specific variables to avoid running git diff for each make execution
+# See: https://www.gnu.org/software/make/manual/html_node/Target_002dspecific.html
+goimports: GO_CHANGED_FILES+=$(shell git diff --cached --name-only --diff-filter=ACMR -- 'lib/*.go')
+goimports: GO_CHANGED_FILES+=$(shell git diff --cached --name-only --diff-filter=ACMR -- 'app/*.go')
 goimports: install-goimports
-	goimports -local github.com/VictoriaMetrics/VictoriaMetrics -w ./lib
-	goimports -local github.com/VictoriaMetrics/VictoriaMetrics -w ./app
+	# GO_CHANGED_FILES will contain a single space if there are no changed files
+	if [ "$(GO_CHANGED_FILES)" != " " ]; then \
+		goimports -local github.com/VictoriaMetrics/VictoriaMetrics -w $(GO_CHANGED_FILES); \
+	fi
 
 check-all: fmt goimports vet golangci-lint govulncheck
 

--- a/Makefile
+++ b/Makefile
@@ -411,8 +411,8 @@ vet:
 
 # Set variables by using target specific variables to avoid running git diff for each make execution
 # See: https://www.gnu.org/software/make/manual/html_node/Target_002dspecific.html
-goimports: GO_CHANGED_FILES+=$(shell git diff --cached --name-only --diff-filter=ACMR -- 'lib/*.go')
-goimports: GO_CHANGED_FILES+=$(shell git diff --cached --name-only --diff-filter=ACMR -- 'app/*.go')
+goimports: GO_CHANGED_FILES+=$(shell git diff --name-only --diff-filter=ACMR HEAD -- 'lib/*.go')
+goimports: GO_CHANGED_FILES+=$(shell git diff --name-only --diff-filter=ACMR HEAD -- 'app/*.go')
 goimports: install-goimports
 	# GO_CHANGED_FILES will contain a single space if there are no changed files
 	if [ "$(GO_CHANGED_FILES)" != " " ]; then \


### PR DESCRIPTION
Adds task to fix imports formatting inplace.
Formats imports into:
- standard library
- external libraries
- local packages based on github.com/VictoriaMetrics/VictoriaMetrics prefix

Note that this PR does not apply new formatting.