### PR TITLE
Fix 'too many redirects' on HTTP to HTTPS redirect by scrape target

### DIFF
--- a/lib/promscrape/client_test.go
+++ b/lib/promscrape/client_test.go
@@ -1,0 +1,31 @@
+package promscrape
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/promauth"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHTTPToHTTPSRedirect(t *testing.T) {
+	c := newClient(context.TODO(), &ScrapeWork{
+		ScrapeURL:      "http://172.21.55.131:8080/_status/vars",
+		ScrapeInterval: 5 * time.Second,
+		ScrapeTimeout:  10 * time.Second,
+		StreamParse:    false,
+		AuthConfig: &promauth.Config{
+			TLSInsecureSkipVerify: true,
+		},
+		DenyRedirects: false,
+	})
+
+	b := []byte{}
+	result, err := c.ReadData(b)
+	assert.NoError(t, err)
+
+	fmt.Printf("ERROR: %v\n", err)
+	fmt.Printf("RESULT: %s\n", string(result))
+}


### PR DESCRIPTION
Scraping a target that redirects http -> https can result in a `too many redirects` error.  This is a jank proof of concept to show that it can be fixed by detecting the case and recreating `fasthttp.HostClient`.