### PR TITLE
lib/storage: adds nextIndexDB to mitigate performance degradation on

### DIFF
--- a/app/vmstorage/main.go
+++ b/app/vmstorage/main.go
@@ -552,6 +552,9 @@ func registerStorageMetrics(strg *storage.Storage) {
 	metrics.NewGauge(`vm_timeseries_repopulated_total`, func() float64 {
 		return float64(idbm().TimeseriesRepopulated)
 	})
+	metrics.NewGauge(`vm_index_records_repopulated_total`, func() float64 {
+		return float64(idbm().DailyIndexRecordsRepopulated)
+	})
 	metrics.NewGauge(`vm_missing_tsids_for_metric_id_total`, func() float64 {
 		return float64(idbm().MissingTSIDsForMetricID)
 	})

--- a/lib/storage/index_db_test.go
+++ b/lib/storage/index_db_test.go
@@ -2005,14 +2005,16 @@ func newTestStorage() *Storage {
 	s := &Storage{
 		cachePath: "test-storage-cache",
 
-		metricIDCache:     workingsetcache.New(1234),
-		metricNameCache:   workingsetcache.New(1234),
-		tsidCache:         workingsetcache.New(1234),
-		dateMetricIDCache: newDateMetricIDCache(),
-		retentionMsecs:    maxRetentionMsecs,
+		metricIDCache:   workingsetcache.New(1234),
+		metricNameCache: workingsetcache.New(1234),
+		tsidCache:       workingsetcache.New(1234),
+
+		retentionMsecs: maxRetentionMsecs,
 	}
 	s.setDeletedMetricIDs(&uint64set.Set{})
-	var idb *indexDB
+	idb := &indexDB{
+		dateMetricIDCache: newDateMetricIDCache(),
+	}
 	s.idbCurr.Store(idb)
 	return s
 }


### PR DESCRIPTION
indexDB rotation

Previously, during indexDB dateMetricID cache was reseted and it caused a lot of new records creation. It may saturate memory usage, since lookups for exist entries were made.
With new logic, daily index records will be pre-created at the 1 hour before indexDB rotation.
There is no need to reset dateMetricID cache, since it belongs to indexDB. It greatly improves perforamnce.
It should help to implement next feature https://github.com/VictoriaMetrics/VictoriaMetrics/issues/4563