### PR TITLE
vmalert: fix `vmalert_remotewrite_send_duration_seconds_total` metric…

### DIFF
--- a/app/vmalert/remotewrite/remotewrite.go
+++ b/app/vmalert/remotewrite/remotewrite.go
@@ -216,7 +216,9 @@ func (c *Client) flush(ctx context.Context, wr *prompbmarshal.WriteRequest) {
 		retryInterval = maxRetryInterval
 	}
 	timeStart := time.Now()
-	defer sendDuration.Add(time.Since(timeStart).Seconds())
+	defer func() {
+		sendDuration.Add(time.Since(timeStart).Seconds())
+	}()
 L:
 	for attempts := 0; ; attempts++ {
 		err := c.send(ctx, b)


### PR DESCRIPTION
… value

The deferred call's arguments are evaluated immediately, but the function call is not executed until the surrounding function returns.

For a simulation, see: https://go.dev/play/p/XTxYljyk1VZ

```go
package main

import (
	"fmt"
	"time"
)

func main() {
	B()
	A()
}
func A() {
	timeStart := time.Now()
	defer Add(time.Since(timeStart).Seconds())  // 0
	time.Sleep(time.Second)
}

func B() {
	timeStart := time.Now()
	defer func() {
		Add(time.Since(timeStart).Seconds())  // 1
	}()
	time.Sleep(time.Second)
}

func Add(d float64) {
	fmt.Println(d)
}
```