### PR TITLE
{vmagent/remotewrite,vminsert/common}: fix dropInput and keepInput flags inconsistency

### DIFF
--- a/app/vmagent/remotewrite/remotewrite.go
+++ b/app/vmagent/remotewrite/remotewrite.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/cespare/xxhash/v2"
 
+	"github.com/VictoriaMetrics/metrics"
+
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/auth"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/bloomfilter"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/bytesutil"
@@ -27,7 +29,6 @@ import (
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/promrelabel"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/streamaggr"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/tenantmetrics"
-	"github.com/VictoriaMetrics/metrics"
 )
 
 var (
@@ -705,11 +706,13 @@ var matchIdxsPool bytesutil.ByteBufferPool
 
 func dropAggregatedSeries(src []prompbmarshal.TimeSeries, matchIdxs []byte, dropInput bool) []prompbmarshal.TimeSeries {
 	dst := src[:0]
-	for i, match := range matchIdxs {
-		if match == 0 {
-			continue
+	if !dropInput {
+		for i, match := range matchIdxs {
+			if match == 1 {
+				continue
+			}
+			dst = append(dst, src[i])
 		}
-		dst = append(dst, src[i])
 	}
 	tail := src[len(dst):]
 	_ = prompbmarshal.ResetTimeSeries(tail)

--- a/app/vminsert/common/insert_ctx.go
+++ b/app/vminsert/common/insert_ctx.go
@@ -171,7 +171,7 @@ func (ctx *InsertCtx) dropAggregatedRows(matchIdxs []byte) {
 	src := ctx.mrs
 	if !*streamAggrDropInput {
 		for idx, match := range matchIdxs {
-			if match != 0 {
+			if match == 1 {
 				continue
 			}
 			dst = append(dst, src[idx])

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -45,6 +45,7 @@ The following `tip` changes can be tested by building VictoriaMetrics components
 * BUGFIX: [vmalert](https://docs.victoriametrics.com/vmalert.html): fix `vmalert_remotewrite_send_duration_seconds_total` value, before it didn't count in the real time spending on remote write requests. See [this pr](https://github.com/VictoriaMetrics/VictoriaMetrics/pull/4801) for details.
 * BUGFIX: [vmbackupmanager](https://docs.victoriametrics.com/vmbackupmanager.html): fix panic when creating a backup to a local filesystem on Windows. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/4704).
 * BUGFIX: [vmui](https://docs.victoriametrics.com/#vmui): fix the response of active queries to valid JSON. See [this pull request](https://github.com/VictoriaMetrics/VictoriaMetrics/pull/4782).
+* BUGFIX: [vmagent](https://docs.victoriametrics.com/vmagent.html): keep unmatched series when `remoteWrite.streamAggr.dropInput` is set to `false` to match intended behaviour introduced at [v1.92.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.92.0). See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/4804).
 
 
 ## [v1.92.1](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.92.1)


### PR DESCRIPTION
Sync behavior for dropInput and keepInput flags between single-node and vmagent. 
Fix vmagent not respecting dropInput flag and reverse logic for keepInput.

See: https://github.com/VictoriaMetrics/VictoriaMetrics/issues/4804