### PR TITLE
vmagent: drop jobs with invalid config with error log

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -49,6 +49,7 @@ The following `tip` changes can be tested by building VictoriaMetrics components
 * BUGFIX: [Official Grafana dashboards for VictoriaMetrics](https://grafana.com/orgs/victoriametrics): fix display of ingested rows rate for `Samples ingested/s` and `Samples rate` panels for vmagent's dasbhoard. Previously, not all ingested protocols were accounted in these panels. An extra panel `Rows rate` was added to `Ingestion` section to display the split for rows ingested rate by protocol.
 * BUGFIX: [vmui](https://docs.victoriametrics.com/#vmui): fix the bug causing render looping when switching to heatmap.
 * BUGFIX: [VictoriaMetrics enterprise](https://docs.victoriametrics.com/enterprise.html) validate `-dedup.minScrapeInterval` value and `-downsampling.period` intervals are multiples of each other. See [these docs](https://docs.victoriametrics.com/#downsampling).
+* BUGFIX: [vmagent](https://docs.victoriametrics.com/vmagent.html): drop scrape job with incorrect config with error log, before vmagent would quit directly. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/4959).
 
 ## [v1.93.5](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.93.5)
 

--- a/lib/promauth/config.go
+++ b/lib/promauth/config.go
@@ -208,11 +208,6 @@ func newOAuth2ConfigInternal(baseDir string, o *OAuth2Config) (*oauth2ConfigInte
 	}
 	if o.ClientSecretFile != "" {
 		oi.clientSecretFile = fs.GetFilepath(baseDir, o.ClientSecretFile)
-		secret, err := readPasswordFromFile(oi.clientSecretFile)
-		if err != nil {
-			return nil, fmt.Errorf("cannot read OAuth2 secret from %q: %w", oi.clientSecretFile, err)
-		}
-		oi.cfg.ClientSecret = secret
 	}
 	opts := &Options{
 		BaseDir:   baseDir,
@@ -660,6 +655,14 @@ func (actx *authContext) initFromOAuth2Config(baseDir string, o *OAuth2Config) e
 		return err
 	}
 	actx.getAuthHeader = func() string {
+		if oi.clientSecretFile != "" {
+			secret, err := readPasswordFromFile(oi.clientSecretFile)
+			if err != nil {
+				logger.Errorf("cannot read OAuth2 secret from %q: %w", oi.clientSecretFile, err)
+				return ""
+			}
+			oi.cfg.ClientSecret = secret
+		}
 		ts, err := oi.getTokenSource()
 		if err != nil {
 			logger.Errorf("cannot get OAuth2 tokenSource: %s", err)

--- a/lib/promauth/config_test.go
+++ b/lib/promauth/config_test.go
@@ -38,12 +38,23 @@ func TestNewConfig(t *testing.T) {
 			expectHeader: "Bearer some-token",
 		},
 		{
+			name: "OAuth2 lazy load non-existing-file",
+			opts: Options{
+				OAuth2: &OAuth2Config{
+					ClientID:         "some-id",
+					ClientSecretFile: "non-existing-file",
+					TokenURL:         "http://localhost:8511",
+				},
+			},
+			wantErr: false,
+		},
+		{
 			name: "OAuth2 want err",
 			opts: Options{
 				OAuth2: &OAuth2Config{
 					ClientID:         "some-id",
 					ClientSecret:     NewSecret("some-secret"),
-					ClientSecretFile: "testdata/test_secretfile.txt",
+					ClientSecretFile: "testdata/non-existing-file",
 					TokenURL:         "http://localhost:8511",
 				},
 			},
@@ -95,6 +106,17 @@ func TestNewConfig(t *testing.T) {
 				},
 			},
 			expectHeader: "Bearer some-token",
+		},
+		{
+			name: "tls config with non-existing file",
+			opts: Options{
+				BearerToken: "some-token",
+				TLSConfig: &TLSConfig{
+					InsecureSkipVerify: true,
+					CertFile:           "non-existing-file",
+				},
+			},
+			wantErr: true,
 		},
 	}
 	for _, tt := range tests {

--- a/lib/promscrape/config.go
+++ b/lib/promscrape/config.go
@@ -480,6 +480,8 @@ func (cfg *Config) parseData(data []byte, path string) ([]byte, error) {
 	}
 
 	// Initialize cfg.ScrapeConfigs
+	// drop jobs with invalid config with error log
+	var validScrapeConfigs []*ScrapeConfig
 	for i, sc := range cfg.ScrapeConfigs {
 		// Make a copy of sc in order to remove references to `data` memory.
 		// This should prevent from memory leaks on config reload.
@@ -488,10 +490,13 @@ func (cfg *Config) parseData(data []byte, path string) ([]byte, error) {
 
 		swc, err := getScrapeWorkConfig(sc, cfg.baseDir, &cfg.Global)
 		if err != nil {
-			return nil, fmt.Errorf("cannot parse `scrape_config`: %w", err)
+			logger.Errorf("cannot parse `scrape_config`: %w", err)
+			continue
 		}
 		sc.swc = swc
+		validScrapeConfigs = append(validScrapeConfigs, sc)
 	}
+	cfg.ScrapeConfigs = validScrapeConfigs
 	return dataNew, nil
 }
 


### PR DESCRIPTION
1. address https://github.com/VictoriaMetrics/VictoriaMetrics/issues/4959, drop jobs with incorrect config with error log
2. read oauth2 `client_secret_file` when needed, so now most of auth files will only be read when using except those in [TLSConfig](https://github.com/VictoriaMetrics/VictoriaMetrics/blob/lazy-load-auth-files/lib/promauth/config.go#L73). 
