### PR TITLE
docs: clarify information about values

### DIFF
--- a/docs/keyConcepts.md
+++ b/docs/keyConcepts.md
@@ -61,6 +61,12 @@ or [Prometheus](https://docs.victoriametrics.com/Single-server-VictoriaMetrics.h
 VictoriaMetrics supports enforcing of label filters for [query API](https://docs.victoriametrics.com/Single-server-VictoriaMetrics.html#prometheus-querying-api-enhancements)
 to emulate data isolation. However, the real data isolation can be achieved via [multi-tenancy](https://docs.victoriametrics.com/Cluster-VictoriaMetrics.html#multitenancy).
 
+VictoriaMetrics stores all the values as `float64`, 
+so these values can lose precision when the value contains more than `12-15` decimal digits.
+Initially, it called `strconv.ParseFloat(str, 64)`. This loses precision in lower 3 decimal digits.
+Input integer values in the range `[-2^54 ... 2^54-1]` shouldn't lose precision, while all the integer values outside this 
+range may lose precision due to conversions explained above.
+
 #### Time series
 
 A combination of a metric name and its labels defines a `time series`. For example,

--- a/docs/keyConcepts.md
+++ b/docs/keyConcepts.md
@@ -61,12 +61,6 @@ or [Prometheus](https://docs.victoriametrics.com/Single-server-VictoriaMetrics.h
 VictoriaMetrics supports enforcing of label filters for [query API](https://docs.victoriametrics.com/Single-server-VictoriaMetrics.html#prometheus-querying-api-enhancements)
 to emulate data isolation. However, the real data isolation can be achieved via [multi-tenancy](https://docs.victoriametrics.com/Cluster-VictoriaMetrics.html#multitenancy).
 
-VictoriaMetrics stores all the values as `float64`, 
-so these values can lose precision when the value contains more than `12-15` decimal digits.
-Initially, it called `strconv.ParseFloat(str, 64)`. This loses precision in lower 3 decimal digits.
-Input integer values in the range `[-2^54 ... 2^54-1]` shouldn't lose precision, while all the integer values outside this 
-range may lose precision due to conversions explained above.
-
 #### Time series
 
 A combination of a metric name and its labels defines a `time series`. For example,
@@ -86,7 +80,9 @@ See [these docs](https://docs.victoriametrics.com/FAQ.html#what-is-high-cardinal
 #### Raw samples
 
 Every unique time series may consist of an arbitrary number of `(value, timestamp)` data points (aka `raw samples`) sorted by `timestamp`.
-The `value` is a [double-precision floating-point number](https://en.wikipedia.org/wiki/Double-precision_floating-point_format).
+VictoriaMetrics stores all the `values` as [float64](https://en.wikipedia.org/wiki/Double-precision_floating-point_format) values 
+with [extra compression](https://faun.pub/victoriametrics-achieving-better-compression-for-time-series-data-than-gorilla-317bc1f95932) applied.
+This guarantees precision correctness for values with up to 12 significant decimal digits ([-2^54 ... 2^54-1]).
 The `timestamp` is a [Unix timestamp](https://en.wikipedia.org/wiki/Unix_time) with millisecond precision.
 
 Below is an example of a single raw sample


### PR DESCRIPTION
Described information in the Key Concepts about the label value where the when the value converts to the `float64`

Related issue: https://github.com/VictoriaMetrics/VictoriaMetrics/issues/5485

Signed-off-by: dmitryk-dk [d.kozlov@victoriametrics.com](mailto:d.kozlov@victoriametrics.com)