### PR TITLE
app/vmselect: drop `rollupDefault` function as duplicate

### DIFF
--- a/app/vmselect/promql/rollup.go
+++ b/app/vmselect/promql/rollup.go
@@ -2184,7 +2184,7 @@ func rollupFirst(rfa *rollupFuncArg) float64 {
 
 var rollupDefault = rollupLast
 
-func rollupLast(rfa *rollupFuncArg) float64 {
+func rollupDefault(rfa *rollupFuncArg) float64 {
 	values := rfa.values
 	if len(values) == 0 {
 		// Do not take into account rfa.prevValue, since it may lead

--- a/app/vmselect/promql/rollup.go
+++ b/app/vmselect/promql/rollup.go
@@ -2182,18 +2182,7 @@ func rollupFirst(rfa *rollupFuncArg) float64 {
 	return values[0]
 }
 
-func rollupDefault(rfa *rollupFuncArg) float64 {
-	values := rfa.values
-	if len(values) == 0 {
-		// Do not take into account rfa.prevValue, since it may lead
-		// to inconsistent results comparing to Prometheus on broken time series
-		// with irregular data points.
-		return nan
-	}
-	// Intentionally do not skip the possible last Prometheus staleness mark.
-	// See https://github.com/VictoriaMetrics/VictoriaMetrics/issues/1526 .
-	return values[len(values)-1]
-}
+var rollupDefault = rollupLast
 
 func rollupLast(rfa *rollupFuncArg) float64 {
 	values := rfa.values
@@ -2203,6 +2192,8 @@ func rollupLast(rfa *rollupFuncArg) float64 {
 		// with irregular data points.
 		return nan
 	}
+	// Intentionally do not skip the possible last Prometheus staleness mark.
+	// See https://github.com/VictoriaMetrics/VictoriaMetrics/issues/1526 .
 	return values[len(values)-1]
 }
 

--- a/app/vmselect/promql/rollup.go
+++ b/app/vmselect/promql/rollup.go
@@ -2182,7 +2182,7 @@ func rollupFirst(rfa *rollupFuncArg) float64 {
 	return values[0]
 }
 
-var rollupDefault = rollupLast
+var rollupLast = rollupDefault
 
 func rollupDefault(rfa *rollupFuncArg) float64 {
 	values := rfa.values


### PR DESCRIPTION
It is unclear why there are two identical fns `rollupDefault` and `rollupDistinct`. Dropping one of them.

-------------------

Related to https://github.com/VictoriaMetrics/VictoriaMetrics/issues/5499