### PR TITLE
vmctl: check error in response from influxdb

### DIFF
--- a/app/vmctl/influx/influx.go
+++ b/app/vmctl/influx/influx.go
@@ -360,9 +360,9 @@ func (c *Client) do(q influx.Query) ([]queryValues, error) {
 	if err != nil {
 		return nil, fmt.Errorf("query %q err: %s", q.Command, err)
 	}
-  if res.Error() != nil {
-    return nil, fmt.Errorf("query %q err: %s", q.Command, res.Error())
-  }
+	if res.Error() != nil {
+		return nil, fmt.Errorf("query %q err: %s", q.Command, res.Error())
+	}
 	if len(res.Results) < 1 {
 		return nil, fmt.Errorf("exploration query %q returned 0 results", q.Command)
 	}

--- a/app/vmctl/influx/influx.go
+++ b/app/vmctl/influx/influx.go
@@ -360,6 +360,9 @@ func (c *Client) do(q influx.Query) ([]queryValues, error) {
 	if err != nil {
 		return nil, fmt.Errorf("query %q err: %s", q.Command, err)
 	}
+  if res.Error() != nil {
+    return nil, fmt.Errorf("query %q err: %s", q.Command, res.Error())
+  }
 	if len(res.Results) < 1 {
 		return nil, fmt.Errorf("exploration query %q returned 0 results", q.Command)
 	}


### PR DESCRIPTION
The query can return an encoded error in the response. For example, if the credentials are wrong.

```
2023/12/10 17:18:34 explore query failed: failed to get field keys: error while executing query "show field keys": query "show field keys" err: authorization failed
```