### PR TITLE
vmui: hide "Logs Explorer" for the base app

### DIFF
--- a/app/vmui/packages/vmui/src/App.tsx
+++ b/app/vmui/packages/vmui/src/App.tsx
@@ -13,7 +13,6 @@ import ExploreMetrics from "./pages/ExploreMetrics";
 import PreviewIcons from "./components/Main/Icons/PreviewIcons";
 import WithTemplate from "./pages/WithTemplate";
 import Relabel from "./pages/Relabel";
-import ExploreLogs from "./pages/ExploreLogs/ExploreLogs";
 import ActiveQueries from "./pages/ActiveQueries";
 
 const App: FC = () => {
@@ -69,10 +68,6 @@ const App: FC = () => {
                 <Route
                   path={router.icons}
                   element={<PreviewIcons/>}
-                />
-                <Route
-                  path={router.logs}
-                  element={<ExploreLogs/>}
                 />
               </Route>
             </Routes>

--- a/app/vmui/packages/vmui/src/constants/navigation.ts
+++ b/app/vmui/packages/vmui/src/constants/navigation.ts
@@ -38,10 +38,6 @@ export const defaultNavigation: NavigationItem[] = [
         label: routerOptions[router.activeQueries].title,
         value: router.activeQueries,
       },
-      {
-        label: routerOptions[router.logs].title,
-        value: router.logs,
-      },
     ]
   },
   {


### PR DESCRIPTION
Hide the `Logs Explorer` from the navigation menu for the base application

<img width="400" alt="menu" src="https://github.com/VictoriaMetrics/VictoriaMetrics/assets/29711459/57184964-2f74-4c94-ba4a-2628a31caa02">
