### PR TITLE
vmalert: fix evalTS after modify group interval

### DIFF
--- a/app/vmalert/group.go
+++ b/app/vmalert/group.go
@@ -384,6 +384,7 @@ func (g *Group) start(ctx context.Context, nts func() []notifier.Notifier, rw *r
 				g.Interval = ng.Interval
 				t.Stop()
 				t = time.NewTicker(g.Interval)
+				evalTS = time.Now()
 			}
 			g.mu.Unlock()
 			logger.Infof("group %q re-started; interval=%v; concurrency=%d", g.Name, g.Interval, g.Concurrency)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -55,6 +55,7 @@ The following tip changes can be tested by building VictoriaMetrics components f
 * BUGFIX: [vmctl](https://docs.victoriametrics.com/vmctl.html): fix issue with adding additional character if length of the if the length of the string has become less than the previous length. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/4555).
 * BUGFIX: [vmalert](https://docs.victoriametrics.com/vmalert.html): use RFC3339 time format in query args instead of unix timestamp for all issued queries to Prometheus-like datasources.
 * BUGFIX: [vmalert](https://docs.victoriametrics.com/vmalert.html): correctly calculate evaluation time for rules. Before, there was a low probability for discrepancy between actual time and rules evaluation time if evaluation interval was lower than the execution time for rules within the group.
+* BUGFIX: [vmalert](https://docs.victoriametrics.com/vmalert.html): reset evaluation timestamp after modifying group interval. Before, there could have latency on rule evaluation time.
 * BUGFIX: vmselect: fix timestamp alignment for Prometheus querying API if time argument is less than 10m from the beginning of Unix epoch.
 
 ## [v1.91.3](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.91.3)


### PR DESCRIPTION
Need to reset evalTS after modify group interval. Otherwise there could be latency on rule evaluation time all the time when (modifyTS-LastestEvalTS)%NewGroupInterval >0, eg: will have 29m latency below.
<img width="1129" alt="image" src="https://github.com/VictoriaMetrics/VictoriaMetrics/assets/39937150/035a755b-7209-4134-8da9-6d02715be23c">




