### PR TITLE
lib/logstorage: fix panic

### DIFF
--- a/lib/logstorage/datadb.go
+++ b/lib/logstorage/datadb.go
@@ -37,6 +37,9 @@ const maxInmemoryPartsPerPartition = 20
 
 // datadb represents a database with log data
 type datadb struct {
+	// mergeIdx is used for generating unique directory names for parts
+	mergeIdx uint64
+
 	inmemoryMergesTotal  uint64
 	inmemoryActiveMerges uint64
 	fileMergesTotal      uint64
@@ -44,9 +47,6 @@ type datadb struct {
 
 	// pt is the partition the datadb belongs to
 	pt *partition
-
-	// mergeIdx is used for generating unique directory names for parts
-	mergeIdx uint64
 
 	// path is the path to the directory with log data
 	path string


### PR DESCRIPTION
This PR fixed panic when test running
```
panic: unaligned 64-bit atomic operation

goroutine 13918 [running]:
runtime/internal/atomic.panicUnaligned()
	/opt/hostedtoolcache/go/1.20.6/x64/src/runtime/internal/atomic/unaligned.go:8 +0x2d
runtime/internal/atomic.Xadd64(0xe038224, 0x1)
	/opt/hostedtoolcache/go/1.20.6/x64/src/runtime/internal/atomic/atomic_386.s:125 +0x11
github.com/VictoriaMetrics/VictoriaMetrics/lib/logstorage.(*datadb).nextMergeIdx(...)
	/home/runner/work/VictoriaMetrics/VictoriaMetrics/lib/logstorage/datadb.go:443
github.com/VictoriaMetrics/VictoriaMetrics/lib/logstorage.(*datadb).mustMergeParts(0xe038200, {0xae460c0, 0xf, 0x10}, 0x0)
	/home/runner/work/VictoriaMetrics/VictoriaMetrics/lib/logstorage/datadb.go:350 +0x337
github.com/VictoriaMetrics/VictoriaMetrics/lib/logstorage.(*datadb).mustMergeExistingParts(0xe038200)
	/home/runner/work/VictoriaMetrics/VictoriaMetrics/lib/logstorage/datadb.go:287 +0x4ad
github.com/VictoriaMetrics/VictoriaMetrics/lib/logstorage.(*datadb).startMergeWorkerLocked.func1()
	/home/runner/work/VictoriaMetrics/VictoriaMetrics/lib/logstorage/datadb.go:238 +0x[54](https://github.com/VictoriaMetrics/VictoriaMetrics/actions/runs/5531683129/jobs/10092745837?pr=4616#step:4:55)
created by github.com/VictoriaMetrics/VictoriaMetrics/lib/logstorage.(*datadb).startMergeWorkerLocked
	/home/runner/work/VictoriaMetrics/VictoriaMetrics/lib/logstorage/datadb.go:236 +0x19b
FAIL	github.com/VictoriaMetrics/VictoriaMetrics/lib/logstorage	9.[58](https://github.com/VictoriaMetrics/VictoriaMetrics/actions/runs/5531683129/jobs/10092745837?pr=4616#step:4:59)4s
```
Signed-off-by: dmitryk-dk [d.kozlov@victoriametrics.com](mailto:d.kozlov@victoriametrics.com)
