### PR TITLE
app/vlstorage add retentionWatchInterval flag

### DIFF
--- a/docs/VictoriaLogs/README.md
+++ b/docs/VictoriaLogs/README.md
@@ -222,6 +222,8 @@ Pass `-help` to VictoriaLogs in order to see the list of supported command-line 
   -retentionPeriod value
     	Log entries with timestamps older than now-retentionPeriod are automatically deleted; log entries with timestamps outside the retention are also rejected during data ingestion; the minimum supported retention is 1d (one day); see https://docs.victoriametrics.com/VictoriaLogs/#retention
     	The following optional suffixes are supported: h (hour), d (day), w (week), y (year). If suffix isn't set, then the duration is counted in months (default 7d)
+  -retentionWatchInterval int
+        Specify the interval period for scanning expired data, in units of hours, the minimum supported value is 1 (default 1)  	
   -search.maxConcurrentRequests int
     	The maximum number of concurrent search requests. It shouldn't be high, since a single request can saturate all the CPU cores, while many concurrently executed requests may require high amounts of memory. See also -search.maxQueueDuration (default 6)
   -search.maxQueryDuration duration

--- a/lib/logstorage/storage.go
+++ b/lib/logstorage/storage.go
@@ -216,6 +216,11 @@ func MustOpenStorage(path string, cfg *StorageConfig) *Storage {
 		retention = 24 * time.Hour
 	}
 
+	retentionWatchInterval := cfg.RetentionWatchInterval
+	if retentionWatchInterval == 0 {
+		retentionWatchInterval = 1
+	}
+
 	futureRetention := cfg.FutureRetention
 	if futureRetention < 24*time.Hour {
 		futureRetention = 24 * time.Hour
@@ -239,7 +244,7 @@ func MustOpenStorage(path string, cfg *StorageConfig) *Storage {
 	s := &Storage{
 		path:                   path,
 		retention:              retention,
-		retentionWatchInterval: cfg.RetentionWatchInterval,
+		retentionWatchInterval: retentionWatchInterval,
 		flushInterval:          flushInterval,
 		futureRetention:        futureRetention,
 		logNewStreams:          cfg.LogNewStreams,


### PR DESCRIPTION
Deleting expired data will lock and lead to performance degradation, users can configure a suitable interval according to their own load situation.