### PR TITLE
datadog: update datadog parsing API to process in batches instead of …

### DIFF
--- a/app/vmagent/datadog/request_handler.go
+++ b/app/vmagent/datadog/request_handler.go
@@ -47,10 +47,13 @@ func insertRows(at *auth.Token, series []prompbmarshal.TimeSeries, extraLabels [
 		s := &series[i]
 		rowsTotal += len(s.Samples)
 
-		s.Labels = append(s.Labels, extraLabels...)
-		tssDst = append(tssDst, *s)
-
+		n := len(labels)
 		labels = append(labels, s.Labels...)
+		labels = append(labels, extraLabels...)
+		// avoid extra allocs by referencing labels
+		s.Labels = labels[n:]
+
+		tssDst = append(tssDst, *s)
 		samples = append(samples, s.Samples...)
 	}
 

--- a/lib/protoparser/datadog/api/series/v1/api_test.go
+++ b/lib/protoparser/datadog/api/series/v1/api_test.go
@@ -34,9 +34,8 @@ func TestRequestExtract(t *testing.T) {
 		}
 
 		var samplesTotal int
-		cb := func(ts prompbmarshal.TimeSeries) error {
+		cb := func(ts prompbmarshal.TimeSeries) {
 			samplesTotal += len(ts.Samples)
-			return nil
 		}
 		sanitizeFn := func(name string) string {
 			return name

--- a/lib/protoparser/datadog/api/series/v2/api.go
+++ b/lib/protoparser/datadog/api/series/v2/api.go
@@ -12,13 +12,16 @@ type Request struct {
 	Series []series `json:"series"`
 }
 
+// SeriesLen returns length of Series field
+func (r *Request) SeriesLen() int { return len(r.Series) }
+
 // Unmarshal decodes byte array to series v2 Request struct
 func (r *Request) Unmarshal(b []byte) error {
 	return json.Unmarshal(b, r)
 }
 
 // Extract iterates fn execution over all timeseries from series v2 request
-func (r *Request) Extract(fn func(prompbmarshal.TimeSeries) error, sanitizeFn func(string) string) error {
+func (r *Request) Extract(callback func(prompbmarshal.TimeSeries), sanitize func(string) string) error {
 	for i := range r.Series {
 		s := r.Series[i]
 		samples := make([]prompbmarshal.Sample, 0, len(s.Points))
@@ -31,11 +34,9 @@ func (r *Request) Extract(fn func(prompbmarshal.TimeSeries) error, sanitizeFn fu
 		}
 		ts := prompbmarshal.TimeSeries{
 			Samples: samples,
-			Labels:  s.getLabels(sanitizeFn),
+			Labels:  s.getLabels(sanitize),
 		}
-		if err := fn(ts); err != nil {
-			return err
-		}
+		callback(ts)
 	}
 	return nil
 }

--- a/lib/protoparser/datadog/api/series/v2/api_test.go
+++ b/lib/protoparser/datadog/api/series/v2/api_test.go
@@ -34,9 +34,8 @@ func TestRequestExtract(t *testing.T) {
 		}
 
 		var samplesTotal int
-		cb := func(ts prompbmarshal.TimeSeries) error {
+		cb := func(ts prompbmarshal.TimeSeries) {
 			samplesTotal += len(ts.Samples)
-			return nil
 		}
 		sanitizeFn := func(name string) string {
 			return name

--- a/lib/protoparser/datadog/parser.go
+++ b/lib/protoparser/datadog/parser.go
@@ -22,6 +22,10 @@ func SplitTag(tag string) (string, string) {
 //
 // See https://docs.datadoghq.com/api/latest/metrics/#submit-metrics
 type Request interface {
-	Extract(func(prompbmarshal.TimeSeries) error, func(string) string) error
+	// Extract goes through Series of Request applying sanitize to Series labels,
+	// and calling callback for each Series transformed into prompbmarshal.TimeSeries
+	Extract(callback func(prompbmarshal.TimeSeries), sanitize func(string) string) error
+	// SeriesLen returns number of Series in Request
+	SeriesLen() int
 	Unmarshal([]byte) error
 }


### PR DESCRIPTION
…per-series

In https://github.com/VictoriaMetrics/VictoriaMetrics/commit/543f218fe96574b9b2189c8350bb09afa349e3bb the processing has been changed from per-batch to per-series for all protocols. This might have negative impact on existing users of datadog /api/v1 as it may generate more concurrent insert requests than before.

This change switches it back to batch processing.