### PR TITLE
fix: remove healthcheck in vector docker-compose

### DIFF
--- a/deployment/docker/victorialogs/vector-docker/docker-compose.yml
+++ b/deployment/docker/victorialogs/vector-docker/docker-compose.yml
@@ -20,11 +20,6 @@ services:
         condition: service_healthy
       victoriametrics:
         condition: service_healthy
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8686/health"]
-      interval: 1s
-      timeout: 1s
-      retries: 10
 
   # Run `make package-victoria-logs` to build victoria-logs image
   victorialogs:


### PR DESCRIPTION
Vector images don't have `curl` installed, so the healthchecks fail.

```
"Log": [
    {
        "Start": "2023-08-03T14:41:21.383735348+05:30",
        "End": "2023-08-03T14:41:21.46569884+05:30",
        "ExitCode": -1,
        "Output": "OCI runtime exec failed: exec failed: unable to start container process: exec: \"curl\": executable file not found in $PATH: unknown"
    },
]
```
