### PR TITLE
vmselect: properly return 503 when can't establish connection to vmstorage

### DIFF
--- a/app/vmselect/netstorage/netstorage.go
+++ b/app/vmselect/netstorage/netstorage.go
@@ -1757,7 +1757,7 @@ func (snr *storageNodesRequest) collectResults(partialResultsCounter *metrics.Co
 
 				// Returns 503 status code for partial response, so the caller could retry it if needed.
 				err = &httpserver.ErrorWithStatusCode{
-					Err: err,
+					Err:        err,
 					StatusCode: http.StatusServiceUnavailable,
 				}
 				return false, err
@@ -1788,7 +1788,7 @@ func (snr *storageNodesRequest) collectResults(partialResultsCounter *metrics.Co
 		// Return only the first error, since it has no sense in returning all errors.
 		// Returns 503 status code for partial response, so the caller could retry it if needed.
 		err := &httpserver.ErrorWithStatusCode{
-			Err: errsPartial[0],
+			Err:        errsPartial[0],
 			StatusCode: http.StatusServiceUnavailable,
 		}
 		return false, err
@@ -2058,7 +2058,10 @@ func (sn *storageNode) execOnConn(qt *querytracer.Tracer, funcName string, f fun
 	}
 	bc, err := sn.connPool.Get()
 	if err != nil {
-		return fmt.Errorf("cannot obtain connection from a pool: %w", err)
+		return &httpserver.ErrorWithStatusCode{
+			Err:        fmt.Errorf("cannot obtain connection from a pool: %w", err),
+			StatusCode: http.StatusServiceUnavailable,
+		}
 	}
 	// Extend the connection deadline by 2 seconds, so the remote storage could return `timeout` error
 	// without the need to break the connection.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -51,6 +51,7 @@ ssue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/4825) and [these
 * BUGFIX: [vminsert enterprise](https://docs.victoriametrics.com/enterprise.html): properly parse `/insert/multitenant/*` urls, which have been broken since [v1.93.2](#v1932). See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/4947).
 * BUGFIX: properly build production armv5 binaries for `GOARCH=arm`. This has been broken after the upgrading of Go builder to Go1.21.0. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/4965).
 * BUGFIX: [vmselect](https://docs.victoriametrics.com/Cluster-VictoriaMetrics.html): return `503 Service Unavailable` status code when [partial responses](https://docs.victoriametrics.com/Cluster-VictoriaMetrics.html#cluster-availability) are denied and some of `vmstorage` nodes are temporarily unavailable. Previously `422 Unprocessable Entiry` status code was mistakenly returned in this case, which could prevent from automatic recovery by re-sending the request to healthy cluster replica in another availability zone.
+* BUGFIX: [vmselect](https://docs.victoriametrics.com/Cluster-VictoriaMetrics.html): return `503 Service Unavailable` status code when connection to `vmstorage` can't be established.
 
 ## [v1.93.3](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.93.3)
 


### PR DESCRIPTION
Previously, 422 status code was returned which meant client error.