### PR TITLE
lib/backup: fix issue with inconsistent copying of appliedRetention.txt

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -48,6 +48,7 @@ ssue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/4825) and [these
 * BUGFIX: [Official Grafana dashboards for VictoriaMetrics](https://grafana.com/orgs/victoriametrics): fix display of ingested rows rate for `Samples ingested/s` and `Samples rate` panels for vmagent's dasbhoard. Previously, not all ingested protocols were accounted in these panels. An extra panel `Rows rate` was added to `Ingestion` section to display the split for rows ingested rate by protocol.
 * BUGFIX: [vmui](https://docs.victoriametrics.com/#vmui): fix the bug causing render looping when switching to heatmap.
 * BUGFIX: [VictoriaMetrics enterprise](https://docs.victoriametrics.com/enterprise.html) validate `-dedup.minScrapeInterval` value and `-downsampling.period` intervals are multiples of each other. See [these docs](https://docs.victoriametrics.com/#downsampling).
+* BUGFIX: [vmbackup](https://docs.victoriametrics.com/vmbackup.html): properly copy `appliedRetention.txt` files inside `<-storageDataPath>/{data}` folders during [incremental backups](https://docs.victoriametrics.com/vmbackup.html#incremental-backups). Previously the new `appliedRetention.txt` could be skipped during incremental backups, which could lead to increased load on storage after restoring from backup. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/5005).
 
 ## [v1.93.5](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.93.5)
 

--- a/lib/backup/common/part.go
+++ b/lib/backup/common/part.go
@@ -40,9 +40,11 @@ type Part struct {
 
 // key returns a string, which uniquely identifies p.
 func (p *Part) key() string {
-	if strings.HasSuffix(p.Path, "/parts.json") {
-		// parts.json file contents changes over time, so it must have an unique key in order
-		// to always copy it during backup, restore and server-side copy.
+	if strings.HasSuffix(p.Path, "/parts.json") ||
+		strings.HasSuffix(p.Path, "/appliedRetention.txt") {
+		// parts.json and appliedRetention.txt files contents changes over time,
+		// so it must have an unique key in order to always copy it during
+		// backup, restore and server-side copy.
 		// See https://github.com/VictoriaMetrics/VictoriaMetrics/issues/5005
 		id := atomic.AddUint64(&uniqueKeyID, 1)
 		return fmt.Sprintf("unique-%016X", id)


### PR DESCRIPTION
appliedRetention.txt can be modified in place, so it should be always copied just the same as parts.json

Updates: https://github.com/victoriaMetrics/victoriaMetrics/issues/5005