### PR TITLE
app/vmselect: fix panic when using `/select/multitenant` endpoint

### DIFF
--- a/app/vmselect/main.go
+++ b/app/vmselect/main.go
@@ -295,7 +295,8 @@ func requestHandler(w http.ResponseWriter, r *http.Request) bool {
 	if at == nil {
 		// the only option for at to be nil is when p.AuthToken == "multitenant"
 		// vmselect does not have multitenant endpoint, so request must be rejected
-		return false
+		httpserver.Errorf(w, r, "auth error: tenantID must be specified explicitly in the request path")
+		return true
 	}
 	switch p.Prefix {
 	case "select":

--- a/app/vmselect/main.go
+++ b/app/vmselect/main.go
@@ -292,6 +292,11 @@ func requestHandler(w http.ResponseWriter, r *http.Request) bool {
 		httpserver.Errorf(w, r, "auth error: %s", err)
 		return true
 	}
+	if at == nil {
+		// the only option for at to be nil is when p.AuthToken == "multitenant"
+		// vmselect does not have multitenant endpoint, so request must be rejected
+		return false
+	}
 	switch p.Prefix {
 	case "select":
 		return selectHandler(qt, startTime, w, r, p, at)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -38,6 +38,7 @@ The following `tip` changes can be tested by building VictoriaMetrics components
 * BUGFIX: [vmagent](https://docs.victoriametrics.com/vmagent.html): consistently set timeout for scraping with enabled or disabled [stream parsing mode](https://docs.victoriametrics.com/vmagent.html#stream-parsing-mode). See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/4847).
 * BUGFIX: [Official Grafana dashboards for VictoriaMetrics](https://grafana.com/orgs/victoriametrics): fix display of ingested rows rate for `Samples ingested/s` and `Samples rate` panels for vmagent's dasbhoard. Previously, not all ingested protocols were accounted in these panels. An extra panel `Rows rate` was added to `Ingestion` section to display the split for rows ingested rate by protocol.
 * BUGFIX: [vmalert](https://docs.victoriametrics.com/vmalert.html): correctly re-use HTTP request object on `EOF` retries when querying the configured datasource. Previously, there was a small chance that query retry wouldn't succeed.
+* BUGFIX: vmselect: correctly handle requests with `/select/multitenant` prefix. Such requests must be rejected since vmselect does not support multitenancy endpoint. Previously, such requests were causing panic. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/4910).
 
 ## [v1.93.1](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.93.1)
 


### PR DESCRIPTION
Such requests must be rejected as not found since vmselect does not support multitenant endpoint.

See: https://github.com/VictoriaMetrics/VictoriaMetrics/issues/4910