### PR TITLE
Fix wrong example in recording rules

### DIFF
--- a/docs/operator/resources/vmrule.md
+++ b/docs/operator/resources/vmrule.md
@@ -104,10 +104,10 @@ metadata:
   name: vmrule-recording-example
 spec:
   groups:
-    - name: vmalert
+    - name: vmrule_recording_groupname
       interval: 1m
       rules:
-        - alert: vmalert config reload error
+        - record: vm_http_request_errors_total:sum_by_cluster_namespace_job:rate:5m
           expr: |-
             sum by (cluster, namespace, job) (
               rate(vm_http_request_errors_total[5m])


### PR DESCRIPTION
The example partially presents an alert as example instead of a recording rule. The name also contains white spaces, which is not supported