### PR TITLE
docs victorialogs use relative links

### DIFF
--- a/docs/VictoriaLogs/CHANGELOG.md
+++ b/docs/VictoriaLogs/CHANGELOG.md
@@ -14,7 +14,7 @@ aliases:
 # VictoriaLogs changelog
 
 The following `tip` changes can be tested by building VictoriaLogs from the latest commit of [VictoriaMetrics](https://github.com/VictoriaMetrics/VictoriaMetrics/) repository
-according to [these docs](https://docs.victoriametrics.com/VictoriaLogs/QuickStart.html#building-from-source-code)
+according to [these docs](/VictoriaLogs/QuickStart.html#building-from-source-code)
 
 ## tip
 
@@ -28,12 +28,12 @@ Released at 2023-10-04
 
 Released at 2023-10-03
 
-* FEATURE: add `-elasticsearch.version` command-line flag, which can be used for specifying Elasticsearch version returned by VictoriaLogs to Filebeat at [elasticsearch bulk API](https://docs.victoriametrics.com/VictoriaLogs/data-ingestion/#elasticsearch-bulk-api). This helps resolving [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/4777).
+* FEATURE: add `-elasticsearch.version` command-line flag, which can be used for specifying Elasticsearch version returned by VictoriaLogs to Filebeat at [elasticsearch bulk API](/VictoriaLogs/data-ingestion/#elasticsearch-bulk-api). This helps resolving [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/4777).
 * FEATURE: expose the following metrics at [/metrics](monitoring) page:
-  * `vl_data_size_bytes{type="storage"}` - on-disk size for data excluding [log stream](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#stream-fields) indexes.
-  * `vl_data_size_bytes{type="indexdb"}` - on-disk size for [log stream](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#stream-fields) indexes.
+  * `vl_data_size_bytes{type="storage"}` - on-disk size for data excluding [log stream](/VictoriaLogs/keyConcepts.html#stream-fields) indexes.
+  * `vl_data_size_bytes{type="indexdb"}` - on-disk size for [log stream](/VictoriaLogs/keyConcepts.html#stream-fields) indexes.
 * FEATURE: add `-insert.maxFieldsPerLine` command-line flag, which can be used for limiting the number of fields per line in logs sent to VictoriaLogs via ingestion protocols. This helps to avoid issues like [this](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/4762).
-* FEATURE: expose `vl_http_request_duration_seconds` histogram at the [/metrics](https://docs.victoriametrics.com/VictoriaLogs/#monitoring) page. Thanks to @crossoverJie for [this pull request](https://github.com/VictoriaMetrics/VictoriaMetrics/pull/4934).
+* FEATURE: expose `vl_http_request_duration_seconds` histogram at the [/metrics](/VictoriaLogs/#monitoring) page. Thanks to @crossoverJie for [this pull request](https://github.com/VictoriaMetrics/VictoriaMetrics/pull/4934).
 * FEATURE: add support of `-storage.minFreeDiskSpaceBytes` command-line flag to allow switching to read-only mode when running out of disk space at `-storageDataPath`. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/4737).
 
 * BUGFIX: fix possible panic when no data is written to VictoriaLogs for a long time. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/4895). Thanks to @crossoverJie for filing and fixing the issue.
@@ -44,15 +44,15 @@ Released at 2023-10-03
 
 Released at 2023-07-20
 
-* FEATURE: add support for data ingestion via Promtail (aka default log shipper for Grafana Loki). See [these](https://docs.victoriametrics.com/VictoriaLogs/data-ingestion/Promtail.html) and [these](https://docs.victoriametrics.com/VictoriaLogs/data-ingestion/#loki-json-api) docs.
+* FEATURE: add support for data ingestion via Promtail (aka default log shipper for Grafana Loki). See [these](/VictoriaLogs/data-ingestion/Promtail.html) and [these](/VictoriaLogs/data-ingestion/#loki-json-api) docs.
 
 ## [v0.2.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v0.2.0-victorialogs)
 
 Released at 2023-07-17
 
-* FEATURE: support short form of `_time` filters over the last X minutes/hours/days/etc. For example, `_time:5m` is a short form for `_time:(now-5m, now]`, which matches logs with [timestamps](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#time-field) for the last 5 minutes. See [these docs](https://docs.victoriametrics.com/VictoriaLogs/LogsQL.html#time-filter) for details.
-* FEATURE: add ability to specify offset for the selected time range. For example, `_time:5m offset 1h` is equivalent to `_time:(now-5m-1h, now-1h]`. See [these docs](https://docs.victoriametrics.com/VictoriaLogs/LogsQL.html#time-filter) for details.
-* FEATURE: [LogsQL](https://docs.victoriametrics.com/VictoriaLogs/LogsQL.html): replace `exact_prefix("...")` with `exact("..."*)`. This makes it consistent with [i()](https://docs.victoriametrics.com/VictoriaLogs/LogsQL.html#case-insensitive-filter) filter, which can accept phrases and prefixes, e.g. `i("phrase")` and `i("phrase"*)`. See [these docs](https://docs.victoriametrics.com/VictoriaLogs/LogsQL.html#exact-prefix-filter).
+* FEATURE: support short form of `_time` filters over the last X minutes/hours/days/etc. For example, `_time:5m` is a short form for `_time:(now-5m, now]`, which matches logs with [timestamps](/VictoriaLogs/keyConcepts.html#time-field) for the last 5 minutes. See [these docs](/VictoriaLogs/LogsQL.html#time-filter) for details.
+* FEATURE: add ability to specify offset for the selected time range. For example, `_time:5m offset 1h` is equivalent to `_time:(now-5m-1h, now-1h]`. See [these docs](/VictoriaLogs/LogsQL.html#time-filter) for details.
+* FEATURE: [LogsQL](/VictoriaLogs/LogsQL.html): replace `exact_prefix("...")` with `exact("..."*)`. This makes it consistent with [i()](/VictoriaLogs/LogsQL.html#case-insensitive-filter) filter, which can accept phrases and prefixes, e.g. `i("phrase")` and `i("phrase"*)`. See [these docs](/VictoriaLogs/LogsQL.html#exact-prefix-filter).
 
 ## [v0.1.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v0.1.0-victorialogs)
 

--- a/docs/VictoriaLogs/FAQ.md
+++ b/docs/VictoriaLogs/FAQ.md
@@ -33,15 +33,15 @@ VictoriaLogs is optimized specifically for logs. So it provides the following fe
 - Up to 30x less RAM usage than Elasticsearch for the same workload.
 - Up to 15x less disk space usage than Elasticsearch for the same amounts of stored logs.
 - Ability to work with hundreds of terabytes of logs on a single node.
-- Very easy to use query language optimized for typical log analysis tasks - [LogsQL](https://docs.victoriametrics.com/VictoriaLogs/LogsQL.html).
-- Fast full-text search over all the [log fields](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#data-model) out of the box.
-- Good integration with traditional command-line tools for log analysis. See [these docs](https://docs.victoriametrics.com/VictoriaLogs/querying/#command-line).
+- Very easy to use query language optimized for typical log analysis tasks - [LogsQL](/VictoriaLogs/LogsQL.html).
+- Fast full-text search over all the [log fields](/VictoriaLogs/keyConcepts.html#data-model) out of the box.
+- Good integration with traditional command-line tools for log analysis. See [these docs](/VictoriaLogs/querying/#command-line).
 
 
 ## What is the difference between VictoriaLogs and Grafana Loki?
 
 Both Grafana Loki and VictoriaLogs are designed for log management and processing.
-Both systems support [log stream](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#stream-fields) concept.
+Both systems support [log stream](/VictoriaLogs/keyConcepts.html#stream-fields) concept.
 
 VictoriaLogs and Grafana Loki have the following differences:
 
@@ -49,13 +49,13 @@ VictoriaLogs and Grafana Loki have the following differences:
   It starts consuming huge amounts of RAM and working very slow when logs with high-cardinality fields are ingested into it.
   See [these docs](https://grafana.com/docs/loki/latest/best-practices/) for details.
 
-  VictoriaMetrics supports high-cardinality [log fields](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#data-model).
+  VictoriaMetrics supports high-cardinality [log fields](/VictoriaLogs/keyConcepts.html#data-model).
   It automatically indexes all the ingested log fields and allows performing fast full-text search over any field.
 
 - Grafana Loki provides very inconvenient query language - [LogQL](https://grafana.com/docs/loki/latest/logql/).
   This query language is hard to use for typical log analysis tasks.
 
-  VictoriaMetrics provides easy to use query language for typical log analysis tasks - [LogsQL](https://docs.victoriametrics.com/VictoriaLogs/LogsQL.html).
+  VictoriaMetrics provides easy to use query language for typical log analysis tasks - [LogsQL](/VictoriaLogs/LogsQL.html).
 
 - VictoriaLogs performs typical full-text queries up to 1000x faster than Grafana Loki.
 
@@ -69,7 +69,7 @@ VictoriaLogs and Grafana Loki have the following differences:
 ClickHouse is an extremely fast and efficient analytical database. It can be used for logs storage, analysis and processing.
 VictoriaLogs is designed solely for logs. VictoriaLogs uses [similar design ideas as ClickHouse](#how-does-victorialogs-work) for achieving high performance.
 
-- ClickHouse is good for logs if you know the set of [log fields](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#data-model) beforehand.
+- ClickHouse is good for logs if you know the set of [log fields](/VictoriaLogs/keyConcepts.html#data-model) beforehand.
   Then you can create a table with a column per each log field and achieve the maximum possible query performance.
 
   If the set of log fields isn't known beforehand, or if it can change at any time, then ClickHouse can still be used,
@@ -79,18 +79,18 @@ VictoriaLogs is designed solely for logs. VictoriaLogs uses [similar design idea
   for achieving high efficiency and query performance.
 
   VictoriaLogs works optimally with any log types out of the box - structured, unstructured and mixed.
-  It works optimally with any sets of [log fields](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#data-model),
+  It works optimally with any sets of [log fields](/VictoriaLogs/keyConcepts.html#data-model),
   which can change in any way across different log sources.
 
 - ClickHouse provides SQL dialect with additional analytical functionality. It allows performing arbitrary complex analytical queries
   over the stored logs.
 
   VictoriaLogs provides easy to use query language with full-text search specifically optimized
-  for log analysis - [LogsQL](https://docs.victoriametrics.com/VictoriaLogs/LogsQL.html).
+  for log analysis - [LogsQL](/VictoriaLogs/LogsQL.html).
   LogsQL is usually much easier to use than SQL for typical log analysis tasks, while some
   non-trivial analytics may require SQL power.
 
-- VictoriaLogs accepts logs from popular log shippers out of the box - see [these docs](https://docs.victoriametrics.com/VictoriaLogs/data-ingestion/).
+- VictoriaLogs accepts logs from popular log shippers out of the box - see [these docs](/VictoriaLogs/data-ingestion/).
 
   ClickHouse needs an intermediate applications for converting the ingested logs into `INSERT` SQL statements for the particular database schema.
   This may increase the complexity of the system and, subsequently, increase its' maintenance costs.
@@ -98,7 +98,7 @@ VictoriaLogs is designed solely for logs. VictoriaLogs uses [similar design idea
 
 ## How does VictoriaLogs work?
 
-VictoriaLogs accepts logs as [JSON entries](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#data-model).
+VictoriaLogs accepts logs as [JSON entries](/VictoriaLogs/keyConcepts.html#data-model).
 It then stores every field value into a distinct data block. E.g. values for the same field across multiple log entries
 are stored in a single data block. This allow reading data blocks only for the needed fields during querying.
 
@@ -117,11 +117,11 @@ This architecture is inspired by [ClickHouse architecture](https://clickhouse.co
 On top of this, VictoriaLogs employs additional optimizations for achieving high query performance:
 
 - It uses [bloom filters](https://en.wikipedia.org/wiki/Bloom_filter) for skipping blocks without the given
-  [word](https://docs.victoriametrics.com/VictoriaLogs/LogsQL.html#word-filter) or [phrase](https://docs.victoriametrics.com/VictoriaLogs/LogsQL.html#phrase-filter).
+  [word](/VictoriaLogs/LogsQL.html#word-filter) or [phrase](/VictoriaLogs/LogsQL.html#phrase-filter).
 - It uses custom encoding and compression for fields with different data types.
   For example, it encodes IP addresses as 4-byte tuples. Custom fields' encoding reduces data size on disk and improves query performance.
-- It physically groups logs for the same [log stream](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#stream-fields)
+- It physically groups logs for the same [log stream](/VictoriaLogs/keyConcepts.html#stream-fields)
   close to each other. This improves compression ratio, which helps reducing disk space usage. This also improves query performance
-  by skipping blocks for unneeded streams when [stream filter](https://docs.victoriametrics.com/VictoriaLogs/LogsQL.html#stream-filter) is used.
-- It maintains sparse index for [log timestamps](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#time-field),
-  which allow improving query performance when [time filter](https://docs.victoriametrics.com/VictoriaLogs/LogsQL.html#time-filter) is used.
+  by skipping blocks for unneeded streams when [stream filter](/VictoriaLogs/LogsQL.html#stream-filter) is used.
+- It maintains sparse index for [log timestamps](/VictoriaLogs/keyConcepts.html#time-field),
+  which allow improving query performance when [time filter](/VictoriaLogs/LogsQL.html#time-filter) is used.

--- a/docs/VictoriaLogs/LogsQL.md
+++ b/docs/VictoriaLogs/LogsQL.md
@@ -12,10 +12,10 @@ aliases:
 
 # LogsQL
 
-LogsQL is a simple yet powerful query language for [VictoriaLogs](https://docs.victoriametrics.com/VictoriaLogs/).
+LogsQL is a simple yet powerful query language for [VictoriaLogs](/VictoriaLogs/).
 It provides the following features:
 
-- Full-text search across [log fields](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#data-model).
+- Full-text search across [log fields](/VictoriaLogs/keyConcepts.html#data-model).
   See [word filter](#word-filter), [phrase filter](#phrase-filter) and [prefix filter](#prefix-filter).
 - Ability to combine filters into arbitrary complex [logical filters](#logical-filter).
 - Ability to extract structured fields from unstructured logs at query time. See [these docs](#transformations).
@@ -23,14 +23,14 @@ It provides the following features:
 
 ## LogsQL tutorial
 
-If you aren't familiar with VictoriaLogs, then start with [key concepts docs](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html).
+If you aren't familiar with VictoriaLogs, then start with [key concepts docs](/VictoriaLogs/keyConcepts.html).
 
 Then follow these docs:
-- [How to run VictoriaLogs](https://docs.victoriametrics.com/VictoriaLogs/QuickStart.html).
-- [how to ingest data into VictoriaLogs](https://docs.victoriametrics.com/VictoriaLogs/data-ingestion/).
-- [How to query VictoriaLogs](https://docs.victoriametrics.com/VictoriaLogs/querying/).
+- [How to run VictoriaLogs](/VictoriaLogs/QuickStart.html).
+- [how to ingest data into VictoriaLogs](/VictoriaLogs/data-ingestion/).
+- [How to query VictoriaLogs](/VictoriaLogs/querying/).
 
-The simplest LogsQL query is just a [word](#word), which must be found in the [log message](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#message-field).
+The simplest LogsQL query is just a [word](#word), which must be found in the [log message](/VictoriaLogs/keyConcepts.html#message-field).
 For example, the following query finds all the logs with `error` word:
 
 ```logsql
@@ -57,7 +57,7 @@ finds log messages with the `error: cannot find file` phrase:
 "error: cannot find file"
 ```
 
-Queries above match logs with any [timestamp](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#time-field),
+Queries above match logs with any [timestamp](/VictoriaLogs/keyConcepts.html#time-field),
 e.g. they may return logs from the previous year alongside recently ingested logs.
 
 Usually logs from the previous year aren't so interesting comparing to the recently ingested logs.
@@ -72,9 +72,9 @@ error AND _time:5m
 This query consists of two [filters](#filters) joined with `AND` [operator](#logical-filter):
 
 - The filter on the `error` [word](#word).
-- The filter on the [`_time` field](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#time-field).
+- The filter on the [`_time` field](/VictoriaLogs/keyConcepts.html#time-field).
 
-The `AND` operator means that the [log entry](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#data-model) must match both filters in order to be selected.
+The `AND` operator means that the [log entry](/VictoriaLogs/keyConcepts.html#data-model) must match both filters in order to be selected.
 
 Typical LogsQL query constists of multiple [filters](#filters) joined with `AND` operator. It may be tiresome typing and then reading all these `AND` words.
 So LogsQL allows omitting `AND` words. For example, the following query is equivalent to the query above:
@@ -83,11 +83,11 @@ So LogsQL allows omitting `AND` words. For example, the following query is equiv
 error _time:5m
 ```
 
-The query returns the following [log fields](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#data-model) by default:
+The query returns the following [log fields](/VictoriaLogs/keyConcepts.html#data-model) by default:
 
-- [`_msg` field](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#message-field)
-- [`_stream` field](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#stream-fields)
-- [`_time` field](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#time-field)
+- [`_msg` field](/VictoriaLogs/keyConcepts.html#message-field)
+- [`_stream` field](/VictoriaLogs/keyConcepts.html#stream-fields)
+- [`_time` field](/VictoriaLogs/keyConcepts.html#time-field)
 
 Logs may contain arbitrary number of other fields. If you need obtaining some of these fields in query results,
 then just refer them in the query with `field_name:*` [filter](#any-value-filter). See [these docs](#querying-specific-fields) for more details.
@@ -133,8 +133,8 @@ Read [these docs](#logical-filter) for more details. There is no need in remembe
 just wrap the needed query parts into explicit parentheses if you aren't sure in priority rules.
 As an additional bonus, explicit parentheses make queries easier to read and maintain.
 
-Queries above assume that the `error` [word](#word) is stored in the [log message](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#message-field).
-This word can be stored in other [field](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#data-model) such as `log.level`.
+Queries above assume that the `error` [word](#word) is stored in the [log message](/VictoriaLogs/keyConcepts.html#message-field).
+This word can be stored in other [field](/VictoriaLogs/keyConcepts.html#data-model) such as `log.level`.
 How to select error logs in this case? Just add the `log.level:` prefix in front of the `error` word:
 
 ```logsq
@@ -161,8 +161,8 @@ _time:5m log.level:error !app:(buggy_app OR foobar)
 ```
 
 The `app` field uniquely identifies the application instance if a single instance runs per each unique `app`.
-In this case it is recommended associating the `app` field with [log stream fields](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#stream-fields)
-during [data ingestion](https://docs.victoriametrics.com/VictoriaLogs/data-ingestion/). This usually improves both compression rate
+In this case it is recommended associating the `app` field with [log stream fields](/VictoriaLogs/keyConcepts.html#stream-fields)
+during [data ingestion](/VictoriaLogs/data-ingestion/). This usually improves both compression rate
 and query performance when querying the needed streams via [`_stream` filter](#stream-filter).
 If the `app` field is associated with the log stream, then the query above can be rewritten to more performant one:
 
@@ -181,7 +181,7 @@ Now you are familiar with LogsQL basics. Read [query syntax](#query-syntax) if y
 
 #### Word
 
-LogsQL splits all the [log fields](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#data-model) into words
+LogsQL splits all the [log fields](/VictoriaLogs/keyConcepts.html#data-model) into words
 delimited by non-word chars such as whitespace, parens, punctuation chars, etc. For example, the `foo: (bar,"тест")!` string
 is split into `foo`, `bar` and `тест` words. Words can contain arbitrary [utf-8](https://en.wikipedia.org/wiki/UTF-8) chars.
 These words are taken into account by full-text search filters such as
@@ -206,8 +206,8 @@ LogsQL query consists of the following parts delimited by `|`:
 LogsQL supports various filters for searching for log messages (see below).
 They can be combined into arbitrary complex queries via [logical filters](#logical-filter).
 
-Filters are applied to [`_msg` field](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#message-field) by default.
-If the filter must be applied to other [log field](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#data-model),
+Filters are applied to [`_msg` field](/VictoriaLogs/keyConcepts.html#message-field) by default.
+If the filter must be applied to other [log field](/VictoriaLogs/keyConcepts.html#data-model),
 then its' name followed by the colon must be put in front of the filter. For example, if `error` [word filter](#word-filter) must be applied
 to the `log.level` field, then use `log.level:error` query.
 
@@ -223,34 +223,34 @@ If doubt, it is recommended quoting field names and filter args.
 
 The list of LogsQL filters:
 
-- [Time filter](#time-filter) - matches logs with [`_time` field](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#time-field) in the given time range
-- [Stream filter](#stream-filter) - matches logs, which belong to the given [streams](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#stream-fields)
+- [Time filter](#time-filter) - matches logs with [`_time` field](/VictoriaLogs/keyConcepts.html#time-field) in the given time range
+- [Stream filter](#stream-filter) - matches logs, which belong to the given [streams](/VictoriaLogs/keyConcepts.html#stream-fields)
 - [Word filter](#word-filter) - matches logs with the given [word](#word)
 - [Phrase filter](#phrase-filter) - matches logs with the given phrase
 - [Prefix filter](#prefix-filter) - matches logs with the given word prefix or phrase prefix
-- [Empty value filter](#empty-value-filter) - matches logs without the given [log field](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#data-model)
-- [Any value filter](#any-value-filter) - matches logs with the given non-empty [log field](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#data-model)
+- [Empty value filter](#empty-value-filter) - matches logs without the given [log field](/VictoriaLogs/keyConcepts.html#data-model)
+- [Any value filter](#any-value-filter) - matches logs with the given non-empty [log field](/VictoriaLogs/keyConcepts.html#data-model)
 - [Exact filter](#exact-filter) - matches logs with the exact value
 - [Exact prefix filter](#exact-prefix-filter) - matches logs starting with the given prefix
 - [Multi-exact filter](#multi-exact-filter) - matches logs with one of the specified exact values
 - [Case-insensitive filter](#case-insensitive-filter) - matches logs with the given case-insensitive word, phrase or prefix
 - [Sequence filter](#sequence-filter) - matches logs with the given sequence of words or phrases
 - [Regexp filter](#regexp-filter) - matches logs for the given regexp
-- [Range filter](#range-filter) - matches logs with numeric [field values](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#data-model) in the given range
-- [IPv4 range filter](#ipv4-range-filter) - matches logs with ip address [field values](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#data-model) in the given range
-- [String range filter](#string-range-filter) - matches logs with [field values](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#data-model) in the given string range
-- [Length range filter](#length-range-filter) - matches logs with [field values](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#data-model) of the given length range
+- [Range filter](#range-filter) - matches logs with numeric [field values](/VictoriaLogs/keyConcepts.html#data-model) in the given range
+- [IPv4 range filter](#ipv4-range-filter) - matches logs with ip address [field values](/VictoriaLogs/keyConcepts.html#data-model) in the given range
+- [String range filter](#string-range-filter) - matches logs with [field values](/VictoriaLogs/keyConcepts.html#data-model) in the given string range
+- [Length range filter](#length-range-filter) - matches logs with [field values](/VictoriaLogs/keyConcepts.html#data-model) of the given length range
 - [Logical filter](#logical-filter) - allows combining other filters
 
 
 ### Time filter
 
-VictoriaLogs scans all the logs per each query if it doesn't contain the filter on [`_time` field](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#time-field).
+VictoriaLogs scans all the logs per each query if it doesn't contain the filter on [`_time` field](/VictoriaLogs/keyConcepts.html#time-field).
 It uses various optimizations in order to speed up full scan queries without the `_time` filter,
 but such queries can be slow if the storage contains large number of logs over long time range. The easiest way to optimize queries
-is to narrow down the search with the filter on [`_time` field](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#time-field).
+is to narrow down the search with the filter on [`_time` field](/VictoriaLogs/keyConcepts.html#time-field).
 
-For example, the following query returns [log messages](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#message-field)
+For example, the following query returns [log messages](/VictoriaLogs/keyConcepts.html#message-field)
 ingested into VictoriaLogs during the last hour, which contain the `error` [word](#word):
 
 ```logsql
@@ -270,10 +270,10 @@ The following formats are supported for `_time` filter:
 - `_time:YYYY-MM-DDTHH:MM` - matches all the logs for the particular minute by UTC. For example, `_time:2023-04-25T22:45` matches logs on April 25, 2023 at 22:45 by UTC.
 - `_time:YYYY-MM-DDTHH:MM:SS` - matches all the logs for the particular second by UTC. For example, `_time:2023-04-25T22:45:59` matches logs on April 25, 2023 at 22:45:59 by UTC.
 - `_time:[min_time, max_time]` - matches logs on the time range `[min_time, max_time]`, including both `min_time` and `max_time`.
-    The `min_time` and `max_time` can contain any format specified [here](https://docs.victoriametrics.com/#timestamp-formats).
+    The `min_time` and `max_time` can contain any format specified [here](/#timestamp-formats).
     For example, `_time:[2023-04-01, 2023-04-30]` matches logs for the whole April, 2023 by UTC, e.g. it is equivalent to `_time:2023-04`.
 - `_time:[min_time, max_time)` - matches logs on the time range `[min_time, max_time)`, not including `max_time`.
-    The `min_time` and `max_time` can contain any format specified [here](https://docs.victoriametrics.com/#timestamp-formats).
+    The `min_time` and `max_time` can contain any format specified [here](/#timestamp-formats).
     For example, `_time:[2023-02-01, 2023-03-01)` matches logs for the whole February, 2023 by UTC, e.g. it is equivalent to `_time:2023-02`.
 
 It is possible to specify time zone offset for all the absolute time formats by appending `+hh:mm` or `-hh:mm` suffix.
@@ -303,11 +303,11 @@ See also:
 
 ### Stream filter
 
-VictoriaLogs provides an optimized way to select log entries, which belong to particular [log streams](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#stream-fields).
+VictoriaLogs provides an optimized way to select log entries, which belong to particular [log streams](/VictoriaLogs/keyConcepts.html#stream-fields).
 This can be done via `_stream:{...}` filter. The `{...}` may contain arbitrary
-[Prometheus-compatible label selector](https://docs.victoriametrics.com/keyConcepts.html#filtering)
-over fields associated with [log streams](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#stream-fields).
-For example, the following query selects [log entries](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#data-model)
+[Prometheus-compatible label selector](/keyConcepts.html#filtering)
+over fields associated with [log streams](/VictoriaLogs/keyConcepts.html#stream-fields).
+For example, the following query selects [log entries](/VictoriaLogs/keyConcepts.html#data-model)
 with `app` field equal to `nginx`:
 
 ```logsql
@@ -338,13 +338,13 @@ See also:
 ### Word filter
 
 The simplest LogsQL query consists of a single [word](#word) to search in log messages. For example, the following query matches
-[log messages](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#message-field) with `error` [word](#word) inside them:
+[log messages](/VictoriaLogs/keyConcepts.html#message-field) with `error` [word](#word) inside them:
 
 ```logsql
 error
 ```
 
-This query matches the following [log messages](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#message-field):
+This query matches the following [log messages](/VictoriaLogs/keyConcepts.html#message-field):
 
 - `error`
 - `an error happened`
@@ -355,8 +355,8 @@ This query doesn't match the following log messages:
 - `ERROR`, since the filter is case-sensitive by default. Use `i(error)` for this case. See [these docs](#case-insensitive-filter) for details.
 - `multiple errors occurred`, since the `errors` word doesn't match `error` word. Use `error*` for this case. See [these docs](#prefix-filter) for details.
 
-By default the given [word](#word) is searched in the [`_msg` field](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#message-field).
-Specify the [field name](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#data-model) in front of the word and put a colon after it
+By default the given [word](#word) is searched in the [`_msg` field](/VictoriaLogs/keyConcepts.html#message-field).
+Specify the [field name](/VictoriaLogs/keyConcepts.html#data-model) in front of the word and put a colon after it
 if it must be searched in the given field. For example, the following query returns log entries containing the `error` [word](#word) in the `log.level` field:
 
 ```logsql
@@ -388,14 +388,14 @@ See also:
 
 Is you need to search for log messages with the specific phrase inside them, then just wrap the phrase in quotes.
 The phrase can contain any chars, including whitespace, punctuation, parens, etc. They are taken into account during the search.
-For example, the following query matches [log messages](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#message-field)
+For example, the following query matches [log messages](/VictoriaLogs/keyConcepts.html#message-field)
 with `ssh: login fail` phrase inside them:
 
 ```logsql
 "ssh: login fail"
 ```
 
-This query matches the following [log messages](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#message-field):
+This query matches the following [log messages](/VictoriaLogs/keyConcepts.html#message-field):
 
 - `ERROR: ssh: login fail for user "foobar"`
 - `ssh: login fail!`
@@ -411,8 +411,8 @@ This query doesn't match the following log messages:
 - `SSH: login fail`, since the `SSH` word is in capital letters. Use `i("ssh: login fail")` for case-insensitive search.
   See [these docs](#case-insensitive-filter) for details.
 
-By default the given phrase is searched in the [`_msg` field](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#message-field).
-Specify the [field name](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#data-model) in front of the phrase and put a colon after it
+By default the given phrase is searched in the [`_msg` field](/VictoriaLogs/keyConcepts.html#message-field).
+Specify the [field name](/VictoriaLogs/keyConcepts.html#data-model) in front of the phrase and put a colon after it
 if it must be searched in the given field. For example, the following query returns log entries containing the `cannot open file` phrase in the `event.original` field:
 
 ```logsql
@@ -443,13 +443,13 @@ See also:
 ### Prefix filter
 
 If you need to search for log messages with [words](#word) / phrases containing some prefix, then just add `*` char to the end of the [word](#word) / phrase in the query.
-For example, the following query returns [log messages](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#message-field), which contain [words](#word) with `err` prefix:
+For example, the following query returns [log messages](/VictoriaLogs/keyConcepts.html#message-field), which contain [words](#word) with `err` prefix:
 
 ```logsql
 err*
 ```
 
-This query matches the following [log messages](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#message-field):
+This query matches the following [log messages](/VictoriaLogs/keyConcepts.html#message-field):
 
 - `err: foobar`
 - `cannot open file: error occurred`
@@ -460,13 +460,13 @@ This query doesn't match the following log messages:
 - `fooerror`, since the `fooerror` [word](#word) doesn't start with `err`. Use `re("err")` for this case. See [these docs](#regexp-filter) for details.
 
 Prefix filter can be applied to [phrases](#phrase-filter). For example, the following query matches
-[log messages](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#message-field) containing phrases with `unexpected fail` prefix:
+[log messages](/VictoriaLogs/keyConcepts.html#message-field) containing phrases with `unexpected fail` prefix:
 
 ```logsql
 "unexpected fail"*
 ```
 
-This query matches the following [log messages](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#message-field):
+This query matches the following [log messages](/VictoriaLogs/keyConcepts.html#message-field):
 
 - `unexpected fail: IO error`
 - `error:unexpected failure`
@@ -478,8 +478,8 @@ This query doesn't match the following log messages:
 - `failed to open file: unexpected EOF`, since `failed` [word](#word) occurs before the `unexpected` word. Use `unexpected AND fail*` for this case.
   See [these docs](#logical-filter) for details.
 
-By default the prefix filter is applied to the [`_msg` field](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#message-field).
-Specify the needed [field name](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#data-model) in front of the prefix filter
+By default the prefix filter is applied to the [`_msg` field](/VictoriaLogs/keyConcepts.html#message-field).
+Specify the needed [field name](/VictoriaLogs/keyConcepts.html#data-model) in front of the prefix filter
 in order to apply it to the given field. For example, the following query matches `log.level` field containing any word with the `err` prefix:
 
 ```logsql
@@ -511,7 +511,7 @@ See also:
 
 ### Empty value filter
 
-Sometimes it is needed to find log entries without the given [log field](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#data-model).
+Sometimes it is needed to find log entries without the given [log field](/VictoriaLogs/keyConcepts.html#data-model).
 This can be performed with `log_field:""` syntax. For example, the following query matches log entries without `host.hostname` field:
 
 ```logsql
@@ -527,7 +527,7 @@ See also:
 
 ### Any value filter
 
-Sometimes it is needed to find log entries containing any non-empty value for the given [log field](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#data-model).
+Sometimes it is needed to find log entries containing any non-empty value for the given [log field](/VictoriaLogs/keyConcepts.html#data-model).
 This can be performed with `log_field:*` syntax. For example, the following query matches log entries with non-empty `host.hostname` field:
 
 ```logsql
@@ -543,9 +543,9 @@ See also:
 
 ### Exact filter
 
-The [word filter](#word-filter) and [phrase filter](#phrase-filter) return [log messages](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#message-field),
+The [word filter](#word-filter) and [phrase filter](#phrase-filter) return [log messages](/VictoriaLogs/keyConcepts.html#message-field),
 which contain the given word or phrase inside them. The message may contain additional text other than the requested word or phrase. If you need searching for log messages
-or [log fields](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#message-field) with the exact value, then use the `exact(...)` filter.
+or [log fields](/VictoriaLogs/keyConcepts.html#message-field) with the exact value, then use the `exact(...)` filter.
 For example, the following query returns log messages wih the exact value `fatal error: cannot find /foo/bar`:
 
 ```logsql
@@ -560,8 +560,8 @@ The query doesn't match the following log messages:
 - `FATAL ERROR: cannot find /foo/bar`, since the `exact()` filter is case-sensitive. Use `i("fatal error: cannot find /foo/bar")` in this case.
   See [these docs](#case-insensitive-filter) for details.
 
-By default the `exact()` filter is applied to the [`_msg` field](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#message-field).
-Specify the [field name](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#data-model) in front of the `exact()` filter and put a colon after it
+By default the `exact()` filter is applied to the [`_msg` field](/VictoriaLogs/keyConcepts.html#message-field).
+Specify the [field name](/VictoriaLogs/keyConcepts.html#data-model) in front of the `exact()` filter and put a colon after it
 if it must be searched in the given field. For example, the following query returns log entries with the exact `error` value at `log.level` field:
 
 ```logsql
@@ -600,7 +600,7 @@ For example, the following query matches log messages, which start from `Process
 exact("Processing request"*)
 ```
 
-This filter matches the following [log messages](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#message-field):
+This filter matches the following [log messages](/VictoriaLogs/keyConcepts.html#message-field):
 
 - `Processing request foobar`
 - `Processing requests from ...`
@@ -612,8 +612,8 @@ It doesn't match the following log messages:
 - `start: Processing request`, since the log message doesn't start with `Processing request`. Use `"Processing request"` query in this case.
   See [these docs](#phrase-filter) for details.
 
-By default the `exact()` filter is applied to the [`_msg` field](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#message-field).
-Specify the [field name](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#data-model) in front of the `exact()` filter and put a colon after it
+By default the `exact()` filter is applied to the [`_msg` field](/VictoriaLogs/keyConcepts.html#message-field).
+Specify the [field name](/VictoriaLogs/keyConcepts.html#data-model) in front of the `exact()` filter and put a colon after it
 if it must be searched in the given field. For example, the following query returns log entries with `log.level` field, which starts with `err` prefix:
 
 ```logsql
@@ -668,7 +668,7 @@ during the last day:
 _time:1h AND user_id:in(_time:1d AND path:admin | fields user_id)
 ```
 
-See the [Roadmap](https://docs.victoriametrics.com/VictoriaLogs/Roadmap.html) for details.
+See the [Roadmap](/VictoriaLogs/Roadmap.html) for details.
 
 See also:
 
@@ -689,7 +689,7 @@ log messages with `error` word in any case:
 i(error)
 ```
 
-The query matches the following [log messages](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#message-field):
+The query matches the following [log messages](/VictoriaLogs/keyConcepts.html#message-field):
 
 - `unknown error happened`
 - `ERROR: cannot read file`
@@ -701,8 +701,8 @@ The query doesn't match the following log messages:
 - `FooError`, since the `FooError` [word](#word) has superflouos prefix `Foo`. Use `re("(?i)error")` for this case. See [these docs](#regexp-filter) for details.
 - `too many Errors`, since the `Errors` [word](#word) has superflouos suffix `s`. Use `i(error*)` for this case.
 
-By default the `i()` filter is applied to the [`_msg` field](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#message-field).
-Specify the needed [field name](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#data-model) in front of the filter
+By default the `i()` filter is applied to the [`_msg` field](/VictoriaLogs/keyConcepts.html#message-field).
+Specify the needed [field name](/VictoriaLogs/keyConcepts.html#data-model) in front of the filter
 in order to apply it to the given field. For example, the following query matches `log.level` field containing `error` [word](#word) in any case:
 
 ```logsql
@@ -734,7 +734,7 @@ See also:
 
 ### Sequence filter
 
-Sometimes it is needed to find [log messages](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#message-field)
+Sometimes it is needed to find [log messages](/VictoriaLogs/keyConcepts.html#message-field)
 with [words](#word) or phrases in a particular order. For example, if log messages with `error` word followed by `open file` phrase
 must be found, then the following LogsQL query can be used:
 
@@ -747,8 +747,8 @@ The query doesn't match the `cannot open file: error` message, since the `open f
 If you need matching log messages with both `error` word and `open file` phrase, then use `error AND "open file"` query. See [these docs](#logical-filter)
 for details.
 
-By default the `seq()` filter is applied to the [`_msg` field](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#message-field).
-Specify the needed [field name](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#data-model) in front of the filter
+By default the `seq()` filter is applied to the [`_msg` field](/VictoriaLogs/keyConcepts.html#message-field).
+Specify the needed [field name](/VictoriaLogs/keyConcepts.html#data-model) in front of the filter
 in order to apply it to the given field. For example, the following query matches `event.original` field containing `(error, "open file")` sequence:
 
 ```logsql
@@ -779,7 +779,7 @@ For example, the following query returns all the log messages containing `err` o
 re("err|warn")
 ```
 
-The query matches the following [log messages](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#message-field), which contain either `err` or `warn` substrings:
+The query matches the following [log messages](/VictoriaLogs/keyConcepts.html#message-field), which contain either `err` or `warn` substrings:
 
 - `error: cannot read data`
 - `2 warnings have been raised`
@@ -791,8 +791,8 @@ The query doesn't match the following log messages:
   See [these docs](https://github.com/google/re2/wiki/Syntax) for details. See also [case-insenstive filter docs](#case-insensitive-filter).
 - `it is warmer than usual`, since it doesn't contain neither `err` nor `warn` substrings.
 
-By default the `re()` filter is applied to the [`_msg` field](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#message-field).
-Specify the needed [field name](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#data-model) in front of the filter
+By default the `re()` filter is applied to the [`_msg` field](/VictoriaLogs/keyConcepts.html#message-field).
+Specify the needed [field name](/VictoriaLogs/keyConcepts.html#data-model) in front of the filter
 in order to apply it to the given field. For example, the following query matches `event.original` field containing either `err` or `warn` substrings:
 
 ```logsql
@@ -839,15 +839,15 @@ parentheses with square brackets. For example:
 - `range(1, 10]` includes `10` in the matching range
 - `range[1, 10]` includes `1` and `10` in the matching range
 
-Note that the `range()` filter doesn't match [log fields](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#data-model)
+Note that the `range()` filter doesn't match [log fields](/VictoriaLogs/keyConcepts.html#data-model)
 with non-numeric values alongside numeric values. For example, `range(1, 10)` doesn't match `the request took 4.2 seconds`
-[log message](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#message-field), since the `4.2` number is surrounded by other text.
+[log message](/VictoriaLogs/keyConcepts.html#message-field), since the `4.2` number is surrounded by other text.
 Extract the numeric value from the message with `parse(_msg, "the request took <request_duration> seconds")` [transformation](#transformations)
 and then apply the `range()` [post-filter](#post-filters) to the extracted `request_duration` field.
 
 Performance tips:
 
-- It is better to query pure numeric [field](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#data-model)
+- It is better to query pure numeric [field](/VictoriaLogs/keyConcepts.html#data-model)
   instead of extracting numeric field from text field via [transformations](#transformations) at query time.
 - See [other performance tips](#performance-tips).
 
@@ -876,29 +876,29 @@ user.ip:ipv4_range("127.0.0.0/8")
 ```
 
 If you need matching a single IPv4 address, then just put it inside `ipv4_range()`. For example, the following query matches `1.2.3.4` IP
-at `user.ip` [field](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#data-model):
+at `user.ip` [field](/VictoriaLogs/keyConcepts.html#data-model):
 
 ```logsql
 user.ip:ipv4_range("1.2.3.4")
 ```
 
 Note that the `ipv4_range()` doesn't match a string with IPv4 address if this string contains other text. For example, `ipv4_range("127.0.0.0/24")`
-doesn't match `request from 127.0.0.1: done` [log message](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#message-field),
+doesn't match `request from 127.0.0.1: done` [log message](/VictoriaLogs/keyConcepts.html#message-field),
 since the `127.0.0.1` ip is surrounded by other text. Extract the IP from the message with `parse(_msg, "request from <ip>: done")` [transformation](#transformations)
 and then apply the `ipv4_range()` [post-filter](#post-filters) to the extracted `ip` field.
 
 Hints:
 
-- If you need searching for [log messages](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#message-field) containing the given `X.Y.Z.Q` IPv4 address,
+- If you need searching for [log messages](/VictoriaLogs/keyConcepts.html#message-field) containing the given `X.Y.Z.Q` IPv4 address,
   then `"X.Y.Z.Q"` query can be used. See [these docs](#phrase-filter) for details.
-- If you need searching for [log messages](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#message-field) containing
+- If you need searching for [log messages](/VictoriaLogs/keyConcepts.html#message-field) containing
   at least a single IPv4 address out of the given list, then `"ip1" OR "ip2" ... OR "ipN"` query can be used. See [these docs](#logical-filter) for details.
 - If you need finding log entries with `ip` field in multiple ranges, then use `ip:(ipv4_range(range1) OR ipv4_range(range2) ... OR ipv4_range(rangeN))` query.
   See [these docs](#logical-filter) for details.
 
 Performance tips:
 
-- It is better querying pure IPv4 [field](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#data-model)
+- It is better querying pure IPv4 [field](/VictoriaLogs/keyConcepts.html#data-model)
   instead of extracting IPv4 from text field via [transformations](#transformations) at query time.
 - See [other performance tips](#performance-tips).
 
@@ -933,7 +933,7 @@ See also:
 ### Length range filter
 
 If you need to filter log message by its length, then `len_range()` filter can be used.
-For example, the following LogsQL query matches [log messages](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#message-field)
+For example, the following LogsQL query matches [log messages](/VictoriaLogs/keyConcepts.html#message-field)
 with lengths in the range `[5, 10]` chars:
 
 ```logsql
@@ -950,8 +950,8 @@ This query doesn't match the following log messages:
 - `foo`, since it is too short
 - `foo bar baz abc`, sinc it is too long
 
-By default the `len_range()` is applied to the [`_msg` field](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#message-field).
-Put the [field name](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#data-model) in front of the `len_range()` in order to apply
+By default the `len_range()` is applied to the [`_msg` field](/VictoriaLogs/keyConcepts.html#message-field).
+Put the [field name](/VictoriaLogs/keyConcepts.html#data-model) in front of the `len_range()` in order to apply
 the filter to the needed field. For example, the following query matches log entries with the `foo` field length in the range `[10, 20]` chars:
 
 ```logsql
@@ -969,34 +969,34 @@ See also:
 Simpler LogsQL [filters](#filters) can be combined into more complex filters with the following logical operations:
 
 - `q1 AND q2` - matches common log entries returned by both `q1` and `q2`. Arbitrary number of [filters](#filters) can be combined with `AND` operation.
-  For example, `error AND file AND app` matches [log messages](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#message-field),
+  For example, `error AND file AND app` matches [log messages](/VictoriaLogs/keyConcepts.html#message-field),
   which simultaneously contain `error`, `file` and `app` [words](#word).
   The `AND` operation is frequently used in LogsQL queries, so it is allowed to skip the `AND` word.
   For example, `error file app` is equivalent to `error AND file AND app`.
 
 - `q1 OR q2` - merges log entries returned by both `q1` and `q2`. Aribtrary number of [filters](#filters) can be combined with `OR` operation.
-  For example, `error OR warning OR info` matches [log messages](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#message-field),
+  For example, `error OR warning OR info` matches [log messages](/VictoriaLogs/keyConcepts.html#message-field),
   which contain at least one of `error`, `warning` or `info` [words](#word).
 
 - `NOT q` - returns all the log entries except of those which match `q`. For example, `NOT info` returns all the
-  [log messages](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#message-field),
+  [log messages](/VictoriaLogs/keyConcepts.html#message-field),
   which do not contain `info` [word](#word). The `NOT` operation is frequently used in LogsQL queries, so it is allowed substituting `NOT` with `!` in queries.
   For example, `!info` is equivalent to `NOT info`.
 
 The `NOT` operation has the highest priority, `AND` has the middle priority and `OR` has the lowest priority.
 The priority order can be changed with parentheses. For example, `NOT info OR debug` is interpreted as `(NOT info) OR debug`,
-so it matches [log messages](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#message-field),
+so it matches [log messages](/VictoriaLogs/keyConcepts.html#message-field),
 which do not contain `info` [word](#word), while it also matches messages with `debug` word (which may contain the `info` word).
 This is not what most users expect. In this case the query can be rewritten to `NOT (info OR debug)`,
 which correctly returns log messages without `info` and `debug` [words](#word).
 
 LogsQL supports arbitrary complex logical queries with arbitrary mix of `AND`, `OR` and `NOT` operations and parentheses.
 
-By default logical filters apply to the [`_msg` field](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#message-field)
-unless the inner filters explicitly specify the needed [log field](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#data-model) via `field_name:filter` syntax.
+By default logical filters apply to the [`_msg` field](/VictoriaLogs/keyConcepts.html#message-field)
+unless the inner filters explicitly specify the needed [log field](/VictoriaLogs/keyConcepts.html#data-model) via `field_name:filter` syntax.
 For example, `(error OR warn) AND host.hostname:host123` is interpreted as `(_msg:error OR _msg:warn) AND host.hostname:host123`.
 
-It is possible to specify a single [log field](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#data-model) for multiple filters
+It is possible to specify a single [log field](/VictoriaLogs/keyConcepts.html#data-model) for multiple filters
 with the following syntax:
 
 ```logsql
@@ -1010,7 +1010,7 @@ Performance tips:
 - VictoriaLogs executes logical operations from the left to the right, so it is recommended moving the most specific
   and the fastest filters (such as [word filter](#word-filter) and [phrase filter](#phrase-filter)) to the left,
   while moving less specific and the slowest filters (such as [regexp filter](#regexp-filter) and [case-insensitive filter](#case-insensitive-filter))
-  to the right. For example, if you need to find [log messages](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#message-field)
+  to the right. For example, if you need to find [log messages](/VictoriaLogs/keyConcepts.html#message-field)
   with the `error` word, which match some `/foo/(bar|baz)` regexp,
   it is better from performance PoV to use the query `error re("/foo/(bar|baz)")` instead of `re("/foo/(bar|baz)") error`.
 
@@ -1021,51 +1021,51 @@ Performance tips:
 ## Stream context
 
 LogsQL will support the ability to select the given number of surrounding log lines for the selected log lines
-on a [per-stream](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#stream-fields) basis.
+on a [per-stream](/VictoriaLogs/keyConcepts.html#stream-fields) basis.
 
-See the [Roadmap](https://docs.victoriametrics.com/VictoriaLogs/Roadmap.html) for details.
+See the [Roadmap](/VictoriaLogs/Roadmap.html) for details.
 
 ## Transformations
 
 It is possible to perform various transformations on the [selected log entries](#filters) at client side
-with `jq`, `awk`, `cut`, etc. Unix commands according to [these docs](https://docs.victoriametrics.com/VictoriaLogs/querying/#command-line).
+with `jq`, `awk`, `cut`, etc. Unix commands according to [these docs](/VictoriaLogs/querying/#command-line).
 
 LogsQL will support the following transformations for the [selected](#filters) log entries:
 
-- Extracting the specified fields from text [log fields](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#data-model) according to the provided pattern.
-- Extracting the specified fields from JSON strings stored inside [log fields](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#data-model).
+- Extracting the specified fields from text [log fields](/VictoriaLogs/keyConcepts.html#data-model) according to the provided pattern.
+- Extracting the specified fields from JSON strings stored inside [log fields](/VictoriaLogs/keyConcepts.html#data-model).
 - Extracting the specified fields from [logfmt](https://brandur.org/logfmt) strings stored
-  inside [log fields](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#data-model).
-- Creating a new field from existing [log fields](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#data-model)
+  inside [log fields](/VictoriaLogs/keyConcepts.html#data-model).
+- Creating a new field from existing [log fields](/VictoriaLogs/keyConcepts.html#data-model)
   according to the provided format.
-- Creating a new field according to math calculations over existing [log fields](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#data-model).
-- Copying of the existing [log fields](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#data-model).
+- Creating a new field according to math calculations over existing [log fields](/VictoriaLogs/keyConcepts.html#data-model).
+- Copying of the existing [log fields](/VictoriaLogs/keyConcepts.html#data-model).
 - Parsing duration strings into floating-point seconds for further [stats calculations](#stats).
 - Creating a boolean field with the result of arbitrary [post-filters](#post-filters) applied to the current fields.
   Boolean fields may be useful for [conditional stats calculation](#stats).
 - Creating an integer field with the length of the given field value. This can be useful for [stats calculations](#stats).
 
-See the [Roadmap](https://docs.victoriametrics.com/VictoriaLogs/Roadmap.html) for details.
+See the [Roadmap](/VictoriaLogs/Roadmap.html) for details.
 
 ## Post-filters
 
 It is possible to perform post-filtering on the [selected log entries](#filters) at client side with `grep` or similar Unix commands
-according to [these docs](https://docs.victoriametrics.com/VictoriaLogs/querying/#command-line).
+according to [these docs](/VictoriaLogs/querying/#command-line).
 
-LogsQL will support post-filtering on the original [log fields](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#data-model)
+LogsQL will support post-filtering on the original [log fields](/VictoriaLogs/keyConcepts.html#data-model)
 and fields created by various [transformations](#transformations). The following post-filters will be supported:
 
 - Full-text [filtering](#filters).
 - [Logical filtering](#logical-filter).
 
-See the [Roadmap](https://docs.victoriametrics.com/VictoriaLogs/Roadmap.html) for details.
+See the [Roadmap](/VictoriaLogs/Roadmap.html) for details.
 
 ## Stats
 
 It is possible to perform stats calculations on the [selected log entries](#filters) at client side with `sort`, `uniq`, etc. Unix commands
-according to [these docs](https://docs.victoriametrics.com/VictoriaLogs/querying/#command-line).
+according to [these docs](/VictoriaLogs/querying/#command-line).
 
-LogsQL will support calculating the following stats based on the [log fields](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#data-model)
+LogsQL will support calculating the following stats based on the [log fields](/VictoriaLogs/keyConcepts.html#data-model)
 and fields created by [transformations](#transformations):
 
 - The number of selected logs.
@@ -1077,41 +1077,41 @@ and fields created by [transformations](#transformations):
 It will be possible specifying an optional condition [filter](#post-filters) when calculating the stats.
 For example, `sumIf(response_size, is_admin:true)` calculates the total response size for admins only.
 
-It will be possible to group stats by the specified [fields](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#data-model)
+It will be possible to group stats by the specified [fields](/VictoriaLogs/keyConcepts.html#data-model)
 and by the specified time buckets.
 
-See the [Roadmap](https://docs.victoriametrics.com/VictoriaLogs/Roadmap.html) for details.
+See the [Roadmap](/VictoriaLogs/Roadmap.html) for details.
 
 ## Sorting
 
-By default VictoriaLogs sorts the returned results by [`_time` field](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#time-field)
+By default VictoriaLogs sorts the returned results by [`_time` field](/VictoriaLogs/keyConcepts.html#time-field)
 if their total size doesn't exceed `-select.maxSortBufferSize` command-line value (by default it is set to one megabytes).
-Otherwise sorting is skipped because of performance and efficiency concerns described [here](https://docs.victoriametrics.com/VictoriaLogs/querying/).
+Otherwise sorting is skipped because of performance and efficiency concerns described [here](/VictoriaLogs/querying/).
 
 It is possible to sort the [selected log entries](#filters) at client side with `sort` Unix command
-according to [these docs](https://docs.victoriametrics.com/VictoriaLogs/querying/#command-line).
+according to [these docs](/VictoriaLogs/querying/#command-line).
 
-LogsQL will support results' sorting by the given set of [log fields](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#data-model).
+LogsQL will support results' sorting by the given set of [log fields](/VictoriaLogs/keyConcepts.html#data-model).
 
-See the [Roadmap](https://docs.victoriametrics.com/VictoriaLogs/Roadmap.html) for details.
+See the [Roadmap](/VictoriaLogs/Roadmap.html) for details.
 
 ## Limiters
 
 It is possible to limit the returned results with `head`, `tail`, `less`, etc. Unix commands
-according to [these docs](https://docs.victoriametrics.com/VictoriaLogs/querying/#command-line).
+according to [these docs](/VictoriaLogs/querying/#command-line).
 
 LogsQL will support the ability to limit the number of returned results alongside the ability to page the returned results.
 Additionally, LogsQL will provide the ability to select fields, which must be returned in the response.
 
-See the [Roadmap](https://docs.victoriametrics.com/VictoriaLogs/Roadmap.html) for details.
+See the [Roadmap](/VictoriaLogs/Roadmap.html) for details.
 
 ## Querying specific fields
 
-By default VictoriaLogs query response contains [`_msg`](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#message-field),
-[`_stream`](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#stream-fields) and
-[`_time`](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#time-field) fields.
+By default VictoriaLogs query response contains [`_msg`](/VictoriaLogs/keyConcepts.html#message-field),
+[`_stream`](/VictoriaLogs/keyConcepts.html#stream-fields) and
+[`_time`](/VictoriaLogs/keyConcepts.html#time-field) fields.
 
-If you want selecting other fields from the ingested [structured logs](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#data-model),
+If you want selecting other fields from the ingested [structured logs](/VictoriaLogs/keyConcepts.html#data-model),
 then they must be mentioned in query filters. For example, if you want selecting `log.level` field, and this field isn't mentioned in the query yet, then add
 `log.level:*` [filter](#any-value-filter) filter to the end of the query.
 The `field_name:*` filter doesn't return log entries with empty or missing `field_name`. If you want returning log entries
@@ -1124,13 +1124,13 @@ See the following docs for details:
 
 In the future LogsQL will support `| fields field1, field2, ... fieldN` syntax for selecting the listed fields.
 It will also support the ability to select all the fields for the matching log entries with `| fields *` syntax.
-See the [Roadmap](https://docs.victoriametrics.com/VictoriaLogs/Roadmap.html) for details.
+See the [Roadmap](/VictoriaLogs/Roadmap.html) for details.
 
 ## Performance tips
 
 - It is highly recommended specifying [time filter](#time-filter) in order to narrow down the search to specific time range.
 - It is highly recommended specifying [stream filter](#stream-filter) in order to narrow down the search
-  to specific [log streams](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#stream-fields).
+  to specific [log streams](/VictoriaLogs/keyConcepts.html#stream-fields).
 - Move faster filters such as [word filter](#word-filter) and [phrase filter](#phrase-filter) to the beginning of the query.
   This rule doesn't apply to [time filter](#time-filter) and [stream filter](#stream-filter), which can be put at any place of the query.
 - Move more specific filters, which match lower number of log entries, to the beginning of the query.

--- a/docs/VictoriaLogs/QuickStart.md
+++ b/docs/VictoriaLogs/QuickStart.md
@@ -12,8 +12,8 @@ aliases:
 
 # VictoriaLogs Quick Start
 
-It is recommended to read [README](https://docs.victoriametrics.com/VictoriaLogs/)
-and [Key Concepts](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html)
+It is recommended to read [README](/VictoriaLogs/)
+and [Key Concepts](/VictoriaLogs/keyConcepts.html)
 before you start working with VictoriaLogs.
 
 ## How to install and run VictoriaLogs
@@ -38,17 +38,17 @@ tar xzf victoria-logs-linux-amd64-v0.4.1-victorialogs.tar.gz
 ./victoria-logs-prod
 ```
 
-VictoriaLogs is ready for [data ingestion](https://docs.victoriametrics.com/VictoriaLogs/data-ingestion/)
-and [querying](https://docs.victoriametrics.com/VictoriaLogs/querying/) at the TCP port `9428` now!
+VictoriaLogs is ready for [data ingestion](/VictoriaLogs/data-ingestion/)
+and [querying](/VictoriaLogs/querying/) at the TCP port `9428` now!
 It has no any external dependencies, so it may run in various environments without additional setup and configuration.
 VictoriaLogs automatically adapts to the available CPU and RAM resources. It also automatically setups and creates
-the needed indexes during [data ingestion](https://docs.victoriametrics.com/VictoriaLogs/data-ingestion/).
+the needed indexes during [data ingestion](/VictoriaLogs/data-ingestion/).
 
 See also:
 
 - [How to configure VictoriaLogs](#how-to-configure-victorialogs)
-- [How to ingest logs into VictoriaLogs](https://docs.victoriametrics.com/VictoriaLogs/data-ingestion/)
-- [How to query VictoriaLogs](https://docs.victoriametrics.com/VictoriaLogs/querying/)
+- [How to ingest logs into VictoriaLogs](/VictoriaLogs/data-ingestion/)
+- [How to query VictoriaLogs](/VictoriaLogs/querying/)
 
 
 ### Docker image
@@ -64,8 +64,8 @@ docker run --rm -it -p 9428:9428 -v ./victoria-logs-data:/victoria-logs-data \
 See also:
 
 - [How to configure VictoriaLogs](#how-to-configure-victorialogs)
-- [How to ingest logs into VictoriaLogs](https://docs.victoriametrics.com/VictoriaLogs/data-ingestion/)
-- [How to query VictoriaLogs](https://docs.victoriametrics.com/VictoriaLogs/querying/)
+- [How to ingest logs into VictoriaLogs](/VictoriaLogs/data-ingestion/)
+- [How to query VictoriaLogs](/VictoriaLogs/querying/)
 
 ### Helm charts
 
@@ -95,17 +95,17 @@ Follow the following steps in order to build VictoriaLogs from source code:
   bin/victoria-logs
   ```
 
-VictoriaLogs is ready for [data ingestion](https://docs.victoriametrics.com/VictoriaLogs/data-ingestion/)
-and [querying](https://docs.victoriametrics.com/VictoriaLogs/querying/) at the TCP port `9428` now!
+VictoriaLogs is ready for [data ingestion](/VictoriaLogs/data-ingestion/)
+and [querying](/VictoriaLogs/querying/) at the TCP port `9428` now!
 It has no any external dependencies, so it may run in various environments without additional setup and configuration.
 VictoriaLogs automatically adapts to the available CPU and RAM resources. It also automatically setups and creates
-the needed indexes during [data ingestion](https://docs.victoriametrics.com/VictoriaLogs/data-ingestion/).
+the needed indexes during [data ingestion](/VictoriaLogs/data-ingestion/).
 
 See also:
 
 - [How to configure VictoriaLogs](#how-to-configure-victorialogs)
-- [How to ingest logs into VictoriaLogs](https://docs.victoriametrics.com/VictoriaLogs/data-ingestion/)
-- [How to query VictoriaLogs](https://docs.victoriametrics.com/VictoriaLogs/querying/)
+- [How to ingest logs into VictoriaLogs](/VictoriaLogs/data-ingestion/)
+- [How to query VictoriaLogs](/VictoriaLogs/querying/)
 
 
 ## How to configure VictoriaLogs
@@ -121,19 +121,19 @@ Pass `-help` to VictoriaLogs in order to see the list of supported command-line 
 ```
 
 VictoriaLogs stores the ingested data to the `victoria-logs-data` directory by default. The directory can be changed
-via `-storageDataPath` command-line flag. See [these docs](https://docs.victoriametrics.com/VictoriaLogs/#storage) for details.
+via `-storageDataPath` command-line flag. See [these docs](/VictoriaLogs/#storage) for details.
 
-By default VictoriaLogs stores [log entries](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html) with timestamps
+By default VictoriaLogs stores [log entries](/VictoriaLogs/keyConcepts.html) with timestamps
 in the time range `[now-7d, now]`, while dropping logs outside the given time range.
-E.g. it uses the retention of 7 days. Read [these docs](https://docs.victoriametrics.com/VictoriaLogs/#retention) on how to control the retention
-for the [ingested](https://docs.victoriametrics.com/VictoriaLogs/data-ingestion/) logs.
+E.g. it uses the retention of 7 days. Read [these docs](/VictoriaLogs/#retention) on how to control the retention
+for the [ingested](/VictoriaLogs/data-ingestion/) logs.
 
-It is recommended setting up monitoring of VictoriaLogs according to [these docs](https://docs.victoriametrics.com/VictoriaLogs/#monitoring).
+It is recommended setting up monitoring of VictoriaLogs according to [these docs](/VictoriaLogs/#monitoring).
 
 See also:
 
-- [How to ingest logs into VictoriaLogs](https://docs.victoriametrics.com/VictoriaLogs/data-ingestion/)
-- [How to query VictoriaLogs](https://docs.victoriametrics.com/VictoriaLogs/querying/)
+- [How to ingest logs into VictoriaLogs](/VictoriaLogs/data-ingestion/)
+- [How to query VictoriaLogs](/VictoriaLogs/querying/)
 
 ## Docker demos
 

--- a/docs/VictoriaLogs/README.md
+++ b/docs/VictoriaLogs/README.md
@@ -12,39 +12,39 @@ from [VictoriaMetrics](https://github.com/VictoriaMetrics/VictoriaMetrics/).
 
 VictoriaLogs provides the following key features:
 
-- VictoriaLogs can accept logs from popular log collectors. See [these docs](https://docs.victoriametrics.com/VictoriaLogs/data-ingestion/).
+- VictoriaLogs can accept logs from popular log collectors. See [these docs](/VictoriaLogs/data-ingestion/).
 - VictoriaLogs is much easier to set up and operate compared to Elasticsearch and Grafana Loki.
-  See [these docs](https://docs.victoriametrics.com/VictoriaLogs/QuickStart.html).
+  See [these docs](/VictoriaLogs/QuickStart.html).
 - VictoriaLogs provides easy yet powerful query language with full-text search capabilities across
-  all the [log fields](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#data-model) -
-  see [LogsQL docs](https://docs.victoriametrics.com/VictoriaLogs/LogsQL.html).
+  all the [log fields](/VictoriaLogs/keyConcepts.html#data-model) -
+  see [LogsQL docs](/VictoriaLogs/LogsQL.html).
 - VictoriaLogs can be seamlessly combined with good old Unix tools for log analysis such as `grep`, `less`, `sort`, `jq`, etc.
-  See [these docs](https://docs.victoriametrics.com/VictoriaLogs/querying/#command-line) for details.
+  See [these docs](/VictoriaLogs/querying/#command-line) for details.
 - VictoriaLogs capacity and performance scales linearly with the available resources (CPU, RAM, disk IO, disk space).
   It runs smoothly on both Raspberry PI and a server with hundreds of CPU cores and terabytes of RAM.
 - VictoriaLogs can handle up to 30x bigger data volumes than Elasticsearch and Grafana Loki when running on the same hardware.
   See [these docs](#benchmarks).
-- VictoriaLogs supports fast full-text search over high-cardinality [log fields](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#data-model)
+- VictoriaLogs supports fast full-text search over high-cardinality [log fields](/VictoriaLogs/keyConcepts.html#data-model)
   such as `trace_id`, `user_id` and `ip`.
 - VictoriaLogs supports multitenancy - see [these docs](#multitenancy).
 - VictoriaLogs supports out-of-order logs' ingestion aka backfilling.
-- VictoriaLogs provides a simple web UI for querying logs - see [these docs](https://docs.victoriametrics.com/VictoriaLogs/querying/#web-ui).
+- VictoriaLogs provides a simple web UI for querying logs - see [these docs](/VictoriaLogs/querying/#web-ui).
 
 VictoriaLogs is at the Preview stage now. It is ready for evaluation in production and verifying the claims given above.
 It isn't recommended to migrate from existing logging solutions to VictoriaLogs Preview in general cases yet.
-See the [Roadmap](https://docs.victoriametrics.com/VictoriaLogs/Roadmap.html) for details.
+See the [Roadmap](/VictoriaLogs/Roadmap.html) for details.
 
-If you have questions about VictoriaLogs, then read [this FAQ](https://docs.victoriametrics.com/VictoriaLogs/FAQ.html).
+If you have questions about VictoriaLogs, then read [this FAQ](/VictoriaLogs/FAQ.html).
 Also feel free asking any questions at [VictoriaMetrics community Slack chat](https://slack.victoriametrics.com/).
 
-See [Quick start docs](https://docs.victoriametrics.com/VictoriaLogs/QuickStart.html) for start working with VictoriaLogs.
+See [Quick start docs](/VictoriaLogs/QuickStart.html) for start working with VictoriaLogs.
 
 ## Monitoring
 
 VictoriaLogs exposes internal metrics in Prometheus exposition format at `http://localhost:9428/metrics` page.
 It is recommended to set up monitoring of these metrics via VictoriaMetrics
-(see [these docs](https://docs.victoriametrics.com/#how-to-scrape-prometheus-exporters-such-as-node-exporter)),
-vmagent (see [these docs](https://docs.victoriametrics.com/vmagent.html#how-to-collect-metrics-in-prometheus-format)) or via Prometheus.
+(see [these docs](/#how-to-scrape-prometheus-exporters-such-as-node-exporter)),
+vmagent (see [these docs](/vmagent.html#how-to-collect-metrics-in-prometheus-format)) or via Prometheus.
 
 VictoriaLogs emits its own logs to stdout. It is recommended to investigate these logs during troubleshooting.
 
@@ -76,13 +76,13 @@ For example, the following command starts VictoriaLogs with the retention of 8 w
 /path/to/victoria-logs -retentionPeriod=8w
 ```
 
-VictoriaLogs stores the [ingested](https://docs.victoriametrics.com/VictoriaLogs/data-ingestion/) logs in per-day partition directories.
+VictoriaLogs stores the [ingested](/VictoriaLogs/data-ingestion/) logs in per-day partition directories.
 It automatically drops partition directories outside the configured retention.
 
-VictoriaLogs automatically drops logs at [data ingestion](https://docs.victoriametrics.com/VictoriaLogs/data-ingestion/) stage
+VictoriaLogs automatically drops logs at [data ingestion](/VictoriaLogs/data-ingestion/) stage
 if they have timestamps outside the configured retention. A sample of dropped logs is logged with `WARN` message in order to simplify troubleshooting.
 The `vl_rows_dropped_total` [metric](#monitoring) is incremented each time an ingested log entry is dropped because of timestamp outside the retention.
-It is recommended to set up the following alerting rule at [vmalert](https://docs.victoriametrics.com/vmalert.html) in order to be notified
+It is recommended to set up the following alerting rule at [vmalert](/vmalert.html) in order to be notified
 when logs with wrong timestamps are ingested into VictoriaLogs:
 
 ```metricsql
@@ -114,25 +114,25 @@ VictoriaLogs automatically creates the `-storageDataPath` directory on the first
 ## Multitenancy
 
 VictoriaLogs supports multitenancy. A tenant is identified by `(AccountID, ProjectID)` pair, where `AccountID` and `ProjectID` are arbitrary 32-bit unsigned integers.
-The `AccountID` and `ProjectID` fields can be set during [data ingestion](https://docs.victoriametrics.com/VictoriaLogs/data-ingestion/)
-and [querying](https://docs.victoriametrics.com/VictoriaLogs/querying/) via `AccountID` and `ProjectID` request headers.
+The `AccountID` and `ProjectID` fields can be set during [data ingestion](/VictoriaLogs/data-ingestion/)
+and [querying](/VictoriaLogs/querying/) via `AccountID` and `ProjectID` request headers.
 
 If `AccountID` and/or `ProjectID` request headers aren't set, then the default `0` value is used.
 
 VictoriaLogs has very low overhead for per-tenant management, so it is OK to have thousands of tenants in a single VictoriaLogs instance.
 
-VictoriaLogs doesn't perform per-tenant authorization. Use [vmauth](https://docs.victoriametrics.com/vmauth.html) or similar tools for per-tenant authorization.
+VictoriaLogs doesn't perform per-tenant authorization. Use [vmauth](/vmauth.html) or similar tools for per-tenant authorization.
 
 ## Benchmarks
 
 Here is a [benchmark suite](https://github.com/VictoriaMetrics/VictoriaMetrics/tree/master/deployment/logs-benchmark) for comparing data ingestion performance
 and resource usage between VictoriaLogs and Elasticsearch.
 
-It is recommended [setting up VictoriaLogs](https://docs.victoriametrics.com/VictoriaLogs/QuickStart.html) in production alongside the existing
+It is recommended [setting up VictoriaLogs](/VictoriaLogs/QuickStart.html) in production alongside the existing
 log management systems and comparing resource usage + query performance between VictoriaLogs and your system such as Elasticsearch or Grafana Loki.
 
 Please share benchmark results and ideas on how to improve benchmarks / VictoriaLogs
-via [VictoriaMetrics community channels](https://docs.victoriametrics.com/#community-and-contributions).
+via [VictoriaMetrics community channels](/#community-and-contributions).
 
 ## List of command-line flags
 
@@ -144,7 +144,7 @@ Pass `-help` to VictoriaLogs in order to see the list of supported command-line 
   -enableTCP6
     	Whether to enable IPv6 for listening and dialing. By default, only IPv4 TCP and UDP are used
   -envflag.enable
-    	Whether to enable reading flags from environment variables in addition to the command line. Command line flag values have priority over values from environment vars. Flags are read only from the command line if this flag isn't set. See https://docs.victoriametrics.com/#environment-variables for more details
+    	Whether to enable reading flags from environment variables in addition to the command line. Command line flag values have priority over values from environment vars. Flags are read only from the command line if this flag isn't set. See /#environment-variables for more details
   -envflag.prefix string
     	Prefix for environment variables if -envflag.enable is set
   -flagsAuthKey string
@@ -152,7 +152,7 @@ Pass `-help` to VictoriaLogs in order to see the list of supported command-line 
   -fs.disableMmap
     	Whether to use pread() instead of mmap() for reading data files. By default, mmap() is used for 64-bit arches and pread() is used for 32-bit arches, since they cannot read data files bigger than 2^32 bytes in memory. mmap() is usually faster for reading small data chunks than pread()
   -futureRetention value
-    	Log entries with timestamps bigger than now+futureRetention are rejected during data ingestion; see https://docs.victoriametrics.com/VictoriaLogs/#retention
+    	Log entries with timestamps bigger than now+futureRetention are rejected during data ingestion; see /VictoriaLogs/#retention
     	The following optional suffixes are supported: h (hour), d (day), w (week), y (year). If suffix isn't set, then the duration is counted in months (default 2d)
   -gogc int
     	GOGC to use. See https://tip.golang.org/doc/gc-guide (default 100)
@@ -192,9 +192,9 @@ Pass `-help` to VictoriaLogs in order to see the list of supported command-line 
   -internStringMaxLen int
     	The maximum length for strings to intern. A lower limit may save memory at the cost of higher CPU usage. See https://en.wikipedia.org/wiki/String_interning . See also -internStringDisableCache and -internStringCacheExpireDuration (default 500)
   -logIngestedRows
-    	Whether to log all the ingested log entries; this can be useful for debugging of data ingestion; see https://docs.victoriametrics.com/VictoriaLogs/data-ingestion/ ; see also -logNewStreams
+    	Whether to log all the ingested log entries; this can be useful for debugging of data ingestion; see /VictoriaLogs/data-ingestion/ ; see also -logNewStreams
   -logNewStreams
-    	Whether to log creation of new streams; this can be useful for debugging of high cardinality issues with log streams; see https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#stream-fields ; see also -logIngestedRows
+    	Whether to log creation of new streams; this can be useful for debugging of high cardinality issues with log streams; see /VictoriaLogs/keyConcepts.html#stream-fields ; see also -logIngestedRows
   -loggerDisableTimestamps
     	Whether to disable writing timestamps in logs
   -loggerErrorsPerSecondLimit int
@@ -230,10 +230,10 @@ Pass `-help` to VictoriaLogs in order to see the list of supported command-line 
   -pushmetrics.interval duration
     	Interval for pushing metrics to -pushmetrics.url (default 10s)
   -pushmetrics.url array
-    	Optional URL to push metrics exposed at /metrics page. See https://docs.victoriametrics.com/#push-metrics . By default, metrics exposed at /metrics page aren't pushed to any remote storage
+    	Optional URL to push metrics exposed at /metrics page. See /#push-metrics . By default, metrics exposed at /metrics page aren't pushed to any remote storage
     	Supports an array of values separated by comma or specified via multiple flags.
   -retentionPeriod value
-    	Log entries with timestamps older than now-retentionPeriod are automatically deleted; log entries with timestamps outside the retention are also rejected during data ingestion; the minimum supported retention is 1d (one day); see https://docs.victoriametrics.com/VictoriaLogs/#retention
+    	Log entries with timestamps older than now-retentionPeriod are automatically deleted; log entries with timestamps outside the retention are also rejected during data ingestion; the minimum supported retention is 1d (one day); see /VictoriaLogs/#retention
     	The following optional suffixes are supported: h (hour), d (day), w (week), y (year). If suffix isn't set, then the duration is counted in months (default 7d)
   -search.maxConcurrentRequests int
     	The maximum number of concurrent search requests. It shouldn't be high, since a single request can saturate all the CPU cores, while many concurrently executed requests may require high amounts of memory. See also -search.maxQueueDuration (default 6)
@@ -245,7 +245,7 @@ Pass `-help` to VictoriaLogs in order to see the list of supported command-line 
     	Query results from /select/logsql/query are automatically sorted by _time if their summary size doesn't exceed this value; otherwise, query results are streamed in the response without sorting; too big value for this flag may result in high memory usage since the sorting is performed in memory
     	Supports the following optional suffixes for size values: KB, MB, GB, TB, KiB, MiB, GiB, TiB (default 1048576)
   -storageDataPath string
-    	Path to directory with the VictoriaLogs data; see https://docs.victoriametrics.com/VictoriaLogs/#storage (default "victoria-logs-data")
+    	Path to directory with the VictoriaLogs data; see /VictoriaLogs/#storage (default "victoria-logs-data")
   -storage.minFreeDiskSpaceBytes size
     	The minimum free disk space at -storageDataPath after which the storage stops accepting new data
     	Supports the following optional suffixes for size values: KB, MB, GB, TB, KiB, MiB, GiB, TiB (default 10000000)

--- a/docs/VictoriaLogs/Roadmap.md
+++ b/docs/VictoriaLogs/Roadmap.md
@@ -13,39 +13,39 @@ aliases:
 
 # VictoriaLogs roadmap
 
-The [VictoriaLogs](https://docs.victoriametrics.com/VictoriaLogs/) Preview is ready for evaluation in production.
+The [VictoriaLogs](/VictoriaLogs/) Preview is ready for evaluation in production.
 It is recommended running it alongside the existing solutions such as Elasticsearch and Grafana Loki
 and comparing their resource usage and usability.
 It isn't recommended migrating from existing solutions to VictoriaLogs Preview yet.
 
 The following functionality is available in VictoriaLogs Preview:
 
-- [Data ingestion](https://docs.victoriametrics.com/VictoriaLogs/data-ingestion/).
-- [Querying](https://docs.victoriametrics.com/VictoriaLogs/querying/).
-- [Querying via command-line](https://docs.victoriametrics.com/VictoriaLogs/querying/#command-line).
+- [Data ingestion](/VictoriaLogs/data-ingestion/).
+- [Querying](/VictoriaLogs/querying/).
+- [Querying via command-line](/VictoriaLogs/querying/#command-line).
 
-See [these docs](https://docs.victoriametrics.com/VictoriaLogs/) for details.
+See [these docs](/VictoriaLogs/) for details.
 
 The following functionality is planned in the future versions of VictoriaLogs:
 
-- Support for [data ingestion](https://docs.victoriametrics.com/VictoriaLogs/data-ingestion/) from popular log collectors and formats:
+- Support for [data ingestion](/VictoriaLogs/data-ingestion/) from popular log collectors and formats:
   - Fluentd
   - Syslog
   - Journald (systemd)
-- Add missing functionality to [LogsQL](https://docs.victoriametrics.com/VictoriaLogs/LogsQL.html):
-  - [Stream context](https://docs.victoriametrics.com/VictoriaLogs/LogsQL.html#stream-context).
-  - [Transformation functions](https://docs.victoriametrics.com/VictoriaLogs/LogsQL.html#transformations).
-  - [Post-filtering](https://docs.victoriametrics.com/VictoriaLogs/LogsQL.html#post-filters).
-  - [Stats calculations](https://docs.victoriametrics.com/VictoriaLogs/LogsQL.html#stats).
-  - [Sorting](https://docs.victoriametrics.com/VictoriaLogs/LogsQL.html#sorting).
-  - [Limiters](https://docs.victoriametrics.com/VictoriaLogs/LogsQL.html#limiters).
-  - The ability to use subqueries inside [in()](https://docs.victoriametrics.com/VictoriaLogs/LogsQL.html#multi-exact-filter) function.
-- Live tailing for [LogsQL filters](https://docs.victoriametrics.com/VictoriaLogs/LogsQL.html#filters) aka `tail -f`.
+- Add missing functionality to [LogsQL](/VictoriaLogs/LogsQL.html):
+  - [Stream context](/VictoriaLogs/LogsQL.html#stream-context).
+  - [Transformation functions](/VictoriaLogs/LogsQL.html#transformations).
+  - [Post-filtering](/VictoriaLogs/LogsQL.html#post-filters).
+  - [Stats calculations](/VictoriaLogs/LogsQL.html#stats).
+  - [Sorting](/VictoriaLogs/LogsQL.html#sorting).
+  - [Limiters](/VictoriaLogs/LogsQL.html#limiters).
+  - The ability to use subqueries inside [in()](/VictoriaLogs/LogsQL.html#multi-exact-filter) function.
+- Live tailing for [LogsQL filters](/VictoriaLogs/LogsQL.html#filters) aka `tail -f`.
 - Web UI with the following abilities:
-  - Explore the ingested logs ([partially done](https://docs.victoriametrics.com/VictoriaLogs/querying/#web-ui)).
+  - Explore the ingested logs ([partially done](/VictoriaLogs/querying/#web-ui)).
   - Build graphs over time for the ingested logs.
 - Integration with Grafana.
-- Ability to make instant snapshots and backups in the way [similar to VictoriaMetrics](https://docs.victoriametrics.com/#how-to-work-with-snapshots).
+- Ability to make instant snapshots and backups in the way [similar to VictoriaMetrics](/#how-to-work-with-snapshots).
 - Cluster version of VictoriaLogs.
 - Ability to store data to object storage (such as S3, GCS, Minio).
 - Alerting on LogsQL queries.

--- a/docs/VictoriaLogs/data-ingestion/Filebeat.md
+++ b/docs/VictoriaLogs/data-ingestion/Filebeat.md
@@ -13,7 +13,7 @@ aliases:
 # Filebeat setup
 
 Specify [`output.elasicsearch`](https://www.elastic.co/guide/en/beats/filebeat/current/elasticsearch-output.html) section in the `filebeat.yml`
-for sending the collected logs to [VictoriaLogs](https://docs.victoriametrics.com/VictoriaLogs/):
+for sending the collected logs to [VictoriaLogs](/VictoriaLogs/):
 
 ```yml
 output.elasticsearch:
@@ -26,11 +26,11 @@ output.elasticsearch:
 
 Substitute the `localhost:9428` address inside `hosts` section with the real TCP address of VictoriaLogs.
 
-See [these docs](https://docs.victoriametrics.com/VictoriaLogs/data-ingestion/#http-parameters) for details on the `parameters` section.
+See [these docs](/VictoriaLogs/data-ingestion/#http-parameters) for details on the `parameters` section.
 
-It is recommended verifying whether the initial setup generates the needed [log fields](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#data-model)
-and uses the correct [stream fields](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#stream-fields).
-This can be done by specifying `debug` [parameter](https://docs.victoriametrics.com/VictoriaLogs/data-ingestion/#http-parameters)
+It is recommended verifying whether the initial setup generates the needed [log fields](/VictoriaLogs/keyConcepts.html#data-model)
+and uses the correct [stream fields](/VictoriaLogs/keyConcepts.html#stream-fields).
+This can be done by specifying `debug` [parameter](/VictoriaLogs/data-ingestion/#http-parameters)
 and inspecting VictoriaLogs logs then:
 
 ```yml
@@ -43,8 +43,8 @@ output.elasticsearch:
     debug: "1"
 ```
 
-If some [log fields](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#data-model) must be skipped
-during data ingestion, then they can be put into `ignore_fields` [parameter](https://docs.victoriametrics.com/VictoriaLogs/data-ingestion/#http-parameters).
+If some [log fields](/VictoriaLogs/keyConcepts.html#data-model) must be skipped
+during data ingestion, then they can be put into `ignore_fields` [parameter](/VictoriaLogs/data-ingestion/#http-parameters).
 For example, the following config instructs VictoriaLogs to ignore `log.offset` and `event.original` fields in the ingested logs:
 
 ```yml
@@ -84,7 +84,7 @@ output.elasticsearch:
   compression_level: 1
 ```
 
-By default, the ingested logs are stored in the `(AccountID=0, ProjectID=0)` [tenant](https://docs.victoriametrics.com/VictoriaLogs/#multitenancy).
+By default, the ingested logs are stored in the `(AccountID=0, ProjectID=0)` [tenant](/VictoriaLogs/#multitenancy).
 If you need storing logs in other tenant, then specify the needed tenant via `headers` at `output.elasticsearch` section.
 For example, the following `filebeat.yml` config instructs Filebeat to store the data to `(AccountID=12, ProjectID=34)` tenant:
 
@@ -118,7 +118,7 @@ command-line flag.
 
 See also:
 
-- [Data ingestion troubleshooting](https://docs.victoriametrics.com/VictoriaLogs/data-ingestion/#troubleshooting).
-- [How to query VictoriaLogs](https://docs.victoriametrics.com/VictoriaLogs/querying/).
+- [Data ingestion troubleshooting](/VictoriaLogs/data-ingestion/#troubleshooting).
+- [How to query VictoriaLogs](/VictoriaLogs/querying/).
 - [Filebeat `output.elasticsearch` docs](https://www.elastic.co/guide/en/beats/filebeat/current/elasticsearch-output.html).
 - [Docker-compose demo for Filebeat integration with VictoriaLogs](https://github.com/VictoriaMetrics/VictoriaMetrics/tree/master/deployment/docker/victorialogs/filebeat-docker).

--- a/docs/VictoriaLogs/data-ingestion/Fluentbit.md
+++ b/docs/VictoriaLogs/data-ingestion/Fluentbit.md
@@ -13,7 +13,7 @@ aliases:
 # Fluentbit setup
 
 Specify [http output](https://docs.fluentbit.io/manual/pipeline/outputs/http) section in the `fluentbit.conf`
-for sending the collected logs to [VictoriaLogs](https://docs.victoriametrics.com/VictoriaLogs/):
+for sending the collected logs to [VictoriaLogs](/VictoriaLogs/):
 
 ```conf
 [Output]
@@ -28,11 +28,11 @@ for sending the collected logs to [VictoriaLogs](https://docs.victoriametrics.co
 
 Substitute the host (`localhost`) and port (`9428`) with the real TCP address of VictoriaLogs.
 
-See [these docs](https://docs.victoriametrics.com/VictoriaLogs/data-ingestion/#http-parameters) for details on the query args specified in the `uri`.
+See [these docs](/VictoriaLogs/data-ingestion/#http-parameters) for details on the query args specified in the `uri`.
 
-It is recommended verifying whether the initial setup generates the needed [log fields](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#data-model)
-and uses the correct [stream fields](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#stream-fields).
-This can be done by specifying `debug` [parameter](https://docs.victoriametrics.com/VictoriaLogs/data-ingestion/#http-parameters) in the `uri`
+It is recommended verifying whether the initial setup generates the needed [log fields](/VictoriaLogs/keyConcepts.html#data-model)
+and uses the correct [stream fields](/VictoriaLogs/keyConcepts.html#stream-fields).
+This can be done by specifying `debug` [parameter](/VictoriaLogs/data-ingestion/#http-parameters) in the `uri`
 and inspecting VictoriaLogs logs then:
 
 ```conf
@@ -46,8 +46,8 @@ and inspecting VictoriaLogs logs then:
      json_date_format iso8601
 ```
 
-If some [log fields](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#data-model) must be skipped
-during data ingestion, then they can be put into `ignore_fields` [parameter](https://docs.victoriametrics.com/VictoriaLogs/data-ingestion/#http-parameters).
+If some [log fields](/VictoriaLogs/keyConcepts.html#data-model) must be skipped
+during data ingestion, then they can be put into `ignore_fields` [parameter](/VictoriaLogs/data-ingestion/#http-parameters).
 For example, the following config instructs VictoriaLogs to ignore `log.offset` and `event.original` fields in the ingested logs:
 
 ```conf
@@ -76,7 +76,7 @@ This usually allows saving network bandwidth and costs by up to 5 times:
      compress gzip
 ```
 
-By default, the ingested logs are stored in the `(AccountID=0, ProjectID=0)` [tenant](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#multitenancy).
+By default, the ingested logs are stored in the `(AccountID=0, ProjectID=0)` [tenant](/VictoriaLogs/keyConcepts.html#multitenancy).
 If you need storing logs in other tenant, then specify the needed tenant via `header` options.
 For example, the following `fluentbit.conf` config instructs Fluentbit to store the data to `(AccountID=12, ProjectID=34)` tenant:
 
@@ -95,7 +95,7 @@ For example, the following `fluentbit.conf` config instructs Fluentbit to store 
 
 See also:
 
-- [Data ingestion troubleshooting](https://docs.victoriametrics.com/VictoriaLogs/data-ingestion/#troubleshooting).
-- [How to query VictoriaLogs](https://docs.victoriametrics.com/VictoriaLogs/querying/).
+- [Data ingestion troubleshooting](/VictoriaLogs/data-ingestion/#troubleshooting).
+- [How to query VictoriaLogs](/VictoriaLogs/querying/).
 - [Fluentbit HTTP output config docs](https://docs.fluentbit.io/manual/pipeline/outputs/http).
 - [Docker-compose demo for Fluentbit integration with VictoriaLogs](https://github.com/VictoriaMetrics/VictoriaMetrics/tree/master/deployment/docker/victorialogs/fluentbit-docker).

--- a/docs/VictoriaLogs/data-ingestion/Logstash.md
+++ b/docs/VictoriaLogs/data-ingestion/Logstash.md
@@ -13,7 +13,7 @@ aliases:
 # Logstash setup
 
 Specify [`output.elasticsearch`](https://www.elastic.co/guide/en/logstash/current/plugins-outputs-elasticsearch.html) section in the `logstash.conf` file
-for sending the collected logs to [VictoriaLogs](https://docs.victoriametrics.com/VictoriaLogs/):
+for sending the collected logs to [VictoriaLogs](/VictoriaLogs/):
 
 ```conf
 output {
@@ -30,11 +30,11 @@ output {
 
 Substitute `localhost:9428` address inside `hosts` with the real TCP address of VictoriaLogs.
 
-See [these docs](https://docs.victoriametrics.com/VictoriaLogs/data-ingestion/#http-parameters) for details on the `parameters` section.
+See [these docs](/VictoriaLogs/data-ingestion/#http-parameters) for details on the `parameters` section.
 
-It is recommended verifying whether the initial setup generates the needed [log fields](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#data-model)
-and uses the correct [stream fields](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#stream-fields).
-This can be done by specifying `debug` [parameter](https://docs.victoriametrics.com/VictoriaLogs/data-ingestion/#http-parameters)
+It is recommended verifying whether the initial setup generates the needed [log fields](/VictoriaLogs/keyConcepts.html#data-model)
+and uses the correct [stream fields](/VictoriaLogs/keyConcepts.html#stream-fields).
+This can be done by specifying `debug` [parameter](/VictoriaLogs/data-ingestion/#http-parameters)
 and inspecting VictoriaLogs logs then:
 
 ```conf
@@ -51,8 +51,8 @@ output {
 }
 ```
 
-If some [log fields](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#data-model) must be skipped
-during data ingestion, then they can be put into `ignore_fields` [parameter](https://docs.victoriametrics.com/VictoriaLogs/data-ingestion/#http-parameters).
+If some [log fields](/VictoriaLogs/keyConcepts.html#data-model) must be skipped
+during data ingestion, then they can be put into `ignore_fields` [parameter](/VictoriaLogs/data-ingestion/#http-parameters).
 For example, the following config instructs VictoriaLogs to ignore `log.offset` and `event.original` fields in the ingested logs:
 
 ```conf
@@ -86,7 +86,7 @@ output {
 }
 ```
 
-By default, the ingested logs are stored in the `(AccountID=0, ProjectID=0)` [tenant](https://docs.victoriametrics.com/VictoriaLogs/#multitenancy).
+By default, the ingested logs are stored in the `(AccountID=0, ProjectID=0)` [tenant](/VictoriaLogs/#multitenancy).
 If you need storing logs in other tenant, then specify the needed tenant via `custom_headers` at `output.elasticsearch` section.
 For example, the following `logstash.conf` config instructs Logstash to store the data to `(AccountID=12, ProjectID=34)` tenant:
 
@@ -109,7 +109,7 @@ output {
 
 See also:
 
-- [Data ingestion troubleshooting](https://docs.victoriametrics.com/VictoriaLogs/data-ingestion/#troubleshooting).
-- [How to query VictoriaLogs](https://docs.victoriametrics.com/VictoriaLogs/querying/).
+- [Data ingestion troubleshooting](/VictoriaLogs/data-ingestion/#troubleshooting).
+- [How to query VictoriaLogs](/VictoriaLogs/querying/).
 - [Logstash `output.elasticsearch` docs](https://www.elastic.co/guide/en/logstash/current/plugins-outputs-elasticsearch.html).
 - [Docker-compose demo for Logstash integration with VictoriaLogs](https://github.com/VictoriaMetrics/VictoriaMetrics/tree/master/deployment/docker/victorialogs/logstash).

--- a/docs/VictoriaLogs/data-ingestion/Promtail.md
+++ b/docs/VictoriaLogs/data-ingestion/Promtail.md
@@ -15,7 +15,7 @@ aliases:
 Promtail can be configured to send the collected logs to VictoriaLogs according to the following docs.
 
 Specify [`clients`](https://grafana.com/docs/loki/latest/clients/promtail/configuration/#clients) section in the configuration file
-for sending the collected logs to [VictoriaLogs](https://docs.victoriametrics.com/VictoriaLogs/):
+for sending the collected logs to [VictoriaLogs](/VictoriaLogs/):
 
 ```yaml
 clients:
@@ -24,18 +24,18 @@ clients:
 
 Substitute `localhost:9428` address inside `clients` with the real TCP address of VictoriaLogs.
 
-By default VictoriaLogs stores all the ingested logs into a single [log stream](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#stream-fields).
+By default VictoriaLogs stores all the ingested logs into a single [log stream](/VictoriaLogs/keyConcepts.html#stream-fields).
 Storing all the logs in a single log stream may be not so efficient, so it is recommended to specify `_stream_fields` query arg
 with the list of labels, which uniquely identify log streams. There is no need in specifying all the labels Promtail generates there -
-it is usually enough specifying `instance` and `job` labels. See [these docs](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#stream-fields)
+it is usually enough specifying `instance` and `job` labels. See [these docs](/VictoriaLogs/keyConcepts.html#stream-fields)
 for details.
 
-See also [these docs](https://docs.victoriametrics.com/VictoriaLogs/data-ingestion/#http-parameters) for details on other supported query args.
+See also [these docs](/VictoriaLogs/data-ingestion/#http-parameters) for details on other supported query args.
 There is no need in specifying `_msg_field` and `_time_field` query args, since VictoriaLogs automatically extracts log message and timestamp from the ingested Loki data.
 
-It is recommended verifying whether the initial setup generates the needed [log fields](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#data-model)
-and uses the correct [stream fields](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#stream-fields).
-This can be done by specifying `debug` [parameter](https://docs.victoriametrics.com/VictoriaLogs/data-ingestion/#http-parameters)
+It is recommended verifying whether the initial setup generates the needed [log fields](/VictoriaLogs/keyConcepts.html#data-model)
+and uses the correct [stream fields](/VictoriaLogs/keyConcepts.html#stream-fields).
+This can be done by specifying `debug` [parameter](/VictoriaLogs/data-ingestion/#http-parameters)
 and inspecting VictoriaLogs logs then:
 
 ```yaml
@@ -43,8 +43,8 @@ clients:
   - url: http://localhost:9428/insert/loki/api/v1/push?_stream_fields=instance,job,host,app&debug=1
 ```
 
-If some [log fields](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#data-model) must be skipped
-during data ingestion, then they can be put into `ignore_fields` [parameter](https://docs.victoriametrics.com/VictoriaLogs/data-ingestion/#http-parameters).
+If some [log fields](/VictoriaLogs/keyConcepts.html#data-model) must be skipped
+during data ingestion, then they can be put into `ignore_fields` [parameter](/VictoriaLogs/data-ingestion/#http-parameters).
 For example, the following config instructs VictoriaLogs to ignore `filename` and `stream` fields in the ingested logs:
 
 ```yaml
@@ -52,11 +52,11 @@ clients:
   - url: http://localhost:9428/insert/loki/api/v1/push?_stream_fields=instance,job,host,app&ignore_fields=filename,stream
 ```
 
-By default the ingested logs are stored in the `(AccountID=0, ProjectID=0)` [tenant](https://docs.victoriametrics.com/VictoriaLogs/#multitenancy).
+By default the ingested logs are stored in the `(AccountID=0, ProjectID=0)` [tenant](/VictoriaLogs/#multitenancy).
 If you need storing logs in other tenant, then specify the needed tenant via `tenant_id` field
 in the [Loki client configuration](https://grafana.com/docs/loki/latest/clients/promtail/configuration/#clients)
 The `tenant_id` must have `AccountID:ProjectID` format, where `AccountID` and `ProjectID` are arbitrary uint32 numbers.
-For example, the following config instructs VictoriaLogs to store logs in the `(AccountID=12, ProjectID=34)` [tenant](https://docs.victoriametrics.com/VictoriaLogs/#multitenancy):
+For example, the following config instructs VictoriaLogs to store logs in the `(AccountID=12, ProjectID=34)` [tenant](/VictoriaLogs/#multitenancy):
 
 ```yaml
 clients:
@@ -64,6 +64,6 @@ clients:
     tenant_id: "12:34"
 ```
 
-The ingested log entries can be queried according to [these docs](https://docs.victoriametrics.com/VictoriaLogs/querying/).
+The ingested log entries can be queried according to [these docs](/VictoriaLogs/querying/).
 
-See also [data ingestion troubleshooting](https://docs.victoriametrics.com/VictoriaLogs/data-ingestion/#troubleshooting) docs.
+See also [data ingestion troubleshooting](/VictoriaLogs/data-ingestion/#troubleshooting) docs.

--- a/docs/VictoriaLogs/data-ingestion/README.md
+++ b/docs/VictoriaLogs/data-ingestion/README.md
@@ -14,15 +14,15 @@ aliases:
 
 # Data ingestion
 
-[VictoriaLogs](https://docs.victoriametrics.com/VictoriaLogs/) can accept logs from the following log collectors:
+[VictoriaLogs](/VictoriaLogs/) can accept logs from the following log collectors:
 
-- Filebeat. See [how to setup Filebeat for sending logs to VictoriaLogs](https://docs.victoriametrics.com/VictoriaLogs/data-ingestion/Filebeat.html).
-- Fluentbit. See [how to setup Fluentbit for sending logs to VictoriaLogs](https://docs.victoriametrics.com/VictoriaLogs/data-ingestion/Fluentbit.html).
-- Logstash. See [how to setup Logstash for sending logs to VictoriaLogs](https://docs.victoriametrics.com/VictoriaLogs/data-ingestion/Logstash.html).
-- Vector. See [how to setup Vector for sending logs to VictoriaLogs](https://docs.victoriametrics.com/VictoriaLogs/data-ingestion/Vector.html).
-- Promtail (aka Grafana Loki). See [how to setup Promtail for sending logs to VictoriaLogs](https://docs.victoriametrics.com/VictoriaLogs/data-ingestion/Promtail.html).
+- Filebeat. See [how to setup Filebeat for sending logs to VictoriaLogs](/VictoriaLogs/data-ingestion/Filebeat.html).
+- Fluentbit. See [how to setup Fluentbit for sending logs to VictoriaLogs](/VictoriaLogs/data-ingestion/Fluentbit.html).
+- Logstash. See [how to setup Logstash for sending logs to VictoriaLogs](/VictoriaLogs/data-ingestion/Logstash.html).
+- Vector. See [how to setup Vector for sending logs to VictoriaLogs](/VictoriaLogs/data-ingestion/Vector.html).
+- Promtail (aka Grafana Loki). See [how to setup Promtail for sending logs to VictoriaLogs](/VictoriaLogs/data-ingestion/Promtail.html).
 
-The ingested logs can be queried according to [these docs](https://docs.victoriametrics.com/VictoriaLogs/querying/).
+The ingested logs can be queried according to [these docs](/VictoriaLogs/querying/).
 
 See also:
 
@@ -56,18 +56,18 @@ echo '{"create":{}}
 
 It is possible to push thousands of log lines in a single request to this API.
 
-If the [timestamp field](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#time-field) is set to `"0"`,
+If the [timestamp field](/VictoriaLogs/keyConcepts.html#time-field) is set to `"0"`,
 then the current timestamp at VictoriaLogs side is used per each ingested log line.
 Otherwise the timestamp field must be in the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) format. For example, `2023-06-20T15:32:10Z`.
 Optional fractional part of seconds can be specified after the dot - `2023-06-20T15:32:10.123Z`.
 Timezone can be specified instead of `Z` suffix - `2023-06-20T15:32:10+02:00`.
 
-See [these docs](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#data-model) for details on fields,
+See [these docs](/VictoriaLogs/keyConcepts.html#data-model) for details on fields,
 which must be present in the ingested log messages.
 
 The API accepts various http parameters, which can change the data ingestion behavior - [these docs](#http-parameters) for details.
 
-The following command verifies that the data has been successfully ingested to VictoriaLogs by [querying](https://docs.victoriametrics.com/VictoriaLogs/querying/) it:
+The following command verifies that the data has been successfully ingested to VictoriaLogs by [querying](/VictoriaLogs/querying/) it:
 
 ```bash
 curl http://localhost:9428/select/logsql/query -d 'query=host.name:host123'
@@ -79,10 +79,10 @@ The command should return the following response:
 {"_msg":"cannot open file","_stream":"{}","_time":"2023-06-21T04:24:24Z","host.name":"host123"}
 ```
 
-The response by default contains [`_msg`](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#message-field),
-[`_stream`](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#stream-fields) and
-[`_time`](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#time-field) fields plus the explicitly mentioned fields.
-See [these docs](https://docs.victoriametrics.com/VictoriaLogs/LogsQL.html#querying-specific-fields) for details.
+The response by default contains [`_msg`](/VictoriaLogs/keyConcepts.html#message-field),
+[`_stream`](/VictoriaLogs/keyConcepts.html#stream-fields) and
+[`_time`](/VictoriaLogs/keyConcepts.html#time-field) fields plus the explicitly mentioned fields.
+See [these docs](/VictoriaLogs/LogsQL.html#querying-specific-fields) for details.
 
 The duration of requests to `/insert/elasticsearch/_bulk` can be monitored with `vl_http_request_duration_seconds{path="/insert/elasticsearch/_bulk"}` metric.
 
@@ -90,7 +90,7 @@ See also:
 
 - [How to debug data ingestion](#troubleshooting).
 - [HTTP parameters, which can be passed to the API](#http-parameters).
-- [How to query VictoriaLogs](https://docs.victoriametrics.com/VictoriaLogs/querying.html).
+- [How to query VictoriaLogs](/VictoriaLogs/querying.html).
 
 ### JSON stream API
 
@@ -108,18 +108,18 @@ echo '{ "log": { "level": "info", "message": "hello world" }, "date": "0", "stre
 
 It is possible to push unlimited number of log lines in a single request to this API.
 
-If the [timestamp field](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#time-field) is set to `"0"`,
+If the [timestamp field](/VictoriaLogs/keyConcepts.html#time-field) is set to `"0"`,
 then the current timestamp at VictoriaLogs side is used per each ingested log line.
 Otherwise the timestamp field must be in the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) format. For example, `2023-06-20T15:32:10Z`.
 Optional fractional part of seconds can be specified after the dot - `2023-06-20T15:32:10.123Z`.
 Timezone can be specified instead of `Z` suffix - `2023-06-20T15:32:10+02:00`.
 
-See [these docs](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#data-model) for details on fields,
+See [these docs](/VictoriaLogs/keyConcepts.html#data-model) for details on fields,
 which must be present in the ingested log messages.
 
 The API accepts various http parameters, which can change the data ingestion behavior - [these docs](#http-parameters) for details.
 
-The following command verifies that the data has been successfully ingested into VictoriaLogs by [querying](https://docs.victoriametrics.com/VictoriaLogs/querying/) it:
+The following command verifies that the data has been successfully ingested into VictoriaLogs by [querying](/VictoriaLogs/querying/) it:
 
 ```bash
 curl http://localhost:9428/select/logsql/query -d 'query=log.level:*'
@@ -133,10 +133,10 @@ The command should return the following response:
 {"_msg":"oh no!","_stream":"{stream=\"stream1\"}","_time":"2023-06-20T15:32:10.567Z","log.level":"error"}
 ```
 
-The response by default contains [`_msg`](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#message-field),
-[`_stream`](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#stream-fields) and
-[`_time`](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#time-field) fields plus the explicitly mentioned fields.
-See [these docs](https://docs.victoriametrics.com/VictoriaLogs/LogsQL.html#querying-specific-fields) for details.
+The response by default contains [`_msg`](/VictoriaLogs/keyConcepts.html#message-field),
+[`_stream`](/VictoriaLogs/keyConcepts.html#stream-fields) and
+[`_time`](/VictoriaLogs/keyConcepts.html#time-field) fields plus the explicitly mentioned fields.
+See [these docs](/VictoriaLogs/LogsQL.html#querying-specific-fields) for details.
 
 The duration of requests to `/insert/jsonline` can be monitored with `vl_http_request_duration_seconds{path="/insert/jsonline"}` metric.
 
@@ -144,7 +144,7 @@ See also:
 
 - [How to debug data ingestion](#troubleshooting).
 - [HTTP parameters, which can be passed to the API](#http-parameters).
-- [How to query VictoriaLogs](https://docs.victoriametrics.com/VictoriaLogs/querying.html).
+- [How to query VictoriaLogs](/VictoriaLogs/querying.html).
 
 ### Loki JSON API
 
@@ -162,7 +162,7 @@ It is possible to push thousands of log streams and log lines in a single reques
 The API accepts various http parameters, which can change the data ingestion behavior - [these docs](#http-parameters) for details.
 There is no need in specifying `_msg_field` and `_time_field` query args, since VictoriaLogs automatically extracts log message and timestamp from the ingested Loki data.
 
-The following command verifies that the data has been successfully ingested into VictoriaLogs by [querying](https://docs.victoriametrics.com/VictoriaLogs/querying/) it:
+The following command verifies that the data has been successfully ingested into VictoriaLogs by [querying](/VictoriaLogs/querying/) it:
 
 ```bash
 curl http://localhost:9428/select/logsql/query -d 'query=fizzbuzz'
@@ -174,10 +174,10 @@ The command should return the following response:
 {"_msg":"foo fizzbuzz bar","_stream":"{instance=\"host123\",job=\"app42\"}","_time":"2023-07-20T23:01:19.288676497Z"}
 ```
 
-The response by default contains [`_msg`](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#message-field),
-[`_stream`](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#stream-fields) and
-[`_time`](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#time-field) fields plus the explicitly mentioned fields.
-See [these docs](https://docs.victoriametrics.com/VictoriaLogs/LogsQL.html#querying-specific-fields) for details.
+The response by default contains [`_msg`](/VictoriaLogs/keyConcepts.html#message-field),
+[`_stream`](/VictoriaLogs/keyConcepts.html#stream-fields) and
+[`_time`](/VictoriaLogs/keyConcepts.html#time-field) fields plus the explicitly mentioned fields.
+See [these docs](/VictoriaLogs/LogsQL.html#querying-specific-fields) for details.
 
 The duration of requests to `/insert/loki/api/v1/push` can be monitored with `vl_http_request_duration_seconds{path="/insert/loki/api/v1/push"}` metric.
 
@@ -185,28 +185,28 @@ See also:
 
 - [How to debug data ingestion](#troubleshooting).
 - [HTTP parameters, which can be passed to the API](#http-parameters).
-- [How to query VictoriaLogs](https://docs.victoriametrics.com/VictoriaLogs/querying.html).
+- [How to query VictoriaLogs](/VictoriaLogs/querying.html).
 
 ### HTTP parameters
 
 VictoriaLogs accepts the following parameters at [data ingestion HTTP APIs](#http-apis):
 
-- `_msg_field` - it must contain the name of the [log field](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#data-model)
-  with the [log message](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#message-field) generated by the log shipper.
+- `_msg_field` - it must contain the name of the [log field](/VictoriaLogs/keyConcepts.html#data-model)
+  with the [log message](/VictoriaLogs/keyConcepts.html#message-field) generated by the log shipper.
   This is usually the `message` field for Filebeat and Logstash.
   If the `_msg_field` parameter isn't set, then VictoriaLogs reads the log message from the `_msg` field.
 
-- `_time_field` - it must contain the name of the [log field](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#data-model)
-  with the [log timestamp](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#time-field) generated by the log shipper.
+- `_time_field` - it must contain the name of the [log field](/VictoriaLogs/keyConcepts.html#data-model)
+  with the [log timestamp](/VictoriaLogs/keyConcepts.html#time-field) generated by the log shipper.
   This is usually the `@timestamp` field for Filebeat and Logstash.
   If the `_time_field` parameter isn't set, then VictoriaLogs reads the timestamp from the `_time` field.
   If this field doesn't exist, then the current timestamp is used.
 
-- `_stream_fields` - it should contain comma-separated list of [log field](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#data-model) names,
-  which uniquely identify every [log stream](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#stream-fields) collected the log shipper.
+- `_stream_fields` - it should contain comma-separated list of [log field](/VictoriaLogs/keyConcepts.html#data-model) names,
+  which uniquely identify every [log stream](/VictoriaLogs/keyConcepts.html#stream-fields) collected the log shipper.
   If the `_stream_fields` parameter isn't set, then all the ingested logs are written to default log stream - `{}`.
 
-- `ignore_fields` - this parameter may contain the list of [log field](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#data-model) names,
+- `ignore_fields` - this parameter may contain the list of [log field](/VictoriaLogs/keyConcepts.html#data-model) names,
   which must be ignored during data ingestion.
 
 - `debug` - if this parameter is set to `1`, then the ingested logs aren't stored in VictoriaLogs. Instead,
@@ -217,7 +217,7 @@ See also [HTTP headers](#http-headers).
 ### HTTP headers
 
 VictoriaLogs accepts optional `AccountID` and `ProjectID` headers at [data ingestion HTTP APIs](#http-apis).
-These headers may contain the needed tenant to ingest data to. See [multitenancy docs](https://docs.victoriametrics.com/VictoriaLogs/#multitenancy) for details.
+These headers may contain the needed tenant to ingest data to. See [multitenancy docs](/VictoriaLogs/#multitenancy) for details.
 
 ## Troubleshooting
 
@@ -227,37 +227,37 @@ The following command can be used for verifying whether the data is successfully
 curl http://localhost:9428/select/logsql/query -d 'query=*' | head
 ```
 
-This command selects all the data ingested into VictoriaLogs via [HTTP query API](https://docs.victoriametrics.com/VictoriaLogs/querying/#http-api)
-using [any value filter](https://docs.victoriametrics.com/VictoriaLogs/LogsQL.html#any-value-filter),
-while `head` cancels query execution after reading the first 10 log lines. See [these docs](https://docs.victoriametrics.com/VictoriaLogs/querying/#command-line)
+This command selects all the data ingested into VictoriaLogs via [HTTP query API](/VictoriaLogs/querying/#http-api)
+using [any value filter](/VictoriaLogs/LogsQL.html#any-value-filter),
+while `head` cancels query execution after reading the first 10 log lines. See [these docs](/VictoriaLogs/querying/#command-line)
 for more details on how `head` integrates with VictoriaLogs.
 
-The response by default contains [`_msg`](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#message-field),
-[`_stream`](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#stream-fields) and
-[`_time`](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#time-field) fields plus the explicitly mentioned fields.
-See [these docs](https://docs.victoriametrics.com/VictoriaLogs/LogsQL.html#querying-specific-fields) for details.
+The response by default contains [`_msg`](/VictoriaLogs/keyConcepts.html#message-field),
+[`_stream`](/VictoriaLogs/keyConcepts.html#stream-fields) and
+[`_time`](/VictoriaLogs/keyConcepts.html#time-field) fields plus the explicitly mentioned fields.
+See [these docs](/VictoriaLogs/LogsQL.html#querying-specific-fields) for details.
 
 VictoriaLogs provides the following command-line flags, which can help debugging data ingestion issues:
 
 - `-logNewStreams` - if this flag is passed to VictoriaLogs, then it logs all the newly
-  registered [log streams](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#stream-fields).
-  This may help debugging [high cardinality issues](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#high-cardinality).
+  registered [log streams](/VictoriaLogs/keyConcepts.html#stream-fields).
+  This may help debugging [high cardinality issues](/VictoriaLogs/keyConcepts.html#high-cardinality).
 - `-logIngestedRows` - if this flag is passed to VictoriaLogs, then it logs all the ingested
-  [log entries](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#data-model).
+  [log entries](/VictoriaLogs/keyConcepts.html#data-model).
   See also `debug` [parameter](#http-parameters).
 
-VictoriaLogs exposes various [metrics](https://docs.victoriametrics.com/VictoriaLogs/#monitoring), which may help debugging data ingestion issues:
+VictoriaLogs exposes various [metrics](/VictoriaLogs/#monitoring), which may help debugging data ingestion issues:
 
-- `vl_rows_ingested_total` - the number of ingested [log entries](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#data-model)
+- `vl_rows_ingested_total` - the number of ingested [log entries](/VictoriaLogs/keyConcepts.html#data-model)
   since the last VictoriaLogs restart. If this number icreases over time, then logs are successfully ingested into VictoriaLogs.
   The ingested logs can be inspected in the following ways:
   - By passing `debug=1` parameter to every request to [data ingestion APIs](#http-apis). The ingested rows aren't stored in VictoriaLogs
     in this case. Instead, they are logged, so they can be investigated later.
-    The `vl_rows_dropped_total` [metric](https://docs.victoriametrics.com/VictoriaLogs/#monitoring) is incremented for each logged row.
+    The `vl_rows_dropped_total` [metric](/VictoriaLogs/#monitoring) is incremented for each logged row.
   - By passing `-logIngestedRows` command-line flag to VictoriaLogs. In this case it logs all the ingested data, so it can be investigated later.
-- `vl_streams_created_total` - the number of created [log streams](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#stream-fields)
+- `vl_streams_created_total` - the number of created [log streams](/VictoriaLogs/keyConcepts.html#stream-fields)
   since the last VictoriaLogs restart. If this metric grows rapidly during extended periods of time, then this may lead
-  to [high cardinality issues](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#high-cardinality).
+  to [high cardinality issues](/VictoriaLogs/keyConcepts.html#high-cardinality).
   The newly created log streams can be inspected in logs by passing `-logNewStreams` command-line flag to VictoriaLogs.
 
 ## Log collectors and data ingestion formats
@@ -266,8 +266,8 @@ Here is the list of log collectors and their ingestion formats supported by Vict
 
 | How to setup the collector                                                               | Format: Elasticsearch                                                                     | Format: JSON Stream                                            | Format: Loki                                                                        |
 |------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------|---------------------------------------------------------------|-------------------------------------------------------------------------------------|
-| [Filebeat](https://docs.victoriametrics.com/VictoriaLogs/data-ingestion/Filebeat.html)   | [Yes](https://www.elastic.co/guide/en/beats/filebeat/current/elasticsearch-output.html)    | No                                                            | No                                                                                  |
-| [Fluentbit](https://docs.victoriametrics.com/VictoriaLogs/data-ingestion/Fluentbit.html) | No                                                                                         | [Yes](https://docs.fluentbit.io/manual/pipeline/outputs/http) | [Yes](https://docs.fluentbit.io/manual/pipeline/outputs/loki)                       |
-| [Logstash](https://docs.victoriametrics.com/VictoriaLogs/data-ingestion/Logstash.html)   | [Yes](https://www.elastic.co/guide/en/logstash/current/plugins-outputs-elasticsearch.html) | No                                                            | No                                                                                  |
-| [Vector](https://docs.victoriametrics.com/VictoriaLogs/data-ingestion/Vector.html)       | [Yes](https://vector.dev/docs/reference/configuration/sinks/elasticsearch/)                | No                                                            | [Yes](https://vector.dev/docs/reference/configuration/sinks/loki/)                  |
-| [Promtail](https://docs.victoriametrics.com/VictoriaLogs/data-ingestion/Promtail.html)   | No                                                                                         | No                                                            | [Yes](https://grafana.com/docs/loki/latest/clients/promtail/configuration/#clients) |
+| [Filebeat](/VictoriaLogs/data-ingestion/Filebeat.html)   | [Yes](https://www.elastic.co/guide/en/beats/filebeat/current/elasticsearch-output.html)    | No                                                            | No                                                                                  |
+| [Fluentbit](/VictoriaLogs/data-ingestion/Fluentbit.html) | No                                                                                         | [Yes](https://docs.fluentbit.io/manual/pipeline/outputs/http) | [Yes](https://docs.fluentbit.io/manual/pipeline/outputs/loki)                       |
+| [Logstash](/VictoriaLogs/data-ingestion/Logstash.html)   | [Yes](https://www.elastic.co/guide/en/logstash/current/plugins-outputs-elasticsearch.html) | No                                                            | No                                                                                  |
+| [Vector](/VictoriaLogs/data-ingestion/Vector.html)       | [Yes](https://vector.dev/docs/reference/configuration/sinks/elasticsearch/)                | No                                                            | [Yes](https://vector.dev/docs/reference/configuration/sinks/loki/)                  |
+| [Promtail](/VictoriaLogs/data-ingestion/Promtail.html)   | No                                                                                         | No                                                            | [Yes](https://grafana.com/docs/loki/latest/clients/promtail/configuration/#clients) |

--- a/docs/VictoriaLogs/data-ingestion/Vector.md
+++ b/docs/VictoriaLogs/data-ingestion/Vector.md
@@ -12,7 +12,7 @@ aliases:
 # Vector setup
 
 Specify [Elasticsearch sink type](https://vector.dev/docs/reference/configuration/sinks/elasticsearch/) in the `vector.toml`
-for sending the collected logs to [VictoriaLogs](https://docs.victoriametrics.com/VictoriaLogs/):
+for sending the collected logs to [VictoriaLogs](/VictoriaLogs/):
 
 ```toml
 [sinks.vlogs]
@@ -33,12 +33,12 @@ Substitute the `localhost:9428` address inside `endpoints` section with the real
 
 Replace `your_input` with the name of the `inputs` section, which collects logs. See [these docs](https://vector.dev/docs/reference/configuration/sources/) for details.
 
-See [these docs](https://docs.victoriametrics.com/VictoriaLogs/data-ingestion/#http-parameters) for details on parameters specified
+See [these docs](/VictoriaLogs/data-ingestion/#http-parameters) for details on parameters specified
 in the `[sinks.vlogs.query]` section.
 
-It is recommended verifying whether the initial setup generates the needed [log fields](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#data-model)
-and uses the correct [stream fields](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#stream-fields).
-This can be done by specifying `debug` [parameter](https://docs.victoriametrics.com/VictoriaLogs/data-ingestion/#http-parameters)
+It is recommended verifying whether the initial setup generates the needed [log fields](/VictoriaLogs/keyConcepts.html#data-model)
+and uses the correct [stream fields](/VictoriaLogs/keyConcepts.html#stream-fields).
+This can be done by specifying `debug` [parameter](/VictoriaLogs/data-ingestion/#http-parameters)
 in the `[sinks.vlogs.query]` section and inspecting VictoriaLogs logs then:
 
 ```toml
@@ -57,8 +57,8 @@ in the `[sinks.vlogs.query]` section and inspecting VictoriaLogs logs then:
     debug = "1"
 ```
 
-If some [log fields](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#data-model) must be skipped
-during data ingestion, then they can be put into `ignore_fields` [parameter](https://docs.victoriametrics.com/VictoriaLogs/data-ingestion/#http-parameters).
+If some [log fields](/VictoriaLogs/keyConcepts.html#data-model) must be skipped
+during data ingestion, then they can be put into `ignore_fields` [parameter](/VictoriaLogs/data-ingestion/#http-parameters).
 For example, the following config instructs VictoriaLogs to ignore `log.offset` and `event.original` fields in the ingested logs:
 
 ```toml
@@ -117,7 +117,7 @@ This usually allows saving network bandwidth and costs by up to 5 times:
     _stream_fields = "host,container_name"
 ```
 
-By default, the ingested logs are stored in the `(AccountID=0, ProjectID=0)` [tenant](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#multitenancy).
+By default, the ingested logs are stored in the `(AccountID=0, ProjectID=0)` [tenant](/VictoriaLogs/keyConcepts.html#multitenancy).
 If you need storing logs in other tenant, then specify the needed tenant via `[sinks.vlogq.request.headers]` section.
 For example, the following `vector.toml` config instructs Vector to store the data to `(AccountID=12, ProjectID=34)` tenant:
 
@@ -142,7 +142,7 @@ For example, the following `vector.toml` config instructs Vector to store the da
 
 See also:
 
-- [Data ingestion troubleshooting](https://docs.victoriametrics.com/VictoriaLogs/data-ingestion/#troubleshooting).
-- [How to query VictoriaLogs](https://docs.victoriametrics.com/VictoriaLogs/querying/).
+- [Data ingestion troubleshooting](/VictoriaLogs/data-ingestion/#troubleshooting).
+- [How to query VictoriaLogs](/VictoriaLogs/querying/).
 - [Elasticsearch output docs for Vector](https://vector.dev/docs/reference/configuration/sinks/elasticsearch/).
 - [Docker-compose demo for Filebeat integration with VictoriaLogs](https://github.com/VictoriaMetrics/VictoriaMetrics/tree/master/deployment/docker/victorialogs/vector-docker).

--- a/docs/VictoriaLogs/keyConcepts.md
+++ b/docs/VictoriaLogs/keyConcepts.md
@@ -14,7 +14,7 @@ aliases:
 
 ## Data model
 
-[VictoriaLogs](https://docs.victoriametrics.com/VictoriaLogs/) works with both structured and unstructured logs.
+[VictoriaLogs](/VictoriaLogs/) works with both structured and unstructured logs.
 Every log entry must contain at least [log message field](#message-field) plus arbitrary number of additional `key=value` fields.
 A single log entry can be expressed as a single-level [JSON](https://www.json.org/json-en.html) object with string keys and values.
 For example:
@@ -31,7 +31,7 @@ For example:
 ```
 
 VictoriaLogs automatically transforms multi-level JSON (aka nested JSON) into single-level JSON
-during [data ingestion](https://docs.victoriametrics.com/VictoriaLogs/data-ingestion/) according to the following rules:
+during [data ingestion](/VictoriaLogs/data-ingestion/) according to the following rules:
 
 - Nested dictionaries are flattened by concatenating dictionary keys with `.` char. For example, the following multi-level JSON
   is transformed into the following single-level JSON:
@@ -54,7 +54,7 @@ during [data ingestion](https://docs.victoriametrics.com/VictoriaLogs/data-inges
   }
   ```
 
-- Arrays, numbers and boolean values are converted into strings. This simplifies [full-text search](https://docs.victoriametrics.com/VictoriaLogs/LogsQL.html) over such values.
+- Arrays, numbers and boolean values are converted into strings. This simplifies [full-text search](/VictoriaLogs/LogsQL.html) over such values.
   For example, the following JSON with an array, a number and a boolean value is converted into the following JSON with string values:
 
   ```json
@@ -74,7 +74,7 @@ during [data ingestion](https://docs.victoriametrics.com/VictoriaLogs/data-inges
   ```
 
 Both label name and label value may contain arbitrary chars. Such chars must be encoded
-during [data ingestion](https://docs.victoriametrics.com/VictoriaLogs/data-ingestion/)
+during [data ingestion](/VictoriaLogs/data-ingestion/)
 according to [JSON string encoding](https://www.rfc-editor.org/rfc/rfc7159.html#section-7).
 Unicode chars must be encoded with [UTF-8](https://en.wikipedia.org/wiki/UTF-8) encoding:
 
@@ -85,8 +85,8 @@ Unicode chars must be encoded with [UTF-8](https://en.wikipedia.org/wiki/UTF-8) 
 }
 ```
 
-VictoriaLogs automatically indexes all the fields in all the [ingested](https://docs.victoriametrics.com/VictoriaLogs/data-ingestion/) logs.
-This enables [full-text search](https://docs.victoriametrics.com/VictoriaLogs/LogsQL.html) across all the fields.
+VictoriaLogs automatically indexes all the fields in all the [ingested](/VictoriaLogs/data-ingestion/) logs.
+This enables [full-text search](/VictoriaLogs/LogsQL.html) across all the fields.
 
 VictoriaLogs supports the following field types:
 
@@ -108,9 +108,9 @@ log entry, which can be ingested into VictoriaLogs:
 ```
 
 If the actual log message has other than `_msg` field name, then it is possible to specify the real log message field
-via `_msg_field` query arg during [data ingestion](https://docs.victoriametrics.com/VictoriaLogs/data-ingestion/).
+via `_msg_field` query arg during [data ingestion](/VictoriaLogs/data-ingestion/).
 For example, if log message is located in the `event.original` field, then specify `_msg_field=event.original` query arg
-during [data ingestion](https://docs.victoriametrics.com/VictoriaLogs/data-ingestion/).
+during [data ingestion](/VictoriaLogs/data-ingestion/).
 
 ### Time field
 
@@ -125,14 +125,14 @@ For example:
 ```
 
 If the actual timestamp has other than `_time` field name, then it is possible to specify the real timestamp
-field via `_time_field` query arg during [data ingestion](https://docs.victoriametrics.com/VictoriaLogs/data-ingestion/).
+field via `_time_field` query arg during [data ingestion](/VictoriaLogs/data-ingestion/).
 For example, if timestamp is located in the `event.created` field, then specify `_time_field=event.created` query arg
-during [data ingestion](https://docs.victoriametrics.com/VictoriaLogs/data-ingestion/).
+during [data ingestion](/VictoriaLogs/data-ingestion/).
 
 If `_time` field is missing, then the data ingestion time is used as log entry timestamp.
 
 The log entry timestamp allows quickly narrowing down the search to a particular time range.
-See [these docs](https://docs.victoriametrics.com/VictoriaLogs/LogsQL.html#time-filter) for details.
+See [these docs](/VictoriaLogs/LogsQL.html#time-filter) for details.
 
 ### Stream fields
 
@@ -148,14 +148,14 @@ VictoriaLogs optimizes storing and querying of individual log streams. This prov
   than a mixed log stream from multiple distinct applications.
 
 - Increased query performance, since VictoriaLogs needs to scan lower amounts of data
-  when [searching by stream labels](https://docs.victoriametrics.com/VictoriaLogs/LogsQL.html#stream-filter).
+  when [searching by stream labels](/VictoriaLogs/LogsQL.html#stream-filter).
 
 VictoriaLogs cannot determine automatically, which fields uniquely identify every log stream,
 so it stores all the received log entries in a single default stream - `{}`.
 This may lead to not-so-optimal resource usage and query performance.
 
 Therefore it is recommended specifying stream-level fields via `_stream_fields` query arg
-during [data ingestion](https://docs.victoriametrics.com/VictoriaLogs/data-ingestion/).
+during [data ingestion](/VictoriaLogs/data-ingestion/).
 For example, if logs from Kubernetes containers have the following fields:
 
 ```json
@@ -169,7 +169,7 @@ For example, if logs from Kubernetes containers have the following fields:
 ```
 
 then sepcify `_stream_fields=kubernetes.namespace,kubernetes.node.name,kubernetes.pod.name,kubernetes.container.name`
-query arg during [data ingestion](https://docs.victoriametrics.com/VictoriaLogs/data-ingestion/) in order to properly store
+query arg during [data ingestion](/VictoriaLogs/data-ingestion/) in order to properly store
 per-container logs into distinct streams.
 
 #### How to determine which fields must be associated with log streams?
@@ -185,7 +185,7 @@ In this case it is OK to associate the log stream with filepath fields such as `
 Structured logs may contain big number of fields, which do not change across log entries received from a single application instance.
 There is no need in associating all these fields with log stream - it is enough to associate only those fields, which uniquely identify
 the application instance across all the ingested logs. Additionally, some fields such as `datacenter`, `environment`, `namespace`, `job` or `app`,
-can be associated with log stream in order to optimize searching by these fields with [stream filtering](https://docs.victoriametrics.com/VictoriaLogs/LogsQL.html#stream-filter).
+can be associated with log stream in order to optimize searching by these fields with [stream filtering](/VictoriaLogs/LogsQL.html#stream-filter).
 
 Never associate log streams with fields, which may change across log entries of the same application instance. See [these docs](#high-cardinality) for details.
 
@@ -198,14 +198,14 @@ VictoriaLogs works perfectly with such fields unless they are associated with [l
 Never associate high-cardinality fields with [log streams](#stream-fields), since this may result
 to the following issues:
 
-- Performance degradation during [data ingestion](https://docs.victoriametrics.com/VictoriaLogs/data-ingestion/)
-  and [querying](https://docs.victoriametrics.com/VictoriaLogs/querying/)
+- Performance degradation during [data ingestion](/VictoriaLogs/data-ingestion/)
+  and [querying](/VictoriaLogs/querying/)
 - Increased memory usage
 - Increased CPU usage
 - Increased disk space usage
 - Increased disk read / write IO
 
-VictoriaLogs exposes `vl_streams_created_total` [metric](https://docs.victoriametrics.com/VictoriaLogs/#monitoring),
+VictoriaLogs exposes `vl_streams_created_total` [metric](/VictoriaLogs/#monitoring),
 which shows the number of created streams since the last VictoriaLogs restart. If this metric grows at a rapid rate
 during long period of time, then there are high chances of high cardinality issues mentioned above.
 VictoriaLogs can log all the newly registered streams when `-logNewStreams` command-line flag is passed to it.
@@ -217,5 +217,5 @@ The rest of [structured logging](#data-model) fields are optional. They can be u
 For example, it is usually faster to search over a dedicated `trace_id` field instead of searching for the `trace_id` inside long log message.
 E.g. the `trace_id:XXXX-YYYY-ZZZZ` query usually works faster than the `_msg:"trace_id=XXXX-YYYY-ZZZZ"` query.
 
-See [LogsQL docs](https://docs.victoriametrics.com/VictoriaLogs/LogsQL.html) for more details.
+See [LogsQL docs](/VictoriaLogs/LogsQL.html) for more details.
 

--- a/docs/VictoriaLogs/querying/README.md
+++ b/docs/VictoriaLogs/querying/README.md
@@ -14,7 +14,7 @@ aliases:
 
 # Querying
 
-[VictoriaLogs](https://docs.victoriametrics.com/VictoriaLogs/) can be queried with [LogsQL](https://docs.victoriametrics.com/VictoriaLogs/LogsQL.html)
+[VictoriaLogs](/VictoriaLogs/) can be queried with [LogsQL](/VictoriaLogs/LogsQL.html)
 via the following ways:
 
 - [Web UI](#web-ui) - a web-based UI for querying logs
@@ -24,23 +24,23 @@ via the following ways:
 ## HTTP API
 
 VictoriaLogs can be queried at the `/select/logsql/query` HTTP endpoint.
-The [LogsQL](https://docs.victoriametrics.com/VictoriaLogs/LogsQL.html) query must be passed via `query` argument.
+The [LogsQL](/VictoriaLogs/LogsQL.html) query must be passed via `query` argument.
 For example, the following query returns all the log entries with the `error` word:
 
 ```bash
 curl http://localhost:9428/select/logsql/query -d 'query=error'
 ```
 
-The response by default contains [`_msg`](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#message-field),
-[`_stream`](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#stream-fields) and
-[`_time`](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#time-field) fields plus the explicitly mentioned fields.
-See [these docs](https://docs.victoriametrics.com/VictoriaLogs/LogsQL.html#querying-specific-fields) for details.
+The response by default contains [`_msg`](/VictoriaLogs/keyConcepts.html#message-field),
+[`_stream`](/VictoriaLogs/keyConcepts.html#stream-fields) and
+[`_time`](/VictoriaLogs/keyConcepts.html#time-field) fields plus the explicitly mentioned fields.
+See [these docs](/VictoriaLogs/LogsQL.html#querying-specific-fields) for details.
 
 The `query` argument can be passed either in the request url itself (aka HTTP GET request) or via request body
 with the `x-www-form-urlencoded` encoding (aka HTTP POST request). The HTTP POST is useful for sending long queries
 when they do not fit the maximum url length of the used clients and proxies.
 
-See [LogsQL docs](https://docs.victoriametrics.com/VictoriaLogs/LogsQL.html) for details on what can be passed to the `query` arg.
+See [LogsQL docs](/VictoriaLogs/LogsQL.html) for details on what can be passed to the `query` arg.
 The `query` arg must be properly encoded with [percent encoding](https://en.wikipedia.org/wiki/URL_encoding) when passing it to `curl`
 or similar tools.
 
@@ -59,13 +59,13 @@ The response can be interrupted at any time by closing the connection to Victori
 This allows post-processing the returned lines at the client side with the usual Unix commands such as `grep`, `jq`, `less`, `head`, etc.
 See [these docs](#command-line) for more details.
 
-The returned lines are sorted by [`_time` field](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#time-field)
+The returned lines are sorted by [`_time` field](/VictoriaLogs/keyConcepts.html#time-field)
 if their total size doesn't exceed `-select.maxSortBufferSize` command-line flag value (by default it is set to one megabyte).
 Otherwise the returned lines aren't sorted, since sorting disables the ability to send matching log entries to response stream as soon as they are found.
-Query results can be sorted either at VictoriaLogs side according [to these docs](https://docs.victoriametrics.com/VictoriaLogs/LogsQL.html#sorting)
+Query results can be sorted either at VictoriaLogs side according [to these docs](/VictoriaLogs/LogsQL.html#sorting)
 or at client side with the usual `sort` command according to [these docs](#command-line).
 
-By default the `(AccountID=0, ProjectID=0)` [tenant](https://docs.victoriametrics.com/VictoriaLogs/#multitenancy) is queried.
+By default the `(AccountID=0, ProjectID=0)` [tenant](/VictoriaLogs/#multitenancy) is queried.
 If you need querying other tenant, then specify the needed tenant via http request headers. For example, the following query searches
 for log messages at `(AccountID=12, ProjectID=34)` tenant:
 
@@ -73,12 +73,12 @@ for log messages at `(AccountID=12, ProjectID=34)` tenant:
 curl http://localhost:9428/select/logsql/query -H 'AccountID: 12' -H 'ProjectID: 34' -d 'query=error'
 ```
 
-The number of requests to `/select/logsql/query` can be [monitored](https://docs.victoriametrics.com/VictoriaLogs/#monitoring)
+The number of requests to `/select/logsql/query` can be [monitored](/VictoriaLogs/#monitoring)
 with `vl_http_requests_total{path="/select/logsql/query"}` metric.
 
 ## Web UI
 
-VictoriaLogs provides a simple Web UI for logs [querying](https://docs.victoriametrics.com/VictoriaLogs/LogsQL.html) and exploration
+VictoriaLogs provides a simple Web UI for logs [querying](/VictoriaLogs/LogsQL.html) and exploration
 at `http://localhost:9428/select/vmui`. The UI allows exploring query results:
 
 <img src="vmui.png" width="800" />
@@ -92,9 +92,9 @@ There are three modes of displaying query results:
 This is the first version that has minimal functionality. It comes with the following limitations:
 
 - The number of query results is always limited to 1000 lines. Iteratively add
-  more specific [filters](https://docs.victoriametrics.com/VictoriaLogs/LogsQL.html#filters) to the query
+  more specific [filters](/VictoriaLogs/LogsQL.html#filters) to the query
   in order to get full response with less than 1000 lines.
-- Queries are always executed against [tenant](https://docs.victoriametrics.com/VictoriaLogs/#multitenancy) `0`.
+- Queries are always executed against [tenant](/VictoriaLogs/#multitenancy) `0`.
 
 These limitations will be removed in future versions.
 
@@ -117,7 +117,7 @@ These features allow executing queries at command-line interface, which potentia
 without the risk of high resource usage (CPU, RAM, disk IO) at VictoriaLogs server.
 
 For example, the following query can return very big number of matching log entries (e.g. billions) if VictoriaLogs contains
-many log messages with the `error` [word](https://docs.victoriametrics.com/VictoriaLogs/LogsQL.html#word):
+many log messages with the `error` [word](/VictoriaLogs/LogsQL.html#word):
 
 ```bash
 curl http://localhost:9428/select/logsql/query -d 'query=error'
@@ -147,9 +147,9 @@ It doesn't consume CPU and disk IO resources during this time. It resumes query 
 when the `less` continues reading the response stream.
 
 Suppose that the initial investigation of the returned query results helped determining that the needed log messages contain
-`cannot open file` [phrase](https://docs.victoriametrics.com/VictoriaLogs/LogsQL.html#phrase-filter).
+`cannot open file` [phrase](/VictoriaLogs/LogsQL.html#phrase-filter).
 Then the query can be narrowed down to `error AND "cannot open file"`
-(see [these docs](https://docs.victoriametrics.com/VictoriaLogs/LogsQL.html#logical-filter) about `AND` operator).
+(see [these docs](/VictoriaLogs/LogsQL.html#logical-filter) about `AND` operator).
 Then run the updated command in order to continue the investigation:
 
 ```bash
@@ -166,45 +166,45 @@ The returned VictoriaLogs query response can be post-processed with any combinat
 which are usually used for log analysis - `grep`, `jq`, `awk`, `sort`, `uniq`, `wc`, etc.
 
 For example, the following command uses `wc -l` Unix command for counting the number of log messages
-with the `error` [word](https://docs.victoriametrics.com/VictoriaLogs/LogsQL.html#word)
-received from [streams](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#stream-fields) with `app="nginx"` field
+with the `error` [word](/VictoriaLogs/LogsQL.html#word)
+received from [streams](/VictoriaLogs/keyConcepts.html#stream-fields) with `app="nginx"` field
 during the last 5 minutes:
 
 ```bash
 curl http://localhost:9428/select/logsql/query -d 'query=_stream:{app="nginx"} AND _time:5m AND error' | wc -l
 ```
 
-See [these docs](https://docs.victoriametrics.com/VictoriaLogs/LogsQL.html#stream-filter) about `_stream` filter,
-[these docs](https://docs.victoriametrics.com/VictoriaLogs/LogsQL.html#time-filter) about `_time` filter
-and [these docs](https://docs.victoriametrics.com/VictoriaLogs/LogsQL.html#logical-filter) about `AND` operator.
+See [these docs](/VictoriaLogs/LogsQL.html#stream-filter) about `_stream` filter,
+[these docs](/VictoriaLogs/LogsQL.html#time-filter) about `_time` filter
+and [these docs](/VictoriaLogs/LogsQL.html#logical-filter) about `AND` operator.
 
-The following example shows how to sort query results by the [`_time` field](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#time-field):
+The following example shows how to sort query results by the [`_time` field](/VictoriaLogs/keyConcepts.html#time-field):
 
 ```bash
 curl http://localhost:9428/select/logsql/query -d 'query=error' | jq -r '._time + " " + ._msg' | sort | less
 ```
 
-This command uses `jq` for extracting [`_time`](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#time-field)
-and [`_msg`](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#message-field) fields from the returned results,
+This command uses `jq` for extracting [`_time`](/VictoriaLogs/keyConcepts.html#time-field)
+and [`_msg`](/VictoriaLogs/keyConcepts.html#message-field) fields from the returned results,
 and piping them to `sort` command.
 
 Note that the `sort` command needs to read all the response stream before returning the sorted results. So the command above
 can take non-trivial amounts of time if the `query` returns too many results. The solution is to narrow down the `query`
-before sorting the results. See [these tips](https://docs.victoriametrics.com/VictoriaLogs/LogsQL.html#performance-tips)
+before sorting the results. See [these tips](/VictoriaLogs/LogsQL.html#performance-tips)
 on how to narrow down query results.
 
 The following example calculates stats on the number of log messages received during the last 5 minutes
-grouped by `log.level` [field](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html#data-model):
+grouped by `log.level` [field](/VictoriaLogs/keyConcepts.html#data-model):
 
 ```bash
 curl http://localhost:9428/select/logsql/query -d 'query=_time:5m log.level:*' | jq -r '."log.level"' | sort | uniq -c 
 ```
 
-The query selects all the log messages with non-empty `log.level` field via ["any value" filter](https://docs.victoriametrics.com/VictoriaLogs/LogsQL.html#any-value-filter),
+The query selects all the log messages with non-empty `log.level` field via ["any value" filter](/VictoriaLogs/LogsQL.html#any-value-filter),
 then pipes them to `jq` command, which extracts the `log.level` field value from the returned JSON stream, then the extracted `log.level` values
 are sorted with `sort` command and, finally, they are passed to `uniq -c` command for calculating the needed stats.
 
 See also:
 
-- [Key concepts](https://docs.victoriametrics.com/VictoriaLogs/keyConcepts.html).
-- [LogsQL docs](https://docs.victoriametrics.com/VictoriaLogs/LogsQL.html).
+- [Key concepts](/VictoriaLogs/keyConcepts.html).
+- [LogsQL docs](/VictoriaLogs/LogsQL.html).


### PR DESCRIPTION
we need to use relative links, otherwise it's impossible to have more than one env with documentation 