### PR TITLE
docs: update information about tsdb usage in cluster version

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,12 +401,10 @@ matching the specified [series selector](https://prometheus.io/docs/prometheus/l
 
 Cardinality explorer is built on top of [/api/v1/status/tsdb](#tsdb-stats).
 
-If you are using [cluster version of VictoriaMetrics](https://docs.victoriametrics.com/Cluster-VictoriaMetrics.html) each 
-vmstorage tracks the number of stored timeseries individually. vmselect requests stats via [/api/v1/status/tsdb](#tsdb-stats) 
-from each vmstorage node and merges the results. This may lead to inflated values when samples for the same time series 
-are spread across multiple vmstorage nodes due to [replication](#replication) or rerouting.
-It happens because vmstorage fetches the collected tsdb stats from every vmstorage node and merges it.
-The `seriesCountByMetricName` stats is just summed across vmstorage nodes.
+In [cluster version of VictoriaMetrics](https://docs.victoriametrics.com/Cluster-VictoriaMetrics.html) each vmstorage tracks the stored time series individually.
+vmselect requests stats via [/api/v1/status/tsdb](#tsdb-stats) API from each vmstorage node and merges the results by summing per-series stats.
+This may lead to inflated values when samples for the same time series are spread across multiple vmstorage nodes
+due to [replication](#replication) or [rerouting](https://docs.victoriametrics.com/Cluster-VictoriaMetrics.html?highlight=re-routes#cluster-availability).
 
 See [cardinality explorer playground](https://play.victoriametrics.com/select/accounting/1/6a716b0f-38bc-4856-90ce-448fd713e3fe/prometheus/graph/#/cardinality).
 See the example of using the cardinality explorer [here](https://victoriametrics.com/blog/cardinality-explorer/).
@@ -1790,12 +1788,10 @@ VictoriaMetrics returns TSDB stats at `/api/v1/status/tsdb` page in the way simi
 * `match[]=SELECTOR` where `SELECTOR` is an arbitrary [time series selector](https://prometheus.io/docs/prometheus/latest/querying/basics/#time-series-selectors) for series to take into account during stats calculation. By default all the series are taken into account.
 * `extra_label=LABEL=VALUE`. See [these docs](#prometheus-querying-api-enhancements) for more details.
 
-If you are using [cluster version of VictoriaMetrics](https://docs.victoriametrics.com/Cluster-VictoriaMetrics.html) each
-vmstorage tracks the number of stored timeseries individually. vmselect requests stats via [/api/v1/status/tsdb](#tsdb-stats)
-from each vmstorage node and merges the results. This may lead to inflated values when samples for the same time series
-are spread across multiple vmstorage nodes due to [replication](#replication) or rerouting.
-It happens because vmstorage fetches the collected tsdb stats from every vmstorage node and merges it.
-The `seriesCountByMetricName` stats is just summed across vmstorage nodes.
+In [cluster version of VictoriaMetrics](https://docs.victoriametrics.com/Cluster-VictoriaMetrics.html) each vmstorage tracks the stored time series individually.
+vmselect requests stats via [/api/v1/status/tsdb](#tsdb-stats) API from each vmstorage node and merges the results by summing per-series stats.
+This may lead to inflated values when samples for the same time series are spread across multiple vmstorage nodes
+due to [replication](#replication) or [rerouting](https://docs.victoriametrics.com/Cluster-VictoriaMetrics.html?highlight=re-routes#cluster-availability).
 
 VictoriaMetrics provides an UI on top of `/api/v1/status/tsdb` - see [cardinality explorer docs](#cardinality-explorer).
 

--- a/README.md
+++ b/README.md
@@ -401,6 +401,13 @@ matching the specified [series selector](https://prometheus.io/docs/prometheus/l
 
 Cardinality explorer is built on top of [/api/v1/status/tsdb](#tsdb-stats).
 
+If you are using [cluster version of VictoriaMetrics](https://docs.victoriametrics.com/Cluster-VictoriaMetrics.html) each 
+vmstorage tracks the number of stored timeseries individually. vmselect requests stats via [/api/v1/status/tsdb](#tsdb-stats) 
+from each vmstorage node and merges the results. This may lead to inflated values when samples for the same time series 
+are spread across multiple vmstorage nodes due to [replication](#replication) or rerouting.
+It happens because vmstorage fetches the collected tsdb stats from every vmstorage node and merges it.
+The `seriesCountByMetricName` stats is just summed across vmstorage nodes.
+
 See [cardinality explorer playground](https://play.victoriametrics.com/select/accounting/1/6a716b0f-38bc-4856-90ce-448fd713e3fe/prometheus/graph/#/cardinality).
 See the example of using the cardinality explorer [here](https://victoriametrics.com/blog/cardinality-explorer/).
 
@@ -1782,6 +1789,13 @@ VictoriaMetrics returns TSDB stats at `/api/v1/status/tsdb` page in the way simi
 * `focusLabel=LABEL_NAME` returns label values with the highest number of time series for the given `LABEL_NAME` in the `seriesCountByFocusLabelValue` list.
 * `match[]=SELECTOR` where `SELECTOR` is an arbitrary [time series selector](https://prometheus.io/docs/prometheus/latest/querying/basics/#time-series-selectors) for series to take into account during stats calculation. By default all the series are taken into account.
 * `extra_label=LABEL=VALUE`. See [these docs](#prometheus-querying-api-enhancements) for more details.
+
+If you are using [cluster version of VictoriaMetrics](https://docs.victoriametrics.com/Cluster-VictoriaMetrics.html) each
+vmstorage tracks the number of stored timeseries individually. vmselect requests stats via [/api/v1/status/tsdb](#tsdb-stats)
+from each vmstorage node and merges the results. This may lead to inflated values when samples for the same time series
+are spread across multiple vmstorage nodes due to [replication](#replication) or rerouting.
+It happens because vmstorage fetches the collected tsdb stats from every vmstorage node and merges it.
+The `seriesCountByMetricName` stats is just summed across vmstorage nodes.
 
 VictoriaMetrics provides an UI on top of `/api/v1/status/tsdb` - see [cardinality explorer docs](#cardinality-explorer).
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -404,6 +404,13 @@ matching the specified [series selector](https://prometheus.io/docs/prometheus/l
 
 Cardinality explorer is built on top of [/api/v1/status/tsdb](#tsdb-stats).
 
+If you are using [cluster version of VictoriaMetrics](https://docs.victoriametrics.com/Cluster-VictoriaMetrics.html) each
+vmstorage tracks the number of stored timeseries individually. vmselect requests stats via [/api/v1/status/tsdb](#tsdb-stats)
+from each vmstorage node and merges the results. This may lead to inflated values when samples for the same time series
+are spread across multiple vmstorage nodes due to [replication](#replication) or rerouting.
+It happens because vmstorage fetches the collected tsdb stats from every vmstorage node and merges it.
+The `seriesCountByMetricName` stats is just summed across vmstorage nodes.
+
 See [cardinality explorer playground](https://play.victoriametrics.com/select/accounting/1/6a716b0f-38bc-4856-90ce-448fd713e3fe/prometheus/graph/#/cardinality).
 See the example of using the cardinality explorer [here](https://victoriametrics.com/blog/cardinality-explorer/).
 
@@ -1785,6 +1792,13 @@ VictoriaMetrics returns TSDB stats at `/api/v1/status/tsdb` page in the way simi
 * `focusLabel=LABEL_NAME` returns label values with the highest number of time series for the given `LABEL_NAME` in the `seriesCountByFocusLabelValue` list.
 * `match[]=SELECTOR` where `SELECTOR` is an arbitrary [time series selector](https://prometheus.io/docs/prometheus/latest/querying/basics/#time-series-selectors) for series to take into account during stats calculation. By default all the series are taken into account.
 * `extra_label=LABEL=VALUE`. See [these docs](#prometheus-querying-api-enhancements) for more details.
+
+If you are using [cluster version of VictoriaMetrics](https://docs.victoriametrics.com/Cluster-VictoriaMetrics.html) each
+vmstorage tracks the number of stored timeseries individually. vmselect requests stats via [/api/v1/status/tsdb](#tsdb-stats)
+from each vmstorage node and merges the results. This may lead to inflated values when samples for the same time series
+are spread across multiple vmstorage nodes due to [replication](#replication) or rerouting.
+It happens because vmstorage fetches the collected tsdb stats from every vmstorage node and merges it.
+The `seriesCountByMetricName` stats is just summed across vmstorage nodes.
 
 VictoriaMetrics provides an UI on top of `/api/v1/status/tsdb` - see [cardinality explorer docs](#cardinality-explorer).
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -404,12 +404,10 @@ matching the specified [series selector](https://prometheus.io/docs/prometheus/l
 
 Cardinality explorer is built on top of [/api/v1/status/tsdb](#tsdb-stats).
 
-If you are using [cluster version of VictoriaMetrics](https://docs.victoriametrics.com/Cluster-VictoriaMetrics.html) each
-vmstorage tracks the number of stored timeseries individually. vmselect requests stats via [/api/v1/status/tsdb](#tsdb-stats)
-from each vmstorage node and merges the results. This may lead to inflated values when samples for the same time series
-are spread across multiple vmstorage nodes due to [replication](#replication) or rerouting.
-It happens because vmstorage fetches the collected tsdb stats from every vmstorage node and merges it.
-The `seriesCountByMetricName` stats is just summed across vmstorage nodes.
+In [cluster version of VictoriaMetrics](https://docs.victoriametrics.com/Cluster-VictoriaMetrics.html) each vmstorage tracks the stored time series individually.
+vmselect requests stats via [/api/v1/status/tsdb](#tsdb-stats) API from each vmstorage node and merges the results by summing per-series stats.
+This may lead to inflated values when samples for the same time series are spread across multiple vmstorage nodes
+due to [replication](#replication) or [rerouting](https://docs.victoriametrics.com/Cluster-VictoriaMetrics.html?highlight=re-routes#cluster-availability).
 
 See [cardinality explorer playground](https://play.victoriametrics.com/select/accounting/1/6a716b0f-38bc-4856-90ce-448fd713e3fe/prometheus/graph/#/cardinality).
 See the example of using the cardinality explorer [here](https://victoriametrics.com/blog/cardinality-explorer/).
@@ -1793,12 +1791,10 @@ VictoriaMetrics returns TSDB stats at `/api/v1/status/tsdb` page in the way simi
 * `match[]=SELECTOR` where `SELECTOR` is an arbitrary [time series selector](https://prometheus.io/docs/prometheus/latest/querying/basics/#time-series-selectors) for series to take into account during stats calculation. By default all the series are taken into account.
 * `extra_label=LABEL=VALUE`. See [these docs](#prometheus-querying-api-enhancements) for more details.
 
-If you are using [cluster version of VictoriaMetrics](https://docs.victoriametrics.com/Cluster-VictoriaMetrics.html) each
-vmstorage tracks the number of stored timeseries individually. vmselect requests stats via [/api/v1/status/tsdb](#tsdb-stats)
-from each vmstorage node and merges the results. This may lead to inflated values when samples for the same time series
-are spread across multiple vmstorage nodes due to [replication](#replication) or rerouting.
-It happens because vmstorage fetches the collected tsdb stats from every vmstorage node and merges it.
-The `seriesCountByMetricName` stats is just summed across vmstorage nodes.
+In [cluster version of VictoriaMetrics](https://docs.victoriametrics.com/Cluster-VictoriaMetrics.html) each vmstorage tracks the stored time series individually.
+vmselect requests stats via [/api/v1/status/tsdb](#tsdb-stats) API from each vmstorage node and merges the results by summing per-series stats.
+This may lead to inflated values when samples for the same time series are spread across multiple vmstorage nodes
+due to [replication](#replication) or [rerouting](https://docs.victoriametrics.com/Cluster-VictoriaMetrics.html?highlight=re-routes#cluster-availability).
 
 VictoriaMetrics provides an UI on top of `/api/v1/status/tsdb` - see [cardinality explorer docs](#cardinality-explorer).
 

--- a/docs/Single-server-VictoriaMetrics.md
+++ b/docs/Single-server-VictoriaMetrics.md
@@ -412,6 +412,13 @@ matching the specified [series selector](https://prometheus.io/docs/prometheus/l
 
 Cardinality explorer is built on top of [/api/v1/status/tsdb](#tsdb-stats).
 
+If you are using [cluster version of VictoriaMetrics](https://docs.victoriametrics.com/Cluster-VictoriaMetrics.html) each
+vmstorage tracks the number of stored timeseries individually. vmselect requests stats via [/api/v1/status/tsdb](#tsdb-stats)
+from each vmstorage node and merges the results. This may lead to inflated values when samples for the same time series
+are spread across multiple vmstorage nodes due to [replication](#replication) or rerouting.
+It happens because vmstorage fetches the collected tsdb stats from every vmstorage node and merges it.
+The `seriesCountByMetricName` stats is just summed across vmstorage nodes.
+
 See [cardinality explorer playground](https://play.victoriametrics.com/select/accounting/1/6a716b0f-38bc-4856-90ce-448fd713e3fe/prometheus/graph/#/cardinality).
 See the example of using the cardinality explorer [here](https://victoriametrics.com/blog/cardinality-explorer/).
 
@@ -1793,6 +1800,13 @@ VictoriaMetrics returns TSDB stats at `/api/v1/status/tsdb` page in the way simi
 * `focusLabel=LABEL_NAME` returns label values with the highest number of time series for the given `LABEL_NAME` in the `seriesCountByFocusLabelValue` list.
 * `match[]=SELECTOR` where `SELECTOR` is an arbitrary [time series selector](https://prometheus.io/docs/prometheus/latest/querying/basics/#time-series-selectors) for series to take into account during stats calculation. By default all the series are taken into account.
 * `extra_label=LABEL=VALUE`. See [these docs](#prometheus-querying-api-enhancements) for more details.
+
+If you are using [cluster version of VictoriaMetrics](https://docs.victoriametrics.com/Cluster-VictoriaMetrics.html) each
+vmstorage tracks the number of stored timeseries individually. vmselect requests stats via [/api/v1/status/tsdb](#tsdb-stats)
+from each vmstorage node and merges the results. This may lead to inflated values when samples for the same time series
+are spread across multiple vmstorage nodes due to [replication](#replication) or rerouting.
+It happens because vmstorage fetches the collected tsdb stats from every vmstorage node and merges it.
+The `seriesCountByMetricName` stats is just summed across vmstorage nodes.
 
 VictoriaMetrics provides an UI on top of `/api/v1/status/tsdb` - see [cardinality explorer docs](#cardinality-explorer).
 

--- a/docs/Single-server-VictoriaMetrics.md
+++ b/docs/Single-server-VictoriaMetrics.md
@@ -412,12 +412,10 @@ matching the specified [series selector](https://prometheus.io/docs/prometheus/l
 
 Cardinality explorer is built on top of [/api/v1/status/tsdb](#tsdb-stats).
 
-If you are using [cluster version of VictoriaMetrics](https://docs.victoriametrics.com/Cluster-VictoriaMetrics.html) each
-vmstorage tracks the number of stored timeseries individually. vmselect requests stats via [/api/v1/status/tsdb](#tsdb-stats)
-from each vmstorage node and merges the results. This may lead to inflated values when samples for the same time series
-are spread across multiple vmstorage nodes due to [replication](#replication) or rerouting.
-It happens because vmstorage fetches the collected tsdb stats from every vmstorage node and merges it.
-The `seriesCountByMetricName` stats is just summed across vmstorage nodes.
+In [cluster version of VictoriaMetrics](https://docs.victoriametrics.com/Cluster-VictoriaMetrics.html) each vmstorage tracks the stored time series individually.
+vmselect requests stats via [/api/v1/status/tsdb](#tsdb-stats) API from each vmstorage node and merges the results by summing per-series stats.
+This may lead to inflated values when samples for the same time series are spread across multiple vmstorage nodes
+due to [replication](#replication) or [rerouting](https://docs.victoriametrics.com/Cluster-VictoriaMetrics.html?highlight=re-routes#cluster-availability).
 
 See [cardinality explorer playground](https://play.victoriametrics.com/select/accounting/1/6a716b0f-38bc-4856-90ce-448fd713e3fe/prometheus/graph/#/cardinality).
 See the example of using the cardinality explorer [here](https://victoriametrics.com/blog/cardinality-explorer/).
@@ -1801,12 +1799,10 @@ VictoriaMetrics returns TSDB stats at `/api/v1/status/tsdb` page in the way simi
 * `match[]=SELECTOR` where `SELECTOR` is an arbitrary [time series selector](https://prometheus.io/docs/prometheus/latest/querying/basics/#time-series-selectors) for series to take into account during stats calculation. By default all the series are taken into account.
 * `extra_label=LABEL=VALUE`. See [these docs](#prometheus-querying-api-enhancements) for more details.
 
-If you are using [cluster version of VictoriaMetrics](https://docs.victoriametrics.com/Cluster-VictoriaMetrics.html) each
-vmstorage tracks the number of stored timeseries individually. vmselect requests stats via [/api/v1/status/tsdb](#tsdb-stats)
-from each vmstorage node and merges the results. This may lead to inflated values when samples for the same time series
-are spread across multiple vmstorage nodes due to [replication](#replication) or rerouting.
-It happens because vmstorage fetches the collected tsdb stats from every vmstorage node and merges it.
-The `seriesCountByMetricName` stats is just summed across vmstorage nodes.
+In [cluster version of VictoriaMetrics](https://docs.victoriametrics.com/Cluster-VictoriaMetrics.html) each vmstorage tracks the stored time series individually.
+vmselect requests stats via [/api/v1/status/tsdb](#tsdb-stats) API from each vmstorage node and merges the results by summing per-series stats.
+This may lead to inflated values when samples for the same time series are spread across multiple vmstorage nodes
+due to [replication](#replication) or [rerouting](https://docs.victoriametrics.com/Cluster-VictoriaMetrics.html?highlight=re-routes#cluster-availability).
 
 VictoriaMetrics provides an UI on top of `/api/v1/status/tsdb` - see [cardinality explorer docs](#cardinality-explorer).
 


### PR DESCRIPTION
Explained potential cardinality statistics inaccuracy in the documentation

Related issue: 
https://github.com/VictoriaMetrics/VictoriaMetrics/issues/3070
https://github.com/VictoriaMetrics/VictoriaMetrics/issues/3528

Signed-off-by: dmitryk-dk [d.kozlov@victoriametrics.com](mailto:d.kozlov@victoriametrics.com)