### PR TITLE
[Proposal] Allow supplying external labeled scalars with query

### DIFF
--- a/app/vmselect/prometheus/prometheus.go
+++ b/app/vmselect/prometheus/prometheus.go
@@ -764,6 +764,7 @@ func QueryHandler(qt *querytracer.Tracer, startTime time.Time, w http.ResponseWr
 		LookbackDelta:       lookbackDelta,
 		RoundDigits:         getRoundDigits(r),
 		EnforcedTagFilterss: etfs,
+		ExternalData:        promql.ParseExternalData(r.Form["extra_data"]),
 		GetRequestURI: func() string {
 			return httpserver.GetRequestURI(r)
 		},

--- a/app/vmselect/prometheus/prometheus.go
+++ b/app/vmselect/prometheus/prometheus.go
@@ -872,7 +872,7 @@ func queryRangeHandler(qt *querytracer.Tracer, startTime time.Time, w http.Respo
 		LookbackDelta:       lookbackDelta,
 		RoundDigits:         getRoundDigits(r),
 		EnforcedTagFilterss: etfs,
-		ExternalData:        promql.ParseExternalData(r.FormValue("extData")),
+		ExternalData:        promql.ParseExternalData(r.Form["extra_data"]),
 		GetRequestURI: func() string {
 			return httpserver.GetRequestURI(r)
 		},

--- a/app/vmselect/prometheus/prometheus.go
+++ b/app/vmselect/prometheus/prometheus.go
@@ -872,6 +872,7 @@ func queryRangeHandler(qt *querytracer.Tracer, startTime time.Time, w http.Respo
 		LookbackDelta:       lookbackDelta,
 		RoundDigits:         getRoundDigits(r),
 		EnforcedTagFilterss: etfs,
+		ExternalData:        promql.ParseExternalData(r.FormValue("extData")),
 		GetRequestURI: func() string {
 			return httpserver.GetRequestURI(r)
 		},

--- a/app/vmselect/promql/eval.go
+++ b/app/vmselect/promql/eval.go
@@ -19,6 +19,7 @@ import (
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/flagutil"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/logger"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/memory"
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/protoparser/prometheus"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/querytracer"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/storage"
 	"github.com/VictoriaMetrics/metrics"
@@ -98,6 +99,12 @@ func alignStartEnd(start, end, step int64) (int64, int64) {
 	return start, end
 }
 
+// LabeledNumber is a number with label tags attached.
+type LabeledNumber struct {
+	Tags  []storage.Tag
+	Value float64
+}
+
 // EvalConfig is the configuration required for query evaluation via Exec
 type EvalConfig struct {
 	Start int64
@@ -128,6 +135,9 @@ type EvalConfig struct {
 	// EnforcedTagFilterss may contain additional label filters to use in the query.
 	EnforcedTagFilterss [][]storage.TagFilter
 
+	// External labeled numbers supplied with the query.
+	ExternalData map[string][]LabeledNumber
+
 	// The callback, which returns the request URI during logging.
 	// The request URI isn't stored here because its' construction may take non-trivial amounts of CPU.
 	GetRequestURI func() string
@@ -155,6 +165,7 @@ func copyEvalConfig(src *EvalConfig) *EvalConfig {
 	ec.LookbackDelta = src.LookbackDelta
 	ec.RoundDigits = src.RoundDigits
 	ec.EnforcedTagFilterss = src.EnforcedTagFilterss
+	ec.ExternalData = src.ExternalData
 	ec.GetRequestURI = src.GetRequestURI
 	ec.QueryStats = src.QueryStats
 
@@ -259,8 +270,22 @@ func evalExpr(qt *querytracer.Tracer, ec *EvalConfig, e metricsql.Expr) ([]*time
 	return rv, nil
 }
 
+// this is private in metricsql
+func isMetricNameFilter(lf *metricsql.LabelFilter) bool {
+	return lf.Label == "__name__" && !lf.IsNegative && !lf.IsRegexp
+}
+
 func evalExprInternal(qt *querytracer.Tracer, ec *EvalConfig, e metricsql.Expr) ([]*timeseries, error) {
 	if me, ok := e.(*metricsql.MetricExpr); ok {
+		if len(me.LabelFilterss) == 1 && len(me.LabelFilterss[0]) > 0 && isMetricNameFilter(&me.LabelFilterss[0][0]) {
+			if datum, ok := ec.ExternalData[me.LabelFilterss[0][0].Value]; ok {
+				ts := make([]*timeseries, len(datum))
+				for i, d := range datum {
+					ts[i] = evalNumberWithTags(ec, d.Value, d.Tags)
+				}
+				return ts, nil
+			}
+		}
 		re := &metricsql.RollupExpr{
 			Expr: me,
 		}
@@ -1321,6 +1346,16 @@ var timeseriesByWorkerIDPool sync.Pool
 var bbPool bytesutil.ByteBufferPool
 
 func evalNumber(ec *EvalConfig, n float64) []*timeseries {
+	return []*timeseries{evalNumberInternal(ec, n)}
+}
+
+func evalNumberWithTags(ec *EvalConfig, n float64, tags []storage.Tag) *timeseries {
+	ts := evalNumberInternal(ec, n)
+	ts.MetricName.Tags = tags
+	return ts
+}
+
+func evalNumberInternal(ec *EvalConfig, n float64) *timeseries {
 	var ts timeseries
 	ts.denyReuse = true
 	timestamps := ec.getSharedTimestamps()
@@ -1330,7 +1365,7 @@ func evalNumber(ec *EvalConfig, n float64) []*timeseries {
 	}
 	ts.Values = values
 	ts.Timestamps = timestamps
-	return []*timeseries{&ts}
+	return &ts
 }
 
 func evalString(ec *EvalConfig, s string) []*timeseries {
@@ -1396,4 +1431,30 @@ func dropStaleNaNs(funcName string, values []float64, timestamps []int64) ([]flo
 		dstTimestamps = append(dstTimestamps, timestamps[i])
 	}
 	return dstValues, dstTimestamps
+}
+
+// ParseExternalData parses external data in Prometheus text export format
+// into a map of sets of LabeledNumber by their metric name.
+func ParseExternalData(extData string) map[string][]LabeledNumber {
+	if extData == "" {
+		return nil
+	}
+
+	var rows prometheus.Rows
+	rows.Unmarshal(extData)
+
+	result := make(map[string][]LabeledNumber)
+	for _, r := range rows.Rows {
+		data := result[r.Metric]
+		tags := make([]storage.Tag, len(r.Tags))
+		for i, t := range r.Tags {
+			tags[i].Key = []byte(t.Key)
+			tags[i].Value = []byte(t.Value)
+		}
+		result[r.Metric] = append(data, LabeledNumber{
+			Tags:  tags,
+			Value: r.Value,
+		})
+	}
+	return result
 }

--- a/app/vmselect/promql/eval.go
+++ b/app/vmselect/promql/eval.go
@@ -1435,15 +1435,22 @@ func dropStaleNaNs(funcName string, values []float64, timestamps []int64) ([]flo
 
 // ParseExternalData parses external data in Prometheus text export format
 // into a map of sets of LabeledNumber by their metric name.
-func ParseExternalData(extData string) map[string][]LabeledNumber {
-	if extData == "" {
+func ParseExternalData(extData []string) map[string][]LabeledNumber {
+	if len(extData) == 0 {
 		return nil
 	}
 
 	var rows prometheus.Rows
-	rows.Unmarshal(extData)
 
 	result := make(map[string][]LabeledNumber)
+	for _, s := range extData {
+		rows.Unmarshal(s)
+		addExternalData(result, &rows)
+	}
+	return result
+}
+
+func addExternalData(result map[string][]LabeledNumber, rows *prometheus.Rows) {
 	for _, r := range rows.Rows {
 		data := result[r.Metric]
 		tags := make([]storage.Tag, len(r.Tags))
@@ -1456,5 +1463,4 @@ func ParseExternalData(extData string) map[string][]LabeledNumber {
 			Value: r.Value,
 		})
 	}
-	return result
 }


### PR DESCRIPTION
Currently, if I need a query to return a weighted sum - for instance, to compute overall CPU costs in a cloud setup where different virtual machine types charge different rates - the only solution is to put weights into the query itself, evaluating as many range/instant vectors as there are virtual machine types. For example:
```
sum(cpu_utilization{vm_type="Standard_X4e"} * 1.75, cpu_utilization{vm_type="Standard_D4q"} * 0.45, ...)
```
This is cumbersome, slows down query evaluation and increases `vmselect` memory consumption, and the query text changes every time weights change, potentially preventing caching or other optimizations. It would be nice to be able to provide labeled weights with the query and write instead
```
sum(cpu_utilization * on(vm_type) cost_per_core)
```
leveraging existing PromQL/MetricsQL labeling mechanics to match time series with weights. This PR implements this functionality for the Prometheus `/query` and `/query_range` endpoints. External 'labeled numbers' are supplied in a new query parameter `extra_data` in the usual Prometheus text export format without timestamps, e.g. for the above case
```
cost_per_core{vm_type="Standard_X4e"}1.75
cost_per_core{vm_type="Standard_D4q"}0.45
...
```
External 'labeled numbers' take priority over normal metrics. Since MetricsQL supports escapes in metric names, a possible convention to prevent clashes would be to prepend the names of external 'labeled numbers' with `?`. In evaluation, they behave the same as normal scalar numbers, except for being labeled and referred by name.

Related issues: #349 is about the general mechanism of querying external data sources from a VM query.