### PR TITLE
vmui: improvements for the Active Queries

### DIFF
--- a/app/vmui/packages/vmui/src/App.tsx
+++ b/app/vmui/packages/vmui/src/App.tsx
@@ -14,7 +14,7 @@ import PreviewIcons from "./components/Main/Icons/PreviewIcons";
 import WithTemplate from "./pages/WithTemplate";
 import Relabel from "./pages/Relabel";
 import ExploreLogs from "./pages/ExploreLogs/ExploreLogs";
-import from "./pages/ActiveQueries";
+import ActiveQueries from "./pages/ActiveQueries";
 
 const App: FC = () => {
   const [loadedTheme, setLoadedTheme] = useState(false);

--- a/app/vmui/packages/vmui/src/types/index.ts
+++ b/app/vmui/packages/vmui/src/types/index.ts
@@ -147,7 +147,6 @@ export interface ActiveQueriesType {
   query: string;
   remote_addr: string;
   step: number;
-  from?: string;
-  to?: string;
+  args?: string;
   data?: string;
 }

--- a/app/vmui/packages/vmui/src/utils/time.ts
+++ b/app/vmui/packages/vmui/src/utils/time.ts
@@ -30,7 +30,7 @@ const shortDurations = supportedDurations.map(d => d.short);
 
 export const roundToMilliseconds = (num: number): number => Math.round(num*1000)/1000;
 
-const roundStep = (step: number) => {
+export const roundStep = (step: number) => {
   let result = roundToMilliseconds(step);
   const integerStep = Math.round(step);
 


### PR DESCRIPTION
- The `id` column has been removed
- The `from`, `to`, and `step` columns have been combined into a single `args` column.
- The `remote_addr` column has been renamed to `client address`.
- The columns have been reordered as follows: `duration`, `client address`, `query`, `args`.
- The table has been sorted in descending order based on the `duration` column.

https://github.com/VictoriaMetrics/VictoriaMetrics/pull/4653#issuecomment-1642888619