### PR TITLE
add inserting comma inside value instruction to flag description

### DIFF
--- a/lib/flagutil/array.go
+++ b/lib/flagutil/array.go
@@ -11,6 +11,7 @@ import (
 // NewArrayString returns new ArrayString with the given name and description.
 func NewArrayString(name, description string) *ArrayString {
 	description += "\nSupports an `array` of values separated by comma or specified via multiple flags."
+	description += "\nValue can contain comma inside single-quoted or double-quoted string, {}, [] and () braces."
 	var a ArrayString
 	flag.Var(&a, name, description)
 	return &a


### PR DESCRIPTION
Add "how to insert comma inside value" instruction to flag description, should help users with question like https://github.com/VictoriaMetrics/VictoriaMetrics/issues/5626