### PR TITLE
app/vmctl: add support the `week` step for time-based chunks

### DIFF
--- a/app/vmctl/stepper/split.go
+++ b/app/vmctl/stepper/split.go
@@ -10,6 +10,8 @@ const (
 	StepMonth string = "month"
 	// StepDay represents a one day interval
 	StepDay string = "day"
+	// StepWeek represents a one week interval
+	StepWeek string = "week"
 	// StepHour represents a one hour interval
 	StepHour string = "hour"
 	// StepMinute represents a one minute interval
@@ -39,6 +41,10 @@ func SplitDateRange(start, end time.Time, step string) ([][]time.Time, error) {
 	case StepDay:
 		nextStep = func(t time.Time) (time.Time, time.Time) {
 			return t, t.AddDate(0, 0, 1)
+		}
+	case StepWeek:
+		nextStep = func(t time.Time) (time.Time, time.Time) {
+			return t, t.Add(7 * 24 * time.Hour)
 		}
 	case StepHour:
 		nextStep = func(t time.Time) (time.Time, time.Time) {

--- a/app/vmctl/stepper/split_test.go
+++ b/app/vmctl/stepper/split_test.go
@@ -170,6 +170,82 @@ func Test_splitDateRange(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "week chunking with not full week",
+			args: args{
+				start:       "2023-07-30T00:00:00Z",
+				end:         "2023-08-05T23:59:59.999999999Z",
+				granularity: StepWeek,
+			},
+			want: []testTimeRange{
+				{
+					"2023-07-30T00:00:00Z",
+					"2023-08-05T23:59:59.999999999Z",
+				},
+			},
+		},
+		{
+			name: "week chunking with start of the week and end of the week",
+			args: args{
+				start:       "2023-07-30T00:00:00Z",
+				end:         "2023-08-06T00:00:00Z",
+				granularity: StepWeek,
+			},
+			want: []testTimeRange{
+				{
+					"2023-07-30T00:00:00Z",
+					"2023-08-06T00:00:00Z",
+				},
+			},
+		},
+		{
+			name: "week chunking with next one day week",
+			args: args{
+				start:       "2023-07-30T00:00:00Z",
+				end:         "2023-08-07T01:12:00Z",
+				granularity: StepWeek,
+			},
+			want: []testTimeRange{
+				{
+					"2023-07-30T00:00:00Z",
+					"2023-08-06T00:00:00Z",
+				},
+				{
+					"2023-08-06T00:00:00Z",
+					"2023-08-07T01:12:00Z",
+				},
+			},
+		},
+		{
+			name: "week chunking with month and not full week representation",
+			args: args{
+				start:       "2023-07-30T00:00:00Z",
+				end:         "2023-09-01T01:12:00Z",
+				granularity: StepWeek,
+			},
+			want: []testTimeRange{
+				{
+					"2023-07-30T00:00:00Z",
+					"2023-08-06T00:00:00Z",
+				},
+				{
+					"2023-08-06T00:00:00Z",
+					"2023-08-13T00:00:00Z",
+				},
+				{
+					"2023-08-13T00:00:00Z",
+					"2023-08-20T00:00:00Z",
+				},
+				{
+					"2023-08-20T00:00:00Z",
+					"2023-08-27T00:00:00Z",
+				},
+				{
+					"2023-08-27T00:00:00Z",
+					"2023-09-01T01:12:00Z",
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -25,6 +25,7 @@ The following `tip` changes can be tested by building VictoriaMetrics components
 ## tip
 
 * BUGFIX: [vmagent](https://docs.victoriametrics.com/vmagent.html): use local scrape timestamps for the scraped metrics unless `honor_timestamps: true` option is explicitly set at [scrape_config](https://docs.victoriametrics.com/sd_configs.html#scrape_configs). This fixes gaps for metrics collected from [cadvisor](https://github.com/google/cadvisor) or similar exporters, which export metrics with invalid timestamps. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/4697) and [this comment](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/4697#issuecomment-1654614799) for details. The issue has been introduced in [v1.68.0](#v1680).
+* FEATURE: [vmctl](https://docs.victoriametrics.com/vmctl.html): add support `week` step for time-based chunks. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/4738).
 
 
 ## [v1.92.1](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.92.1)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -25,7 +25,7 @@ The following `tip` changes can be tested by building VictoriaMetrics components
 ## tip
 
 * BUGFIX: [vmagent](https://docs.victoriametrics.com/vmagent.html): use local scrape timestamps for the scraped metrics unless `honor_timestamps: true` option is explicitly set at [scrape_config](https://docs.victoriametrics.com/sd_configs.html#scrape_configs). This fixes gaps for metrics collected from [cadvisor](https://github.com/google/cadvisor) or similar exporters, which export metrics with invalid timestamps. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/4697) and [this comment](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/4697#issuecomment-1654614799) for details. The issue has been introduced in [v1.68.0](#v1680).
-* FEATURE: [vmctl](https://docs.victoriametrics.com/vmctl.html): add support `week` step for time-based chunks. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/4738).
+* FEATURE: [vmctl](https://docs.victoriametrics.com/vmctl.html): add support of `week` step for [time-based chunking migration](https://docs.victoriametrics.com/vmctl.html#using-time-based-chunking-of-migration). See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/4738).
 
 
 ## [v1.92.1](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.92.1)


### PR DESCRIPTION
Added support of the `week` step.

Related issue: https://github.com/VictoriaMetrics/VictoriaMetrics/issues/4738

Signed-off-by: dmitryk-dk [d.kozlov@victoriametrics.com](mailto:d.kozlov@victoriametrics.com)