### PR TITLE
lib/stringsutil: fix failing test

### DIFF
--- a/lib/stringsutil/stringsutil.go
+++ b/lib/stringsutil/stringsutil.go
@@ -5,7 +5,7 @@ package stringsutil
 // If len(s) > maxLen, then s is replaced with "s_prefix..s_suffix",
 // so the total length of the returned string doesn't exceed maxLen.
 func LimitStringLen(s string, maxLen int) string {
-	if len(s) <= maxLen || maxLen <= 4 {
+	if len(s) <= maxLen || maxLen < 4 {
 		return s
 	}
 	n := (maxLen / 2) - 1


### PR DESCRIPTION
We have failed test on master branch.

```
--- FAIL: TestFormatLogMessage (0.00s)
    logger_test.go:24: unexpected result; got
        "foo: abcde, \"foo bar baz\", xx"
        want
        "foo: a..e, \"f..z\", xx"
```
if failed because maxArgs maxLen <= 4 in the  `LimitStringLen` in that case we always will return the income string but in the test we limit the maxLen by value 4
```
f("foo: %s, %q, %s", []interface{}{"abcde", fmt.Errorf("foo bar baz"), "xx"}, 4, `foo: a..e, "f..z", xx`)