### PR TITLE
app/vmselect: optimize blocks processing

### DIFF
--- a/app/vmselect/graphite/eval.go
+++ b/app/vmselect/graphite/eval.go
@@ -163,6 +163,7 @@ func newNextSeriesForSearchQuery(ec *evalConfig, sq *storage.SearchQuery, expr g
 	seriesCh := make(chan *series, cgroup.AvailableCPUs())
 	errCh := make(chan error, 1)
 	go func() {
+		defer netstorage.PutResults(rss)
 		err := rss.RunParallel(nil, func(rs *netstorage.Result, workerID uint) error {
 			nameWithTags := getCanonicalPath(&rs.MetricName)
 			tags := unmarshalTags(nameWithTags)

--- a/app/vmselect/netstorage/netstorage_timing_test.go
+++ b/app/vmselect/netstorage/netstorage_timing_test.go
@@ -3,6 +3,9 @@ package netstorage
 import (
 	"fmt"
 	"testing"
+
+	"github.com/VictoriaMetrics/VictoriaMetrics/app/vmselect/searchutils"
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/storage"
 )
 
 func BenchmarkMergeSortBlocks(b *testing.B) {
@@ -102,6 +105,68 @@ func benchmarkMergeSortBlocks(b *testing.B, blocks []*sortBlock) {
 			}
 			sbh.sbs = sbs
 			mergeSortBlocks(&result, sbh, dedupInterval)
+		}
+	})
+}
+
+func BenchmarkTmpFileWrapper(b *testing.B) {
+	sns := []*storageNode{
+		{},
+	}
+	maxBlocks := 20
+	var mbs []storage.MetricBlock
+	for i := 0; i < maxBlocks; i++ {
+		mn := storage.MetricName{
+			AccountID: 0 + uint32(i),
+			ProjectID: 0 + uint32(i),
+			Tags: []storage.Tag{
+				{
+					Key:   []byte(`key`),
+					Value: []byte(fmt.Sprintf(`value-%d`, i)),
+				},
+			},
+		}
+		mnB := mn.Marshal(nil)
+		for j := 0; j < 10; j++ {
+			var block storage.Block
+			var tsid storage.TSID
+			ts := make([]int64, 0, 64*i)
+			block.Init(&tsid, ts, ts, 0, 0)
+			mb := storage.MetricBlock{
+				MetricName: mnB,
+				Block:      block,
+			}
+			mbs = append(mbs, mb)
+		}
+
+	}
+	var tr storage.TimeRange
+	var deadline searchutils.Deadline
+	//	b.SetBytes(int64(samplesPerBlock))
+	b.ReportAllocs()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			tbfw := getTBFW(len(sns))
+			for i := range mbs {
+				mb := &mbs[i]
+				if err := tbfw.RegisterAndWriteBlock(mb, 0); err != nil {
+					b.Fatalf("not expected error: %s", err)
+				}
+			}
+			var err error
+			rss := GetResults()
+			rss.tr = tr
+			rss.deadline = deadline
+			rss.packedTimeseries, _, err = tbfw.FinalizeTo(rss.packedTimeseries[:0])
+			if err != nil {
+				b.Fatalf("not expected finalize error: %s", err)
+			}
+			if len(rss.packedTimeseries) != maxBlocks {
+				b.Fatalf("not expected number of series, want=%d, got=%d", maxBlocks, len(rss.packedTimeseries))
+			}
+			closeTmpBlockFiles(tbfw.tbfs)
+			putTBFW(tbfw)
+			PutResults(rss)
 		}
 	})
 }

--- a/app/vmselect/promql/eval.go
+++ b/app/vmselect/promql/eval.go
@@ -1716,6 +1716,7 @@ func evalRollupFuncNoCache(qt *querytracer.Tracer, ec *EvalConfig, funcName stri
 	if err != nil {
 		return nil, err
 	}
+	defer netstorage.PutResults(rss)
 	ec.updateIsPartialResponse(isPartial)
 	rssLen := rss.Len()
 	if rssLen == 0 {


### PR DESCRIPTION
reduce the number of allocations for processSearch function it must reduce gc pressure and reduce cpu usage for instant queries with big number of series