### PR TITLE
vmselec/prometheus truncate long queries on logs and json response

### DIFF
--- a/app/vmselect/prometheus/prometheus_test.go
+++ b/app/vmselect/prometheus/prometheus_test.go
@@ -4,6 +4,7 @@ import (
 	"math"
 	"net/http"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/VictoriaMetrics/VictoriaMetrics/app/vmselect/netstorage"
@@ -228,4 +229,15 @@ func TestGetLatencyOffsetMillisecondsFailure(t *testing.T) {
 		}
 	}
 	f("http://localhost?latency_offset=foobar")
+}
+
+func TestFormatQueryString(t *testing.T) {
+	str := strings.Repeat("s", maxQueryLengthForLogs)
+	if got := formatQueryString(str); got != str {
+		t.Errorf("expected the same queries got %s expected %s", got, str)
+	}
+	str2 := strings.Repeat("s", maxQueryLengthForLogs+1)
+	if got := formatQueryString(str2); got == str2 {
+		t.Errorf("expected the different queries got %s expected %s", got, str)
+	}
 }


### PR DESCRIPTION
we can log queries which are too long, for example

query is longer than `maxQueryLen`

```
// Validate input args.
	if len(query) > maxQueryLen.IntN() {
		return fmt.Errorf("too long query; got %d bytes; mustn't exceed `-search.maxQueryLen=%d` bytes", len(query), maxQueryLen.N)
	}
```

we return the error 
the code block which parses this error, adds queries to the response 

```
if err := queryRangeHandler(qt, startTime, w, childQuery, start, end, step, r, ct, etfs); err != nil {
			return fmt.Errorf("error when executing query=%q on the time range (start=%d, end=%d, step=%d): %w", truncateQuery(childQuery), start, end, step, err)
		}
```