### PR TITLE
Allow forcing HTTP Connect proxy passthrough for Konnectivity support

### DIFF
--- a/docs/sd_configs.md
+++ b/docs/sd_configs.md
@@ -1609,6 +1609,10 @@ and in the majority of [supported service discovery configs](#supported-service-
     # - "HeaderName1: HeaderValue"
     # - "HeaderNameN: HeaderValueN"
 
+    # proxy_force_http_connect is an optional boolean to force HTTP bound scrape requests to use HTTP CONNECT Passthrough for proxying.
+    # By default, HTTP CONNECT Passthrough is only used on HTTPS destinations, and HTTP destinations proxy as a GET request.
+    # proxy_force_http_connect: <boolean>
+
     # follow_redirects can be used for disallowing HTTP redirects.
     # By default HTTP redirects are followed.
     # follow_redirects: false

--- a/lib/promauth/config.go
+++ b/lib/promauth/config.go
@@ -135,6 +135,9 @@ type ProxyClientConfig struct {
 
 	// Headers contains optional HTTP headers, which must be sent in the request to the proxy
 	Headers []string `yaml:"proxy_headers,omitempty"`
+
+	// Use to force the connection to HTTP CONNECT Passthrough, even for non-TLS destinations.
+	ForceHTTPConnect *bool `yaml:"proxy_force_http_connect,omitempty"`
 }
 
 // OAuth2Config represent OAuth2 configuration

--- a/lib/promscrape/client_test.go
+++ b/lib/promscrape/client_test.go
@@ -1,0 +1,192 @@
+package promscrape
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/promauth"
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/proxy"
+)
+
+func TestReadData_HTTPConnectPassthrough(t *testing.T) {
+	ctx := context.Background()
+
+	testCases := []struct {
+		name             string
+		ScrapeURL        string
+		ForceHTTPConnect bool
+		expectsConnect   bool
+	}{
+		{
+			name:           "http connect passthrough defaults to true for HTTPS",
+			ScrapeURL:      "https://my-metrics-server.com:8080",
+			expectsConnect: true,
+		},
+		{
+			name:           "http connect passthrough defaults to false for HTTP",
+			ScrapeURL:      "http://my-metrics-server.com:8080",
+			expectsConnect: false,
+		},
+		{
+			name:             "http connect passthrough forced to true for HTTP",
+			ScrapeURL:        "http://my-metrics-server.com:8080",
+			ForceHTTPConnect: true,
+			expectsConnect:   true,
+		},
+		{
+			name:             "http connect passthrough remains to true for HTTPs",
+			ScrapeURL:        "https://my-metrics-server.com:8080",
+			ForceHTTPConnect: true,
+			expectsConnect:   true,
+		},
+	}
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%d/%s", i, tc.name), func(t *testing.T) {
+			// the handler simulates a proxy, but doesn't actually proxy to anything.
+			var backend *httptest.Server
+			scrapeURL, err := url.Parse(tc.ScrapeURL)
+			if err != nil {
+				t.Fatalf("unexpected error parsing scrape url: %s", err)
+			}
+
+			if scrapeURL.Scheme == "https" {
+				backend = httptest.NewTLSServer(http.HandlerFunc(simpleHandler))
+			} else {
+				backend = httptest.NewServer(http.HandlerFunc(simpleHandler))
+			}
+			defer backend.Close()
+			tp := &testProxy{}
+			proxyServer := httptest.NewTLSServer(tp)
+			defer proxyServer.Close()
+
+			authConfig, err := authOptions().NewConfig()
+			if err != nil {
+				t.Fatalf("unexpected error creating tls config: %s", err)
+			}
+			client, err := newClient(ctx, &ScrapeWork{
+				ProxyURL:              proxy.MustNewURL(proxyServer.URL),
+				ScrapeURL:             backend.URL, // don't use the scrapeURL, use the backend url.
+				ProxyForceHTTPConnect: tc.ForceHTTPConnect,
+				AuthConfig:            authConfig,
+				ProxyAuthConfig:       authConfig,
+				ScrapeTimeout:         2 * time.Second,
+			})
+			if err != nil {
+				t.Fatalf("unexpected error creating client: %s", err)
+			}
+			buf := make([]byte, 1024)
+			// we expect an error since we haven't implemented the actual destination
+			_, err = client.ReadData(buf)
+			if err != nil {
+				t.Errorf("unexpected error reading data: %s", err)
+			}
+			if !tp.receivedRequest {
+				t.Errorf("the handler function never received a request")
+			}
+			if tc.expectsConnect != tp.receivedConnect {
+				t.Errorf("expected connect to be %t, got %t", tc.expectsConnect, tp.receivedConnect)
+			}
+
+			// Now test the stream reader
+			tp.receivedConnect = false
+			tp.receivedRequest = false
+
+			sr, err := client.GetStreamReader()
+			if err != nil {
+				t.Errorf("unexpected error creating stream reader: %s", err)
+			}
+
+			_, err = io.ReadAll(sr)
+			if err != nil {
+				t.Errorf("unexpected error reading data: %s", err)
+			}
+			if tc.expectsConnect != tp.receivedConnect {
+				t.Errorf("expected connect to be %t, got %t", tc.expectsConnect, tp.receivedConnect)
+			}
+			if !tp.receivedRequest {
+				t.Errorf("the handler function never received a request")
+			}
+		})
+	}
+}
+
+func authOptions() *promauth.Options {
+	return &promauth.Options{
+		TLSConfig: &promauth.TLSConfig{
+			InsecureSkipVerify: true,
+		},
+	}
+}
+
+func simpleHandler(w http.ResponseWriter, _ *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte("hello world"))
+}
+
+type testProxy struct {
+	receivedRequest bool
+	receivedConnect bool
+}
+
+func (tp *testProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	tp.receivedRequest = true
+	if r.Method == http.MethodConnect {
+		tp.receivedConnect = true
+		tunnel(w, r)
+	} else {
+		handleHTTP(w, r)
+	}
+}
+
+func tunnel(w http.ResponseWriter, r *http.Request) {
+	destConn, err := net.DialTimeout("tcp", r.Host, 10*time.Second)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusServiceUnavailable)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+	hijacker, ok := w.(http.Hijacker)
+	if !ok {
+		http.Error(w, "Hijacking not supported", http.StatusInternalServerError)
+		return
+	}
+	clientConn, _, err := hijacker.Hijack()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusServiceUnavailable)
+	}
+	go transfer(destConn, clientConn)
+	go transfer(clientConn, destConn)
+}
+
+func handleHTTP(w http.ResponseWriter, req *http.Request) {
+	resp, err := http.DefaultTransport.RoundTrip(req)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusServiceUnavailable)
+		return
+	}
+	defer resp.Body.Close()
+	copyHeader(w.Header(), resp.Header)
+	w.WriteHeader(resp.StatusCode)
+	io.Copy(w, resp.Body) // nolint
+}
+
+func copyHeader(dst, src http.Header) {
+	for k, vv := range src {
+		for _, v := range vv {
+			dst.Add(k, v)
+		}
+	}
+}
+
+func transfer(destination io.WriteCloser, source io.ReadCloser) {
+	defer destination.Close()    // nolint
+	defer source.Close()         // nolint
+	io.Copy(destination, source) // nolint
+}

--- a/lib/promscrape/client_test.go
+++ b/lib/promscrape/client_test.go
@@ -100,7 +100,7 @@ func TestReadData_HTTPConnectPassthrough(t *testing.T) {
 
 			sr, err := client.GetStreamReader()
 			if err != nil {
-				t.Errorf("unexpected error creating stream reader: %s", err)
+				t.Fatalf("unexpected error creating stream reader: %s", err)
 			}
 
 			_, err = io.ReadAll(sr)

--- a/lib/promscrape/config.go
+++ b/lib/promscrape/config.go
@@ -854,62 +854,68 @@ func getScrapeWorkConfig(sc *ScrapeConfig, baseDir string, globalCfg *GlobalConf
 	if sc.SeriesLimit > 0 {
 		seriesLimit = sc.SeriesLimit
 	}
+	var forceHTTPConnect bool
+	if sc.ProxyClientConfig.ForceHTTPConnect != nil {
+		forceHTTPConnect = *sc.ProxyClientConfig.ForceHTTPConnect
+	}
 	swc := &scrapeWorkConfig{
-		scrapeInterval:       scrapeInterval,
-		scrapeIntervalString: scrapeInterval.String(),
-		scrapeTimeout:        scrapeTimeout,
-		scrapeTimeoutString:  scrapeTimeout.String(),
-		jobName:              jobName,
-		metricsPath:          metricsPath,
-		scheme:               scheme,
-		params:               params,
-		proxyURL:             sc.ProxyURL,
-		proxyAuthConfig:      proxyAC,
-		authConfig:           ac,
-		honorLabels:          honorLabels,
-		honorTimestamps:      honorTimestamps,
-		denyRedirects:        denyRedirects,
-		externalLabels:       externalLabels,
-		relabelConfigs:       relabelConfigs,
-		metricRelabelConfigs: metricRelabelConfigs,
-		sampleLimit:          sc.SampleLimit,
-		disableCompression:   sc.DisableCompression,
-		disableKeepAlive:     sc.DisableKeepAlive,
-		streamParse:          sc.StreamParse,
-		scrapeAlignInterval:  sc.ScrapeAlignInterval.Duration(),
-		scrapeOffset:         sc.ScrapeOffset.Duration(),
-		seriesLimit:          seriesLimit,
-		noStaleMarkers:       noStaleTracking,
+		scrapeInterval:        scrapeInterval,
+		scrapeIntervalString:  scrapeInterval.String(),
+		scrapeTimeout:         scrapeTimeout,
+		scrapeTimeoutString:   scrapeTimeout.String(),
+		jobName:               jobName,
+		metricsPath:           metricsPath,
+		scheme:                scheme,
+		params:                params,
+		proxyURL:              sc.ProxyURL,
+		proxyAuthConfig:       proxyAC,
+		proxyForceHTTPConnect: forceHTTPConnect,
+		authConfig:            ac,
+		honorLabels:           honorLabels,
+		honorTimestamps:       honorTimestamps,
+		denyRedirects:         denyRedirects,
+		externalLabels:        externalLabels,
+		relabelConfigs:        relabelConfigs,
+		metricRelabelConfigs:  metricRelabelConfigs,
+		sampleLimit:           sc.SampleLimit,
+		disableCompression:    sc.DisableCompression,
+		disableKeepAlive:      sc.DisableKeepAlive,
+		streamParse:           sc.StreamParse,
+		scrapeAlignInterval:   sc.ScrapeAlignInterval.Duration(),
+		scrapeOffset:          sc.ScrapeOffset.Duration(),
+		seriesLimit:           seriesLimit,
+		noStaleMarkers:        noStaleTracking,
 	}
 	return swc, nil
 }
 
 type scrapeWorkConfig struct {
-	scrapeInterval       time.Duration
-	scrapeIntervalString string
-	scrapeTimeout        time.Duration
-	scrapeTimeoutString  string
-	jobName              string
-	metricsPath          string
-	scheme               string
-	params               map[string][]string
-	proxyURL             *proxy.URL
-	proxyAuthConfig      *promauth.Config
-	authConfig           *promauth.Config
-	honorLabels          bool
-	honorTimestamps      bool
-	denyRedirects        bool
-	externalLabels       *promutils.Labels
-	relabelConfigs       *promrelabel.ParsedConfigs
-	metricRelabelConfigs *promrelabel.ParsedConfigs
-	sampleLimit          int
-	disableCompression   bool
-	disableKeepAlive     bool
-	streamParse          bool
-	scrapeAlignInterval  time.Duration
-	scrapeOffset         time.Duration
-	seriesLimit          int
-	noStaleMarkers       bool
+	scrapeInterval        time.Duration
+	scrapeIntervalString  string
+	scrapeTimeout         time.Duration
+	scrapeTimeoutString   string
+	jobName               string
+	metricsPath           string
+	scheme                string
+	params                map[string][]string
+	proxyURL              *proxy.URL
+	proxyAuthConfig       *promauth.Config
+	proxyForceHTTPConnect bool
+	authConfig            *promauth.Config
+	honorLabels           bool
+	honorTimestamps       bool
+	denyRedirects         bool
+	externalLabels        *promutils.Labels
+	relabelConfigs        *promrelabel.ParsedConfigs
+	metricRelabelConfigs  *promrelabel.ParsedConfigs
+	sampleLimit           int
+	disableCompression    bool
+	disableKeepAlive      bool
+	streamParse           bool
+	scrapeAlignInterval   time.Duration
+	scrapeOffset          time.Duration
+	seriesLimit           int
+	noStaleMarkers        bool
 }
 
 func appendScrapeWorkForTargetLabels(dst []*ScrapeWork, swc *scrapeWorkConfig, targetLabels []*promutils.Labels, discoveryType string) []*ScrapeWork {
@@ -1157,29 +1163,30 @@ func (swc *scrapeWorkConfig) getScrapeWork(target string, extraLabels, metaLabel
 
 	originalLabels = sortOriginalLabelsIfNeeded(originalLabels)
 	sw := &ScrapeWork{
-		ScrapeURL:            scrapeURL,
-		ScrapeInterval:       scrapeInterval,
-		ScrapeTimeout:        scrapeTimeout,
-		HonorLabels:          swc.honorLabels,
-		HonorTimestamps:      swc.honorTimestamps,
-		DenyRedirects:        swc.denyRedirects,
-		OriginalLabels:       originalLabels,
-		Labels:               labelsCopy,
-		ExternalLabels:       swc.externalLabels,
-		ProxyURL:             swc.proxyURL,
-		ProxyAuthConfig:      swc.proxyAuthConfig,
-		AuthConfig:           swc.authConfig,
-		RelabelConfigs:       swc.relabelConfigs,
-		MetricRelabelConfigs: swc.metricRelabelConfigs,
-		SampleLimit:          swc.sampleLimit,
-		DisableCompression:   swc.disableCompression,
-		DisableKeepAlive:     swc.disableKeepAlive,
-		StreamParse:          streamParse,
-		ScrapeAlignInterval:  swc.scrapeAlignInterval,
-		ScrapeOffset:         swc.scrapeOffset,
-		SeriesLimit:          seriesLimit,
-		NoStaleMarkers:       swc.noStaleMarkers,
-		AuthToken:            at,
+		ScrapeURL:             scrapeURL,
+		ScrapeInterval:        scrapeInterval,
+		ScrapeTimeout:         scrapeTimeout,
+		HonorLabels:           swc.honorLabels,
+		HonorTimestamps:       swc.honorTimestamps,
+		DenyRedirects:         swc.denyRedirects,
+		OriginalLabels:        originalLabels,
+		Labels:                labelsCopy,
+		ExternalLabels:        swc.externalLabels,
+		ProxyURL:              swc.proxyURL,
+		ProxyAuthConfig:       swc.proxyAuthConfig,
+		ProxyForceHTTPConnect: swc.proxyForceHTTPConnect,
+		AuthConfig:            swc.authConfig,
+		RelabelConfigs:        swc.relabelConfigs,
+		MetricRelabelConfigs:  swc.metricRelabelConfigs,
+		SampleLimit:           swc.sampleLimit,
+		DisableCompression:    swc.disableCompression,
+		DisableKeepAlive:      swc.disableKeepAlive,
+		StreamParse:           streamParse,
+		ScrapeAlignInterval:   swc.scrapeAlignInterval,
+		ScrapeOffset:          swc.scrapeOffset,
+		SeriesLimit:           seriesLimit,
+		NoStaleMarkers:        swc.noStaleMarkers,
+		AuthToken:             at,
 
 		jobNameOriginal: swc.jobName,
 	}

--- a/lib/promscrape/scrapework.go
+++ b/lib/promscrape/scrapework.go
@@ -107,6 +107,9 @@ type ScrapeWork struct {
 	// ProxyURL HTTP proxy url
 	ProxyURL *proxy.URL
 
+	// ProxyForceHTTPConnect forces HTTP Connect Passthrough when proxying to non TLS, HTTP targets.
+	ProxyForceHTTPConnect bool
+
 	// Auth config for ProxyUR:
 	ProxyAuthConfig *promauth.Config
 


### PR DESCRIPTION
Konnectivity server only accepts HTTP CONNECT passthrough proxying. The standard lib proxies via a GET request for destinations that are non-TLS however. This means that when scraping a non-secured HTTP endpoint through a proxy, the request is always sent as a GET. Only HTTPS destinations are sent as a CONNECT Passthrough. There is nothing in any spec that requires this however. 

This PR adds a flag to scrape configs, to force HTTP destinations to use CONNECT passthrough.

See #5109 