### PR TITLE
Including changes to skip TLS cert check in -dryRun

### DIFF
--- a/app/victoria-metrics/main.go
+++ b/app/victoria-metrics/main.go
@@ -54,6 +54,7 @@ func main() {
 		*dryRun = true
 	}
 	if *dryRun {
+		promscrape.SetDryRun(true)
 		if err := promscrape.CheckConfig(); err != nil {
 			logger.Fatalf("error when checking -promscrape.config: %s", err)
 		}

--- a/app/vmagent/main.go
+++ b/app/vmagent/main.go
@@ -103,6 +103,7 @@ func main() {
 		return
 	}
 	if *dryRun {
+		promscrape.SetDryRun(true)
 		if err := promscrape.CheckConfig(); err != nil {
 			logger.Fatalf("error when checking -promscrape.config: %s", err)
 		}


### PR DESCRIPTION

Changes to skip the TLS files check in dryRun case if the TLS cert files specified in promscrape config do not exist.

Changes for issue: https://github.com/VictoriaMetrics/VictoriaMetrics/issues/4625