### PR TITLE
lib/promscrape/client: sync timeout for HostClient and http.Client 

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -34,6 +34,7 @@ The following `tip` changes can be tested by building VictoriaMetrics components
 * FEATURE: [vmui](https://docs.victoriametrics.com/#vmui): organize `min`, `max`, `median` values on the chart legend and tooltips for better visibility.
 
 * BUGFIX: [vmagent](https://docs.victoriametrics.com/vmagent.html): consistently set UserAgent header to `vm_promscrape` during scraping with enabled or disabled `promscrape.streamParse`. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/4884) for details.
+* BUGFIX: [vmagent](https://docs.victoriametrics.com/vmagent.html): consistently set timeout for scraping with enabled or disabled `promscrape.streamParse`. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/4847) for details.
 * BUGFIX: [vmui](https://docs.victoriametrics.com/#vmui): consistently round sample values on chart, tooltip and legend.
 
 ## [v1.93.1](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.93.1)

--- a/lib/promscrape/client.go
+++ b/lib/promscrape/client.go
@@ -151,17 +151,8 @@ func newClient(ctx context.Context, sw *ScrapeWork) *client {
 			DialContext:            statStdDial,
 			MaxIdleConnsPerHost:    100,
 			MaxResponseHeaderBytes: int64(maxResponseHeadersSize.N),
-
-			// Set timeout for receiving the first response byte,
-			// since the duration for reading the full response can be much bigger because of stream parsing.
-			// See https://github.com/VictoriaMetrics/VictoriaMetrics/issues/1017#issuecomment-767235047
-			ResponseHeaderTimeout: sw.ScrapeTimeout,
 		},
-
-		// Set 30x bigger timeout than the sw.ScrapeTimeout, since the duration for reading the full response
-		// can be much bigger because of stream parsing.
-		// See https://github.com/VictoriaMetrics/VictoriaMetrics/issues/1017#issuecomment-767235047
-		Timeout: 30 * sw.ScrapeTimeout,
+		Timeout: sw.ScrapeTimeout,
 	}
 	if sw.DenyRedirects {
 		sc.CheckRedirect = func(req *http.Request, via []*http.Request) error {


### PR DESCRIPTION
Initially, stream parse mode was reading data from response and parsing it on flight. This was causing longer delay to read the whole response and required increasing timeout value to allow data processing while reading. So that https://github.com/VictoriaMetrics/VictoriaMetrics/commit/908e35affd31975bf808effa7072f59197d8d507 increased timeout value to fix this.

But after https://github.com/VictoriaMetrics/VictoriaMetrics/commit/74c00a87623718f9c1a8ecaeab3a6a0febc2db2f response in stream parse mode is saved into memory and then parsed eliminating necessity of having timeout value higher that for usual scrape.

Updates: https://github.com/VictoriaMetrics/VictoriaMetrics/issues/4847