### PR TITLE
fixed label values decoding for pushgateway compatibility

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -87,6 +87,7 @@ The previous behavior can be restored in the following ways:
 * BUGFIX: [vmalert](https://docs.victoriametrics.com/vmalert.html): reset evaluation timestamp after modifying group interval. Before, there could have latency on rule evaluation time.
 * BUGFIX: vmselect: fix timestamp alignment for Prometheus querying API if time argument is less than 10m from the beginning of Unix epoch.
 * BUGFIX: [vmagent](https://docs.victoriametrics.com/vmagent.html): do not show [relabel debug](https://docs.victoriametrics.com/vmagent.html#relabel-debug) links at the `/targets` page when `vmagent` runs with `-promscrape.dropOriginalLabels` command-line flag, since it has no the original labels needed for relabel debug. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/4597).
+* BUGFIX: vminsert: fixed decoding of label values with slash for pushgateway and prometheus golang client compatibility. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/4692).
 * BUGFIX: [MetricsQL](https://docs.victoriametrics.com/MetricsQL.html): properly parse binary operations with reserved words on the right side such as `foo + (on{bar="baz"})`. Previously such queries could lead to panic. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/4422).
 * BUGFIX: [Official Grafana dashboards for VictoriaMetrics](https://grafana.com/orgs/victoriametrics): display cache usage for all components on panel `Cache usage % by type` for cluster dashboard. Before, only vmstorage caches were shown.
 

--- a/lib/protoparser/common/extra_labels.go
+++ b/lib/protoparser/common/extra_labels.go
@@ -64,7 +64,7 @@ func getPushgatewayLabels(path string) ([]prompbmarshal.Label, error) {
 			s = s[n+1:]
 		}
 		if isBase64 {
-			data, err := base64.URLEncoding.DecodeString(value)
+			data, err := base64.RawURLEncoding.DecodeString(strings.TrimRight(value, "="))
 			if err != nil {
 				return nil, fmt.Errorf("cannot base64-decode value=%q for label=%q: %w", value, name, err)
 			}

--- a/lib/protoparser/common/extra_labels_test.go
+++ b/lib/protoparser/common/extra_labels_test.go
@@ -62,6 +62,9 @@ func TestGetPushgatewayLabelsSuccess(t *testing.T) {
 	f("/foo/metrics/job@base64/Zm9v", `{job="foo"}`)
 	f("/foo/metrics/job/x/a/foo/aaa/bar", `{a="foo",aaa="bar",job="x"}`)
 	f("/foo/metrics/job/x/a@base64/Zm9v", `{a="foo",job="x"}`)
+	f("/metrics/job/test/region@base64/YXotc291dGhlYXN0LTEtZjAxL3d6eS1hei1zb3V0aGVhc3QtMQ", `{job="test",region="az-southeast-1-f01/wzy-az-southeast-1"}`)
+	f("/metrics/job/test/empty@base64/=", `{job="test"}`)
+	f("/metrics/job/test/test@base64/PT0vPT0", `{job="test",test="==/=="}`)
 }
 
 func TestGetPushgatewayLabelsFailure(t *testing.T) {


### PR DESCRIPTION
Fixed decoding of label values with slash for pushgateway and prometheus golang client compatibility + added some tests.

Related links:
- issue #4692
- [pushgateway](https://github.com/prometheus/pushgateway/blob/1da09352b953a78ad6aaa47a47414513e78adccf/handler/push.go#L171)
- [prometheus client](https://github.com/prometheus/client_golang/blob/644c80d1360fb1409a3fe8dfc5bad4228f282f3b/prometheus/push/push.go#L353)