### PR TITLE
lib/logstorage: fix streamID and tenantID search (#4856)

### DIFF
--- a/lib/logstorage/storage_search.go
+++ b/lib/logstorage/storage_search.go
@@ -382,7 +382,7 @@ func (p *part) searchByTenantIDs(so *searchOptions, bhss *blockHeaders, workCh c
 			n = sort.Search(len(ibhs), func(i int) bool {
 				return !ibhs[i].streamID.tenantID.less(tenantID)
 			})
-			if n == len(ibhs) || n > 0 && ibhs[n].streamID.tenantID.equal(tenantID) {
+			if n == len(ibhs) || n > 0 && !ibhs[n].streamID.tenantID.equal(tenantID) {
 				// The end of ibhs[n-1] may contain blocks for the given tenantID, so move it backwards
 				n--
 			}
@@ -493,7 +493,7 @@ func (p *part) searchByStreamIDs(so *searchOptions, bhss *blockHeaders, workCh c
 			n = sort.Search(len(ibhs), func(i int) bool {
 				return !ibhs[i].streamID.less(streamID)
 			})
-			if n == len(ibhs) || n > 0 && ibhs[n].streamID.equal(streamID) {
+			if n == len(ibhs) || n > 0 && !ibhs[n].streamID.equal(streamID) {
 				// The end of ibhs[n-1] may contain blocks for the given streamID, so move it backwards
 				n--
 			}


### PR DESCRIPTION
solve the issue: #4856 


Steps to reproduce：

1. Set up a clean VictoriaLogs instance
2. Execute the provided script to generate test data:
```shell
#!/bin/bash

for i in {0..3000}; do
    log="{\"log\": {\"level\": \"info\", \"message\": \"hello world\"}, \"date\": \"0\", \"foo\": \"bar\", \"stream\": \"stream$i\"}"
    echo $log >> logs.json
done
```
3. Import the test data into VictoriaLogs instance
`curl -X POST -H 'Content-Type: application/stream+json' --data-binary @logs.json 'http://localhost:9428/insert/jsonline?_stream_fields=stream&_time_field=date&_msg_field=log.message'`

4. Execute the provided script to identify the stream that cannot be queried.

```shell
#!/bin/bash

for i in {0..3000}; do
    query='_stream:{stream="stream'$i'"}'
    response=$(curl -s http://vmlog:vmlog@localhost:9428/select/logsql/query -d 'query='$query'')

    if [[ -z "$response" ]]; then
        echo "$query query failed"
        break
    fi
done
```