### PR TITLE
dashboards/cluster: fix using storage filter for cache usage panel

### DIFF
--- a/dashboards/victoriametrics-cluster.json
+++ b/dashboards/victoriametrics-cluster.json
@@ -3503,7 +3503,7 @@
               },
               "editorMode": "code",
               "exemplar": true,
-              "expr": "max(\n    vm_cache_size_bytes{job=~\"$job_storage\", instance=~\"$instance\"} \n    /\n    vm_cache_size_max_bytes{job=~\"$job\", instance=~\"$instance\"}\n) by(type)",
+              "expr": "max(\n    vm_cache_size_bytes{job=~\"$job\", instance=~\"$instance\"} \n    /\n    vm_cache_size_max_bytes{job=~\"$job\", instance=~\"$instance\"}\n) by(type)",
               "interval": "",
               "legendFormat": "__auto",
               "range": true,


### PR DESCRIPTION
Using `job=~$job_storage` forces "Cache usage" panel to display only vmstorage caches, but there is a cache peresent at vmselect(`promql/rollupResult`). 
Updated selector to match generic `$job` so that all caches will be displayed with an option to display per-job caches.