### PR TITLE
lib/netutil/tcpdialer: enhance timeout handling

### DIFF
--- a/lib/netutil/tcpdialer_default.go
+++ b/lib/netutil/tcpdialer_default.go
@@ -1,0 +1,12 @@
+//go:build !linux
+// +build !linux
+
+package netutil
+
+import (
+	"time"
+)
+
+func setTCPUserTimeout(fd uintptr, timeout time.Duration) error {
+	return nil
+}

--- a/lib/netutil/tcpdialer_linux.go
+++ b/lib/netutil/tcpdialer_linux.go
@@ -1,0 +1,13 @@
+package netutil
+
+import (
+	"syscall"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+func setTCPUserTimeout(fd uintptr, timeout time.Duration) error {
+	return syscall.SetsockoptInt(
+		int(fd), syscall.IPPROTO_TCP, unix.TCP_USER_TIMEOUT, int(timeout.Milliseconds()))
+}


### PR DESCRIPTION
Use TCP_TIMEOUT_USER linux socket option to close connection based on user provided timeout. Using default timeout and keepalive flow is not sufficient to close connection in some cases which leads to timeout not being applied.

Effectively, if connection stops processing new packets it will take up to 1 minute(with default configuration) instead of 1 second(based on keepalive value) to mark connection as broken.

This can be tested by adding firewall rule to deny packets to vmstorage port: 
```
iptables -A INPUT -p tcp --dport {port} -j DROP
```
To reverse this:
```
iptables -D INPUT -p tcp --dport {port} -j DROP
```

See: https://github.com/VictoriaMetrics/VictoriaMetrics/pull/4423 for more details.