### PR TITLE
app/vmbackup: limit GOMAXPROCS to value of -concurrency command-line flag

### DIFF
--- a/app/vmbackup/main.go
+++ b/app/vmbackup/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/backup/fslocal"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/backup/fsnil"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/buildinfo"
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/cgroup"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/envflag"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/flagutil"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/httpserver"
@@ -48,6 +49,9 @@ func main() {
 	buildinfo.Init()
 	logger.Init()
 	pushmetrics.Init()
+	// Limit amount of CPU cores used by vmbackup.
+	// Using all the CPU cores may lead to high CPU usage created by usage of FADVISE syscall
+	cgroup.SetGOMAXPROCS(*concurrency)
 
 	// Storing snapshot delete function to be able to call it in case
 	// of error since logger.Fatal will exit the program without

--- a/lib/cgroup/cpu.go
+++ b/lib/cgroup/cpu.go
@@ -17,6 +17,21 @@ func AvailableCPUs() int {
 	return runtime.GOMAXPROCS(-1)
 }
 
+// SetGOMAXPROCS sets GOMAXPROCS to the given value.
+// If n is less than or equal to 0, then GOMAXPROCS is set to the number of available CPU cores.
+// If n is greater than the number of available CPU cores, then GOMAXPROCS is set to the number of available CPU cores.
+func SetGOMAXPROCS(n int) {
+	if n <= 0 {
+		n = int(getCPUQuota() + 0.5)
+	}
+
+	if n >= runtime.NumCPU() {
+		n = runtime.NumCPU()
+	}
+
+	runtime.GOMAXPROCS(n)
+}
+
 func init() {
 	cpuQuota := getCPUQuota()
 	if cpuQuota > 0 {


### PR DESCRIPTION
This helps to lower CPU usage on systems which are using large number of CPU cores available to vmbackup. On such systems, GOMAXPROCS will be limited to number of all available CPU cores and using FADVISE syscall might require expensive cache prune calls in linux kernel across different CPU cores(see https://github.com/torvalds/linux/blob/ce36c8b149873b50f2a4b9818eb3dcdd74ddd5a3/mm/fadvise.c#L145C11-L170)