### PR TITLE
Changed doc values to match description

### DIFF
--- a/docs/guides/k8s-ha-monitoring-via-vm-cluster.md
+++ b/docs/guides/k8s-ha-monitoring-via-vm-cluster.md
@@ -41,7 +41,7 @@ Execute the following command in your terminal:
 cat <<EOF | helm install vmcluster vm/victoria-metrics-cluster -f -
 vmselect:
   extraArgs:
-    dedup.minScrapeInterval: 1ms
+    dedup.minScrapeInterval: 1s
     replicationFactor: 2
   podAnnotations:
     prometheus.io/scrape: "true"
@@ -66,7 +66,7 @@ EOF
 </div>
 
 * The `Helm install vmcluster vm/victoria-metrics-cluster` command installs [VictoriaMetrics cluster](https://docs.victoriametrics.com/Cluster-VictoriaMetrics.html) to the default [namespace](https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/).
-* `dedup.minScrapeInterval: 1ms` configures [de-duplication](https://docs.victoriametrics.com/#deduplication) for the cluster that de-duplicates data points in the same time series if they fall within the same discrete 1s bucket. The earliest data point will be kept. In the case of equal timestamps, an arbitrary data point will be kept.
+* `dedup.minScrapeInterval: 1s` configures [de-duplication](https://docs.victoriametrics.com/#deduplication) for the cluster that de-duplicates data points in the same time series if they fall within the same discrete 1s bucket. The earliest data point will be kept. In the case of equal timestamps, an arbitrary data point will be kept.
 * `replicationFactor: 2` Replication factor for the ingested data, i.e. how many copies should be made among distinct `-storageNode` instances. If the replication factor is greater than one, the deduplication must be enabled on the remote storage side.
 * `podAnnotations: prometheus.io/scrape: "true"` enables the scraping of metrics from the vmselect, vminsert and vmstorage pods.
 * `podAnnotations:prometheus.io/port: "some_port" ` enables the scraping of metrics from the vmselect, vminsert and vmstorage pods from corresponding ports.


### PR DESCRIPTION
The documentation speaks about dedup scrape interval of "1s", while the values are configured to miliseconds `1ms`