### PR TITLE
dependabot: disable version update for packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,16 +6,12 @@ updates:
       interval: "daily"
   - package-ecosystem: "gomod"
     directory: "/"
-    schedule:
-      interval: "weekly"
+    open-pull-requests-limit: 0
   - package-ecosystem: "bundler"
     directory: "/docs"
-    schedule:
-      interval: "daily"
+    open-pull-requests-limit: 0
   - package-ecosystem: "gomod"
     directory: "/app/vmui/packages/vmui/web"
-    schedule:
-      interval: "weekly"
     open-pull-requests-limit: 0
   - package-ecosystem: "docker"
     directory: "/"
@@ -23,6 +19,4 @@ updates:
       interval: "daily"
   - package-ecosystem: "npm"
     directory: "/app/vmui/packages/vmui"
-    schedule:
-      interval: "weekly"
     open-pull-requests-limit: 0


### PR DESCRIPTION
The change disables version updates for repo packages. Please note, security updates should not be affected by the change according to https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#open-pull-requests-limit:

```
open-pull-requests-limit
By default, Dependabot opens a maximum of five pull requests for version updates. Once there are five open pull requests from Dependabot, Dependabot will not open any new requests until some of those open requests are merged or closed.

This option has no impact on security updates, which have a separate, internal limit of ten open pull requests.
```