### PR TITLE
vmagent: enable attach_metadata.node of kubernetes_sd_configs in all scrape configs

### DIFF
--- a/lib/promscrape/config_test.go
+++ b/lib/promscrape/config_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/promauth"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/promrelabel"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/promscrape/discovery/gce"
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/promscrape/discovery/kubernetes"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/promutils"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/proxy"
 )
@@ -200,6 +201,26 @@ func TestLoadConfig(t *testing.T) {
 	}
 }
 
+func TestLoadConfigWithEnableNodeMetadata(t *testing.T) {
+	// set the EnableAttachNodeMetadataAll flag to true
+	*kubernetes.EnableAttachNodeMetadataAll = true
+	cfg, err := loadConfig("testdata/prometheus.yml")
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if cfg == nil {
+		t.Fatalf("expecting non-nil config")
+	}
+	for _, scrapeConfig := range cfg.ScrapeConfigs {
+		if scrapeConfig.JobName == "service-kubernetes" {
+			// assert that attach_metadata.node is true
+			if scrapeConfig.KubernetesSDConfigs[0].AttachMetadata.Node != true {
+				t.Fatalf("expecting AttachMetadata.Node to be true, but was false ")
+			}
+		}
+
+	}
+}
 func TestAddressWithFullURL(t *testing.T) {
 	data := `
 scrape_configs:

--- a/lib/promscrape/discovery/kubernetes/kubernetes.go
+++ b/lib/promscrape/discovery/kubernetes/kubernetes.go
@@ -15,6 +15,9 @@ var SDCheckInterval = flag.Duration("promscrape.kubernetesSDCheckInterval", 30*t
 	"This works only if kubernetes_sd_configs is configured in '-promscrape.config' file. "+
 	"See https://docs.victoriametrics.com/sd_configs.html#kubernetes_sd_configs for details")
 
+// sets the attach_metadata.node to true for all the kubernetes_sd_configs
+var EnableAttachNodeMetadataAll = flag.Bool("promscrape.enableAttachNodeMetadataAll", false, "Sets the attach_metadata.node to true for all the kubernetes_sd_configs. Valid for roles: pod, endpoints, endpointslice")
+
 // SDConfig represents kubernetes-based service discovery config.
 //
 // See https://prometheus.io/docs/prometheus/latest/configuration/configuration/#kubernetes_sd_config


### PR DESCRIPTION
Including changes to enable `attach_metadata.node` to `kubernetes_sd_configs` for all the scrape configs based on the feature flag `promscrape.enableAttachNodeMetadataAll`.

Closes https://github.com/VictoriaMetrics/VictoriaMetrics/issues/4640
