### PR TITLE
Fix sum(aggr_over_time) 'got 1 args' error (#3028)

### DIFF
--- a/app/vmselect/promql/eval.go
+++ b/app/vmselect/promql/eval.go
@@ -686,10 +686,7 @@ func tryGetArgRollupFuncWithMetricExpr(ae *metricsql.AggrFuncExpr) (*metricsql.F
 			return nil, nil
 		}
 		// e = rollupFunc(metricExpr)
-		return &metricsql.FuncExpr{
-			Name: fe.Name,
-			Args: []metricsql.Expr{me},
-		}, nrf
+		return fe, nrf
 	}
 	if re, ok := arg.(*metricsql.RollupExpr); ok {
 		if me, ok := re.Expr.(*metricsql.MetricExpr); !ok || me.IsEmpty() || re.ForSubquery() {


### PR DESCRIPTION
app/vmselect/promql/eval.go:evalAggrFunc shunts evaluation of AggrFuncExpr over rollupFunc over MetricsExpr to an optimized path. `tryGetArgRollupFuncWithMetricExpr()` checks whether expression can be shunted, but it re-creates the AggrFuncExpr with the single MetricExpr argument which is wrong when the aggregation function has more than one argument. This results in queries like `sum(aggr_over_time("avg_over_time",m))` failing with error message

> expecting at least 2 args to "aggr_over_time"; got 1 args; expr: "aggr_over_time(m)"

while the analogous query `sum(avg_over_time(m))` executes successfully. This fix removes the unnecessary mangling.