### PR TITLE
docs/enterprise: add info about license flags 

### DIFF
--- a/docs/enterprise.md
+++ b/docs/enterprise.md
@@ -20,8 +20,8 @@ and [the license](https://github.com/VictoriaMetrics/VictoriaMetrics/blob/master
 
 The use of VictoriaMetrics enterprise components is permitted in the following cases:
 
-- Evaluation use in non-production setups. Just download and run enterprise binaries or packages of VictoriaMetrics
-  components from usual places - [releases page](https://github.com/VictoriaMetrics/VictoriaMetrics/releases) and [docker hub](https://hub.docker.com/u/victoriametrics).
+- Evaluation use in non-production setups. Please, request trial license [here](https://victoriametrics.com/products/enterprise/).
+  Download components from usual places - [releases page](https://github.com/VictoriaMetrics/VictoriaMetrics/releases) and [docker hub](https://hub.docker.com/u/victoriametrics).
   Enterprise binaries and packages have `enterprise` suffix in their names.
 
 - Production use if you have a valid enterprise contract or valid permit from VictoriaMetrics company.
@@ -29,7 +29,7 @@ The use of VictoriaMetrics enterprise components is permitted in the following c
 
 - [Managed VictoriaMetrics](https://docs.victoriametrics.com/managed-victoriametrics/) is built on top of enterprise binaries of VictoriaMetrics.
 
-All the enterprise apps require `-eula` command-line flag to be passed to them. This flag acknowledges that your usage fits one of the cases listed above.
+See [running VictoriaMetrics enterprise](#running-victoriametrics-enterprise) for details on how to run VictoriaMetrics enterprise.
 
 ## VictoriaMetrics enterprise features
 
@@ -61,3 +61,55 @@ On top of this, enterprise package of VictoriaMetrics includes the following imp
 - Prioritizing of feature requests from Enterprise customers.
 
 [Contact us](mailto:info@victoriametrics.com) if you are interested in VictoriaMetrics enterprise.
+
+## Running VictoriaMetrics enterprise
+
+Before vX.Y.Z all the enterprise apps required `-eula` command-line flag to be passed to them.
+This flag acknowledges that your usage fits one of the cases listed above.
+
+After vX.Y.Z either `-eula` flag or the following flags are used:
+```console
+  -license string
+        See https://victoriametrics.com/products/enterprise/ for trial license
+  -license-file string
+        See https://victoriametrics.com/products/enterprise/ for trial license
+  -license.forceOffline
+        Force offline verification of license code. License is verified online by default. This flag runs license verification offline.
+```
+
+### Monitoring license expiration
+
+All victoria metrics enterprise components expose the following metrics:
+```
+vm_license_expires_at 1694304000
+vm_license_expires_in_seconds 1592720
+```
+Please, refer to monitoring section of each component for details on how to scrape these metrics.
+
+`vm_license_expires_at` is the expiration date in unix timestamp format.
+`vm_license_expires_in_seconds` is the amount of seconds until the license expires.
+
+Example alerts for [vmalert](https://docs.victoriametrics.com/vmalert.html):
+```yaml
+groups:
+  - name: vm-license
+    # note the `job` label and update accordingly to your setup
+    rules:
+      - alert: LicenseExpiresInLessThan30Days
+        expr: vm_license_expires_in_seconds < 30 * 24 * 3600
+        labels:
+          severity: warning
+        annotations:
+          summary: "{{ $labels.job }} instance {{ $labels.instance }} license expires in less than 30 days"
+          description: "{{ $labels.instance }} of job {{ $labels.job }} license expires in {{ $value | humanizeDuration }}. 
+            Please make sure to update the license before it expires."
+
+      - alert: LicenseExpiresInLessThan7Days
+        expr: vm_license_expires_in_seconds < 7 * 24 * 3600
+        labels:
+          severity: critical
+        annotations:
+          summary: "{{ $labels.job }} instance {{ $labels.instance }} license expires in less than 7 days"
+          description: "{{ $labels.instance }} of job {{ $labels.job }} license expires in {{ $value | humanizeDuration }}. 
+            Please make sure to update the license before it expires."
+```

--- a/docs/enterprise.md
+++ b/docs/enterprise.md
@@ -116,12 +116,12 @@ flag similar to the one described in the previous section.
 
 For example, the following command runs [VictoriaMetrics single-node](https://docs.victoriametrics.com/Single-server-VictoriaMetrics.html) docker image with the specified license:
 ```console
-docker run --name=victoria-metrics victoriametrics/victoria-metrics:v1.94.0 -license={VM_KEY_VALUE}
+docker run --name=victoria-metrics victoriametrics/victoria-metrics:v1.94.0-enteprise -license={VM_KEY_VALUE}
 ```
 
 Alternatively, the license can be specified via `-license-file` command-line flag:
 ```console
-docker run --name=victoria-metrics -v /vm-license:/vm-license  victoriametrics/victoria-metrics:v1.94.0 -license-file=/vm-license
+docker run --name=victoria-metrics -v /vm-license:/vm-license  victoriametrics/victoria-metrics:v1.94.0-enteprise -license-file=/vm-license
 ```
 
 ### Helm charts

--- a/docs/enterprise.md
+++ b/docs/enterprise.md
@@ -21,11 +21,12 @@ and [the license](https://github.com/VictoriaMetrics/VictoriaMetrics/blob/master
 The use of VictoriaMetrics enterprise components is permitted in the following cases:
 
 - Evaluation use in non-production setups. Please, request trial license [here](https://victoriametrics.com/products/enterprise/).
+  Trial key will be sent to your email after filling the trial form.
   Download components from usual places - [releases page](https://github.com/VictoriaMetrics/VictoriaMetrics/releases) and [docker hub](https://hub.docker.com/u/victoriametrics).
   Enterprise binaries and packages have `enterprise` suffix in their names.
 
 - Production use if you have a valid enterprise contract or valid permit from VictoriaMetrics company.
-  [Contact us](mailto:info@victoriametrics.com) if you need such contract.
+  [Contact us](mailto:sales@victoriametrics.com) if you need such contract.
 
 - [Managed VictoriaMetrics](https://docs.victoriametrics.com/managed-victoriametrics/) is built on top of enterprise binaries of VictoriaMetrics.
 
@@ -164,6 +165,11 @@ data:
   license: {BASE64_ENCODED_LICENSE_KEY}
 ```
 
+Or create secret via `kubectl`:
+```console
+kubectl create secret generic vm-license --from-literal=license={VM_KEY_VALUE}
+```
+
 ### Kubernetes operator
 
 VictoriaMetrics enterprise components can be deployed via [VictoriaMetrics operator](https://docs.victoriametrics.com/operator/).
@@ -210,6 +216,11 @@ metadata:
 type: Opaque
 data:
   license: {BASE64_ENCODED_LICENSE_KEY}
+```
+
+Or create secret via `kubectl`:
+```console
+kubectl create secret generic vm-license --from-literal=license={VM_KEY_VALUE}
 ```
 
 See full list of CRD specifications [here](https://docs.victoriametrics.com/operator/api.html).

--- a/docs/enterprise.md
+++ b/docs/enterprise.md
@@ -74,15 +74,15 @@ There are several ways to run VictoriaMetrics enterprise:
 ### Binary releases
 
 Binary releases of VictoriaMetrics enterprise are available [here](https://github.com/VictoriaMetrics/VictoriaMetrics/releases).
-Enterprise binaries and packages have `enterprise` suffix in their names. For example, `victoria-metrics-linux-amd64-vX.Y.Z-enterprise.tar.gz`.
+Enterprise binaries and packages have `enterprise` suffix in their names. For example, `victoria-metrics-linux-amd64-v1.94.0-enterprise.tar.gz`.
 
 In order to run binary release of VictoriaMetrics enterprise, download the release for your OS and unpack it.
 Then run `victoria-metrics-enterprise` binary from the unpacked directory.
 
-Before vX.Y.Z all the enterprise apps required `-eula` command-line flag to be passed to them.
+Before v1.94.0 all the enterprise apps required `-eula` command-line flag to be passed to them.
 This flag acknowledges that your usage fits one of the cases listed above.
 
-After vX.Y.Z either `-eula` flag or the following flags are used:
+After v1.94.0 either `-eula` flag or the following flags are used:
 ```console
   -license string
         See https://victoriametrics.com/products/enterprise/ for trial license
@@ -94,8 +94,8 @@ After vX.Y.Z either `-eula` flag or the following flags are used:
 
 For example, the following command runs `victoria-metrics-enterprise` binary with the specified license:
 ```console
-wget https://github.com/VictoriaMetrics/VictoriaMetrics/releases/download/vX.Y.Z/victoria-metrics-linux-amd64-vX.Y.Z-enterprise.tar.gz
-tar -xzf victoria-metrics-linux-amd64-vX.Y.Z-enterprise.tar.gz
+wget https://github.com/VictoriaMetrics/VictoriaMetrics/releases/download/v1.94.0/victoria-metrics-linux-amd64-v1.94.0-enterprise.tar.gz
+tar -xzf victoria-metrics-linux-amd64-v1.94.0-enterprise.tar.gz
 ./victoria-metrics-prod -license={VM_KEY_VALUE}
 ```
 
@@ -109,19 +109,19 @@ The license file must contain the license key.
 ### Docker images
 
 Docker images for VictoriaMetrics enterprise are available [here](https://hub.docker.com/u/victoriametrics).
-Enterprise docker images have `enterprise` suffix in their names. For example, `victoriametrics/victoria-metrics:vX.Y.Z-enteprise`.
+Enterprise docker images have `enterprise` suffix in their names. For example, `victoriametrics/victoria-metrics:v1.94.0-enteprise`.
 
 In order to run docker image of VictoriaMetrics enterprise component it is required to provide the license key command-line
 flag similar to the one described in the previous section.
 
 For example, the following command runs [VictoriaMetrics single-node](https://docs.victoriametrics.com/Single-server-VictoriaMetrics.html) docker image with the specified license:
 ```console
-docker run --name=victoria-metrics victoriametrics/victoria-metrics:vX.Y.Z -license={VM_KEY_VALUE}
+docker run --name=victoria-metrics victoriametrics/victoria-metrics:v1.94.0 -license={VM_KEY_VALUE}
 ```
 
 Alternatively, the license can be specified via `-license-file` command-line flag:
 ```console
-docker run --name=victoria-metrics -v /vm-license:/vm-license  victoriametrics/victoria-metrics:vX.Y.Z -license-file=/vm-license
+docker run --name=victoria-metrics -v /vm-license:/vm-license  victoriametrics/victoria-metrics:v1.94.0 -license-file=/vm-license
 ```
 
 ### Helm charts
@@ -136,7 +136,7 @@ is used to provide key in plain-text:
 ```yaml
 server:
   image:
-    tag: vX.Y.Z-enterprise 
+    tag: v1.94.0-enterprise 
 
 license:
   key: {VM_KEY_VALUE}
@@ -146,7 +146,7 @@ In order to provide key via existing secret, the following values file is used:
 ```yaml
 server:
   image:
-    tag: vX.Y.Z-enterprise 
+    tag: v1.94.0-enterprise 
 
 license:
   secret:
@@ -187,7 +187,7 @@ spec:
   license:
     key: "VM_KEY_VALUE"
   image:
-    tag: vX.Y.Z-enterprise 
+    tag: v1.94.0-enterprise 
 ```
 
 In order to provide key via existing secret, the following custom resource is used:
@@ -203,7 +203,7 @@ spec:
       name: vm-key
       key: license
   image:
-    tag: vX.Y.Z-enterprise 
+    tag: v1.94.0-enterprise 
 ```
 
 Example secret with license key:

--- a/docs/enterprise.md
+++ b/docs/enterprise.md
@@ -124,6 +124,26 @@ Alternatively, the license can be specified via `-license-file` command-line fla
 docker run --name=victoria-metrics -v /vm-license:/vm-license  victoriametrics/victoria-metrics:v1.94.0-enteprise -license-file=/vm-license
 ```
 
+Example docker-compose configuration:
+```yaml
+version: "3.5"
+services:
+  victoriametrics:
+    container_name: victoriametrics
+    image: victoriametrics/victoria-metrics:v1.94.0
+    ports:
+      - 8428:8428
+    volumes:
+      - vmdata:/storage
+      - /vm-license:/vm-license
+    command:
+      - "--storageDataPath=/storage"
+      - "--license-file=/vm-license"
+volumes:
+  vmdata: {}
+```
+Note, that example assumes that license file is located at `/vm-license` path on the host.
+
 ### Helm charts
 
 Helm charts for VictoriaMetrics components are available [here](https://github.com/VictoriaMetrics/helm-charts).
@@ -200,7 +220,7 @@ spec:
   retentionPeriod: "1"
   license:
     keyRef:
-      name: vm-key
+      name: vm-license
       key: license
   image:
     tag: v1.94.0-enterprise 

--- a/docs/enterprise.md
+++ b/docs/enterprise.md
@@ -64,6 +64,20 @@ On top of this, enterprise package of VictoriaMetrics includes the following imp
 
 ## Running VictoriaMetrics enterprise
 
+There are several ways to run VictoriaMetrics enterprise:
+- [Binary releases](#binary-releases)
+- [Docker images](#docker-images)
+- [Helm charts](#helm-charts)
+- [Kubernetes operator](#kubernetes-operator)
+
+### Binary releases
+
+Binary releases of VictoriaMetrics enterprise are available [here](https://github.com/VictoriaMetrics/VictoriaMetrics/releases).
+Enterprise binaries and packages have `enterprise` suffix in their names. For example, `victoria-metrics-linux-amd64-vX.Y.Z-enterprise.tar.gz`.
+
+In order to run binary release of VictoriaMetrics enterprise, download the release for your OS and unpack it.
+Then run `victoria-metrics-enterprise` binary from the unpacked directory.
+
 Before vX.Y.Z all the enterprise apps required `-eula` command-line flag to be passed to them.
 This flag acknowledges that your usage fits one of the cases listed above.
 
@@ -77,7 +91,130 @@ After vX.Y.Z either `-eula` flag or the following flags are used:
         Force offline verification of license code. License is verified online by default. This flag runs license verification offline.
 ```
 
-### Monitoring license expiration
+For example, the following command runs `victoria-metrics-enterprise` binary with the specified license:
+```console
+wget https://github.com/VictoriaMetrics/VictoriaMetrics/releases/download/vX.Y.Z/victoria-metrics-linux-amd64-vX.Y.Z-enterprise.tar.gz
+tar -xzf victoria-metrics-linux-amd64-vX.Y.Z-enterprise.tar.gz
+./victoria-metrics-prod -license={VM_KEY_VALUE}
+```
+
+Alternatively, the license can be specified via `-license-file` command-line flag:
+```console
+./victoria-metrics-prod -license-file=/path/to/license/file
+```
+
+The license file must contain the license key.
+
+### Docker images
+
+Docker images for VictoriaMetrics enterprise are available [here](https://hub.docker.com/u/victoriametrics).
+Enterprise docker images have `enterprise` suffix in their names. For example, `victoriametrics/victoria-metrics:vX.Y.Z-enteprise`.
+
+In order to run docker image of VictoriaMetrics enterprise component it is required to provide the license key command-line
+flag similar to the one described in the previous section.
+
+For example, the following command runs [VictoriaMetrics single-node](https://docs.victoriametrics.com/Single-server-VictoriaMetrics.html) docker image with the specified license:
+```console
+docker run --name=victoria-metrics victoriametrics/victoria-metrics:vX.Y.Z -license={VM_KEY_VALUE}
+```
+
+Alternatively, the license can be specified via `-license-file` command-line flag:
+```console
+docker run --name=victoria-metrics -v /vm-license:/vm-license  victoriametrics/victoria-metrics:vX.Y.Z -license-file=/vm-license
+```
+
+### Helm charts
+
+Helm charts for VictoriaMetrics components are available [here](https://github.com/VictoriaMetrics/helm-charts).
+
+In order to run VictoriaMetrics enterprise helm chart it is required to provide the license key via `license` value in `values.yaml` file 
+and adjust the image tag to the enterprise one. 
+
+For example, the following values file for [VictoriaMetrics single-node chart](https://github.com/VictoriaMetrics/helm-charts/tree/master/charts/victoria-metrics-single)
+is used to provide key in plain-text:
+```yaml
+server:
+  image:
+    tag: vX.Y.Z-enterprise 
+
+license:
+  key: {VM_KEY_VALUE}
+```
+
+In order to provide key via existing secret, the following values file is used:
+```yaml
+server:
+  image:
+    tag: vX.Y.Z-enterprise 
+
+license:
+  secret:
+    name: vm-license
+    key: license
+```
+
+Example secret with license key:
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: vm-license
+type: Opaque
+data:
+  license: {BASE64_ENCODED_LICENSE_KEY}
+```
+
+### Kubernetes operator
+
+VictoriaMetrics enterprise components can be deployed via [VictoriaMetrics operator](https://docs.victoriametrics.com/operator/).
+In order to use enterprise components it is required to provide the license key via `license` field and adjust the image tag to the enterprise one.
+
+For example, the following custom resource for [VictoriaMetrics single-node](https://docs.victoriametrics.com/Single-server-VictoriaMetrics.html) 
+is used to provide key in plain-text:
+```yaml
+apiVersion: operator.victoriametrics.com/v1beta1
+kind: VMSingle
+metadata:
+  name: example-vmsingle
+spec:
+  retentionPeriod: "1"
+  license:
+    key: "VM_KEY_VALUE"
+  image:
+    tag: vX.Y.Z-enterprise 
+```
+
+In order to provide key via existing secret, the following custom resource is used:
+```yaml
+apiVersion: operator.victoriametrics.com/v1beta1
+kind: VMSingle
+metadata:
+  name: example-vmsingle
+spec:
+  retentionPeriod: "1"
+  license:
+    keyRef:
+      name: vm-key
+      key: license
+  image:
+    tag: vX.Y.Z-enterprise 
+```
+
+Example secret with license key:
+```yaml
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: vm-license
+type: Opaque
+data:
+  license: {BASE64_ENCODED_LICENSE_KEY}
+```
+
+See full list of CRD specifications [here](https://docs.victoriametrics.com/operator/api.html).
+
+## Monitoring license expiration
 
 All victoria metrics enterprise components expose the following metrics:
 ```

--- a/docs/vmanomaly.md
+++ b/docs/vmanomaly.md
@@ -205,11 +205,11 @@ vm_license_expires_at 1.6963776e+09
 vm_license_expires_in_seconds 4.886608e+06
 ```
 
-You can find example alerts for [vmalert](https://docs.victoriametrics.com/vmalert.html):
+Example alerts for [vmalert](https://docs.victoriametrics.com/vmalert.html):
 ```yaml
 groups:
   - name: vm-license
-    # note the `job` filter and update accordingly to your setup
+    # note the `job` label and update accordingly to your setup
     rules:
       - alert: LicenseExpiresInLessThan30Days
         expr: vm_license_expires_in_seconds < 30 * 24 * 3600


### PR DESCRIPTION
- added information about new `-license` flags
- added more details about how to run enterprise binaries