### PR TITLE
lib/streamaggr: add count_series_bloomfilter with const memory usage

### DIFF
--- a/docs/stream-aggregation.md
+++ b/docs/stream-aggregation.md
@@ -474,6 +474,14 @@ or [Cloud Functions](https://cloud.google.com/functions)) can be controlled via 
 
 The results of `count_series` is equal to the `count(some_metric)` query.
 
+### count_series_bloomfilter
+
+`count_series_bloomfilter` counts the number of unique [time series](https://docs.victoriametrics.com/keyConcepts.html#time-series)
+via [bloom filters](https://en.wikipedia.org/wiki/Bloom_filter).
+Instead of `count_series`, `count_series_bloomfilter` use constant memory (~64MiB for 4194304 uniq metrics).
+
+The results of `count_series_bloomfilter` is equal or less to the `count(some_metric)` query, but never great.
+
 ### count_samples
 
 `count_samples` counts the number of input [samples](https://docs.victoriametrics.com/keyConcepts.html#raw-samples).
@@ -652,6 +660,12 @@ at [single-node VictoriaMetrics](https://docs.victoriametrics.com/Single-server-
   # Is `false` by default.
   # flush_on_shutdown: false
 
+  # bloomfilter_max_series defines max series for bloomfilter data structure.
+  # Memory usage can be calculated by formula: (count_series_bloomfilter * 16 + 63) / 64 bytes
+  # The parameter is only relevant for outputs: count_series_bloomfilter.
+  #
+  # bloomfilter_max_series: 4193304
+  
   # without is an optional list of labels, which must be removed from the output aggregation.
   # See https://docs.victoriametrics.com/stream-aggregation.html#aggregating-by-labels
   #

--- a/lib/bloomfilter/filter.go
+++ b/lib/bloomfilter/filter.go
@@ -10,15 +10,19 @@ import (
 const hashesCount = 4
 const bitsPerItem = 16
 
-type filter struct {
+// Filter count uniq elements.
+//
+// It is safe using the Filter from concurrent goroutines.
+type Filter struct {
 	maxItems int
 	bits     []uint64
 }
 
-func newFilter(maxItems int) *filter {
+// NewFilter creates new Filter, which can hold up to maxItems unique items.
+func NewFilter(maxItems int) *Filter {
 	bitsCount := maxItems * bitsPerItem
 	bits := make([]uint64, (bitsCount+63)/64)
-	return &filter{
+	return &Filter{
 		maxItems: maxItems,
 		bits:     bits,
 	}
@@ -27,7 +31,7 @@ func newFilter(maxItems int) *filter {
 // Reset resets f to initial state.
 //
 // It is expected no other goroutines call f methods during Reset call.
-func (f *filter) Reset() {
+func (f *Filter) Reset() {
 	bits := f.bits
 	for i := range bits {
 		bits[i] = 0
@@ -37,7 +41,7 @@ func (f *filter) Reset() {
 // Has checks whether h presents in f.
 //
 // Has can be called from concurrent goroutines.
-func (f *filter) Has(h uint64) bool {
+func (f *Filter) Has(h uint64) bool {
 	bits := f.bits
 	maxBits := uint64(len(bits)) * 64
 	bp := (*[8]byte)(unsafe.Pointer(&h))
@@ -63,7 +67,7 @@ func (f *filter) Has(h uint64) bool {
 //
 // Add can be called from concurrent goroutines.
 // If the same h is added to f from concurrent goroutines, then both goroutines may return true.
-func (f *filter) Add(h uint64) bool {
+func (f *Filter) Add(h uint64) bool {
 	bits := f.bits
 	maxBits := uint64(len(bits)) * 64
 	bp := (*[8]byte)(unsafe.Pointer(&h))

--- a/lib/bloomfilter/filter_test.go
+++ b/lib/bloomfilter/filter_test.go
@@ -15,7 +15,7 @@ func TestFilter(t *testing.T) {
 
 func testFilter(t *testing.T, maxItems int) {
 	r := rand.New(rand.NewSource(int64(0)))
-	f := newFilter(maxItems)
+	f := NewFilter(maxItems)
 	items := make(map[uint64]struct{}, maxItems)
 
 	// Populate f with maxItems
@@ -76,7 +76,7 @@ func TestFilterConcurrent(t *testing.T) {
 	concurrency := 3
 	maxItems := 10000
 	doneCh := make(chan struct{}, concurrency)
-	f := newFilter(maxItems)
+	f := NewFilter(maxItems)
 	for i := 0; i < concurrency; i++ {
 		go func(randSeed int) {
 			r := rand.New(rand.NewSource(int64(randSeed)))

--- a/lib/bloomfilter/filter_timing_test.go
+++ b/lib/bloomfilter/filter_timing_test.go
@@ -16,7 +16,7 @@ func BenchmarkFilterAdd(b *testing.B) {
 func benchmarkFilterAdd(b *testing.B, maxItems int) {
 	b.ReportAllocs()
 	b.RunParallel(func(pb *testing.PB) {
-		f := newFilter(maxItems)
+		f := NewFilter(maxItems)
 		for pb.Next() {
 			h := uint64(0)
 			for i := 0; i < 10000; i++ {
@@ -39,7 +39,7 @@ func BenchmarkFilterHasHit(b *testing.B) {
 func benchmarkFilterHasHit(b *testing.B, maxItems int) {
 	b.ReportAllocs()
 	b.RunParallel(func(pb *testing.PB) {
-		f := newFilter(maxItems)
+		f := NewFilter(maxItems)
 		h := uint64(0)
 		for i := 0; i < 10000; i++ {
 			h += uint64(maxItems)
@@ -68,7 +68,7 @@ func BenchmarkFilterHasMiss(b *testing.B) {
 func benchmarkFilterHasMiss(b *testing.B, maxItems int) {
 	b.ReportAllocs()
 	b.RunParallel(func(pb *testing.PB) {
-		f := newFilter(maxItems)
+		f := NewFilter(maxItems)
 		for pb.Next() {
 			h := uint64(0)
 			for i := 0; i < 10000; i++ {

--- a/lib/bloomfilter/limiter.go
+++ b/lib/bloomfilter/limiter.go
@@ -73,12 +73,12 @@ func (l *Limiter) Add(h uint64) bool {
 
 type limiter struct {
 	currentItems uint64
-	f            *filter
+	f            *Filter
 }
 
 func newLimiter(maxItems int) *limiter {
 	return &limiter{
-		f: newFilter(maxItems),
+		f: NewFilter(maxItems),
 	}
 }
 

--- a/lib/streamaggr/count_series_bloomfilter.go
+++ b/lib/streamaggr/count_series_bloomfilter.go
@@ -1,0 +1,82 @@
+package streamaggr
+
+import (
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/bloomfilter"
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/bytesutil"
+	"github.com/cespare/xxhash/v2"
+	"sync"
+
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/fasttime"
+)
+
+// countSeriesBloomfilterAggrState calculates output=count_series, e.g. the number of unique series.
+type countSeriesBloomfilterAggrState struct {
+	m         sync.Map
+	maxSeries int
+}
+
+type countSeriesBloomfilterStateValue struct {
+	mu          sync.Mutex
+	bloomfilter *bloomfilter.Filter
+	n           uint64
+	deleted     bool
+}
+
+func newcountSeriesBloomfilterAggrState(maxSeries int) *countSeriesBloomfilterAggrState {
+	return &countSeriesBloomfilterAggrState{maxSeries: maxSeries}
+}
+
+func (as *countSeriesBloomfilterAggrState) pushSample(inputKey, outputKey string, _ float64) {
+again:
+	v, ok := as.m.Load(outputKey)
+	if !ok {
+		// The entry is missing in the map. Try creating it.
+		filter := bloomfilter.NewFilter(as.maxSeries)
+		filter.Add(xxhash.Sum64(bytesutil.ToUnsafeBytes(inputKey)))
+		v = &countSeriesBloomfilterStateValue{
+			bloomfilter: filter,
+			n:           1,
+		}
+		vNew, loaded := as.m.LoadOrStore(outputKey, v)
+		if !loaded {
+			// The entry has been added to the map.
+			return
+		}
+		// Update the entry created by a concurrent goroutine.
+		v = vNew
+	}
+	sv := v.(*countSeriesBloomfilterStateValue)
+	sv.mu.Lock()
+	deleted := sv.deleted
+	if !deleted {
+		h := xxhash.Sum64(bytesutil.ToUnsafeBytes(inputKey))
+		if sv.bloomfilter.Add(h) {
+			sv.n++
+		}
+	}
+	sv.mu.Unlock()
+	if deleted {
+		// The entry has been deleted by the concurrent call to appendSeriesForFlush
+		// Try obtaining and updating the entry again.
+		goto again
+	}
+}
+
+func (as *countSeriesBloomfilterAggrState) appendSeriesForFlush(ctx *flushCtx) {
+	currentTimeMsec := int64(fasttime.UnixTimestamp()) * 1000
+	m := &as.m
+	m.Range(func(k, v interface{}) bool {
+		// Atomically delete the entry from the map, so new entry is created for the next flush.
+		m.Delete(k)
+
+		sv := v.(*countSeriesBloomfilterStateValue)
+		sv.mu.Lock()
+		n := sv.n
+		// Mark the entry as deleted, so it won't be updated anymore by concurrent pushSample() calls.
+		sv.deleted = true
+		sv.mu.Unlock()
+		key := k.(string)
+		ctx.appendSeries(key, "count_series_bloomfilter", currentTimeMsec, float64(n))
+		return true
+	})
+}

--- a/lib/streamaggr/streamaggr_test.go
+++ b/lib/streamaggr/streamaggr_test.go
@@ -230,7 +230,7 @@ func TestAggregatorsSuccess(t *testing.T) {
 	// Empty by list - aggregate only by time
 	f(`
 - interval: 1m
-  outputs: [count_samples, sum_samples, count_series, last]
+  outputs: [count_samples, sum_samples, count_series, count_series_bloomfilter, last]
 `, `
 foo{abc="123"} 4
 bar 5
@@ -238,10 +238,13 @@ foo{abc="123"} 8.5
 foo{abc="456",de="fg"} 8
 `, `bar:1m_count_samples 1
 bar:1m_count_series 1
+bar:1m_count_series_bloomfilter 1
 bar:1m_last 5
 bar:1m_sum_samples 5
 foo:1m_count_samples{abc="123"} 2
 foo:1m_count_samples{abc="456",de="fg"} 1
+foo:1m_count_series_bloomfilter{abc="123"} 1
+foo:1m_count_series_bloomfilter{abc="456",de="fg"} 1
 foo:1m_count_series{abc="123"} 1
 foo:1m_count_series{abc="456",de="fg"} 1
 foo:1m_last{abc="123"} 8.5
@@ -254,7 +257,7 @@ foo:1m_sum_samples{abc="456",de="fg"} 8
 	f(`
 - interval: 1m
   by: [__name__]
-  outputs: [count_samples, sum_samples, count_series]
+  outputs: [count_samples, sum_samples, count_series, count_series_bloomfilter]
 `, `
 foo{abc="123"} 4
 bar 5
@@ -262,9 +265,11 @@ foo{abc="123"} 8.5
 foo{abc="456",de="fg"} 8
 `, `bar:1m_count_samples 1
 bar:1m_count_series 1
+bar:1m_count_series_bloomfilter 1
 bar:1m_sum_samples 5
 foo:1m_count_samples 3
 foo:1m_count_series 2
+foo:1m_count_series_bloomfilter 2
 foo:1m_sum_samples 20.5
 `, "1111")
 
@@ -272,7 +277,7 @@ foo:1m_sum_samples 20.5
 	f(`
 - interval: 1m
   by: [foo, bar]
-  outputs: [count_samples, sum_samples, count_series]
+  outputs: [count_samples, sum_samples, count_series, count_series_bloomfilter]
 `, `
 foo{abc="123"} 4
 bar 5
@@ -280,9 +285,11 @@ foo{abc="123"} 8.5
 foo{abc="456",de="fg"} 8
 `, `bar:1m_by_bar_foo_count_samples 1
 bar:1m_by_bar_foo_count_series 1
+bar:1m_by_bar_foo_count_series_bloomfilter 1
 bar:1m_by_bar_foo_sum_samples 5
 foo:1m_by_bar_foo_count_samples 3
 foo:1m_by_bar_foo_count_series 2
+foo:1m_by_bar_foo_count_series_bloomfilter 2
 foo:1m_by_bar_foo_sum_samples 20.5
 `, "1111")
 
@@ -290,7 +297,7 @@ foo:1m_by_bar_foo_sum_samples 20.5
 	f(`
 - interval: 1m
   by: [abc]
-  outputs: [count_samples, sum_samples, count_series]
+  outputs: [count_samples, sum_samples, count_series, count_series_bloomfilter]
 `, `
 foo{abc="123"} 4
 bar 5
@@ -298,9 +305,12 @@ foo{abc="123"} 8.5
 foo{abc="456",de="fg"} 8
 `, `bar:1m_by_abc_count_samples 1
 bar:1m_by_abc_count_series 1
+bar:1m_by_abc_count_series_bloomfilter 1
 bar:1m_by_abc_sum_samples 5
 foo:1m_by_abc_count_samples{abc="123"} 2
 foo:1m_by_abc_count_samples{abc="456"} 1
+foo:1m_by_abc_count_series_bloomfilter{abc="123"} 1
+foo:1m_by_abc_count_series_bloomfilter{abc="456"} 1
 foo:1m_by_abc_count_series{abc="123"} 1
 foo:1m_by_abc_count_series{abc="456"} 1
 foo:1m_by_abc_sum_samples{abc="123"} 12.5
@@ -311,7 +321,7 @@ foo:1m_by_abc_sum_samples{abc="456"} 8
 	f(`
 - interval: 1m
   by: [abc, abc]
-  outputs: [count_samples, sum_samples, count_series]
+  outputs: [count_samples, sum_samples, count_series, count_series_bloomfilter]
 `, `
 foo{abc="123"} 4
 bar 5
@@ -319,9 +329,12 @@ foo{abc="123"} 8.5
 foo{abc="456",de="fg"} 8
 `, `bar:1m_by_abc_count_samples 1
 bar:1m_by_abc_count_series 1
+bar:1m_by_abc_count_series_bloomfilter 1
 bar:1m_by_abc_sum_samples 5
 foo:1m_by_abc_count_samples{abc="123"} 2
 foo:1m_by_abc_count_samples{abc="456"} 1
+foo:1m_by_abc_count_series_bloomfilter{abc="123"} 1
+foo:1m_by_abc_count_series_bloomfilter{abc="456"} 1
 foo:1m_by_abc_count_series{abc="123"} 1
 foo:1m_by_abc_count_series{abc="456"} 1
 foo:1m_by_abc_sum_samples{abc="123"} 12.5
@@ -332,7 +345,7 @@ foo:1m_by_abc_sum_samples{abc="456"} 8
 	f(`
 - interval: 1m
   without: [foo]
-  outputs: [count_samples, sum_samples, count_series]
+  outputs: [count_samples, sum_samples, count_series, count_series_bloomfilter]
 `, `
 foo{abc="123"} 4
 bar 5
@@ -340,9 +353,12 @@ foo{abc="123"} 8.5
 foo{abc="456",de="fg"} 8
 `, `bar:1m_without_foo_count_samples 1
 bar:1m_without_foo_count_series 1
+bar:1m_without_foo_count_series_bloomfilter 1
 bar:1m_without_foo_sum_samples 5
 foo:1m_without_foo_count_samples{abc="123"} 2
 foo:1m_without_foo_count_samples{abc="456",de="fg"} 1
+foo:1m_without_foo_count_series_bloomfilter{abc="123"} 1
+foo:1m_without_foo_count_series_bloomfilter{abc="456",de="fg"} 1
 foo:1m_without_foo_count_series{abc="123"} 1
 foo:1m_without_foo_count_series{abc="456",de="fg"} 1
 foo:1m_without_foo_sum_samples{abc="123"} 12.5
@@ -353,7 +369,7 @@ foo:1m_without_foo_sum_samples{abc="456",de="fg"} 8
 	f(`
 - interval: 1m
   without: [abc]
-  outputs: [count_samples, sum_samples, count_series]
+  outputs: [count_samples, sum_samples, count_series, count_series_bloomfilter]
 `, `
 foo{abc="123"} 4
 bar 5
@@ -361,10 +377,13 @@ foo{abc="123"} 8.5
 foo{abc="456",de="fg"} 8
 `, `bar:1m_without_abc_count_samples 1
 bar:1m_without_abc_count_series 1
+bar:1m_without_abc_count_series_bloomfilter 1
 bar:1m_without_abc_sum_samples 5
 foo:1m_without_abc_count_samples 2
 foo:1m_without_abc_count_samples{de="fg"} 1
 foo:1m_without_abc_count_series 1
+foo:1m_without_abc_count_series_bloomfilter 1
+foo:1m_without_abc_count_series_bloomfilter{de="fg"} 1
 foo:1m_without_abc_count_series{de="fg"} 1
 foo:1m_without_abc_sum_samples 12.5
 foo:1m_without_abc_sum_samples{de="fg"} 8
@@ -374,7 +393,7 @@ foo:1m_without_abc_sum_samples{de="fg"} 8
 	f(`
 - interval: 1m
   without: [__name__]
-  outputs: [count_samples, sum_samples, count_series]
+  outputs: [count_samples, sum_samples, count_series, count_series_bloomfilter]
 `, `
 foo{abc="123"} 4
 bar 5
@@ -384,6 +403,9 @@ foo{abc="456",de="fg"} 8
 :1m_count_samples{abc="123"} 2
 :1m_count_samples{abc="456",de="fg"} 1
 :1m_count_series 1
+:1m_count_series_bloomfilter 1
+:1m_count_series_bloomfilter{abc="123"} 1
+:1m_count_series_bloomfilter{abc="456",de="fg"} 1
 :1m_count_series{abc="123"} 1
 :1m_count_series{abc="456",de="fg"} 1
 :1m_sum_samples 5
@@ -395,7 +417,7 @@ foo{abc="456",de="fg"} 8
 	f(`
 - interval: 1m
   without: [abc]
-  outputs: [count_samples, sum_samples, count_series]
+  outputs: [count_samples, sum_samples, count_series, count_series_bloomfilter]
   input_relabel_configs:
   - if: 'foo'
     action: drop
@@ -406,6 +428,7 @@ foo{abc="123"} 8.5
 foo{abc="456",de="fg"} 8
 `, `bar:1m_without_abc_count_samples 1
 bar:1m_without_abc_count_series 1
+bar:1m_without_abc_count_series_bloomfilter 1
 bar:1m_without_abc_sum_samples 5
 `, "1111")
 
@@ -413,7 +436,7 @@ bar:1m_without_abc_sum_samples 5
 	f(`
 - interval: 1m
   without: [abc]
-  outputs: [count_samples, sum_samples, count_series]
+  outputs: [count_samples, sum_samples, count_series, count_series_bloomfilter]
   output_relabel_configs:
   - action: replace_all
     source_labels: [__name__]
@@ -430,9 +453,11 @@ foo{abc="123"} 8.5
 foo{abc="456",de="fg"} 8
 `, `bar-1m-without-abc-count-samples 1
 bar-1m-without-abc-count-series 1
+bar-1m-without-abc-count-series-bloomfilter 1
 bar-1m-without-abc-sum-samples 5
 foo-1m-without-abc-count-samples 2
 foo-1m-without-abc-count-series 1
+foo-1m-without-abc-count-series-bloomfilter 1
 foo-1m-without-abc-sum-samples 12.5
 `, "1111")
 
@@ -440,7 +465,7 @@ foo-1m-without-abc-sum-samples 12.5
 	f(`
 - interval: 1m
   without: [abc]
-  outputs: [count_samples, sum_samples, count_series]
+  outputs: [count_samples, sum_samples, count_series, count_series_bloomfilter]
   match: '{non_existing_label!=""}'
 `, `
 foo{abc="123"} 4
@@ -453,7 +478,7 @@ foo{abc="456",de="fg"} 8
 	f(`
 - interval: 1m
   by: [abc]
-  outputs: [count_samples, sum_samples, count_series]
+  outputs: [count_samples, sum_samples, count_series, count_series_bloomfilter]
   match:
   - foo{abc=~".+"}
   - '{non_existing_label!=""}'
@@ -464,6 +489,8 @@ foo{abc="123"} 8.5
 foo{abc="456",de="fg"} 8
 `, `foo:1m_by_abc_count_samples{abc="123"} 2
 foo:1m_by_abc_count_samples{abc="456"} 1
+foo:1m_by_abc_count_series_bloomfilter{abc="123"} 1
+foo:1m_by_abc_count_series_bloomfilter{abc="456"} 1
 foo:1m_by_abc_count_series{abc="123"} 1
 foo:1m_by_abc_count_series{abc="456"} 1
 foo:1m_by_abc_sum_samples{abc="123"} 12.5
@@ -551,7 +578,7 @@ foo:1m_increase{baz="qwe"} 15
 	// multiple aggregate configs
 	f(`
 - interval: 1m
-  outputs: [count_series, sum_samples]
+  outputs: [count_series, count_series_bloomfilter, sum_samples]
 - interval: 5m
   by: [bar]
   outputs: [sum_samples]
@@ -560,6 +587,8 @@ foo 1
 foo{bar="baz"} 2
 foo 3.3
 `, `foo:1m_count_series 1
+foo:1m_count_series_bloomfilter 1
+foo:1m_count_series_bloomfilter{bar="baz"} 1
 foo:1m_count_series{bar="baz"} 1
 foo:1m_sum_samples 4.3
 foo:1m_sum_samples{bar="baz"} 2
@@ -705,7 +734,7 @@ cpu_usage:1m_without_cpu_quantiles{quantile="1"} 90
 	f(`
 - interval: 1m
   without: [abc]
-  outputs: [count_samples, sum_samples, count_series]
+  outputs: [count_samples, sum_samples, count_series, count_series_bloomfilter]
   output_relabel_configs:
   - action: replace_all
     source_labels: [__name__]
@@ -723,9 +752,11 @@ bar 5
 foo{abc="123"} 8.5
 foo{abc="456",de="fg"} 8
 `, `bar-1m-without-abc-count-samples{new_label="must_keep_metric_name"} 1
+bar-1m-without-abc-count-series-bloomfilter{new_label="must_keep_metric_name"} 1
 bar-1m-without-abc-count-series{new_label="must_keep_metric_name"} 1
 bar-1m-without-abc-sum-samples{new_label="must_keep_metric_name"} 5
 foo-1m-without-abc-count-samples{new_label="must_keep_metric_name"} 2
+foo-1m-without-abc-count-series-bloomfilter{new_label="must_keep_metric_name"} 1
 foo-1m-without-abc-count-series{new_label="must_keep_metric_name"} 1
 foo-1m-without-abc-sum-samples{new_label="must_keep_metric_name"} 12.5
 `, "1111")

--- a/lib/streamaggr/streamaggr_timing_test.go
+++ b/lib/streamaggr/streamaggr_timing_test.go
@@ -14,6 +14,7 @@ func BenchmarkAggregatorsPushByJobAvg(b *testing.B) {
 		"increase",
 		"count_series",
 		"count_samples",
+		"count_series_bloomfilter",
 		"sum_samples",
 		"last",
 		"min",


### PR DESCRIPTION
I am use stream-aggregation for count labels per team, but `count_series` use too much memory. 
This PR add `count_series_bloomfilter`, that use constant memory for make same work.