### PR TITLE
lib/storage: fix ingesting stale point

### DIFF
--- a/lib/storage/storage.go
+++ b/lib/storage/storage.go
@@ -1720,7 +1720,7 @@ func (s *Storage) add(rows []rawRow, dstMrs []*MetricRow, mrs []MetricRow, preci
 	for i := range mrs {
 		mr := &mrs[i]
 		if math.IsNaN(mr.Value) {
-			if decimal.IsStaleNaN(mr.Value) {
+			if !decimal.IsStaleNaN(mr.Value) {
 				// Skip NaNs other than Prometheus staleness marker, since the underlying encoding
 				// doesn't know how to work with them.
 				continue


### PR DESCRIPTION
follow up https://github.com/VictoriaMetrics/VictoriaMetrics/commit/fe8cc573d1d839d84e7d71949bca0b7f16f8faf8, seems to be a test code merged by mistake.
Which failed the [test](https://github.com/VictoriaMetrics/VictoriaMetrics/actions/runs/6528888299/job/17725766359?pr=5153)(vmalert-tool unittest can be a good e2e implementation for vm))