### PR TITLE
deployment/docker: add VictoriaLogs

### DIFF
--- a/deployment/docker/README.md
+++ b/deployment/docker/README.md
@@ -128,3 +128,13 @@ of alerting rules is the following:
 
 Please, also see [how to monitor](https://docs.victoriametrics.com/Single-server-VictoriaMetrics.html#monitoring) 
 VictoriaMetrics installations.
+
+## VictoriaLogs server
+
+VictoriaLogs will be accessible on the following port: `--httpListenAddr=:9428`
+
+[Fluent Bit](https://docs.fluentbit.io/manual) is used to send logs to VictoriaLogs instance.
+Fluent Bit is configured to send logs from running containers to VictoriaLogs instance.
+Additionally, it is configured to listen for syslog logs on port `5140` and send them to VictoriaLogs instance.
+
+To access VictoriaLogs UI use link [http://localhost:9428/select/vmui/](http://localhost:9428/select/vmui/).

--- a/deployment/docker/README.md
+++ b/deployment/docker/README.md
@@ -138,3 +138,6 @@ Fluent Bit is configured to send logs from running containers to VictoriaLogs in
 Additionally, it is configured to listen for syslog logs on port `5140` and send them to VictoriaLogs instance.
 
 To access VictoriaLogs UI use link [http://localhost:9428/select/vmui/](http://localhost:9428/select/vmui/).
+
+Please, also see [how to monitor](https://docs.victoriametrics.com/VictoriaLogs/#monitoring) 
+VictoriaLogs installations.

--- a/deployment/docker/docker-compose.yml
+++ b/deployment/docker/docker-compose.yml
@@ -92,9 +92,27 @@ services:
     networks:
       - vm_net
     restart: always
+  fluentbit:
+    image: cr.fluentbit.io/fluent/fluent-bit:2.1.4
+    volumes:
+      - /var/lib/docker/containers:/var/lib/docker/containers:ro
+      - ./fluent-bit.conf:/fluent-bit/etc/fluent-bit.conf
+    depends_on: [victorialogs]
+    ports:
+      - "5140:5140"
+  victorialogs:
+    image: docker.io/victoriametrics/victoria-logs:v0.3.0-victorialogs
+    command:
+      - "--storageDataPath=/vlogs"
+      - "--httpListenAddr=:9428"
+    volumes:
+      - victorialogs-fluentbit:/vlogs
+    ports:
+      - "9428:9428"
 volumes:
   vmagentdata: {}
   vmdata: {}
   grafanadata: {}
+  victorialogs-fluentbit: {}
 networks:
   vm_net:

--- a/deployment/docker/fluent-bit.conf
+++ b/deployment/docker/fluent-bit.conf
@@ -1,0 +1,30 @@
+[INPUT]
+    name              tail
+    path              /var/lib/docker/containers/**/*.log
+    path_key         path
+    multiline.parser  docker, cri
+    Parser docker
+    Docker_Mode  On
+
+[INPUT]
+    Name     syslog
+    Listen   0.0.0.0
+    Port     5140
+    Parser   syslog-rfc3164
+    Mode     tcp
+
+[SERVICE]
+    Flush        1
+    Parsers_File parsers.conf
+
+[Output]
+    Name http
+    Match *
+    host victorialogs
+    port 9428
+    compress gzip
+    uri /insert/jsonline?_stream_fields=stream,path&_msg_field=log&_time_field=date
+    format json_lines
+    json_date_format iso8601
+    header AccountID 0
+    header ProjectID 0

--- a/deployment/docker/victorialogs/filebeat-docker/docker-compose.yml
+++ b/deployment/docker/victorialogs/filebeat-docker/docker-compose.yml
@@ -21,7 +21,6 @@ services:
     command:
       - -beat.uri=http://filebeat-victorialogs:5066
 
-  # Run `make package-victoria-logs` to build victoria-logs image
   victorialogs:
     image: docker.io/victoriametrics/victoria-logs:v0.3.0-victorialogs
     volumes:

--- a/deployment/docker/victorialogs/filebeat-syslog/docker-compose.yml
+++ b/deployment/docker/victorialogs/filebeat-syslog/docker-compose.yml
@@ -12,7 +12,6 @@ services:
     ports:
       - "5140:5140"
 
-  # Run `make package-victoria-logs` to build victoria-logs image
   victorialogs:
     image: docker.io/victoriametrics/victoria-logs:v0.3.0-victorialogs
     volumes:

--- a/deployment/docker/victorialogs/fluentbit-docker/docker-compose.yml
+++ b/deployment/docker/victorialogs/fluentbit-docker/docker-compose.yml
@@ -10,7 +10,6 @@ services:
     ports:
       - "5140:5140"
 
-  # Run `make package-victoria-logs` to build victoria-logs image
   victorialogs:
     image: docker.io/victoriametrics/victoria-logs:v0.3.0-victorialogs
     volumes:

--- a/deployment/docker/victorialogs/fluentbit-docker/fluent-bit.conf
+++ b/deployment/docker/victorialogs/fluentbit-docker/fluent-bit.conf
@@ -1,6 +1,7 @@
 [INPUT]
     name              tail
     path              /var/lib/docker/containers/**/*.log
+    path_key         path
     multiline.parser  docker, cri
     Parser docker
     Docker_Mode  On
@@ -22,7 +23,7 @@
     host victorialogs
     port 9428
     compress gzip
-    uri /insert/jsonline?_stream_fields=stream&_msg_field=log&_time_field=date
+    uri /insert/jsonline?_stream_fields=stream,path&_msg_field=log&_time_field=date
     format json_lines
     json_date_format iso8601
     header AccountID 0

--- a/deployment/docker/victorialogs/logstash/docker-compose.yml
+++ b/deployment/docker/victorialogs/logstash/docker-compose.yml
@@ -13,7 +13,6 @@ services:
     ports:
       - "5140:5140"
 
-  # Run `make package-victoria-logs` to build victoria-logs image
   victorialogs:
     image: docker.io/victoriametrics/victoria-logs:v0.3.0-victorialogs
     volumes:

--- a/deployment/docker/victorialogs/promtail/docker-compose.yml
+++ b/deployment/docker/victorialogs/promtail/docker-compose.yml
@@ -11,7 +11,6 @@ services:
     ports:
       - "5140:5140"
 
-  # Run `make package-victoria-logs` to build victoria-logs image
   vlogs:
     image: docker.io/victoriametrics/victoria-logs:v0.3.0-victorialogs
     volumes:

--- a/deployment/docker/victorialogs/vector-docker/docker-compose.yml
+++ b/deployment/docker/victorialogs/vector-docker/docker-compose.yml
@@ -21,7 +21,6 @@ services:
       victoriametrics:
         condition: service_healthy
 
-  # Run `make package-victoria-logs` to build victoria-logs image
   victorialogs:
     image: docker.io/victoriametrics/victoria-logs:v0.3.0-victorialogs
     volumes:


### PR DESCRIPTION
- added VictoriaLogs to main docker-compose file
- removed outdated comments
- added `path` to fluentbit stream fields
  Previously, stream only contained `stream` field which stands for `stdout` or `stderr`. This leads to performance in case this configuration will be used.