### PR TITLE
VMUI: Handle unknown query error response type

### DIFF
--- a/app/vmui/packages/vmui/src/hooks/useFetchQuery.ts
+++ b/app/vmui/packages/vmui/src/hooks/useFetchQuery.ts
@@ -136,7 +136,13 @@ export const useFetchQuery = ({
           totalLength += resp.data.result.length;
         } else {
           tempData.push({ metric: {}, values: [], group: counter } as MetricBase);
-          setQueryErrors(prev => [...prev, `${resp.errorType}\r\n${resp?.error}`]);
+          if (resp.errorType !== undefined) {
+            setQueryErrors(prev => [...prev, `${resp.errorType}\r\n${resp?.error}`]);
+          } else {
+            console.log("Unknown server response format:", resp);
+            setQueryErrors(prev => [...prev,
+              "Unknown server response format: must have 'errorType', see console for more details"]);
+          }
         }
         counter++;
       }

--- a/app/vmui/packages/vmui/src/hooks/useFetchQuery.ts
+++ b/app/vmui/packages/vmui/src/hooks/useFetchQuery.ts
@@ -136,13 +136,11 @@ export const useFetchQuery = ({
           totalLength += resp.data.result.length;
         } else {
           tempData.push({ metric: {}, values: [], group: counter } as MetricBase);
-          if (resp.errorType !== undefined) {
-            setQueryErrors(prev => [...prev, `${resp.errorType}\r\n${resp?.error}`]);
-          } else {
-            console.log("Unknown server response format:", resp);
-            setQueryErrors(prev => [...prev,
-              "Unknown server response format: must have 'errorType', see console for more details"]);
-          }
+          const errorType = resp.errorType || ErrorTypes.unknownType;
+          const errorMessage = resp?.error || resp?.message || "see console for more details";
+          const error = [errorType, errorMessage].join(",\r\n");
+          setQueryErrors(prev => [...prev, `${error}`]);
+          console.error(`Fetch query error: ${errorType}`, resp);
         }
         counter++;
       }

--- a/app/vmui/packages/vmui/src/types/index.ts
+++ b/app/vmui/packages/vmui/src/types/index.ts
@@ -47,7 +47,8 @@ export enum ErrorTypes {
   traceNotFound = "Not found the tracing information",
   emptyTitle = "Please enter title",
   positiveNumber = "Please enter positive number",
-  validStep = "Please enter a valid step"
+  validStep = "Please enter a valid step",
+  unknownType = "Unknown server response format: must have 'errorType'",
 }
 
 export interface PanelSettings {


### PR DESCRIPTION

![image](https://github.com/VictoriaMetrics/VictoriaMetrics/assets/58356625/80ca8b23-0e8e-4ffc-af09-e60a2916e26d)
To reproduce, point serverUrl to a wrong URL that returns an HTTP error without "errorType"
