### PR TITLE
lib/logstorage: proper exit during block search

### DIFF
--- a/lib/logstorage/storage_search.go
+++ b/lib/logstorage/storage_search.go
@@ -409,7 +409,9 @@ func (p *part) searchByTenantIDs(so *searchOptions, bhss *blockHeaders, workCh c
 				if so.minTimestamp > th.maxTimestamp || so.maxTimestamp < th.minTimestamp {
 					continue
 				}
-				scheduleBlockSearch(bh)
+				if !scheduleBlockSearch(bh) {
+					return
+				}
 			}
 			if len(bhs) == 0 {
 				break


### PR DESCRIPTION
Maybe the block search in the `searchByTenantIDs` method should exit the same as in `searchByStreamIDs`. When `scheduleBlockSearch` returns false, there is no need to traverse subsequent data.