### PR TITLE
vmalert: restart group if interval has changed

### DIFF
--- a/app/vmalert/group.go
+++ b/app/vmalert/group.go
@@ -163,6 +163,7 @@ func (g *Group) ID() uint64 {
 	hash.Write([]byte("\xff"))
 	hash.Write([]byte(g.Name))
 	hash.Write([]byte(g.Type.Get()))
+	hash.Write([]byte(g.Interval.String()))
 	return hash.Sum64()
 }
 
@@ -379,12 +380,6 @@ func (g *Group) start(ctx context.Context, nts func() []notifier.Notifier, rw *r
 			e.purgeStaleSeries(g.Rules)
 
 			e.notifierHeaders = g.NotifierHeaders
-
-			if g.Interval != ng.Interval {
-				g.Interval = ng.Interval
-				t.Stop()
-				t = time.NewTicker(g.Interval)
-			}
 			g.mu.Unlock()
 			logger.Infof("group %q re-started; interval=%v; concurrency=%d", g.Name, g.Interval, g.Concurrency)
 		case <-t.C:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -55,6 +55,7 @@ The following tip changes can be tested by building VictoriaMetrics components f
 * BUGFIX: [vmctl](https://docs.victoriametrics.com/vmctl.html): fix formatting issue, which could add superflouos `s` characters at the end of `samples/s` output during data migration. For example, it could write `samples/ssssss`. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/4555).
 * BUGFIX: [vmalert](https://docs.victoriametrics.com/vmalert.html): use RFC3339 time format in query args instead of unix timestamp for all issued queries to Prometheus-like datasources.
 * BUGFIX: [vmalert](https://docs.victoriametrics.com/vmalert.html): correctly calculate evaluation time for rules. Before, there was a low probability for discrepancy between actual time and rules evaluation time if evaluation interval was lower than the execution time for rules within the group.
+* BUGFIX: [vmalert](https://docs.victoriametrics.com/vmalert.html): properly restart rule's group if evaluation interval has changed. See more details about reasoning [here](https://github.com/VictoriaMetrics/VictoriaMetrics/pull/4634).
 * BUGFIX: vmselect: fix timestamp alignment for Prometheus querying API if time argument is less than 10m from the beginning of Unix epoch.
 
 ## [v1.91.3](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.91.3)


### PR DESCRIPTION
Interval field now becomes a part of group's ID hash. When group is updated, vmalert check if ID has changed. If it changed, old group is deleted and new group starts. If not changed, old group fields are updated with new fields.

Before the change, Interval field could have been updated without group deletion, as it wasn't a part of ID hash. This has the following cons:
1. Interval update may cause permanent eval timestamp shift, as mentioned here https://github.com/VictoriaMetrics/VictoriaMetrics/pull/4629
2. Updating the interval ignores the artifical delay on group start. Effectively it means that all groups which were updated by eval interval will start their execution simultaneously. This defeats the purpose of artificial delay on group start.