### PR TITLE
lib/vmselectapi: do not send empty label names for labelNames request

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -46,6 +46,7 @@ The following `tip` changes can be tested by building VictoriaMetrics components
 * BUGFIX: [vmalert](https://docs.victoriametrics.com/vmalert.html): correctly re-use HTTP request object on `EOF` retries when querying the configured datasource. Previously, there was a small chance that query retry wouldn't succeed.
 * BUGFIX: [vmselect](https://docs.victoriametrics.com/Cluster-VictoriaMetrics.html): correctly handle requests with `/select/multitenant` prefix. Such requests must be rejected since vmselect does not support multitenancy endpoint. Previously, such requests were causing panic. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/4910).
 * BUGFIX: [vminsert](https://docs.victoriametrics.com/Cluster-VictoriaMetrics.html): properly check for [read-only state](https://docs.victoriametrics.com/Cluster-VictoriaMetrics.html#readonly-mode) at `vmstorage`. Previously it wasn't properly checked, which could lead to increased resource usage and data ingestion slowdown when some of `vmstorage` nodes are in read-only mode. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/4870).
+* BUGFIX: [vmstorage](https://docs.victoriametrics.com/Cluster-VictoriaMetrics.html):  Correctly return response for `/api/v1/labels` requests. Previously an empty label names broke entire `vmcluster` RPC communication . See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/4932).
 
 ## [v1.93.1](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.93.1)
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -41,6 +41,7 @@ The following `tip` changes can be tested by building VictoriaMetrics components
 
 * BUGFIX: [Official Grafana dashboards for VictoriaMetrics](https://grafana.com/orgs/victoriametrics): fix display of ingested rows rate for `Samples ingested/s` and `Samples rate` panels for vmagent's dasbhoard. Previously, not all ingested protocols were accounted in these panels. An extra panel `Rows rate` was added to `Ingestion` section to display the split for rows ingested rate by protocol.
 * BUGFIX: [vminsert](https://docs.victoriametrics.com/Cluster-VictoriaMetrics.html): properly close broken vmstorage connection during [read-only state](https://docs.victoriametrics.com/Cluster-VictoriaMetrics.html#readonly-mode) checks at `vmstorage`. Previously it wasn't properly closed, which prevents restoring `vmstorage` node from read-only mode. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/4870).
+* BUGFIX: [vmstorage](https://docs.victoriametrics.com/Cluster-VictoriaMetrics.html):  prevent from breaking `vmselect` -> `vmstorage` RPC communication when `vmstorage` returns an empty label name at `/api/v1/labels` request. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/4932).
 
 ## [v1.93.2](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.93.2)
 
@@ -55,7 +56,6 @@ The v1.93.x line will be supported for at least 12 months since [v1.93.0](https:
 * BUGFIX: [vmalert](https://docs.victoriametrics.com/vmalert.html): correctly re-use HTTP request object on `EOF` retries when querying the configured datasource. Previously, there was a small chance that query retry wouldn't succeed.
 * BUGFIX: [vmselect](https://docs.victoriametrics.com/Cluster-VictoriaMetrics.html): correctly handle requests with `/select/multitenant` prefix. Such requests must be rejected since vmselect does not support multitenancy endpoint. Previously, such requests were causing panic. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/4910).
 * BUGFIX: [vminsert](https://docs.victoriametrics.com/Cluster-VictoriaMetrics.html): properly check for [read-only state](https://docs.victoriametrics.com/Cluster-VictoriaMetrics.html#readonly-mode) at `vmstorage`. Previously it wasn't properly checked, which could lead to increased resource usage and data ingestion slowdown when some of `vmstorage` nodes are in read-only mode. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/4870).
-* BUGFIX: [vmstorage](https://docs.victoriametrics.com/Cluster-VictoriaMetrics.html):  Correctly return response for `/api/v1/labels` requests. Previously an empty label names broke entire `vmcluster` RPC communication . See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/4932).
 
 ## [v1.93.1](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.93.1)
 

--- a/lib/vmselectapi/server.go
+++ b/lib/vmselectapi/server.go
@@ -690,6 +690,10 @@ func (s *Server) processLabelNames(ctx *vmselectRequestCtx) error {
 
 	// Send labelNames to vmselect
 	for _, labelName := range labelNames {
+		if len(labelName) == 0 {
+			// Skip empty label names, since they have no sense for prometheus.
+			continue
+		}
 		if err := ctx.writeString(labelName); err != nil {
 			return fmt.Errorf("cannot write label name %q: %w", labelName, err)
 		}
@@ -919,6 +923,9 @@ func (s *Server) processTenants(ctx *vmselectRequestCtx) error {
 
 	// Send tenants to vmselect
 	for _, tenant := range tenants {
+		if len(tenant) == 0 {
+			return fmt.Errorf("BUG: unexpected empty tenant name")
+		}
 		if err := ctx.writeString(tenant); err != nil {
 			return fmt.Errorf("cannot write tenant %q: %w", tenant, err)
 		}

--- a/lib/vmselectapi/server.go
+++ b/lib/vmselectapi/server.go
@@ -691,7 +691,7 @@ func (s *Server) processLabelNames(ctx *vmselectRequestCtx) error {
 	// Send labelNames to vmselect
 	for _, labelName := range labelNames {
 		if len(labelName) == 0 {
-			// Skip empty label names, since they have no sense for prometheus.
+			// Skip empty label names
 			continue
 		}
 		if err := ctx.writeString(labelName); err != nil {

--- a/lib/vmselectapi/server.go
+++ b/lib/vmselectapi/server.go
@@ -691,7 +691,7 @@ func (s *Server) processLabelNames(ctx *vmselectRequestCtx) error {
 	// Send labelNames to vmselect
 	for _, labelName := range labelNames {
 		if len(labelName) == 0 {
-			// Skip empty label names
+			// Skip empty label names, since they may break RPC communication with vmselect
 			continue
 		}
 		if err := ctx.writeString(labelName); err != nil {
@@ -745,7 +745,7 @@ func (s *Server) processLabelValues(ctx *vmselectRequestCtx) error {
 	// Send labelValues to vmselect
 	for _, labelValue := range labelValues {
 		if len(labelValue) == 0 {
-			// Skip empty label values, since they have no sense for prometheus.
+			// Skip empty label values, since they may break RPC communication with vmselect
 			continue
 		}
 		if err := ctx.writeString(labelValue); err != nil {
@@ -924,7 +924,7 @@ func (s *Server) processTenants(ctx *vmselectRequestCtx) error {
 	// Send tenants to vmselect
 	for _, tenant := range tenants {
 		if len(tenant) == 0 {
-			return fmt.Errorf("BUG: unexpected empty tenant name")
+			logger.Panicf("BUG: unexpected empty tenant name")
 		}
 		if err := ctx.writeString(tenant); err != nil {
 			return fmt.Errorf("cannot write tenant %q: %w", tenant, err)


### PR DESCRIPTION
it breaks cluster communication, since vmselect incorrectly reads request buffer, leaving unread data on it https://github.com/VictoriaMetrics/VictoriaMetrics/issues/4932