### PR TITLE
lib/promscrape/discovery/kubernetes: fix leaking api watcher

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -102,6 +102,7 @@ The v1.93.x line will be supported for at least 12 months since [v1.93.0](https:
 * BUGFIX: properly replace `:` chars in label names with `_` when `-usePromCompatibleNaming` command-line flag is passed to `vmagent`, `vminsert` or single-node VictoriaMetrics. This addresses [this comment](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/3113#issuecomment-1275077071).
 * BUGFIX: [vmbackup](https://docs.victoriametrics.com/vmbackup.html): correctly check if specified `-dst` belongs to specified `-storageDataPath`. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/4837).
 * BUGFIX: [vmctl](https://docs.victoriametrics.com/vmctl.html): don't interrupt the migration process if no metrics were found for a specific tenant. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/4796).
+* BUGFIX: [vmagent](https://docs.victoriametrics.com/vmagent.html): fix the thread leak that occurs during the polling of the Kubernetes API server after a configuration reload. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/4850).
 
 ## [v1.93.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.93.0)
 

--- a/lib/promscrape/discovery/kubernetes/api_watcher.go
+++ b/lib/promscrape/discovery/kubernetes/api_watcher.go
@@ -464,7 +464,8 @@ type urlWatcher struct {
 	apiURL    string
 	gw        *groupWatcher
 
-	// refCount is the number of apiWatcher objects subscribed to this urlWatcher.
+	// refCount keeps track on the number of subscribeAPIWatcherLocked and
+	// unsubscribeAPIWatcherLocked calls for the given urlWatcher.
 	refCount int
 	ctx      context.Context
 	cancel   context.CancelFunc

--- a/lib/promscrape/discovery/kubernetes/api_watcher.go
+++ b/lib/promscrape/discovery/kubernetes/api_watcher.go
@@ -464,9 +464,6 @@ type urlWatcher struct {
 	apiURL    string
 	gw        *groupWatcher
 
-	// refCount keeps track on the number of subscribeAPIWatcherLocked and
-	// unsubscribeAPIWatcherLocked calls for the given urlWatcher.
-	refCount int
 	ctx      context.Context
 	cancel   context.CancelFunc
 
@@ -529,7 +526,6 @@ func newURLWatcher(role, apiURL string, gw *groupWatcher) *urlWatcher {
 }
 
 func (uw *urlWatcher) subscribeAPIWatcherLocked(aw *apiWatcher) {
-	uw.refCount++
 	if _, ok := uw.aws[aw]; !ok {
 		if _, ok := uw.awsPending[aw]; !ok {
 			uw.awsPending[aw] = struct{}{}
@@ -589,7 +585,6 @@ func (uw *urlWatcher) unsubscribeAPIWatcherLocked(aw *apiWatcher) {
 		delete(uw.aws, aw)
 		metrics.GetOrCreateCounter(fmt.Sprintf(`vm_promscrape_discovery_kubernetes_subscribers{role=%q,status="working"}`, uw.role)).Dec()
 	}
-	uw.refCount--
 }
 
 // reloadObjects reloads objects to the latest state and returns resourceVersion for the latest state.


### PR DESCRIPTION
goroutine which was polling k8s API had no execution control. This leaded to leaking goroutines during config reload.

See: https://github.com/VictoriaMetrics/VictoriaMetrics/issues/4850

cc: @hagen1778 vmalert is using `lib/*` Consul and DNS implementations of service discovery and not affected by this.