### PR TITLE
add filter by group or rule name to vmalert ui

### DIFF
--- a/app/vmalert/static/js/custom.js
+++ b/app/vmalert/static/js/custom.js
@@ -75,8 +75,8 @@ function filterRuleByName(){
         }else{
             let target = $(this).attr('data-bs-target')
 
-            $("div[id='rules-"+target+"'").addClass('show');
-            $("div[data-bs-target='rules-"+target+"'").show();
+            $(`#rules-${target}`).addClass('show');
+            $(`div[data-bs-target='rules-${target}']`).show();
             $(this).show();
         }
     });  

--- a/app/vmalert/static/js/custom.js
+++ b/app/vmalert/static/js/custom.js
@@ -17,21 +17,15 @@ function toggleByID(id) {
     }
 }
 
-//http://davidwalsh.name/javascript-debounce-function
-function debounce(func, wait, immediate) {
-    var timeout;
-    return function() {
-        var context = this, args = arguments;
-        var later = function() {
-            timeout = null;
-            if (!immediate) func.apply(context, args);
-        };
-        var callNow = immediate && !timeout;
-        clearTimeout(timeout);
-        timeout = setTimeout(later, wait);
-        if (callNow) func.apply(context, args);
+function debounce(func, delay) {
+    let timer;
+    return function(...args) {
+        clearTimeout(timer);
+        timer = setTimeout(() => {
+            func.apply(this, args);
+        }, delay);
     };
-};
+}
 
 $('#filter').on("keyup", debounce(filter, 500));
 

--- a/app/vmalert/static/js/custom.js
+++ b/app/vmalert/static/js/custom.js
@@ -33,10 +33,7 @@ function debounce(func, wait, immediate) {
     };
 };
 
-$('#filter').on("keyup", (debounce(function(){
-    console.log("type")
-    filter();
-},500)));
+$('#filter').on("keyup", debounce(filter, 500));
 
 function filter(){
     $(".rule-table").removeClass('show');

--- a/app/vmalert/static/js/custom.js
+++ b/app/vmalert/static/js/custom.js
@@ -94,8 +94,8 @@ function filterRuleByLabels(){
         if (matches > 0){
             let target = $(this).attr('data-bs-target')
 
-            $("div[id='rules-"+target+"'").addClass('show');
-            $("div[data-bs-target='rules-"+target+"'").show();
+            $(`#rules-${target}`).addClass('show');
+            $(`div[data-bs-target='rules-${target}']`).show();
             $(this).show();
         }
     }); 

--- a/app/vmalert/static/js/custom.js
+++ b/app/vmalert/static/js/custom.js
@@ -47,11 +47,12 @@ function filter(){
 
 function filterGroupsByName(){
     $( ".group-heading" ).each(function() {
-        var groupName = $(this).attr('data-group-name');
-        var filter = $("#filter").val()
+        const groupName = $(this).attr('data-group-name');
+        const filter = $("#filter").val()
+        const hasValue = groupName.indexOf(filter) >= 0
 
-        if (groupName.indexOf(filter) >= 0){
-            let target = $(this).attr("data-bs-target");
+        if (hasValue){
+            const target = $(this).attr("data-bs-target");
             
             $(this).show();
             $(`div[id="${target}"] .rule`).show();
@@ -61,32 +62,34 @@ function filterGroupsByName(){
 
 function filterRuleByName(){
     $( ".rule" ).each(function() {
-        var ruleName = $(this).attr("data-rule-name");
-        var filter = $("#filter").val()
-        
-        if (ruleName.indexOf(filter) < 0){
-            $(this).hide();
-        }else{
-            let target = $(this).attr('data-bs-target')
+        const ruleName = $(this).attr("data-rule-name");
+        const filter = $("#filter").val()
+        const hasValue = ruleName.indexOf(filter) >= 0
+
+        if (hasValue){
+            const target = $(this).attr('data-bs-target')
 
             $(`#rules-${target}`).addClass('show');
             $(`div[data-bs-target='rules-${target}']`).show();
             $(this).show();
+        }else{
+            $(this).hide();
         }
     });  
 }
 
 function filterRuleByLabels(){
     $( ".rule" ).each(function() {
-        let filter = $("#filter").val()
+        const filter = $("#filter").val()
         
-        let matches = $( ".label", this ).filter(function() {
-            let label = $(this).text();
-            return label.indexOf(filter) >= 0;
+        const matches = $( ".label", this ).filter(function() {
+            const label = $(this).text();
+            const hasValue = label.indexOf(filter) >= 0
+            return hasValue;
         }).length; 
 
         if (matches > 0){
-            let target = $(this).attr('data-bs-target')
+            const target = $(this).attr('data-bs-target')
 
             $(`#rules-${target}`).addClass('show');
             $(`div[data-bs-target='rules-${target}']`).show();

--- a/app/vmalert/static/js/custom.js
+++ b/app/vmalert/static/js/custom.js
@@ -17,16 +17,28 @@ function toggleByID(id) {
     }
 }
 
-function filter(){
-    if($('#groups').is(':checked')){
-        filterGroups();
-    }else{
-        filterRules();
-    }
-}
+//http://davidwalsh.name/javascript-debounce-function
+function debounce(func, wait, immediate) {
+    var timeout;
+    return function() {
+        var context = this, args = arguments;
+        var later = function() {
+            timeout = null;
+            if (!immediate) func.apply(context, args);
+        };
+        var callNow = immediate && !timeout;
+        clearTimeout(timeout);
+        timeout = setTimeout(later, wait);
+        if (callNow) func.apply(context, args);
+    };
+};
 
-function filterGroups(){
-    $(".group-heading").show()
+$('#filter').on("keyup", (debounce(function(){
+    console.log("type")
+    filter();
+},500)));
+
+function filter(){
     $(".rule-table").removeClass('show');
     $(".rule").show();
     
@@ -35,52 +47,61 @@ function filterGroups(){
         return
     }
 
+    $(".group-heading").hide()
+
+    filterRuleByName();
+    filterRuleByLabels();
+    filterGroupsByName();
+}
+
+function filterGroupsByName(){
     $( ".group-heading" ).each(function() {
         var groupName = $(this).attr('data-group-name');
         var filter = $("#filter").val()
 
-        if (groupName.indexOf(filter) < 0){
-            let id = $(this).attr('data-bs-target')
-            $("div[id='"+id+"'").removeClass('show');
-            $(this).hide();
-        }else{
+        if (groupName.indexOf(filter) >= 0){
+            let target = $(this).attr("data-bs-target");
+            
             $(this).show();
+            $("div[id='"+target+"'] .rule").show();
         }
     });
 }
 
-function filterRules(){
-    $(".group-heading").show()
-    $(".rule-table").removeClass('show');
-    $(".rule").show();
-
-    if($("#filter").val().length === 0){
-        return
-    }
-
+function filterRuleByName(){
     $( ".rule" ).each(function() {
         var ruleName = $(this).attr("data-rule-name");
         var filter = $("#filter").val()
-        let target = $(this).attr('data-bs-target')
-
+        
         if (ruleName.indexOf(filter) < 0){
             $(this).hide();
         }else{
+            let target = $(this).attr('data-bs-target')
+
             $("div[id='rules-"+target+"'").addClass('show');
+            $("div[data-bs-target='rules-"+target+"'").show();
             $(this).show();
         }
-    });
+    });  
+}
 
-    $( ".rule-table" ).each(function() {
-        let c = $( ".row", this ).filter(function() {
-            return $(this).is(":visible")
-        }).length;
-        if (c === 0) {
-            let target = $(this).attr('id')
-            $("div[data-bs-target='"+target+"'").removeClass('show');
-            $("div[data-bs-target='"+target+"'").hide()
+function filterRuleByLabels(){
+    $( ".rule" ).each(function() {
+        let filter = $("#filter").val()
+        
+        let matches = $( ".label", this ).filter(function() {
+            let label = $(this).text();
+            return label.indexOf(filter) >= 0;
+        }).length; 
+
+        if (matches > 0){
+            let target = $(this).attr('data-bs-target')
+
+            $("div[id='rules-"+target+"'").addClass('show');
+            $("div[data-bs-target='rules-"+target+"'").show();
+            $(this).show();
         }
-    });
+    }); 
 }
 
 $(document).ready(function () {

--- a/app/vmalert/static/js/custom.js
+++ b/app/vmalert/static/js/custom.js
@@ -1,8 +1,10 @@
 function expandAll() {
+    $(".group-heading").show()
     $('.collapse').addClass('show');
 }
 
 function collapseAll() {
+    $(".group-heading").show()
     $('.collapse').removeClass('show');
 }
 
@@ -13,6 +15,72 @@ function toggleByID(id) {
             el.click();
         }
     }
+}
+
+function filter(){
+    if($('#groups').is(':checked')){
+        filterGroups();
+    }else{
+        filterRules();
+    }
+}
+
+function filterGroups(){
+    $(".group-heading").show()
+    $(".rule-table").removeClass('show');
+    $(".rule").show();
+    
+    if($("#filter").val().length === 0){
+        $(".group-heading").show()
+        return
+    }
+
+    $( ".group-heading" ).each(function() {
+        var groupName = $(this).attr('data-group-name');
+        var filter = $("#filter").val()
+
+        if (groupName.indexOf(filter) < 0){
+            let id = $(this).attr('data-bs-target')
+            $("div[id='"+id+"'").removeClass('show');
+            $(this).hide();
+        }else{
+            $(this).show();
+        }
+    });
+}
+
+function filterRules(){
+    $(".group-heading").show()
+    $(".rule-table").removeClass('show');
+    $(".rule").show();
+
+    if($("#filter").val().length === 0){
+        return
+    }
+
+    $( ".rule" ).each(function() {
+        var ruleName = $(this).attr("data-rule-name");
+        var filter = $("#filter").val()
+        let target = $(this).attr('data-bs-target')
+
+        if (ruleName.indexOf(filter) < 0){
+            $(this).hide();
+        }else{
+            $("div[id='rules-"+target+"'").addClass('show');
+            $(this).show();
+        }
+    });
+
+    $( ".rule-table" ).each(function() {
+        let c = $( ".row", this ).filter(function() {
+            return $(this).is(":visible")
+        }).length;
+        if (c === 0) {
+            let target = $(this).attr('id')
+            $("div[data-bs-target='"+target+"'").removeClass('show');
+            $("div[data-bs-target='"+target+"'").hide()
+        }
+    });
 }
 
 $(document).ready(function () {

--- a/app/vmalert/static/js/custom.js
+++ b/app/vmalert/static/js/custom.js
@@ -60,7 +60,7 @@ function filterGroupsByName(){
             let target = $(this).attr("data-bs-target");
             
             $(this).show();
-            $("div[id='"+target+"'] .rule").show();
+            $(`div[id="${target}"] .rule`).show();
         }
     });
 }

--- a/app/vmalert/web.qtpl
+++ b/app/vmalert/web.qtpl
@@ -75,10 +75,18 @@ btn-primary
          <a class="btn btn-primary" role="button" onclick="expandAll()">Expand All</a>
          <a class="btn {%= buttonActive(filter, "unhealthy") %}" role="button" onclick="location.href='?filter=unhealthy'" title="Show only rules with errors">Unhealthy</a>
          <a class="btn {%= buttonActive(filter, "noMatch") %}" role="button" onclick="location.href='?filter=noMatch'" title="Show only rules matching no time series during last evaluation">NoMatch</a>
+         <p>
+          <input id="filter" class="input-group" role="input"></input>
+            <a class="btn btn-primary" role="button" onclick="filter()">Filter</a>
+            <form>
+              <input type="radio" name="filterType" id="groups" role="input" checked>By Group Name</input>
+              <input type="radio" name="filterType" id="rules" role="input">By Rule Name</input>
+            </form>
+        </p>
         {%  if len(groups) > 0 %}
             {% for _, g := range groups  %}
                   <div
-                    class="group-heading{% if rNotOk[g.ID] > 0 %} alert-danger{%endif%}" data-bs-target="rules-{%s g.ID %}">
+                    class="group-heading{% if rNotOk[g.ID] > 0 %} alert-danger{%endif%}" data-bs-target="rules-{%s g.ID %}" data-group-name="{%s g.Name %}">
                     <span class="anchor" id="group-{%s g.ID %}"></span>
                     <a href="#group-{%s g.ID %}">{%s g.Name %}{% if g.Type != "prometheus" %} ({%s g.Type %}){% endif %} (every {%f.0 g.Interval %}s) #</a>
                      {% if rNotOk[g.ID] > 0 %}<span class="badge bg-danger" title="Number of rules with status Error">{%d rNotOk[g.ID] %}</span> {% endif %}
@@ -100,7 +108,7 @@ btn-primary
                         </div>
                     {% endif %}
                 </div>
-                <div class="collapse" id="rules-{%s g.ID %}">
+                <div class="collapse rule-table" id="rules-{%s g.ID %}">
                     <table class="table table-striped table-hover table-sm">
                         <thead>
                             <tr>
@@ -111,7 +119,7 @@ btn-primary
                         </thead>
                         <tbody>
                         {% for _, r := range g.Rules %}
-                            <tr{% if r.LastError != "" %} class="alert-danger"{% endif %}>
+                            <tr class="rule{% if r.LastError != "" %} alert-danger{% endif %}" data-rule-name="{%s r.Name %}" data-bs-target="{%s g.ID %}">
                                 <td>
                                     <div class="row">
                                         <div class="col-12 mb-2">

--- a/app/vmalert/web.qtpl
+++ b/app/vmalert/web.qtpl
@@ -75,14 +75,7 @@ btn-primary
          <a class="btn btn-primary" role="button" onclick="expandAll()">Expand All</a>
          <a class="btn {%= buttonActive(filter, "unhealthy") %}" role="button" onclick="location.href='?filter=unhealthy'" title="Show only rules with errors">Unhealthy</a>
          <a class="btn {%= buttonActive(filter, "noMatch") %}" role="button" onclick="location.href='?filter=noMatch'" title="Show only rules matching no time series during last evaluation">NoMatch</a>
-         <p>
-          <input id="filter" class="input-group" role="input"></input>
-            <a class="btn btn-primary" role="button" onclick="filter()">Filter</a>
-            <form>
-              <input type="radio" name="filterType" id="groups" role="input" checked>By Group Name</input>
-              <input type="radio" name="filterType" id="rules" role="input">By Rule Name</input>
-            </form>
-        </p>
+         <input id="filter" class="input-group" role="input"></input>
         {%  if len(groups) > 0 %}
             {% for _, g := range groups  %}
                   <div
@@ -142,7 +135,7 @@ btn-primary
                                         <div class="col-12 mb-2">
                                             {% if len(r.Labels) > 0 %} <b>Labels:</b>{% endif %}
                                             {% for k, v := range r.Labels %}
-                                                    <span class="ms-1 badge bg-primary">{%s k %}={%s v %}</span>
+                                                    <span class="ms-1 badge bg-primary label">{%s k %}={%s v %}</span>
                                             {% endfor %}
                                         </div>
                                         {% if r.LastError != "" %}

--- a/app/vmalert/web.qtpl
+++ b/app/vmalert/web.qtpl
@@ -70,23 +70,19 @@ btn-primary
                 }
             }
         %}
-        <div class="btn-toolbar mb-3" role="toolbar">
-          <div>
-            <a class="btn {%= buttonActive(filter, "") %}" role="button" onclick="window.location = window.location.pathname">All</a>
-            <a class="btn btn-primary" role="button" onclick="collapseAll()">Collapse All</a>
-            <a class="btn btn-primary" role="button" onclick="expandAll()">Expand All</a>
-            <a class="btn {%= buttonActive(filter, "unhealthy") %}" role="button" onclick="location.href='?filter=unhealthy'" title="Show only rules with errors">Unhealthy</a>
-            <a class="btn {%= buttonActive(filter, "noMatch") %}" role="button" onclick="location.href='?filter=noMatch'" title="Show only rules matching no time series during last evaluation">NoMatch</a>
-          </div>
-          <div class="col-md-4 col-lg-5">
-            <div class="px-3 input-group">
-              <div class="input-group-prepend">
-                <span class="input-group-text">
-                  <svg fill="#000000" height="25px" width="20px" version="1.1" id="Capa_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 490.4 490.4" xml:space="preserve"><g id="SVGRepo_bgCarrier" stroke-width="0"></g><g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"></g><g id="SVGRepo_iconCarrier"> <g> <path d="M484.1,454.796l-110.5-110.6c29.8-36.3,47.6-82.8,47.6-133.4c0-116.3-94.3-210.6-210.6-210.6S0,94.496,0,210.796 s94.3,210.6,210.6,210.6c50.8,0,97.4-18,133.8-48l110.5,110.5c12.9,11.8,25,4.2,29.2,0C492.5,475.596,492.5,463.096,484.1,454.796z M41.1,210.796c0-93.6,75.9-169.5,169.5-169.5s169.6,75.9,169.6,169.5s-75.9,169.5-169.5,169.5S41.1,304.396,41.1,210.796z"></path> </g> </g></svg>
-                </span>
-              </div>
-              <input id="filter" placeholder="Filter by group, rule or labels" type="text" class="form-control"/>
+        <a class="btn {%= buttonActive(filter, "") %}" role="button" onclick="window.location = window.location.pathname">All</a>
+        <a class="btn btn-primary" role="button" onclick="collapseAll()">Collapse All</a>
+        <a class="btn btn-primary" role="button" onclick="expandAll()">Expand All</a>
+        <a class="btn {%= buttonActive(filter, "unhealthy") %}" role="button" onclick="location.href='?filter=unhealthy'" title="Show only rules with errors">Unhealthy</a>
+        <a class="btn {%= buttonActive(filter, "noMatch") %}" role="button" onclick="location.href='?filter=noMatch'" title="Show only rules matching no time series during last evaluation">NoMatch</a>
+        <div class="pt-2 col-md-4 col-lg-4">
+          <div class="input-group">
+            <div class="input-group-prepend">
+              <span class="input-group-text">
+                <svg fill="#000000" height="25px" width="20px" version="1.1" id="Capa_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 490.4 490.4" xml:space="preserve"><g id="SVGRepo_bgCarrier" stroke-width="0"></g><g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"></g><g id="SVGRepo_iconCarrier"> <g> <path d="M484.1,454.796l-110.5-110.6c29.8-36.3,47.6-82.8,47.6-133.4c0-116.3-94.3-210.6-210.6-210.6S0,94.496,0,210.796 s94.3,210.6,210.6,210.6c50.8,0,97.4-18,133.8-48l110.5,110.5c12.9,11.8,25,4.2,29.2,0C492.5,475.596,492.5,463.096,484.1,454.796z M41.1,210.796c0-93.6,75.9-169.5,169.5-169.5s169.6,75.9,169.6,169.5s-75.9,169.5-169.5,169.5S41.1,304.396,41.1,210.796z"></path> </g> </g></svg>
+              </span>
             </div>
+            <input id="filter" placeholder="Filter by group, rule or labels" type="text" class="form-control"/>
           </div>
         </div>
         {%  if len(groups) > 0 %}

--- a/app/vmalert/web.qtpl
+++ b/app/vmalert/web.qtpl
@@ -70,12 +70,25 @@ btn-primary
                 }
             }
         %}
-         <a class="btn {%= buttonActive(filter, "") %}" role="button" onclick="window.location = window.location.pathname">All</a>
-         <a class="btn btn-primary" role="button" onclick="collapseAll()">Collapse All</a>
-         <a class="btn btn-primary" role="button" onclick="expandAll()">Expand All</a>
-         <a class="btn {%= buttonActive(filter, "unhealthy") %}" role="button" onclick="location.href='?filter=unhealthy'" title="Show only rules with errors">Unhealthy</a>
-         <a class="btn {%= buttonActive(filter, "noMatch") %}" role="button" onclick="location.href='?filter=noMatch'" title="Show only rules matching no time series during last evaluation">NoMatch</a>
-         <input id="filter" class="input-group" role="input"></input>
+        <div class="btn-toolbar mb-3" role="toolbar">
+          <div>
+            <a class="btn {%= buttonActive(filter, "") %}" role="button" onclick="window.location = window.location.pathname">All</a>
+            <a class="btn btn-primary" role="button" onclick="collapseAll()">Collapse All</a>
+            <a class="btn btn-primary" role="button" onclick="expandAll()">Expand All</a>
+            <a class="btn {%= buttonActive(filter, "unhealthy") %}" role="button" onclick="location.href='?filter=unhealthy'" title="Show only rules with errors">Unhealthy</a>
+            <a class="btn {%= buttonActive(filter, "noMatch") %}" role="button" onclick="location.href='?filter=noMatch'" title="Show only rules matching no time series during last evaluation">NoMatch</a>
+          </div>
+          <div class="col-md-4 col-lg-5">
+            <div class="px-3 input-group">
+              <div class="input-group-prepend">
+                <span class="input-group-text">
+                  <svg fill="#000000" height="25px" width="20px" version="1.1" id="Capa_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 490.4 490.4" xml:space="preserve"><g id="SVGRepo_bgCarrier" stroke-width="0"></g><g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"></g><g id="SVGRepo_iconCarrier"> <g> <path d="M484.1,454.796l-110.5-110.6c29.8-36.3,47.6-82.8,47.6-133.4c0-116.3-94.3-210.6-210.6-210.6S0,94.496,0,210.796 s94.3,210.6,210.6,210.6c50.8,0,97.4-18,133.8-48l110.5,110.5c12.9,11.8,25,4.2,29.2,0C492.5,475.596,492.5,463.096,484.1,454.796z M41.1,210.796c0-93.6,75.9-169.5,169.5-169.5s169.6,75.9,169.6,169.5s-75.9,169.5-169.5,169.5S41.1,304.396,41.1,210.796z"></path> </g> </g></svg>
+                </span>
+              </div>
+              <input id="filter" placeholder="Filter by group, rule or labels" type="text" class="form-control"/>
+            </div>
+          </div>
+        </div>
         {%  if len(groups) > 0 %}
             {% for _, g := range groups  %}
                   <div

--- a/app/vmalert/web.qtpl.go
+++ b/app/vmalert/web.qtpl.go
@@ -259,153 +259,165 @@ func StreamListGroups(qw422016 *qt422016.Writer, r *http.Request, originGroups [
 	streambuttonActive(qw422016, filter, "noMatch")
 //line app/vmalert/web.qtpl:77
 	qw422016.N().S(`" role="button" onclick="location.href='?filter=noMatch'" title="Show only rules matching no time series during last evaluation">NoMatch</a>
+         <p>
+          <input id="filter" class="input-group" role="input"></input>
+            <a class="btn btn-primary" role="button" onclick="filter()">Filter</a>
+            <form>
+              <input type="radio" name="filterType" id="groups" role="input" checked>By Group Name</input>
+              <input type="radio" name="filterType" id="rules" role="input">By Rule Name</input>
+            </form>
+        </p>
         `)
-//line app/vmalert/web.qtpl:78
+//line app/vmalert/web.qtpl:86
 	if len(groups) > 0 {
-//line app/vmalert/web.qtpl:78
+//line app/vmalert/web.qtpl:86
 		qw422016.N().S(`
             `)
-//line app/vmalert/web.qtpl:79
+//line app/vmalert/web.qtpl:87
 		for _, g := range groups {
-//line app/vmalert/web.qtpl:79
+//line app/vmalert/web.qtpl:87
 			qw422016.N().S(`
                   <div
                     class="group-heading`)
-//line app/vmalert/web.qtpl:81
+//line app/vmalert/web.qtpl:89
 			if rNotOk[g.ID] > 0 {
-//line app/vmalert/web.qtpl:81
+//line app/vmalert/web.qtpl:89
 				qw422016.N().S(` alert-danger`)
-//line app/vmalert/web.qtpl:81
+//line app/vmalert/web.qtpl:89
 			}
-//line app/vmalert/web.qtpl:81
+//line app/vmalert/web.qtpl:89
 			qw422016.N().S(`" data-bs-target="rules-`)
-//line app/vmalert/web.qtpl:81
+//line app/vmalert/web.qtpl:89
 			qw422016.E().S(g.ID)
-//line app/vmalert/web.qtpl:81
+//line app/vmalert/web.qtpl:89
+			qw422016.N().S(`" data-group-name="`)
+//line app/vmalert/web.qtpl:89
+			qw422016.E().S(g.Name)
+//line app/vmalert/web.qtpl:89
 			qw422016.N().S(`">
                     <span class="anchor" id="group-`)
-//line app/vmalert/web.qtpl:82
+//line app/vmalert/web.qtpl:90
 			qw422016.E().S(g.ID)
-//line app/vmalert/web.qtpl:82
+//line app/vmalert/web.qtpl:90
 			qw422016.N().S(`"></span>
                     <a href="#group-`)
-//line app/vmalert/web.qtpl:83
+//line app/vmalert/web.qtpl:91
 			qw422016.E().S(g.ID)
-//line app/vmalert/web.qtpl:83
+//line app/vmalert/web.qtpl:91
 			qw422016.N().S(`">`)
-//line app/vmalert/web.qtpl:83
+//line app/vmalert/web.qtpl:91
 			qw422016.E().S(g.Name)
-//line app/vmalert/web.qtpl:83
+//line app/vmalert/web.qtpl:91
 			if g.Type != "prometheus" {
-//line app/vmalert/web.qtpl:83
+//line app/vmalert/web.qtpl:91
 				qw422016.N().S(` (`)
-//line app/vmalert/web.qtpl:83
+//line app/vmalert/web.qtpl:91
 				qw422016.E().S(g.Type)
-//line app/vmalert/web.qtpl:83
+//line app/vmalert/web.qtpl:91
 				qw422016.N().S(`)`)
-//line app/vmalert/web.qtpl:83
+//line app/vmalert/web.qtpl:91
 			}
-//line app/vmalert/web.qtpl:83
+//line app/vmalert/web.qtpl:91
 			qw422016.N().S(` (every `)
-//line app/vmalert/web.qtpl:83
+//line app/vmalert/web.qtpl:91
 			qw422016.N().FPrec(g.Interval, 0)
-//line app/vmalert/web.qtpl:83
+//line app/vmalert/web.qtpl:91
 			qw422016.N().S(`s) #</a>
                      `)
-//line app/vmalert/web.qtpl:84
+//line app/vmalert/web.qtpl:92
 			if rNotOk[g.ID] > 0 {
-//line app/vmalert/web.qtpl:84
+//line app/vmalert/web.qtpl:92
 				qw422016.N().S(`<span class="badge bg-danger" title="Number of rules with status Error">`)
-//line app/vmalert/web.qtpl:84
+//line app/vmalert/web.qtpl:92
 				qw422016.N().D(rNotOk[g.ID])
-//line app/vmalert/web.qtpl:84
+//line app/vmalert/web.qtpl:92
 				qw422016.N().S(`</span> `)
-//line app/vmalert/web.qtpl:84
+//line app/vmalert/web.qtpl:92
 			}
-//line app/vmalert/web.qtpl:84
+//line app/vmalert/web.qtpl:92
 			qw422016.N().S(`
                      `)
-//line app/vmalert/web.qtpl:85
+//line app/vmalert/web.qtpl:93
 			if rNoMatch[g.ID] > 0 {
-//line app/vmalert/web.qtpl:85
+//line app/vmalert/web.qtpl:93
 				qw422016.N().S(`<span class="badge bg-warning" title="Number of rules with status NoMatch">`)
-//line app/vmalert/web.qtpl:85
+//line app/vmalert/web.qtpl:93
 				qw422016.N().D(rNoMatch[g.ID])
-//line app/vmalert/web.qtpl:85
+//line app/vmalert/web.qtpl:93
 				qw422016.N().S(`</span> `)
-//line app/vmalert/web.qtpl:85
+//line app/vmalert/web.qtpl:93
 			}
-//line app/vmalert/web.qtpl:85
+//line app/vmalert/web.qtpl:93
 			qw422016.N().S(`
                     <span class="badge bg-success" title="Number of rules withs status Ok">`)
-//line app/vmalert/web.qtpl:86
+//line app/vmalert/web.qtpl:94
 			qw422016.N().D(rOk[g.ID])
-//line app/vmalert/web.qtpl:86
+//line app/vmalert/web.qtpl:94
 			qw422016.N().S(`</span>
                     <p class="fs-6 fw-lighter">`)
-//line app/vmalert/web.qtpl:87
+//line app/vmalert/web.qtpl:95
 			qw422016.E().S(g.File)
-//line app/vmalert/web.qtpl:87
+//line app/vmalert/web.qtpl:95
 			qw422016.N().S(`</p>
                     `)
-//line app/vmalert/web.qtpl:88
+//line app/vmalert/web.qtpl:96
 			if len(g.Params) > 0 {
-//line app/vmalert/web.qtpl:88
+//line app/vmalert/web.qtpl:96
 				qw422016.N().S(`
                         <div class="fs-6 fw-lighter">Extra params
                         `)
-//line app/vmalert/web.qtpl:90
+//line app/vmalert/web.qtpl:98
 				for _, param := range g.Params {
-//line app/vmalert/web.qtpl:90
+//line app/vmalert/web.qtpl:98
 					qw422016.N().S(`
                                 <span class="float-left badge bg-primary">`)
-//line app/vmalert/web.qtpl:91
+//line app/vmalert/web.qtpl:99
 					qw422016.E().S(param)
-//line app/vmalert/web.qtpl:91
+//line app/vmalert/web.qtpl:99
 					qw422016.N().S(`</span>
                         `)
-//line app/vmalert/web.qtpl:92
+//line app/vmalert/web.qtpl:100
 				}
-//line app/vmalert/web.qtpl:92
+//line app/vmalert/web.qtpl:100
 				qw422016.N().S(`
                         </div>
                     `)
-//line app/vmalert/web.qtpl:94
+//line app/vmalert/web.qtpl:102
 			}
-//line app/vmalert/web.qtpl:94
+//line app/vmalert/web.qtpl:102
 			qw422016.N().S(`
                     `)
-//line app/vmalert/web.qtpl:95
+//line app/vmalert/web.qtpl:103
 			if len(g.Headers) > 0 {
-//line app/vmalert/web.qtpl:95
+//line app/vmalert/web.qtpl:103
 				qw422016.N().S(`
                         <div class="fs-6 fw-lighter">Extra headers
                         `)
-//line app/vmalert/web.qtpl:97
+//line app/vmalert/web.qtpl:105
 				for _, header := range g.Headers {
-//line app/vmalert/web.qtpl:97
+//line app/vmalert/web.qtpl:105
 					qw422016.N().S(`
                                 <span class="float-left badge bg-primary">`)
-//line app/vmalert/web.qtpl:98
+//line app/vmalert/web.qtpl:106
 					qw422016.E().S(header)
-//line app/vmalert/web.qtpl:98
+//line app/vmalert/web.qtpl:106
 					qw422016.N().S(`</span>
                         `)
-//line app/vmalert/web.qtpl:99
+//line app/vmalert/web.qtpl:107
 				}
-//line app/vmalert/web.qtpl:99
+//line app/vmalert/web.qtpl:107
 				qw422016.N().S(`
                         </div>
                     `)
-//line app/vmalert/web.qtpl:101
+//line app/vmalert/web.qtpl:109
 			}
-//line app/vmalert/web.qtpl:101
+//line app/vmalert/web.qtpl:109
 			qw422016.N().S(`
                 </div>
-                <div class="collapse" id="rules-`)
-//line app/vmalert/web.qtpl:103
+                <div class="collapse rule-table" id="rules-`)
+//line app/vmalert/web.qtpl:111
 			qw422016.E().S(g.ID)
-//line app/vmalert/web.qtpl:103
+//line app/vmalert/web.qtpl:111
 			qw422016.N().S(`">
                     <table class="table table-striped table-hover table-sm">
                         <thead>
@@ -417,300 +429,308 @@ func StreamListGroups(qw422016 *qt422016.Writer, r *http.Request, originGroups [
                         </thead>
                         <tbody>
                         `)
-//line app/vmalert/web.qtpl:113
+//line app/vmalert/web.qtpl:121
 			for _, r := range g.Rules {
-//line app/vmalert/web.qtpl:113
+//line app/vmalert/web.qtpl:121
 				qw422016.N().S(`
-                            <tr`)
-//line app/vmalert/web.qtpl:114
+                            <tr class="rule`)
+//line app/vmalert/web.qtpl:122
 				if r.LastError != "" {
-//line app/vmalert/web.qtpl:114
-					qw422016.N().S(` class="alert-danger"`)
-//line app/vmalert/web.qtpl:114
+//line app/vmalert/web.qtpl:122
+					qw422016.N().S(` alert-danger`)
+//line app/vmalert/web.qtpl:122
 				}
-//line app/vmalert/web.qtpl:114
-				qw422016.N().S(`>
+//line app/vmalert/web.qtpl:122
+				qw422016.N().S(`" data-rule-name="`)
+//line app/vmalert/web.qtpl:122
+				qw422016.E().S(r.Name)
+//line app/vmalert/web.qtpl:122
+				qw422016.N().S(`" data-bs-target="`)
+//line app/vmalert/web.qtpl:122
+				qw422016.E().S(g.ID)
+//line app/vmalert/web.qtpl:122
+				qw422016.N().S(`">
                                 <td>
                                     <div class="row">
                                         <div class="col-12 mb-2">
                                             `)
-//line app/vmalert/web.qtpl:118
+//line app/vmalert/web.qtpl:126
 				if r.Type == "alerting" {
-//line app/vmalert/web.qtpl:118
+//line app/vmalert/web.qtpl:126
 					qw422016.N().S(`
                                             `)
-//line app/vmalert/web.qtpl:119
+//line app/vmalert/web.qtpl:127
 					if r.KeepFiringFor > 0 {
-//line app/vmalert/web.qtpl:119
+//line app/vmalert/web.qtpl:127
 						qw422016.N().S(`
                                             <b>alert:</b> `)
-//line app/vmalert/web.qtpl:120
+//line app/vmalert/web.qtpl:128
 						qw422016.E().S(r.Name)
-//line app/vmalert/web.qtpl:120
+//line app/vmalert/web.qtpl:128
 						qw422016.N().S(` (for: `)
-//line app/vmalert/web.qtpl:120
+//line app/vmalert/web.qtpl:128
 						qw422016.E().V(r.Duration)
-//line app/vmalert/web.qtpl:120
+//line app/vmalert/web.qtpl:128
 						qw422016.N().S(` seconds, keep_firing_for: `)
-//line app/vmalert/web.qtpl:120
+//line app/vmalert/web.qtpl:128
 						qw422016.E().V(r.KeepFiringFor)
-//line app/vmalert/web.qtpl:120
+//line app/vmalert/web.qtpl:128
 						qw422016.N().S(` seconds)
                                             `)
-//line app/vmalert/web.qtpl:121
+//line app/vmalert/web.qtpl:129
 					} else {
-//line app/vmalert/web.qtpl:121
+//line app/vmalert/web.qtpl:129
 						qw422016.N().S(`
                                             <b>alert:</b> `)
-//line app/vmalert/web.qtpl:122
+//line app/vmalert/web.qtpl:130
 						qw422016.E().S(r.Name)
-//line app/vmalert/web.qtpl:122
+//line app/vmalert/web.qtpl:130
 						qw422016.N().S(` (for: `)
-//line app/vmalert/web.qtpl:122
+//line app/vmalert/web.qtpl:130
 						qw422016.E().V(r.Duration)
-//line app/vmalert/web.qtpl:122
+//line app/vmalert/web.qtpl:130
 						qw422016.N().S(` seconds)
                                             `)
-//line app/vmalert/web.qtpl:123
+//line app/vmalert/web.qtpl:131
 					}
-//line app/vmalert/web.qtpl:123
+//line app/vmalert/web.qtpl:131
 					qw422016.N().S(`
                                             `)
-//line app/vmalert/web.qtpl:124
+//line app/vmalert/web.qtpl:132
 				} else {
-//line app/vmalert/web.qtpl:124
+//line app/vmalert/web.qtpl:132
 					qw422016.N().S(`
                                             <b>record:</b> `)
-//line app/vmalert/web.qtpl:125
+//line app/vmalert/web.qtpl:133
 					qw422016.E().S(r.Name)
-//line app/vmalert/web.qtpl:125
+//line app/vmalert/web.qtpl:133
 					qw422016.N().S(`
                                             `)
-//line app/vmalert/web.qtpl:126
+//line app/vmalert/web.qtpl:134
 				}
-//line app/vmalert/web.qtpl:126
+//line app/vmalert/web.qtpl:134
 				qw422016.N().S(`
                                             |
                                             `)
-//line app/vmalert/web.qtpl:128
+//line app/vmalert/web.qtpl:136
 				streamseriesFetchedWarn(qw422016, r)
-//line app/vmalert/web.qtpl:128
+//line app/vmalert/web.qtpl:136
 				qw422016.N().S(`
                                             <span><a target="_blank" href="`)
-//line app/vmalert/web.qtpl:129
+//line app/vmalert/web.qtpl:137
 				qw422016.E().S(prefix + r.WebLink())
-//line app/vmalert/web.qtpl:129
+//line app/vmalert/web.qtpl:137
 				qw422016.N().S(`">Details</a></span>
                                         </div>
                                         <div class="col-12">
                                             <code><pre>`)
-//line app/vmalert/web.qtpl:132
+//line app/vmalert/web.qtpl:140
 				qw422016.E().S(r.Query)
-//line app/vmalert/web.qtpl:132
+//line app/vmalert/web.qtpl:140
 				qw422016.N().S(`</pre></code>
                                         </div>
                                         <div class="col-12 mb-2">
                                             `)
-//line app/vmalert/web.qtpl:135
+//line app/vmalert/web.qtpl:143
 				if len(r.Labels) > 0 {
-//line app/vmalert/web.qtpl:135
+//line app/vmalert/web.qtpl:143
 					qw422016.N().S(` <b>Labels:</b>`)
-//line app/vmalert/web.qtpl:135
+//line app/vmalert/web.qtpl:143
 				}
-//line app/vmalert/web.qtpl:135
+//line app/vmalert/web.qtpl:143
 				qw422016.N().S(`
                                             `)
-//line app/vmalert/web.qtpl:136
+//line app/vmalert/web.qtpl:144
 				for k, v := range r.Labels {
-//line app/vmalert/web.qtpl:136
+//line app/vmalert/web.qtpl:144
 					qw422016.N().S(`
                                                     <span class="ms-1 badge bg-primary">`)
-//line app/vmalert/web.qtpl:137
+//line app/vmalert/web.qtpl:145
 					qw422016.E().S(k)
-//line app/vmalert/web.qtpl:137
+//line app/vmalert/web.qtpl:145
 					qw422016.N().S(`=`)
-//line app/vmalert/web.qtpl:137
+//line app/vmalert/web.qtpl:145
 					qw422016.E().S(v)
-//line app/vmalert/web.qtpl:137
+//line app/vmalert/web.qtpl:145
 					qw422016.N().S(`</span>
                                             `)
-//line app/vmalert/web.qtpl:138
+//line app/vmalert/web.qtpl:146
 				}
-//line app/vmalert/web.qtpl:138
+//line app/vmalert/web.qtpl:146
 				qw422016.N().S(`
                                         </div>
                                         `)
-//line app/vmalert/web.qtpl:140
+//line app/vmalert/web.qtpl:148
 				if r.LastError != "" {
-//line app/vmalert/web.qtpl:140
+//line app/vmalert/web.qtpl:148
 					qw422016.N().S(`
                                         <div class="col-12">
                                             <b>Error:</b>
                                             <div class="error-cell">
                                             `)
-//line app/vmalert/web.qtpl:144
+//line app/vmalert/web.qtpl:152
 					qw422016.E().S(r.LastError)
-//line app/vmalert/web.qtpl:144
+//line app/vmalert/web.qtpl:152
 					qw422016.N().S(`
                                             </div>
                                         </div>
                                         `)
-//line app/vmalert/web.qtpl:147
+//line app/vmalert/web.qtpl:155
 				}
-//line app/vmalert/web.qtpl:147
+//line app/vmalert/web.qtpl:155
 				qw422016.N().S(`
                                     </div>
                                 </td>
                                 <td class="text-center">`)
-//line app/vmalert/web.qtpl:150
+//line app/vmalert/web.qtpl:158
 				qw422016.N().D(r.LastSamples)
-//line app/vmalert/web.qtpl:150
+//line app/vmalert/web.qtpl:158
 				qw422016.N().S(`</td>
                                 <td class="text-center">`)
-//line app/vmalert/web.qtpl:151
+//line app/vmalert/web.qtpl:159
 				qw422016.N().FPrec(time.Since(r.LastEvaluation).Seconds(), 3)
-//line app/vmalert/web.qtpl:151
+//line app/vmalert/web.qtpl:159
 				qw422016.N().S(`s ago</td>
                             </tr>
                         `)
-//line app/vmalert/web.qtpl:153
+//line app/vmalert/web.qtpl:161
 			}
-//line app/vmalert/web.qtpl:153
+//line app/vmalert/web.qtpl:161
 			qw422016.N().S(`
                      </tbody>
                     </table>
                 </div>
             `)
-//line app/vmalert/web.qtpl:157
+//line app/vmalert/web.qtpl:165
 		}
-//line app/vmalert/web.qtpl:157
+//line app/vmalert/web.qtpl:165
 		qw422016.N().S(`
         `)
-//line app/vmalert/web.qtpl:158
+//line app/vmalert/web.qtpl:166
 	} else {
-//line app/vmalert/web.qtpl:158
+//line app/vmalert/web.qtpl:166
 		qw422016.N().S(`
             <div>
                 <p>No groups...</p>
             </div>
         `)
-//line app/vmalert/web.qtpl:162
+//line app/vmalert/web.qtpl:170
 	}
-//line app/vmalert/web.qtpl:162
+//line app/vmalert/web.qtpl:170
 	qw422016.N().S(`
 
     `)
-//line app/vmalert/web.qtpl:164
+//line app/vmalert/web.qtpl:172
 	tpl.StreamFooter(qw422016, r)
-//line app/vmalert/web.qtpl:164
+//line app/vmalert/web.qtpl:172
 	qw422016.N().S(`
 
 `)
-//line app/vmalert/web.qtpl:166
+//line app/vmalert/web.qtpl:174
 }
 
-//line app/vmalert/web.qtpl:166
+//line app/vmalert/web.qtpl:174
 func WriteListGroups(qq422016 qtio422016.Writer, r *http.Request, originGroups []apiGroup) {
-//line app/vmalert/web.qtpl:166
+//line app/vmalert/web.qtpl:174
 	qw422016 := qt422016.AcquireWriter(qq422016)
-//line app/vmalert/web.qtpl:166
+//line app/vmalert/web.qtpl:174
 	StreamListGroups(qw422016, r, originGroups)
-//line app/vmalert/web.qtpl:166
+//line app/vmalert/web.qtpl:174
 	qt422016.ReleaseWriter(qw422016)
-//line app/vmalert/web.qtpl:166
+//line app/vmalert/web.qtpl:174
 }
 
-//line app/vmalert/web.qtpl:166
+//line app/vmalert/web.qtpl:174
 func ListGroups(r *http.Request, originGroups []apiGroup) string {
-//line app/vmalert/web.qtpl:166
+//line app/vmalert/web.qtpl:174
 	qb422016 := qt422016.AcquireByteBuffer()
-//line app/vmalert/web.qtpl:166
+//line app/vmalert/web.qtpl:174
 	WriteListGroups(qb422016, r, originGroups)
-//line app/vmalert/web.qtpl:166
+//line app/vmalert/web.qtpl:174
 	qs422016 := string(qb422016.B)
-//line app/vmalert/web.qtpl:166
+//line app/vmalert/web.qtpl:174
 	qt422016.ReleaseByteBuffer(qb422016)
-//line app/vmalert/web.qtpl:166
+//line app/vmalert/web.qtpl:174
 	return qs422016
-//line app/vmalert/web.qtpl:166
+//line app/vmalert/web.qtpl:174
 }
 
-//line app/vmalert/web.qtpl:169
+//line app/vmalert/web.qtpl:177
 func StreamListAlerts(qw422016 *qt422016.Writer, r *http.Request, groupAlerts []groupAlerts) {
-//line app/vmalert/web.qtpl:169
+//line app/vmalert/web.qtpl:177
 	qw422016.N().S(`
     `)
-//line app/vmalert/web.qtpl:170
+//line app/vmalert/web.qtpl:178
 	prefix := utils.Prefix(r.URL.Path)
 
-//line app/vmalert/web.qtpl:170
+//line app/vmalert/web.qtpl:178
 	qw422016.N().S(`
     `)
-//line app/vmalert/web.qtpl:171
+//line app/vmalert/web.qtpl:179
 	tpl.StreamHeader(qw422016, r, navItems, "Alerts", getLastConfigError())
-//line app/vmalert/web.qtpl:171
+//line app/vmalert/web.qtpl:179
 	qw422016.N().S(`
     `)
-//line app/vmalert/web.qtpl:172
+//line app/vmalert/web.qtpl:180
 	if len(groupAlerts) > 0 {
-//line app/vmalert/web.qtpl:172
+//line app/vmalert/web.qtpl:180
 		qw422016.N().S(`
          <a class="btn btn-primary" role="button" onclick="collapseAll()">Collapse All</a>
          <a class="btn btn-primary" role="button" onclick="expandAll()">Expand All</a>
          `)
-//line app/vmalert/web.qtpl:175
+//line app/vmalert/web.qtpl:183
 		for _, ga := range groupAlerts {
-//line app/vmalert/web.qtpl:175
+//line app/vmalert/web.qtpl:183
 			qw422016.N().S(`
             `)
-//line app/vmalert/web.qtpl:176
+//line app/vmalert/web.qtpl:184
 			g := ga.Group
 
-//line app/vmalert/web.qtpl:176
+//line app/vmalert/web.qtpl:184
 			qw422016.N().S(`
             <div class="group-heading alert-danger" data-bs-target="rules-`)
-//line app/vmalert/web.qtpl:177
+//line app/vmalert/web.qtpl:185
 			qw422016.E().S(g.ID)
-//line app/vmalert/web.qtpl:177
+//line app/vmalert/web.qtpl:185
 			qw422016.N().S(`">
                 <span class="anchor" id="group-`)
-//line app/vmalert/web.qtpl:178
+//line app/vmalert/web.qtpl:186
 			qw422016.E().S(g.ID)
-//line app/vmalert/web.qtpl:178
+//line app/vmalert/web.qtpl:186
 			qw422016.N().S(`"></span>
                 <a href="#group-`)
-//line app/vmalert/web.qtpl:179
+//line app/vmalert/web.qtpl:187
 			qw422016.E().S(g.ID)
-//line app/vmalert/web.qtpl:179
+//line app/vmalert/web.qtpl:187
 			qw422016.N().S(`">`)
-//line app/vmalert/web.qtpl:179
+//line app/vmalert/web.qtpl:187
 			qw422016.E().S(g.Name)
-//line app/vmalert/web.qtpl:179
+//line app/vmalert/web.qtpl:187
 			if g.Type != "prometheus" {
-//line app/vmalert/web.qtpl:179
+//line app/vmalert/web.qtpl:187
 				qw422016.N().S(` (`)
-//line app/vmalert/web.qtpl:179
+//line app/vmalert/web.qtpl:187
 				qw422016.E().S(g.Type)
-//line app/vmalert/web.qtpl:179
+//line app/vmalert/web.qtpl:187
 				qw422016.N().S(`)`)
-//line app/vmalert/web.qtpl:179
+//line app/vmalert/web.qtpl:187
 			}
-//line app/vmalert/web.qtpl:179
+//line app/vmalert/web.qtpl:187
 			qw422016.N().S(`</a>
                 <span class="badge bg-danger" title="Number of active alerts">`)
-//line app/vmalert/web.qtpl:180
+//line app/vmalert/web.qtpl:188
 			qw422016.N().D(len(ga.Alerts))
-//line app/vmalert/web.qtpl:180
+//line app/vmalert/web.qtpl:188
 			qw422016.N().S(`</span>
                 <br>
                 <p class="fs-6 fw-lighter">`)
-//line app/vmalert/web.qtpl:182
+//line app/vmalert/web.qtpl:190
 			qw422016.E().S(g.File)
-//line app/vmalert/web.qtpl:182
+//line app/vmalert/web.qtpl:190
 			qw422016.N().S(`</p>
             </div>
             `)
-//line app/vmalert/web.qtpl:185
+//line app/vmalert/web.qtpl:193
 			var keys []string
 			alertsByRule := make(map[string][]*apiAlert)
 			for _, alert := range ga.Alerts {
@@ -721,20 +741,20 @@ func StreamListAlerts(qw422016 *qt422016.Writer, r *http.Request, groupAlerts []
 			}
 			sort.Strings(keys)
 
-//line app/vmalert/web.qtpl:194
+//line app/vmalert/web.qtpl:202
 			qw422016.N().S(`
             <div class="collapse" id="rules-`)
-//line app/vmalert/web.qtpl:195
+//line app/vmalert/web.qtpl:203
 			qw422016.E().S(g.ID)
-//line app/vmalert/web.qtpl:195
+//line app/vmalert/web.qtpl:203
 			qw422016.N().S(`">
                 `)
-//line app/vmalert/web.qtpl:196
+//line app/vmalert/web.qtpl:204
 			for _, ruleID := range keys {
-//line app/vmalert/web.qtpl:196
+//line app/vmalert/web.qtpl:204
 				qw422016.N().S(`
                     `)
-//line app/vmalert/web.qtpl:198
+//line app/vmalert/web.qtpl:206
 				defaultAR := alertsByRule[ruleID][0]
 				var labelKeys []string
 				for k := range defaultAR.Labels {
@@ -742,28 +762,28 @@ func StreamListAlerts(qw422016 *qt422016.Writer, r *http.Request, groupAlerts []
 				}
 				sort.Strings(labelKeys)
 
-//line app/vmalert/web.qtpl:204
+//line app/vmalert/web.qtpl:212
 				qw422016.N().S(`
                     <br>
                     <b>alert:</b> `)
-//line app/vmalert/web.qtpl:206
+//line app/vmalert/web.qtpl:214
 				qw422016.E().S(defaultAR.Name)
-//line app/vmalert/web.qtpl:206
+//line app/vmalert/web.qtpl:214
 				qw422016.N().S(` (`)
-//line app/vmalert/web.qtpl:206
+//line app/vmalert/web.qtpl:214
 				qw422016.N().D(len(alertsByRule[ruleID]))
-//line app/vmalert/web.qtpl:206
+//line app/vmalert/web.qtpl:214
 				qw422016.N().S(`)
                      | <span><a target="_blank" href="`)
-//line app/vmalert/web.qtpl:207
+//line app/vmalert/web.qtpl:215
 				qw422016.E().S(defaultAR.SourceLink)
-//line app/vmalert/web.qtpl:207
+//line app/vmalert/web.qtpl:215
 				qw422016.N().S(`">Source</a></span>
                     <br>
                     <b>expr:</b><code><pre>`)
-//line app/vmalert/web.qtpl:209
+//line app/vmalert/web.qtpl:217
 				qw422016.E().S(defaultAR.Expression)
-//line app/vmalert/web.qtpl:209
+//line app/vmalert/web.qtpl:217
 				qw422016.N().S(`</pre></code>
                     <table class="table table-striped table-hover table-sm">
                         <thead>
@@ -777,213 +797,213 @@ func StreamListAlerts(qw422016 *qt422016.Writer, r *http.Request, groupAlerts []
                         </thead>
                         <tbody>
                         `)
-//line app/vmalert/web.qtpl:221
+//line app/vmalert/web.qtpl:229
 				for _, ar := range alertsByRule[ruleID] {
-//line app/vmalert/web.qtpl:221
+//line app/vmalert/web.qtpl:229
 					qw422016.N().S(`
                             <tr>
                                 <td>
                                     `)
-//line app/vmalert/web.qtpl:224
+//line app/vmalert/web.qtpl:232
 					for _, k := range labelKeys {
-//line app/vmalert/web.qtpl:224
+//line app/vmalert/web.qtpl:232
 						qw422016.N().S(`
                                         <span class="ms-1 badge bg-primary">`)
-//line app/vmalert/web.qtpl:225
+//line app/vmalert/web.qtpl:233
 						qw422016.E().S(k)
-//line app/vmalert/web.qtpl:225
+//line app/vmalert/web.qtpl:233
 						qw422016.N().S(`=`)
-//line app/vmalert/web.qtpl:225
+//line app/vmalert/web.qtpl:233
 						qw422016.E().S(ar.Labels[k])
-//line app/vmalert/web.qtpl:225
+//line app/vmalert/web.qtpl:233
 						qw422016.N().S(`</span>
                                     `)
-//line app/vmalert/web.qtpl:226
+//line app/vmalert/web.qtpl:234
 					}
-//line app/vmalert/web.qtpl:226
+//line app/vmalert/web.qtpl:234
 					qw422016.N().S(`
                                 </td>
                                 <td>`)
-//line app/vmalert/web.qtpl:228
+//line app/vmalert/web.qtpl:236
 					streambadgeState(qw422016, ar.State)
-//line app/vmalert/web.qtpl:228
+//line app/vmalert/web.qtpl:236
 					qw422016.N().S(`</td>
                                 <td>
                                     `)
-//line app/vmalert/web.qtpl:230
+//line app/vmalert/web.qtpl:238
 					qw422016.E().S(ar.ActiveAt.Format("2006-01-02T15:04:05Z07:00"))
-//line app/vmalert/web.qtpl:230
+//line app/vmalert/web.qtpl:238
 					qw422016.N().S(`
                                     `)
-//line app/vmalert/web.qtpl:231
+//line app/vmalert/web.qtpl:239
 					if ar.Restored {
-//line app/vmalert/web.qtpl:231
+//line app/vmalert/web.qtpl:239
 						streambadgeRestored(qw422016)
-//line app/vmalert/web.qtpl:231
+//line app/vmalert/web.qtpl:239
 					}
-//line app/vmalert/web.qtpl:231
+//line app/vmalert/web.qtpl:239
 					qw422016.N().S(`
                                     `)
-//line app/vmalert/web.qtpl:232
+//line app/vmalert/web.qtpl:240
 					if ar.Stabilizing {
-//line app/vmalert/web.qtpl:232
+//line app/vmalert/web.qtpl:240
 						streambadgeStabilizing(qw422016)
-//line app/vmalert/web.qtpl:232
+//line app/vmalert/web.qtpl:240
 					}
-//line app/vmalert/web.qtpl:232
+//line app/vmalert/web.qtpl:240
 					qw422016.N().S(`
                                 </td>
                                 <td>`)
-//line app/vmalert/web.qtpl:234
+//line app/vmalert/web.qtpl:242
 					qw422016.E().S(ar.Value)
-//line app/vmalert/web.qtpl:234
+//line app/vmalert/web.qtpl:242
 					qw422016.N().S(`</td>
                                 <td>
                                     <a href="`)
-//line app/vmalert/web.qtpl:236
+//line app/vmalert/web.qtpl:244
 					qw422016.E().S(prefix + ar.WebLink())
-//line app/vmalert/web.qtpl:236
+//line app/vmalert/web.qtpl:244
 					qw422016.N().S(`">Details</a>
                                 </td>
                             </tr>
                         `)
-//line app/vmalert/web.qtpl:239
+//line app/vmalert/web.qtpl:247
 				}
-//line app/vmalert/web.qtpl:239
+//line app/vmalert/web.qtpl:247
 				qw422016.N().S(`
                      </tbody>
                     </table>
                 `)
-//line app/vmalert/web.qtpl:242
+//line app/vmalert/web.qtpl:250
 			}
-//line app/vmalert/web.qtpl:242
+//line app/vmalert/web.qtpl:250
 			qw422016.N().S(`
             </div>
             <br>
         `)
-//line app/vmalert/web.qtpl:245
+//line app/vmalert/web.qtpl:253
 		}
-//line app/vmalert/web.qtpl:245
+//line app/vmalert/web.qtpl:253
 		qw422016.N().S(`
 
     `)
-//line app/vmalert/web.qtpl:247
+//line app/vmalert/web.qtpl:255
 	} else {
-//line app/vmalert/web.qtpl:247
+//line app/vmalert/web.qtpl:255
 		qw422016.N().S(`
         <div>
             <p>No active alerts...</p>
         </div>
     `)
-//line app/vmalert/web.qtpl:251
+//line app/vmalert/web.qtpl:259
 	}
-//line app/vmalert/web.qtpl:251
+//line app/vmalert/web.qtpl:259
 	qw422016.N().S(`
 
     `)
-//line app/vmalert/web.qtpl:253
+//line app/vmalert/web.qtpl:261
 	tpl.StreamFooter(qw422016, r)
-//line app/vmalert/web.qtpl:253
+//line app/vmalert/web.qtpl:261
 	qw422016.N().S(`
 
 `)
-//line app/vmalert/web.qtpl:255
+//line app/vmalert/web.qtpl:263
 }
 
-//line app/vmalert/web.qtpl:255
+//line app/vmalert/web.qtpl:263
 func WriteListAlerts(qq422016 qtio422016.Writer, r *http.Request, groupAlerts []groupAlerts) {
-//line app/vmalert/web.qtpl:255
+//line app/vmalert/web.qtpl:263
 	qw422016 := qt422016.AcquireWriter(qq422016)
-//line app/vmalert/web.qtpl:255
+//line app/vmalert/web.qtpl:263
 	StreamListAlerts(qw422016, r, groupAlerts)
-//line app/vmalert/web.qtpl:255
+//line app/vmalert/web.qtpl:263
 	qt422016.ReleaseWriter(qw422016)
-//line app/vmalert/web.qtpl:255
+//line app/vmalert/web.qtpl:263
 }
 
-//line app/vmalert/web.qtpl:255
+//line app/vmalert/web.qtpl:263
 func ListAlerts(r *http.Request, groupAlerts []groupAlerts) string {
-//line app/vmalert/web.qtpl:255
+//line app/vmalert/web.qtpl:263
 	qb422016 := qt422016.AcquireByteBuffer()
-//line app/vmalert/web.qtpl:255
+//line app/vmalert/web.qtpl:263
 	WriteListAlerts(qb422016, r, groupAlerts)
-//line app/vmalert/web.qtpl:255
+//line app/vmalert/web.qtpl:263
 	qs422016 := string(qb422016.B)
-//line app/vmalert/web.qtpl:255
+//line app/vmalert/web.qtpl:263
 	qt422016.ReleaseByteBuffer(qb422016)
-//line app/vmalert/web.qtpl:255
+//line app/vmalert/web.qtpl:263
 	return qs422016
-//line app/vmalert/web.qtpl:255
+//line app/vmalert/web.qtpl:263
 }
 
-//line app/vmalert/web.qtpl:257
+//line app/vmalert/web.qtpl:265
 func StreamListTargets(qw422016 *qt422016.Writer, r *http.Request, targets map[notifier.TargetType][]notifier.Target) {
-//line app/vmalert/web.qtpl:257
+//line app/vmalert/web.qtpl:265
 	qw422016.N().S(`
     `)
-//line app/vmalert/web.qtpl:258
+//line app/vmalert/web.qtpl:266
 	tpl.StreamHeader(qw422016, r, navItems, "Notifiers", getLastConfigError())
-//line app/vmalert/web.qtpl:258
+//line app/vmalert/web.qtpl:266
 	qw422016.N().S(`
     `)
-//line app/vmalert/web.qtpl:259
+//line app/vmalert/web.qtpl:267
 	if len(targets) > 0 {
-//line app/vmalert/web.qtpl:259
+//line app/vmalert/web.qtpl:267
 		qw422016.N().S(`
          <a class="btn btn-primary" role="button" onclick="collapseAll()">Collapse All</a>
          <a class="btn btn-primary" role="button" onclick="expandAll()">Expand All</a>
 
          `)
-//line app/vmalert/web.qtpl:264
+//line app/vmalert/web.qtpl:272
 		var keys []string
 		for key := range targets {
 			keys = append(keys, string(key))
 		}
 		sort.Strings(keys)
 
-//line app/vmalert/web.qtpl:269
+//line app/vmalert/web.qtpl:277
 		qw422016.N().S(`
 
          `)
-//line app/vmalert/web.qtpl:271
+//line app/vmalert/web.qtpl:279
 		for i := range keys {
-//line app/vmalert/web.qtpl:271
+//line app/vmalert/web.qtpl:279
 			qw422016.N().S(`
            `)
-//line app/vmalert/web.qtpl:272
+//line app/vmalert/web.qtpl:280
 			typeK, ns := keys[i], targets[notifier.TargetType(keys[i])]
 			count := len(ns)
 
-//line app/vmalert/web.qtpl:274
+//line app/vmalert/web.qtpl:282
 			qw422016.N().S(`
            <div class="group-heading" data-bs-target="notifiers-`)
-//line app/vmalert/web.qtpl:275
+//line app/vmalert/web.qtpl:283
 			qw422016.E().S(typeK)
-//line app/vmalert/web.qtpl:275
+//line app/vmalert/web.qtpl:283
 			qw422016.N().S(`">
              <span class="anchor" id="group-`)
-//line app/vmalert/web.qtpl:276
+//line app/vmalert/web.qtpl:284
 			qw422016.E().S(typeK)
-//line app/vmalert/web.qtpl:276
+//line app/vmalert/web.qtpl:284
 			qw422016.N().S(`"></span>
              <a href="#group-`)
-//line app/vmalert/web.qtpl:277
+//line app/vmalert/web.qtpl:285
 			qw422016.E().S(typeK)
-//line app/vmalert/web.qtpl:277
+//line app/vmalert/web.qtpl:285
 			qw422016.N().S(`">`)
-//line app/vmalert/web.qtpl:277
+//line app/vmalert/web.qtpl:285
 			qw422016.E().S(typeK)
-//line app/vmalert/web.qtpl:277
+//line app/vmalert/web.qtpl:285
 			qw422016.N().S(` (`)
-//line app/vmalert/web.qtpl:277
+//line app/vmalert/web.qtpl:285
 			qw422016.N().D(count)
-//line app/vmalert/web.qtpl:277
+//line app/vmalert/web.qtpl:285
 			qw422016.N().S(`)</a>
          </div>
          <div class="collapse show" id="notifiers-`)
-//line app/vmalert/web.qtpl:279
+//line app/vmalert/web.qtpl:287
 			qw422016.E().S(typeK)
-//line app/vmalert/web.qtpl:279
+//line app/vmalert/web.qtpl:287
 			qw422016.N().S(`">
              <table class="table table-striped table-hover table-sm">
                  <thead>
@@ -994,119 +1014,119 @@ func StreamListTargets(qw422016 *qt422016.Writer, r *http.Request, targets map[n
                  </thead>
                  <tbody>
                  `)
-//line app/vmalert/web.qtpl:288
+//line app/vmalert/web.qtpl:296
 			for _, n := range ns {
-//line app/vmalert/web.qtpl:288
+//line app/vmalert/web.qtpl:296
 				qw422016.N().S(`
                      <tr>
                          <td>
                               `)
-//line app/vmalert/web.qtpl:291
+//line app/vmalert/web.qtpl:299
 				for _, l := range n.Labels.GetLabels() {
-//line app/vmalert/web.qtpl:291
+//line app/vmalert/web.qtpl:299
 					qw422016.N().S(`
                                       <span class="ms-1 badge bg-primary">`)
-//line app/vmalert/web.qtpl:292
+//line app/vmalert/web.qtpl:300
 					qw422016.E().S(l.Name)
-//line app/vmalert/web.qtpl:292
+//line app/vmalert/web.qtpl:300
 					qw422016.N().S(`=`)
-//line app/vmalert/web.qtpl:292
+//line app/vmalert/web.qtpl:300
 					qw422016.E().S(l.Value)
-//line app/vmalert/web.qtpl:292
+//line app/vmalert/web.qtpl:300
 					qw422016.N().S(`</span>
                               `)
-//line app/vmalert/web.qtpl:293
+//line app/vmalert/web.qtpl:301
 				}
-//line app/vmalert/web.qtpl:293
+//line app/vmalert/web.qtpl:301
 				qw422016.N().S(`
                           </td>
                          <td>`)
-//line app/vmalert/web.qtpl:295
+//line app/vmalert/web.qtpl:303
 				qw422016.E().S(n.Notifier.Addr())
-//line app/vmalert/web.qtpl:295
+//line app/vmalert/web.qtpl:303
 				qw422016.N().S(`</td>
                      </tr>
                  `)
-//line app/vmalert/web.qtpl:297
+//line app/vmalert/web.qtpl:305
 			}
-//line app/vmalert/web.qtpl:297
+//line app/vmalert/web.qtpl:305
 			qw422016.N().S(`
               </tbody>
              </table>
          </div>
      `)
-//line app/vmalert/web.qtpl:301
+//line app/vmalert/web.qtpl:309
 		}
-//line app/vmalert/web.qtpl:301
+//line app/vmalert/web.qtpl:309
 		qw422016.N().S(`
 
     `)
-//line app/vmalert/web.qtpl:303
+//line app/vmalert/web.qtpl:311
 	} else {
-//line app/vmalert/web.qtpl:303
+//line app/vmalert/web.qtpl:311
 		qw422016.N().S(`
         <div>
             <p>No targets...</p>
         </div>
     `)
-//line app/vmalert/web.qtpl:307
+//line app/vmalert/web.qtpl:315
 	}
-//line app/vmalert/web.qtpl:307
+//line app/vmalert/web.qtpl:315
 	qw422016.N().S(`
 
     `)
-//line app/vmalert/web.qtpl:309
+//line app/vmalert/web.qtpl:317
 	tpl.StreamFooter(qw422016, r)
-//line app/vmalert/web.qtpl:309
+//line app/vmalert/web.qtpl:317
 	qw422016.N().S(`
 
 `)
-//line app/vmalert/web.qtpl:311
+//line app/vmalert/web.qtpl:319
 }
 
-//line app/vmalert/web.qtpl:311
+//line app/vmalert/web.qtpl:319
 func WriteListTargets(qq422016 qtio422016.Writer, r *http.Request, targets map[notifier.TargetType][]notifier.Target) {
-//line app/vmalert/web.qtpl:311
+//line app/vmalert/web.qtpl:319
 	qw422016 := qt422016.AcquireWriter(qq422016)
-//line app/vmalert/web.qtpl:311
+//line app/vmalert/web.qtpl:319
 	StreamListTargets(qw422016, r, targets)
-//line app/vmalert/web.qtpl:311
+//line app/vmalert/web.qtpl:319
 	qt422016.ReleaseWriter(qw422016)
-//line app/vmalert/web.qtpl:311
+//line app/vmalert/web.qtpl:319
 }
 
-//line app/vmalert/web.qtpl:311
+//line app/vmalert/web.qtpl:319
 func ListTargets(r *http.Request, targets map[notifier.TargetType][]notifier.Target) string {
-//line app/vmalert/web.qtpl:311
+//line app/vmalert/web.qtpl:319
 	qb422016 := qt422016.AcquireByteBuffer()
-//line app/vmalert/web.qtpl:311
+//line app/vmalert/web.qtpl:319
 	WriteListTargets(qb422016, r, targets)
-//line app/vmalert/web.qtpl:311
+//line app/vmalert/web.qtpl:319
 	qs422016 := string(qb422016.B)
-//line app/vmalert/web.qtpl:311
+//line app/vmalert/web.qtpl:319
 	qt422016.ReleaseByteBuffer(qb422016)
-//line app/vmalert/web.qtpl:311
+//line app/vmalert/web.qtpl:319
 	return qs422016
-//line app/vmalert/web.qtpl:311
+//line app/vmalert/web.qtpl:319
 }
 
-//line app/vmalert/web.qtpl:313
+//line app/vmalert/web.qtpl:321
 func StreamAlert(qw422016 *qt422016.Writer, r *http.Request, alert *apiAlert) {
-//line app/vmalert/web.qtpl:313
+//line app/vmalert/web.qtpl:321
 	qw422016.N().S(`
     `)
-//line app/vmalert/web.qtpl:314
+//line app/vmalert/web.qtpl:322
 	prefix := utils.Prefix(r.URL.Path)
 
-//line app/vmalert/web.qtpl:314
+//line app/vmalert/web.qtpl:322
 	qw422016.N().S(`
     `)
-//line app/vmalert/web.qtpl:315
+//line app/vmalert/web.qtpl:323
 	tpl.StreamHeader(qw422016, r, navItems, "", getLastConfigError())
-//line app/vmalert/web.qtpl:315
+//line app/vmalert/web.qtpl:323
 	qw422016.N().S(`
     `)
-//line app/vmalert/web.qtpl:317
+//line app/vmalert/web.qtpl:325
 	var labelKeys []string
 	for k := range alert.Labels {
 		labelKeys = append(labelKeys, k)
@@ -1119,28 +1139,28 @@ func StreamAlert(qw422016 *qt422016.Writer, r *http.Request, alert *apiAlert) {
 	}
 	sort.Strings(annotationKeys)
 
-//line app/vmalert/web.qtpl:328
+//line app/vmalert/web.qtpl:336
 	qw422016.N().S(`
     <div class="display-6 pb-3 mb-3">Alert: `)
-//line app/vmalert/web.qtpl:329
+//line app/vmalert/web.qtpl:337
 	qw422016.E().S(alert.Name)
-//line app/vmalert/web.qtpl:329
+//line app/vmalert/web.qtpl:337
 	qw422016.N().S(`<span class="ms-2 badge `)
-//line app/vmalert/web.qtpl:329
+//line app/vmalert/web.qtpl:337
 	if alert.State == "firing" {
-//line app/vmalert/web.qtpl:329
+//line app/vmalert/web.qtpl:337
 		qw422016.N().S(`bg-danger`)
-//line app/vmalert/web.qtpl:329
+//line app/vmalert/web.qtpl:337
 	} else {
-//line app/vmalert/web.qtpl:329
+//line app/vmalert/web.qtpl:337
 		qw422016.N().S(` bg-warning text-dark`)
-//line app/vmalert/web.qtpl:329
+//line app/vmalert/web.qtpl:337
 	}
-//line app/vmalert/web.qtpl:329
+//line app/vmalert/web.qtpl:337
 	qw422016.N().S(`">`)
-//line app/vmalert/web.qtpl:329
+//line app/vmalert/web.qtpl:337
 	qw422016.E().S(alert.State)
-//line app/vmalert/web.qtpl:329
+//line app/vmalert/web.qtpl:337
 	qw422016.N().S(`</span></div>
     <div class="container border-bottom p-2">
       <div class="row">
@@ -1149,9 +1169,9 @@ func StreamAlert(qw422016 *qt422016.Writer, r *http.Request, alert *apiAlert) {
         </div>
         <div class="col">
           `)
-//line app/vmalert/web.qtpl:336
+//line app/vmalert/web.qtpl:344
 	qw422016.E().S(alert.ActiveAt.Format("2006-01-02T15:04:05Z07:00"))
-//line app/vmalert/web.qtpl:336
+//line app/vmalert/web.qtpl:344
 	qw422016.N().S(`
         </div>
       </div>
@@ -1163,9 +1183,9 @@ func StreamAlert(qw422016 *qt422016.Writer, r *http.Request, alert *apiAlert) {
         </div>
         <div class="col">
           <code><pre>`)
-//line app/vmalert/web.qtpl:346
+//line app/vmalert/web.qtpl:354
 	qw422016.E().S(alert.Expression)
-//line app/vmalert/web.qtpl:346
+//line app/vmalert/web.qtpl:354
 	qw422016.N().S(`</pre></code>
         </div>
       </div>
@@ -1177,23 +1197,23 @@ func StreamAlert(qw422016 *qt422016.Writer, r *http.Request, alert *apiAlert) {
         </div>
         <div class="col">
            `)
-//line app/vmalert/web.qtpl:356
+//line app/vmalert/web.qtpl:364
 	for _, k := range labelKeys {
-//line app/vmalert/web.qtpl:356
+//line app/vmalert/web.qtpl:364
 		qw422016.N().S(`
                 <span class="m-1 badge bg-primary">`)
-//line app/vmalert/web.qtpl:357
+//line app/vmalert/web.qtpl:365
 		qw422016.E().S(k)
-//line app/vmalert/web.qtpl:357
+//line app/vmalert/web.qtpl:365
 		qw422016.N().S(`=`)
-//line app/vmalert/web.qtpl:357
+//line app/vmalert/web.qtpl:365
 		qw422016.E().S(alert.Labels[k])
-//line app/vmalert/web.qtpl:357
+//line app/vmalert/web.qtpl:365
 		qw422016.N().S(`</span>
           `)
-//line app/vmalert/web.qtpl:358
+//line app/vmalert/web.qtpl:366
 	}
-//line app/vmalert/web.qtpl:358
+//line app/vmalert/web.qtpl:366
 	qw422016.N().S(`
         </div>
       </div>
@@ -1205,24 +1225,24 @@ func StreamAlert(qw422016 *qt422016.Writer, r *http.Request, alert *apiAlert) {
         </div>
         <div class="col">
            `)
-//line app/vmalert/web.qtpl:368
+//line app/vmalert/web.qtpl:376
 	for _, k := range annotationKeys {
-//line app/vmalert/web.qtpl:368
+//line app/vmalert/web.qtpl:376
 		qw422016.N().S(`
                 <b>`)
-//line app/vmalert/web.qtpl:369
+//line app/vmalert/web.qtpl:377
 		qw422016.E().S(k)
-//line app/vmalert/web.qtpl:369
+//line app/vmalert/web.qtpl:377
 		qw422016.N().S(`:</b><br>
                 <p>`)
-//line app/vmalert/web.qtpl:370
+//line app/vmalert/web.qtpl:378
 		qw422016.E().S(alert.Annotations[k])
-//line app/vmalert/web.qtpl:370
+//line app/vmalert/web.qtpl:378
 		qw422016.N().S(`</p>
           `)
-//line app/vmalert/web.qtpl:371
+//line app/vmalert/web.qtpl:379
 	}
-//line app/vmalert/web.qtpl:371
+//line app/vmalert/web.qtpl:379
 	qw422016.N().S(`
         </div>
       </div>
@@ -1234,17 +1254,17 @@ func StreamAlert(qw422016 *qt422016.Writer, r *http.Request, alert *apiAlert) {
         </div>
         <div class="col">
            <a target="_blank" href="`)
-//line app/vmalert/web.qtpl:381
+//line app/vmalert/web.qtpl:389
 	qw422016.E().S(prefix)
-//line app/vmalert/web.qtpl:381
+//line app/vmalert/web.qtpl:389
 	qw422016.N().S(`groups#group-`)
-//line app/vmalert/web.qtpl:381
+//line app/vmalert/web.qtpl:389
 	qw422016.E().S(alert.GroupID)
-//line app/vmalert/web.qtpl:381
+//line app/vmalert/web.qtpl:389
 	qw422016.N().S(`">`)
-//line app/vmalert/web.qtpl:381
+//line app/vmalert/web.qtpl:389
 	qw422016.E().S(alert.GroupID)
-//line app/vmalert/web.qtpl:381
+//line app/vmalert/web.qtpl:389
 	qw422016.N().S(`</a>
         </div>
       </div>
@@ -1256,66 +1276,66 @@ func StreamAlert(qw422016 *qt422016.Writer, r *http.Request, alert *apiAlert) {
         </div>
         <div class="col">
            <a target="_blank" href="`)
-//line app/vmalert/web.qtpl:391
+//line app/vmalert/web.qtpl:399
 	qw422016.E().S(alert.SourceLink)
-//line app/vmalert/web.qtpl:391
+//line app/vmalert/web.qtpl:399
 	qw422016.N().S(`">Link</a>
         </div>
       </div>
     </div>
     `)
-//line app/vmalert/web.qtpl:395
+//line app/vmalert/web.qtpl:403
 	tpl.StreamFooter(qw422016, r)
-//line app/vmalert/web.qtpl:395
+//line app/vmalert/web.qtpl:403
 	qw422016.N().S(`
 
 `)
-//line app/vmalert/web.qtpl:397
+//line app/vmalert/web.qtpl:405
 }
 
-//line app/vmalert/web.qtpl:397
+//line app/vmalert/web.qtpl:405
 func WriteAlert(qq422016 qtio422016.Writer, r *http.Request, alert *apiAlert) {
-//line app/vmalert/web.qtpl:397
+//line app/vmalert/web.qtpl:405
 	qw422016 := qt422016.AcquireWriter(qq422016)
-//line app/vmalert/web.qtpl:397
+//line app/vmalert/web.qtpl:405
 	StreamAlert(qw422016, r, alert)
-//line app/vmalert/web.qtpl:397
+//line app/vmalert/web.qtpl:405
 	qt422016.ReleaseWriter(qw422016)
-//line app/vmalert/web.qtpl:397
+//line app/vmalert/web.qtpl:405
 }
 
-//line app/vmalert/web.qtpl:397
+//line app/vmalert/web.qtpl:405
 func Alert(r *http.Request, alert *apiAlert) string {
-//line app/vmalert/web.qtpl:397
+//line app/vmalert/web.qtpl:405
 	qb422016 := qt422016.AcquireByteBuffer()
-//line app/vmalert/web.qtpl:397
+//line app/vmalert/web.qtpl:405
 	WriteAlert(qb422016, r, alert)
-//line app/vmalert/web.qtpl:397
+//line app/vmalert/web.qtpl:405
 	qs422016 := string(qb422016.B)
-//line app/vmalert/web.qtpl:397
+//line app/vmalert/web.qtpl:405
 	qt422016.ReleaseByteBuffer(qb422016)
-//line app/vmalert/web.qtpl:397
+//line app/vmalert/web.qtpl:405
 	return qs422016
-//line app/vmalert/web.qtpl:397
+//line app/vmalert/web.qtpl:405
 }
 
-//line app/vmalert/web.qtpl:400
+//line app/vmalert/web.qtpl:408
 func StreamRuleDetails(qw422016 *qt422016.Writer, r *http.Request, rule apiRule) {
-//line app/vmalert/web.qtpl:400
+//line app/vmalert/web.qtpl:408
 	qw422016.N().S(`
     `)
-//line app/vmalert/web.qtpl:401
+//line app/vmalert/web.qtpl:409
 	prefix := utils.Prefix(r.URL.Path)
 
-//line app/vmalert/web.qtpl:401
+//line app/vmalert/web.qtpl:409
 	qw422016.N().S(`
     `)
-//line app/vmalert/web.qtpl:402
+//line app/vmalert/web.qtpl:410
 	tpl.StreamHeader(qw422016, r, navItems, "", getLastConfigError())
-//line app/vmalert/web.qtpl:402
+//line app/vmalert/web.qtpl:410
 	qw422016.N().S(`
     `)
-//line app/vmalert/web.qtpl:404
+//line app/vmalert/web.qtpl:412
 	var labelKeys []string
 	for k := range rule.Labels {
 		labelKeys = append(labelKeys, k)
@@ -1339,28 +1359,28 @@ func StreamRuleDetails(qw422016 *qt422016.Writer, r *http.Request, rule apiRule)
 		}
 	}
 
-//line app/vmalert/web.qtpl:427
+//line app/vmalert/web.qtpl:435
 	qw422016.N().S(`
     <div class="display-6 pb-3 mb-3">Rule: `)
-//line app/vmalert/web.qtpl:428
+//line app/vmalert/web.qtpl:436
 	qw422016.E().S(rule.Name)
-//line app/vmalert/web.qtpl:428
+//line app/vmalert/web.qtpl:436
 	qw422016.N().S(`<span class="ms-2 badge `)
-//line app/vmalert/web.qtpl:428
+//line app/vmalert/web.qtpl:436
 	if rule.Health != "ok" {
-//line app/vmalert/web.qtpl:428
+//line app/vmalert/web.qtpl:436
 		qw422016.N().S(`bg-danger`)
-//line app/vmalert/web.qtpl:428
+//line app/vmalert/web.qtpl:436
 	} else {
-//line app/vmalert/web.qtpl:428
+//line app/vmalert/web.qtpl:436
 		qw422016.N().S(` bg-success text-dark`)
-//line app/vmalert/web.qtpl:428
+//line app/vmalert/web.qtpl:436
 	}
-//line app/vmalert/web.qtpl:428
+//line app/vmalert/web.qtpl:436
 	qw422016.N().S(`">`)
-//line app/vmalert/web.qtpl:428
+//line app/vmalert/web.qtpl:436
 	qw422016.E().S(rule.Health)
-//line app/vmalert/web.qtpl:428
+//line app/vmalert/web.qtpl:436
 	qw422016.N().S(`</span></div>
     <div class="container border-bottom p-2">
       <div class="row">
@@ -1369,17 +1389,17 @@ func StreamRuleDetails(qw422016 *qt422016.Writer, r *http.Request, rule apiRule)
         </div>
         <div class="col">
           <code><pre>`)
-//line app/vmalert/web.qtpl:435
+//line app/vmalert/web.qtpl:443
 	qw422016.E().S(rule.Query)
-//line app/vmalert/web.qtpl:435
+//line app/vmalert/web.qtpl:443
 	qw422016.N().S(`</pre></code>
         </div>
       </div>
     </div>
     `)
-//line app/vmalert/web.qtpl:439
+//line app/vmalert/web.qtpl:447
 	if rule.Type == "alerting" {
-//line app/vmalert/web.qtpl:439
+//line app/vmalert/web.qtpl:447
 		qw422016.N().S(`
     <div class="container border-bottom p-2">
       <div class="row">
@@ -1388,17 +1408,17 @@ func StreamRuleDetails(qw422016 *qt422016.Writer, r *http.Request, rule apiRule)
         </div>
         <div class="col">
          `)
-//line app/vmalert/web.qtpl:446
+//line app/vmalert/web.qtpl:454
 		qw422016.E().V(rule.Duration)
-//line app/vmalert/web.qtpl:446
+//line app/vmalert/web.qtpl:454
 		qw422016.N().S(` seconds
         </div>
       </div>
     </div>
     `)
-//line app/vmalert/web.qtpl:450
+//line app/vmalert/web.qtpl:458
 		if rule.KeepFiringFor > 0 {
-//line app/vmalert/web.qtpl:450
+//line app/vmalert/web.qtpl:458
 			qw422016.N().S(`
     <div class="container border-bottom p-2">
       <div class="row">
@@ -1407,22 +1427,22 @@ func StreamRuleDetails(qw422016 *qt422016.Writer, r *http.Request, rule apiRule)
         </div>
         <div class="col">
          `)
-//line app/vmalert/web.qtpl:457
+//line app/vmalert/web.qtpl:465
 			qw422016.E().V(rule.KeepFiringFor)
-//line app/vmalert/web.qtpl:457
+//line app/vmalert/web.qtpl:465
 			qw422016.N().S(` seconds
         </div>
       </div>
     </div>
     `)
-//line app/vmalert/web.qtpl:461
+//line app/vmalert/web.qtpl:469
 		}
-//line app/vmalert/web.qtpl:461
+//line app/vmalert/web.qtpl:469
 		qw422016.N().S(`
     `)
-//line app/vmalert/web.qtpl:462
+//line app/vmalert/web.qtpl:470
 	}
-//line app/vmalert/web.qtpl:462
+//line app/vmalert/web.qtpl:470
 	qw422016.N().S(`
     <div class="container border-bottom p-2">
       <div class="row">
@@ -1431,31 +1451,31 @@ func StreamRuleDetails(qw422016 *qt422016.Writer, r *http.Request, rule apiRule)
         </div>
         <div class="col">
           `)
-//line app/vmalert/web.qtpl:469
+//line app/vmalert/web.qtpl:477
 	for _, k := range labelKeys {
-//line app/vmalert/web.qtpl:469
+//line app/vmalert/web.qtpl:477
 		qw422016.N().S(`
                 <span class="m-1 badge bg-primary">`)
-//line app/vmalert/web.qtpl:470
+//line app/vmalert/web.qtpl:478
 		qw422016.E().S(k)
-//line app/vmalert/web.qtpl:470
+//line app/vmalert/web.qtpl:478
 		qw422016.N().S(`=`)
-//line app/vmalert/web.qtpl:470
+//line app/vmalert/web.qtpl:478
 		qw422016.E().S(rule.Labels[k])
-//line app/vmalert/web.qtpl:470
+//line app/vmalert/web.qtpl:478
 		qw422016.N().S(`</span>
           `)
-//line app/vmalert/web.qtpl:471
+//line app/vmalert/web.qtpl:479
 	}
-//line app/vmalert/web.qtpl:471
+//line app/vmalert/web.qtpl:479
 	qw422016.N().S(`
         </div>
       </div>
     </div>
     `)
-//line app/vmalert/web.qtpl:475
+//line app/vmalert/web.qtpl:483
 	if rule.Type == "alerting" {
-//line app/vmalert/web.qtpl:475
+//line app/vmalert/web.qtpl:483
 		qw422016.N().S(`
     <div class="container border-bottom p-2">
       <div class="row">
@@ -1464,24 +1484,24 @@ func StreamRuleDetails(qw422016 *qt422016.Writer, r *http.Request, rule apiRule)
         </div>
         <div class="col">
           `)
-//line app/vmalert/web.qtpl:482
+//line app/vmalert/web.qtpl:490
 		for _, k := range annotationKeys {
-//line app/vmalert/web.qtpl:482
+//line app/vmalert/web.qtpl:490
 			qw422016.N().S(`
                 <b>`)
-//line app/vmalert/web.qtpl:483
+//line app/vmalert/web.qtpl:491
 			qw422016.E().S(k)
-//line app/vmalert/web.qtpl:483
+//line app/vmalert/web.qtpl:491
 			qw422016.N().S(`:</b><br>
                 <p>`)
-//line app/vmalert/web.qtpl:484
+//line app/vmalert/web.qtpl:492
 			qw422016.E().S(rule.Annotations[k])
-//line app/vmalert/web.qtpl:484
+//line app/vmalert/web.qtpl:492
 			qw422016.N().S(`</p>
           `)
-//line app/vmalert/web.qtpl:485
+//line app/vmalert/web.qtpl:493
 		}
-//line app/vmalert/web.qtpl:485
+//line app/vmalert/web.qtpl:493
 		qw422016.N().S(`
         </div>
       </div>
@@ -1493,17 +1513,17 @@ func StreamRuleDetails(qw422016 *qt422016.Writer, r *http.Request, rule apiRule)
         </div>
         <div class="col">
            `)
-//line app/vmalert/web.qtpl:495
+//line app/vmalert/web.qtpl:503
 		qw422016.E().V(rule.Debug)
-//line app/vmalert/web.qtpl:495
+//line app/vmalert/web.qtpl:503
 		qw422016.N().S(`
         </div>
       </div>
     </div>
     `)
-//line app/vmalert/web.qtpl:499
+//line app/vmalert/web.qtpl:507
 	}
-//line app/vmalert/web.qtpl:499
+//line app/vmalert/web.qtpl:507
 	qw422016.N().S(`
     <div class="container border-bottom p-2">
       <div class="row">
@@ -1512,17 +1532,17 @@ func StreamRuleDetails(qw422016 *qt422016.Writer, r *http.Request, rule apiRule)
         </div>
         <div class="col">
            <a target="_blank" href="`)
-//line app/vmalert/web.qtpl:506
+//line app/vmalert/web.qtpl:514
 	qw422016.E().S(prefix)
-//line app/vmalert/web.qtpl:506
+//line app/vmalert/web.qtpl:514
 	qw422016.N().S(`groups#group-`)
-//line app/vmalert/web.qtpl:506
+//line app/vmalert/web.qtpl:514
 	qw422016.E().S(rule.GroupID)
-//line app/vmalert/web.qtpl:506
+//line app/vmalert/web.qtpl:514
 	qw422016.N().S(`">`)
-//line app/vmalert/web.qtpl:506
+//line app/vmalert/web.qtpl:514
 	qw422016.E().S(rule.GroupID)
-//line app/vmalert/web.qtpl:506
+//line app/vmalert/web.qtpl:514
 	qw422016.N().S(`</a>
         </div>
       </div>
@@ -1530,9 +1550,9 @@ func StreamRuleDetails(qw422016 *qt422016.Writer, r *http.Request, rule apiRule)
 
     <br>
     `)
-//line app/vmalert/web.qtpl:512
+//line app/vmalert/web.qtpl:520
 	if seriesFetchedWarning {
-//line app/vmalert/web.qtpl:512
+//line app/vmalert/web.qtpl:520
 		qw422016.N().S(`
     <div class="alert alert-warning" role="alert">
        <strong>Warning:</strong> some of updates have "Series fetched" equal to 0.<br>
@@ -1546,18 +1566,18 @@ func StreamRuleDetails(qw422016 *qt422016.Writer, r *http.Request, rule apiRule)
        See more details about this detection <a target="_blank" href="https://github.com/VictoriaMetrics/VictoriaMetrics/issues/4039">here</a>.
     </div>
     `)
-//line app/vmalert/web.qtpl:524
+//line app/vmalert/web.qtpl:532
 	}
-//line app/vmalert/web.qtpl:524
+//line app/vmalert/web.qtpl:532
 	qw422016.N().S(`
     <div class="display-6 pb-3">Last `)
-//line app/vmalert/web.qtpl:525
+//line app/vmalert/web.qtpl:533
 	qw422016.N().D(len(rule.Updates))
-//line app/vmalert/web.qtpl:525
+//line app/vmalert/web.qtpl:533
 	qw422016.N().S(`/`)
-//line app/vmalert/web.qtpl:525
+//line app/vmalert/web.qtpl:533
 	qw422016.N().D(rule.MaxUpdates)
-//line app/vmalert/web.qtpl:525
+//line app/vmalert/web.qtpl:533
 	qw422016.N().S(` updates</span>:</div>
         <table class="table table-striped table-hover table-sm">
             <thead>
@@ -1565,13 +1585,13 @@ func StreamRuleDetails(qw422016 *qt422016.Writer, r *http.Request, rule apiRule)
                     <th scope="col" title="The time when event was created">Updated at</th>
                     <th scope="col" style="width: 10%" class="text-center" title="How many samples were returned">Samples</th>
                     `)
-//line app/vmalert/web.qtpl:531
+//line app/vmalert/web.qtpl:539
 	if seriesFetchedEnabled {
-//line app/vmalert/web.qtpl:531
+//line app/vmalert/web.qtpl:539
 		qw422016.N().S(`<th scope="col" style="width: 10%" class="text-center" title="How many series were scanned by datasource during the evaluation">Series fetched</th>`)
-//line app/vmalert/web.qtpl:531
+//line app/vmalert/web.qtpl:539
 	}
-//line app/vmalert/web.qtpl:531
+//line app/vmalert/web.qtpl:539
 	qw422016.N().S(`
                     <th scope="col" style="width: 10%" class="text-center" title="How many seconds request took">Duration</th>
                     <th scope="col" class="text-center" title="Time used for rule execution">Executed at</th>
@@ -1581,285 +1601,285 @@ func StreamRuleDetails(qw422016 *qt422016.Writer, r *http.Request, rule apiRule)
             <tbody>
 
      `)
-//line app/vmalert/web.qtpl:539
+//line app/vmalert/web.qtpl:547
 	for _, u := range rule.Updates {
-//line app/vmalert/web.qtpl:539
+//line app/vmalert/web.qtpl:547
 		qw422016.N().S(`
              <tr`)
-//line app/vmalert/web.qtpl:540
+//line app/vmalert/web.qtpl:548
 		if u.Err != nil {
-//line app/vmalert/web.qtpl:540
+//line app/vmalert/web.qtpl:548
 			qw422016.N().S(` class="alert-danger"`)
-//line app/vmalert/web.qtpl:540
+//line app/vmalert/web.qtpl:548
 		}
-//line app/vmalert/web.qtpl:540
+//line app/vmalert/web.qtpl:548
 		qw422016.N().S(`>
                  <td>
                     <span class="badge bg-primary rounded-pill me-3" title="Updated at">`)
-//line app/vmalert/web.qtpl:542
+//line app/vmalert/web.qtpl:550
 		qw422016.E().S(u.Time.Format(time.RFC3339))
-//line app/vmalert/web.qtpl:542
+//line app/vmalert/web.qtpl:550
 		qw422016.N().S(`</span>
                  </td>
                  <td class="text-center">`)
-//line app/vmalert/web.qtpl:544
+//line app/vmalert/web.qtpl:552
 		qw422016.N().D(u.Samples)
-//line app/vmalert/web.qtpl:544
+//line app/vmalert/web.qtpl:552
 		qw422016.N().S(`</td>
                  `)
-//line app/vmalert/web.qtpl:545
+//line app/vmalert/web.qtpl:553
 		if seriesFetchedEnabled {
-//line app/vmalert/web.qtpl:545
+//line app/vmalert/web.qtpl:553
 			qw422016.N().S(`<td class="text-center">`)
-//line app/vmalert/web.qtpl:545
+//line app/vmalert/web.qtpl:553
 			if u.SeriesFetched != nil {
-//line app/vmalert/web.qtpl:545
+//line app/vmalert/web.qtpl:553
 				qw422016.N().D(*u.SeriesFetched)
-//line app/vmalert/web.qtpl:545
+//line app/vmalert/web.qtpl:553
 			}
-//line app/vmalert/web.qtpl:545
+//line app/vmalert/web.qtpl:553
 			qw422016.N().S(`</td>`)
-//line app/vmalert/web.qtpl:545
+//line app/vmalert/web.qtpl:553
 		}
-//line app/vmalert/web.qtpl:545
+//line app/vmalert/web.qtpl:553
 		qw422016.N().S(`
                  <td class="text-center">`)
-//line app/vmalert/web.qtpl:546
+//line app/vmalert/web.qtpl:554
 		qw422016.N().FPrec(u.Duration.Seconds(), 3)
-//line app/vmalert/web.qtpl:546
+//line app/vmalert/web.qtpl:554
 		qw422016.N().S(`s</td>
                  <td class="text-center">`)
-//line app/vmalert/web.qtpl:547
+//line app/vmalert/web.qtpl:555
 		qw422016.E().S(u.At.Format(time.RFC3339))
-//line app/vmalert/web.qtpl:547
+//line app/vmalert/web.qtpl:555
 		qw422016.N().S(`</td>
                  <td>
                     <textarea class="curl-area" rows="1" onclick="this.focus();this.select()">`)
-//line app/vmalert/web.qtpl:549
+//line app/vmalert/web.qtpl:557
 		qw422016.E().S(u.Curl)
-//line app/vmalert/web.qtpl:549
+//line app/vmalert/web.qtpl:557
 		qw422016.N().S(`</textarea>
                 </td>
              </tr>
           </li>
           `)
-//line app/vmalert/web.qtpl:553
+//line app/vmalert/web.qtpl:561
 		if u.Err != nil {
-//line app/vmalert/web.qtpl:553
+//line app/vmalert/web.qtpl:561
 			qw422016.N().S(`
              <tr`)
-//line app/vmalert/web.qtpl:554
+//line app/vmalert/web.qtpl:562
 			if u.Err != nil {
-//line app/vmalert/web.qtpl:554
+//line app/vmalert/web.qtpl:562
 				qw422016.N().S(` class="alert-danger"`)
-//line app/vmalert/web.qtpl:554
+//line app/vmalert/web.qtpl:562
 			}
-//line app/vmalert/web.qtpl:554
+//line app/vmalert/web.qtpl:562
 			qw422016.N().S(`>
                <td colspan="`)
-//line app/vmalert/web.qtpl:555
+//line app/vmalert/web.qtpl:563
 			if seriesFetchedEnabled {
-//line app/vmalert/web.qtpl:555
+//line app/vmalert/web.qtpl:563
 				qw422016.N().S(`6`)
-//line app/vmalert/web.qtpl:555
+//line app/vmalert/web.qtpl:563
 			} else {
-//line app/vmalert/web.qtpl:555
+//line app/vmalert/web.qtpl:563
 				qw422016.N().S(`5`)
-//line app/vmalert/web.qtpl:555
+//line app/vmalert/web.qtpl:563
 			}
-//line app/vmalert/web.qtpl:555
+//line app/vmalert/web.qtpl:563
 			qw422016.N().S(`">
                    <span class="alert-danger">`)
-//line app/vmalert/web.qtpl:556
+//line app/vmalert/web.qtpl:564
 			qw422016.E().V(u.Err)
-//line app/vmalert/web.qtpl:556
+//line app/vmalert/web.qtpl:564
 			qw422016.N().S(`</span>
                </td>
              </tr>
           `)
-//line app/vmalert/web.qtpl:559
+//line app/vmalert/web.qtpl:567
 		}
-//line app/vmalert/web.qtpl:559
+//line app/vmalert/web.qtpl:567
 		qw422016.N().S(`
      `)
-//line app/vmalert/web.qtpl:560
+//line app/vmalert/web.qtpl:568
 	}
-//line app/vmalert/web.qtpl:560
+//line app/vmalert/web.qtpl:568
 	qw422016.N().S(`
 
     `)
-//line app/vmalert/web.qtpl:562
+//line app/vmalert/web.qtpl:570
 	tpl.StreamFooter(qw422016, r)
-//line app/vmalert/web.qtpl:562
+//line app/vmalert/web.qtpl:570
 	qw422016.N().S(`
 `)
-//line app/vmalert/web.qtpl:563
+//line app/vmalert/web.qtpl:571
 }
 
-//line app/vmalert/web.qtpl:563
+//line app/vmalert/web.qtpl:571
 func WriteRuleDetails(qq422016 qtio422016.Writer, r *http.Request, rule apiRule) {
-//line app/vmalert/web.qtpl:563
+//line app/vmalert/web.qtpl:571
 	qw422016 := qt422016.AcquireWriter(qq422016)
-//line app/vmalert/web.qtpl:563
+//line app/vmalert/web.qtpl:571
 	StreamRuleDetails(qw422016, r, rule)
-//line app/vmalert/web.qtpl:563
+//line app/vmalert/web.qtpl:571
 	qt422016.ReleaseWriter(qw422016)
-//line app/vmalert/web.qtpl:563
+//line app/vmalert/web.qtpl:571
 }
 
-//line app/vmalert/web.qtpl:563
+//line app/vmalert/web.qtpl:571
 func RuleDetails(r *http.Request, rule apiRule) string {
-//line app/vmalert/web.qtpl:563
+//line app/vmalert/web.qtpl:571
 	qb422016 := qt422016.AcquireByteBuffer()
-//line app/vmalert/web.qtpl:563
+//line app/vmalert/web.qtpl:571
 	WriteRuleDetails(qb422016, r, rule)
-//line app/vmalert/web.qtpl:563
+//line app/vmalert/web.qtpl:571
 	qs422016 := string(qb422016.B)
-//line app/vmalert/web.qtpl:563
+//line app/vmalert/web.qtpl:571
 	qt422016.ReleaseByteBuffer(qb422016)
-//line app/vmalert/web.qtpl:563
+//line app/vmalert/web.qtpl:571
 	return qs422016
-//line app/vmalert/web.qtpl:563
+//line app/vmalert/web.qtpl:571
 }
 
-//line app/vmalert/web.qtpl:567
+//line app/vmalert/web.qtpl:575
 func streambadgeState(qw422016 *qt422016.Writer, state string) {
-//line app/vmalert/web.qtpl:567
+//line app/vmalert/web.qtpl:575
 	qw422016.N().S(`
 `)
-//line app/vmalert/web.qtpl:569
+//line app/vmalert/web.qtpl:577
 	badgeClass := "bg-warning text-dark"
 	if state == "firing" {
 		badgeClass = "bg-danger"
 	}
 
-//line app/vmalert/web.qtpl:573
+//line app/vmalert/web.qtpl:581
 	qw422016.N().S(`
 <span class="badge `)
-//line app/vmalert/web.qtpl:574
+//line app/vmalert/web.qtpl:582
 	qw422016.E().S(badgeClass)
-//line app/vmalert/web.qtpl:574
+//line app/vmalert/web.qtpl:582
 	qw422016.N().S(`">`)
-//line app/vmalert/web.qtpl:574
+//line app/vmalert/web.qtpl:582
 	qw422016.E().S(state)
-//line app/vmalert/web.qtpl:574
+//line app/vmalert/web.qtpl:582
 	qw422016.N().S(`</span>
 `)
-//line app/vmalert/web.qtpl:575
+//line app/vmalert/web.qtpl:583
 }
 
-//line app/vmalert/web.qtpl:575
+//line app/vmalert/web.qtpl:583
 func writebadgeState(qq422016 qtio422016.Writer, state string) {
-//line app/vmalert/web.qtpl:575
+//line app/vmalert/web.qtpl:583
 	qw422016 := qt422016.AcquireWriter(qq422016)
-//line app/vmalert/web.qtpl:575
+//line app/vmalert/web.qtpl:583
 	streambadgeState(qw422016, state)
-//line app/vmalert/web.qtpl:575
+//line app/vmalert/web.qtpl:583
 	qt422016.ReleaseWriter(qw422016)
-//line app/vmalert/web.qtpl:575
+//line app/vmalert/web.qtpl:583
 }
 
-//line app/vmalert/web.qtpl:575
+//line app/vmalert/web.qtpl:583
 func badgeState(state string) string {
-//line app/vmalert/web.qtpl:575
+//line app/vmalert/web.qtpl:583
 	qb422016 := qt422016.AcquireByteBuffer()
-//line app/vmalert/web.qtpl:575
+//line app/vmalert/web.qtpl:583
 	writebadgeState(qb422016, state)
-//line app/vmalert/web.qtpl:575
+//line app/vmalert/web.qtpl:583
 	qs422016 := string(qb422016.B)
-//line app/vmalert/web.qtpl:575
+//line app/vmalert/web.qtpl:583
 	qt422016.ReleaseByteBuffer(qb422016)
-//line app/vmalert/web.qtpl:575
+//line app/vmalert/web.qtpl:583
 	return qs422016
-//line app/vmalert/web.qtpl:575
+//line app/vmalert/web.qtpl:583
 }
 
-//line app/vmalert/web.qtpl:577
+//line app/vmalert/web.qtpl:585
 func streambadgeRestored(qw422016 *qt422016.Writer) {
-//line app/vmalert/web.qtpl:577
+//line app/vmalert/web.qtpl:585
 	qw422016.N().S(`
 <span class="badge bg-warning text-dark" title="Alert state was restored after the service restart from remote storage">restored</span>
 `)
-//line app/vmalert/web.qtpl:579
+//line app/vmalert/web.qtpl:587
 }
 
-//line app/vmalert/web.qtpl:579
+//line app/vmalert/web.qtpl:587
 func writebadgeRestored(qq422016 qtio422016.Writer) {
-//line app/vmalert/web.qtpl:579
+//line app/vmalert/web.qtpl:587
 	qw422016 := qt422016.AcquireWriter(qq422016)
-//line app/vmalert/web.qtpl:579
+//line app/vmalert/web.qtpl:587
 	streambadgeRestored(qw422016)
-//line app/vmalert/web.qtpl:579
+//line app/vmalert/web.qtpl:587
 	qt422016.ReleaseWriter(qw422016)
-//line app/vmalert/web.qtpl:579
+//line app/vmalert/web.qtpl:587
 }
 
-//line app/vmalert/web.qtpl:579
+//line app/vmalert/web.qtpl:587
 func badgeRestored() string {
-//line app/vmalert/web.qtpl:579
+//line app/vmalert/web.qtpl:587
 	qb422016 := qt422016.AcquireByteBuffer()
-//line app/vmalert/web.qtpl:579
+//line app/vmalert/web.qtpl:587
 	writebadgeRestored(qb422016)
-//line app/vmalert/web.qtpl:579
+//line app/vmalert/web.qtpl:587
 	qs422016 := string(qb422016.B)
-//line app/vmalert/web.qtpl:579
+//line app/vmalert/web.qtpl:587
 	qt422016.ReleaseByteBuffer(qb422016)
-//line app/vmalert/web.qtpl:579
+//line app/vmalert/web.qtpl:587
 	return qs422016
-//line app/vmalert/web.qtpl:579
+//line app/vmalert/web.qtpl:587
 }
 
-//line app/vmalert/web.qtpl:581
+//line app/vmalert/web.qtpl:589
 func streambadgeStabilizing(qw422016 *qt422016.Writer) {
-//line app/vmalert/web.qtpl:581
+//line app/vmalert/web.qtpl:589
 	qw422016.N().S(`
 <span class="badge bg-warning text-dark" title="This firing state is kept because of `)
-//line app/vmalert/web.qtpl:581
+//line app/vmalert/web.qtpl:589
 	qw422016.N().S("`")
-//line app/vmalert/web.qtpl:581
+//line app/vmalert/web.qtpl:589
 	qw422016.N().S(`keep_firing_for`)
-//line app/vmalert/web.qtpl:581
+//line app/vmalert/web.qtpl:589
 	qw422016.N().S("`")
-//line app/vmalert/web.qtpl:581
+//line app/vmalert/web.qtpl:589
 	qw422016.N().S(`">stabilizing</span>
 `)
-//line app/vmalert/web.qtpl:583
+//line app/vmalert/web.qtpl:591
 }
 
-//line app/vmalert/web.qtpl:583
+//line app/vmalert/web.qtpl:591
 func writebadgeStabilizing(qq422016 qtio422016.Writer) {
-//line app/vmalert/web.qtpl:583
+//line app/vmalert/web.qtpl:591
 	qw422016 := qt422016.AcquireWriter(qq422016)
-//line app/vmalert/web.qtpl:583
+//line app/vmalert/web.qtpl:591
 	streambadgeStabilizing(qw422016)
-//line app/vmalert/web.qtpl:583
+//line app/vmalert/web.qtpl:591
 	qt422016.ReleaseWriter(qw422016)
-//line app/vmalert/web.qtpl:583
+//line app/vmalert/web.qtpl:591
 }
 
-//line app/vmalert/web.qtpl:583
+//line app/vmalert/web.qtpl:591
 func badgeStabilizing() string {
-//line app/vmalert/web.qtpl:583
+//line app/vmalert/web.qtpl:591
 	qb422016 := qt422016.AcquireByteBuffer()
-//line app/vmalert/web.qtpl:583
+//line app/vmalert/web.qtpl:591
 	writebadgeStabilizing(qb422016)
-//line app/vmalert/web.qtpl:583
+//line app/vmalert/web.qtpl:591
 	qs422016 := string(qb422016.B)
-//line app/vmalert/web.qtpl:583
+//line app/vmalert/web.qtpl:591
 	qt422016.ReleaseByteBuffer(qb422016)
-//line app/vmalert/web.qtpl:583
+//line app/vmalert/web.qtpl:591
 	return qs422016
-//line app/vmalert/web.qtpl:583
+//line app/vmalert/web.qtpl:591
 }
 
-//line app/vmalert/web.qtpl:585
+//line app/vmalert/web.qtpl:593
 func streamseriesFetchedWarn(qw422016 *qt422016.Writer, r apiRule) {
-//line app/vmalert/web.qtpl:585
+//line app/vmalert/web.qtpl:593
 	qw422016.N().S(`
 `)
-//line app/vmalert/web.qtpl:586
+//line app/vmalert/web.qtpl:594
 	if isNoMatch(r) {
-//line app/vmalert/web.qtpl:586
+//line app/vmalert/web.qtpl:594
 		qw422016.N().S(`
 <svg xmlns="http://www.w3.org/2000/svg"
     data-bs-toggle="tooltip"
@@ -1870,41 +1890,41 @@ func streamseriesFetchedWarn(qw422016 *qt422016.Writer, r apiRule) {
        <path d="M8 16A8 8 0 1 0 8 0a8 8 0 0 0 0 16zm.93-9.412-1 4.705c-.07.34.029.533.304.533.194 0 .487-.07.686-.246l-.088.416c-.287.346-.92.598-1.465.598-.703 0-1.002-.422-.808-1.319l.738-3.468c.064-.293.006-.399-.287-.47l-.451-.081.082-.381 2.29-.287zM8 5.5a1 1 0 1 1 0-2 1 1 0 0 1 0 2z"/>
 </svg>
 `)
-//line app/vmalert/web.qtpl:595
+//line app/vmalert/web.qtpl:603
 	}
-//line app/vmalert/web.qtpl:595
+//line app/vmalert/web.qtpl:603
 	qw422016.N().S(`
 `)
-//line app/vmalert/web.qtpl:596
+//line app/vmalert/web.qtpl:604
 }
 
-//line app/vmalert/web.qtpl:596
+//line app/vmalert/web.qtpl:604
 func writeseriesFetchedWarn(qq422016 qtio422016.Writer, r apiRule) {
-//line app/vmalert/web.qtpl:596
+//line app/vmalert/web.qtpl:604
 	qw422016 := qt422016.AcquireWriter(qq422016)
-//line app/vmalert/web.qtpl:596
+//line app/vmalert/web.qtpl:604
 	streamseriesFetchedWarn(qw422016, r)
-//line app/vmalert/web.qtpl:596
+//line app/vmalert/web.qtpl:604
 	qt422016.ReleaseWriter(qw422016)
-//line app/vmalert/web.qtpl:596
+//line app/vmalert/web.qtpl:604
 }
 
-//line app/vmalert/web.qtpl:596
+//line app/vmalert/web.qtpl:604
 func seriesFetchedWarn(r apiRule) string {
-//line app/vmalert/web.qtpl:596
+//line app/vmalert/web.qtpl:604
 	qb422016 := qt422016.AcquireByteBuffer()
-//line app/vmalert/web.qtpl:596
+//line app/vmalert/web.qtpl:604
 	writeseriesFetchedWarn(qb422016, r)
-//line app/vmalert/web.qtpl:596
+//line app/vmalert/web.qtpl:604
 	qs422016 := string(qb422016.B)
-//line app/vmalert/web.qtpl:596
+//line app/vmalert/web.qtpl:604
 	qt422016.ReleaseByteBuffer(qb422016)
-//line app/vmalert/web.qtpl:596
+//line app/vmalert/web.qtpl:604
 	return qs422016
-//line app/vmalert/web.qtpl:596
+//line app/vmalert/web.qtpl:604
 }
 
-//line app/vmalert/web.qtpl:599
+//line app/vmalert/web.qtpl:607
 func isNoMatch(r apiRule) bool {
 	return r.LastSamples == 0 && r.LastSeriesFetched != nil && *r.LastSeriesFetched == 0
 }

--- a/app/vmalert/web.qtpl.go
+++ b/app/vmalert/web.qtpl.go
@@ -242,188 +242,184 @@ func StreamListGroups(qw422016 *qt422016.Writer, r *http.Request, originGroups [
 
 //line app/vmalert/web.qtpl:72
 	qw422016.N().S(`
-        <div class="btn-toolbar mb-3" role="toolbar">
-          <div>
-            <a class="btn `)
-//line app/vmalert/web.qtpl:75
+        <a class="btn `)
+//line app/vmalert/web.qtpl:73
 	streambuttonActive(qw422016, filter, "")
-//line app/vmalert/web.qtpl:75
+//line app/vmalert/web.qtpl:73
 	qw422016.N().S(`" role="button" onclick="window.location = window.location.pathname">All</a>
-            <a class="btn btn-primary" role="button" onclick="collapseAll()">Collapse All</a>
-            <a class="btn btn-primary" role="button" onclick="expandAll()">Expand All</a>
-            <a class="btn `)
-//line app/vmalert/web.qtpl:78
+        <a class="btn btn-primary" role="button" onclick="collapseAll()">Collapse All</a>
+        <a class="btn btn-primary" role="button" onclick="expandAll()">Expand All</a>
+        <a class="btn `)
+//line app/vmalert/web.qtpl:76
 	streambuttonActive(qw422016, filter, "unhealthy")
-//line app/vmalert/web.qtpl:78
+//line app/vmalert/web.qtpl:76
 	qw422016.N().S(`" role="button" onclick="location.href='?filter=unhealthy'" title="Show only rules with errors">Unhealthy</a>
-            <a class="btn `)
-//line app/vmalert/web.qtpl:79
+        <a class="btn `)
+//line app/vmalert/web.qtpl:77
 	streambuttonActive(qw422016, filter, "noMatch")
-//line app/vmalert/web.qtpl:79
+//line app/vmalert/web.qtpl:77
 	qw422016.N().S(`" role="button" onclick="location.href='?filter=noMatch'" title="Show only rules matching no time series during last evaluation">NoMatch</a>
-          </div>
-          <div class="col-md-4 col-lg-5">
-            <div class="px-3 input-group">
-              <div class="input-group-prepend">
-                <span class="input-group-text">
-                  <svg fill="#000000" height="25px" width="20px" version="1.1" id="Capa_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 490.4 490.4" xml:space="preserve"><g id="SVGRepo_bgCarrier" stroke-width="0"></g><g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"></g><g id="SVGRepo_iconCarrier"> <g> <path d="M484.1,454.796l-110.5-110.6c29.8-36.3,47.6-82.8,47.6-133.4c0-116.3-94.3-210.6-210.6-210.6S0,94.496,0,210.796 s94.3,210.6,210.6,210.6c50.8,0,97.4-18,133.8-48l110.5,110.5c12.9,11.8,25,4.2,29.2,0C492.5,475.596,492.5,463.096,484.1,454.796z M41.1,210.796c0-93.6,75.9-169.5,169.5-169.5s169.6,75.9,169.6,169.5s-75.9,169.5-169.5,169.5S41.1,304.396,41.1,210.796z"></path> </g> </g></svg>
-                </span>
-              </div>
-              <input id="filter" placeholder="Filter by group, rule or labels" type="text" class="form-control"/>
+        <div class="pt-2 col-md-4 col-lg-4">
+          <div class="input-group">
+            <div class="input-group-prepend">
+              <span class="input-group-text">
+                <svg fill="#000000" height="25px" width="20px" version="1.1" id="Capa_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 490.4 490.4" xml:space="preserve"><g id="SVGRepo_bgCarrier" stroke-width="0"></g><g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"></g><g id="SVGRepo_iconCarrier"> <g> <path d="M484.1,454.796l-110.5-110.6c29.8-36.3,47.6-82.8,47.6-133.4c0-116.3-94.3-210.6-210.6-210.6S0,94.496,0,210.796 s94.3,210.6,210.6,210.6c50.8,0,97.4-18,133.8-48l110.5,110.5c12.9,11.8,25,4.2,29.2,0C492.5,475.596,492.5,463.096,484.1,454.796z M41.1,210.796c0-93.6,75.9-169.5,169.5-169.5s169.6,75.9,169.6,169.5s-75.9,169.5-169.5,169.5S41.1,304.396,41.1,210.796z"></path> </g> </g></svg>
+              </span>
             </div>
+            <input id="filter" placeholder="Filter by group, rule or labels" type="text" class="form-control"/>
           </div>
         </div>
         `)
-//line app/vmalert/web.qtpl:92
+//line app/vmalert/web.qtpl:88
 	if len(groups) > 0 {
-//line app/vmalert/web.qtpl:92
+//line app/vmalert/web.qtpl:88
 		qw422016.N().S(`
             `)
-//line app/vmalert/web.qtpl:93
+//line app/vmalert/web.qtpl:89
 		for _, g := range groups {
-//line app/vmalert/web.qtpl:93
+//line app/vmalert/web.qtpl:89
 			qw422016.N().S(`
                   <div
                     class="group-heading`)
-//line app/vmalert/web.qtpl:95
+//line app/vmalert/web.qtpl:91
 			if rNotOk[g.ID] > 0 {
-//line app/vmalert/web.qtpl:95
+//line app/vmalert/web.qtpl:91
 				qw422016.N().S(` alert-danger`)
-//line app/vmalert/web.qtpl:95
+//line app/vmalert/web.qtpl:91
 			}
-//line app/vmalert/web.qtpl:95
+//line app/vmalert/web.qtpl:91
 			qw422016.N().S(`" data-bs-target="rules-`)
-//line app/vmalert/web.qtpl:95
+//line app/vmalert/web.qtpl:91
 			qw422016.E().S(g.ID)
-//line app/vmalert/web.qtpl:95
+//line app/vmalert/web.qtpl:91
 			qw422016.N().S(`" data-group-name="`)
-//line app/vmalert/web.qtpl:95
+//line app/vmalert/web.qtpl:91
 			qw422016.E().S(g.Name)
-//line app/vmalert/web.qtpl:95
+//line app/vmalert/web.qtpl:91
 			qw422016.N().S(`">
                     <span class="anchor" id="group-`)
-//line app/vmalert/web.qtpl:96
+//line app/vmalert/web.qtpl:92
 			qw422016.E().S(g.ID)
-//line app/vmalert/web.qtpl:96
+//line app/vmalert/web.qtpl:92
 			qw422016.N().S(`"></span>
                     <a href="#group-`)
-//line app/vmalert/web.qtpl:97
+//line app/vmalert/web.qtpl:93
 			qw422016.E().S(g.ID)
-//line app/vmalert/web.qtpl:97
+//line app/vmalert/web.qtpl:93
 			qw422016.N().S(`">`)
-//line app/vmalert/web.qtpl:97
+//line app/vmalert/web.qtpl:93
 			qw422016.E().S(g.Name)
-//line app/vmalert/web.qtpl:97
+//line app/vmalert/web.qtpl:93
 			if g.Type != "prometheus" {
-//line app/vmalert/web.qtpl:97
+//line app/vmalert/web.qtpl:93
 				qw422016.N().S(` (`)
-//line app/vmalert/web.qtpl:97
+//line app/vmalert/web.qtpl:93
 				qw422016.E().S(g.Type)
-//line app/vmalert/web.qtpl:97
+//line app/vmalert/web.qtpl:93
 				qw422016.N().S(`)`)
-//line app/vmalert/web.qtpl:97
+//line app/vmalert/web.qtpl:93
 			}
-//line app/vmalert/web.qtpl:97
+//line app/vmalert/web.qtpl:93
 			qw422016.N().S(` (every `)
-//line app/vmalert/web.qtpl:97
+//line app/vmalert/web.qtpl:93
 			qw422016.N().FPrec(g.Interval, 0)
-//line app/vmalert/web.qtpl:97
+//line app/vmalert/web.qtpl:93
 			qw422016.N().S(`s) #</a>
                      `)
-//line app/vmalert/web.qtpl:98
+//line app/vmalert/web.qtpl:94
 			if rNotOk[g.ID] > 0 {
-//line app/vmalert/web.qtpl:98
+//line app/vmalert/web.qtpl:94
 				qw422016.N().S(`<span class="badge bg-danger" title="Number of rules with status Error">`)
-//line app/vmalert/web.qtpl:98
+//line app/vmalert/web.qtpl:94
 				qw422016.N().D(rNotOk[g.ID])
-//line app/vmalert/web.qtpl:98
+//line app/vmalert/web.qtpl:94
 				qw422016.N().S(`</span> `)
-//line app/vmalert/web.qtpl:98
+//line app/vmalert/web.qtpl:94
 			}
-//line app/vmalert/web.qtpl:98
+//line app/vmalert/web.qtpl:94
 			qw422016.N().S(`
                      `)
-//line app/vmalert/web.qtpl:99
+//line app/vmalert/web.qtpl:95
 			if rNoMatch[g.ID] > 0 {
-//line app/vmalert/web.qtpl:99
+//line app/vmalert/web.qtpl:95
 				qw422016.N().S(`<span class="badge bg-warning" title="Number of rules with status NoMatch">`)
-//line app/vmalert/web.qtpl:99
+//line app/vmalert/web.qtpl:95
 				qw422016.N().D(rNoMatch[g.ID])
-//line app/vmalert/web.qtpl:99
+//line app/vmalert/web.qtpl:95
 				qw422016.N().S(`</span> `)
-//line app/vmalert/web.qtpl:99
+//line app/vmalert/web.qtpl:95
 			}
-//line app/vmalert/web.qtpl:99
+//line app/vmalert/web.qtpl:95
 			qw422016.N().S(`
                     <span class="badge bg-success" title="Number of rules withs status Ok">`)
-//line app/vmalert/web.qtpl:100
+//line app/vmalert/web.qtpl:96
 			qw422016.N().D(rOk[g.ID])
-//line app/vmalert/web.qtpl:100
+//line app/vmalert/web.qtpl:96
 			qw422016.N().S(`</span>
                     <p class="fs-6 fw-lighter">`)
-//line app/vmalert/web.qtpl:101
+//line app/vmalert/web.qtpl:97
 			qw422016.E().S(g.File)
-//line app/vmalert/web.qtpl:101
+//line app/vmalert/web.qtpl:97
 			qw422016.N().S(`</p>
                     `)
-//line app/vmalert/web.qtpl:102
+//line app/vmalert/web.qtpl:98
 			if len(g.Params) > 0 {
-//line app/vmalert/web.qtpl:102
+//line app/vmalert/web.qtpl:98
 				qw422016.N().S(`
                         <div class="fs-6 fw-lighter">Extra params
                         `)
-//line app/vmalert/web.qtpl:104
+//line app/vmalert/web.qtpl:100
 				for _, param := range g.Params {
-//line app/vmalert/web.qtpl:104
+//line app/vmalert/web.qtpl:100
 					qw422016.N().S(`
                                 <span class="float-left badge bg-primary">`)
-//line app/vmalert/web.qtpl:105
+//line app/vmalert/web.qtpl:101
 					qw422016.E().S(param)
-//line app/vmalert/web.qtpl:105
+//line app/vmalert/web.qtpl:101
 					qw422016.N().S(`</span>
                         `)
-//line app/vmalert/web.qtpl:106
+//line app/vmalert/web.qtpl:102
 				}
-//line app/vmalert/web.qtpl:106
+//line app/vmalert/web.qtpl:102
 				qw422016.N().S(`
                         </div>
                     `)
-//line app/vmalert/web.qtpl:108
+//line app/vmalert/web.qtpl:104
 			}
-//line app/vmalert/web.qtpl:108
+//line app/vmalert/web.qtpl:104
 			qw422016.N().S(`
                     `)
-//line app/vmalert/web.qtpl:109
+//line app/vmalert/web.qtpl:105
 			if len(g.Headers) > 0 {
-//line app/vmalert/web.qtpl:109
+//line app/vmalert/web.qtpl:105
 				qw422016.N().S(`
                         <div class="fs-6 fw-lighter">Extra headers
                         `)
-//line app/vmalert/web.qtpl:111
+//line app/vmalert/web.qtpl:107
 				for _, header := range g.Headers {
-//line app/vmalert/web.qtpl:111
+//line app/vmalert/web.qtpl:107
 					qw422016.N().S(`
                                 <span class="float-left badge bg-primary">`)
-//line app/vmalert/web.qtpl:112
+//line app/vmalert/web.qtpl:108
 					qw422016.E().S(header)
-//line app/vmalert/web.qtpl:112
+//line app/vmalert/web.qtpl:108
 					qw422016.N().S(`</span>
                         `)
-//line app/vmalert/web.qtpl:113
+//line app/vmalert/web.qtpl:109
 				}
-//line app/vmalert/web.qtpl:113
+//line app/vmalert/web.qtpl:109
 				qw422016.N().S(`
                         </div>
                     `)
-//line app/vmalert/web.qtpl:115
+//line app/vmalert/web.qtpl:111
 			}
-//line app/vmalert/web.qtpl:115
+//line app/vmalert/web.qtpl:111
 			qw422016.N().S(`
                 </div>
                 <div class="collapse rule-table" id="rules-`)
-//line app/vmalert/web.qtpl:117
+//line app/vmalert/web.qtpl:113
 			qw422016.E().S(g.ID)
-//line app/vmalert/web.qtpl:117
+//line app/vmalert/web.qtpl:113
 			qw422016.N().S(`">
                     <table class="table table-striped table-hover table-sm">
                         <thead>
@@ -435,308 +431,308 @@ func StreamListGroups(qw422016 *qt422016.Writer, r *http.Request, originGroups [
                         </thead>
                         <tbody>
                         `)
-//line app/vmalert/web.qtpl:127
+//line app/vmalert/web.qtpl:123
 			for _, r := range g.Rules {
-//line app/vmalert/web.qtpl:127
+//line app/vmalert/web.qtpl:123
 				qw422016.N().S(`
                             <tr class="rule`)
-//line app/vmalert/web.qtpl:128
+//line app/vmalert/web.qtpl:124
 				if r.LastError != "" {
-//line app/vmalert/web.qtpl:128
+//line app/vmalert/web.qtpl:124
 					qw422016.N().S(` alert-danger`)
-//line app/vmalert/web.qtpl:128
+//line app/vmalert/web.qtpl:124
 				}
-//line app/vmalert/web.qtpl:128
+//line app/vmalert/web.qtpl:124
 				qw422016.N().S(`" data-rule-name="`)
-//line app/vmalert/web.qtpl:128
+//line app/vmalert/web.qtpl:124
 				qw422016.E().S(r.Name)
-//line app/vmalert/web.qtpl:128
+//line app/vmalert/web.qtpl:124
 				qw422016.N().S(`" data-bs-target="`)
-//line app/vmalert/web.qtpl:128
+//line app/vmalert/web.qtpl:124
 				qw422016.E().S(g.ID)
-//line app/vmalert/web.qtpl:128
+//line app/vmalert/web.qtpl:124
 				qw422016.N().S(`">
                                 <td>
                                     <div class="row">
                                         <div class="col-12 mb-2">
                                             `)
-//line app/vmalert/web.qtpl:132
+//line app/vmalert/web.qtpl:128
 				if r.Type == "alerting" {
-//line app/vmalert/web.qtpl:132
+//line app/vmalert/web.qtpl:128
 					qw422016.N().S(`
                                             `)
-//line app/vmalert/web.qtpl:133
+//line app/vmalert/web.qtpl:129
 					if r.KeepFiringFor > 0 {
-//line app/vmalert/web.qtpl:133
+//line app/vmalert/web.qtpl:129
 						qw422016.N().S(`
                                             <b>alert:</b> `)
-//line app/vmalert/web.qtpl:134
+//line app/vmalert/web.qtpl:130
 						qw422016.E().S(r.Name)
-//line app/vmalert/web.qtpl:134
+//line app/vmalert/web.qtpl:130
 						qw422016.N().S(` (for: `)
-//line app/vmalert/web.qtpl:134
+//line app/vmalert/web.qtpl:130
 						qw422016.E().V(r.Duration)
-//line app/vmalert/web.qtpl:134
+//line app/vmalert/web.qtpl:130
 						qw422016.N().S(` seconds, keep_firing_for: `)
-//line app/vmalert/web.qtpl:134
+//line app/vmalert/web.qtpl:130
 						qw422016.E().V(r.KeepFiringFor)
-//line app/vmalert/web.qtpl:134
+//line app/vmalert/web.qtpl:130
 						qw422016.N().S(` seconds)
                                             `)
-//line app/vmalert/web.qtpl:135
+//line app/vmalert/web.qtpl:131
 					} else {
-//line app/vmalert/web.qtpl:135
+//line app/vmalert/web.qtpl:131
 						qw422016.N().S(`
                                             <b>alert:</b> `)
-//line app/vmalert/web.qtpl:136
+//line app/vmalert/web.qtpl:132
 						qw422016.E().S(r.Name)
-//line app/vmalert/web.qtpl:136
+//line app/vmalert/web.qtpl:132
 						qw422016.N().S(` (for: `)
-//line app/vmalert/web.qtpl:136
+//line app/vmalert/web.qtpl:132
 						qw422016.E().V(r.Duration)
-//line app/vmalert/web.qtpl:136
+//line app/vmalert/web.qtpl:132
 						qw422016.N().S(` seconds)
                                             `)
-//line app/vmalert/web.qtpl:137
+//line app/vmalert/web.qtpl:133
 					}
-//line app/vmalert/web.qtpl:137
+//line app/vmalert/web.qtpl:133
 					qw422016.N().S(`
                                             `)
-//line app/vmalert/web.qtpl:138
+//line app/vmalert/web.qtpl:134
 				} else {
-//line app/vmalert/web.qtpl:138
+//line app/vmalert/web.qtpl:134
 					qw422016.N().S(`
                                             <b>record:</b> `)
-//line app/vmalert/web.qtpl:139
+//line app/vmalert/web.qtpl:135
 					qw422016.E().S(r.Name)
-//line app/vmalert/web.qtpl:139
+//line app/vmalert/web.qtpl:135
 					qw422016.N().S(`
                                             `)
-//line app/vmalert/web.qtpl:140
+//line app/vmalert/web.qtpl:136
 				}
-//line app/vmalert/web.qtpl:140
+//line app/vmalert/web.qtpl:136
 				qw422016.N().S(`
                                             |
                                             `)
-//line app/vmalert/web.qtpl:142
+//line app/vmalert/web.qtpl:138
 				streamseriesFetchedWarn(qw422016, r)
-//line app/vmalert/web.qtpl:142
+//line app/vmalert/web.qtpl:138
 				qw422016.N().S(`
                                             <span><a target="_blank" href="`)
-//line app/vmalert/web.qtpl:143
+//line app/vmalert/web.qtpl:139
 				qw422016.E().S(prefix + r.WebLink())
-//line app/vmalert/web.qtpl:143
+//line app/vmalert/web.qtpl:139
 				qw422016.N().S(`">Details</a></span>
                                         </div>
                                         <div class="col-12">
                                             <code><pre>`)
-//line app/vmalert/web.qtpl:146
+//line app/vmalert/web.qtpl:142
 				qw422016.E().S(r.Query)
-//line app/vmalert/web.qtpl:146
+//line app/vmalert/web.qtpl:142
 				qw422016.N().S(`</pre></code>
                                         </div>
                                         <div class="col-12 mb-2">
                                             `)
-//line app/vmalert/web.qtpl:149
+//line app/vmalert/web.qtpl:145
 				if len(r.Labels) > 0 {
-//line app/vmalert/web.qtpl:149
+//line app/vmalert/web.qtpl:145
 					qw422016.N().S(` <b>Labels:</b>`)
-//line app/vmalert/web.qtpl:149
+//line app/vmalert/web.qtpl:145
 				}
-//line app/vmalert/web.qtpl:149
+//line app/vmalert/web.qtpl:145
 				qw422016.N().S(`
                                             `)
-//line app/vmalert/web.qtpl:150
+//line app/vmalert/web.qtpl:146
 				for k, v := range r.Labels {
-//line app/vmalert/web.qtpl:150
+//line app/vmalert/web.qtpl:146
 					qw422016.N().S(`
                                                     <span class="ms-1 badge bg-primary label">`)
-//line app/vmalert/web.qtpl:151
+//line app/vmalert/web.qtpl:147
 					qw422016.E().S(k)
-//line app/vmalert/web.qtpl:151
+//line app/vmalert/web.qtpl:147
 					qw422016.N().S(`=`)
-//line app/vmalert/web.qtpl:151
+//line app/vmalert/web.qtpl:147
 					qw422016.E().S(v)
-//line app/vmalert/web.qtpl:151
+//line app/vmalert/web.qtpl:147
 					qw422016.N().S(`</span>
                                             `)
-//line app/vmalert/web.qtpl:152
+//line app/vmalert/web.qtpl:148
 				}
-//line app/vmalert/web.qtpl:152
+//line app/vmalert/web.qtpl:148
 				qw422016.N().S(`
                                         </div>
                                         `)
-//line app/vmalert/web.qtpl:154
+//line app/vmalert/web.qtpl:150
 				if r.LastError != "" {
-//line app/vmalert/web.qtpl:154
+//line app/vmalert/web.qtpl:150
 					qw422016.N().S(`
                                         <div class="col-12">
                                             <b>Error:</b>
                                             <div class="error-cell">
                                             `)
-//line app/vmalert/web.qtpl:158
+//line app/vmalert/web.qtpl:154
 					qw422016.E().S(r.LastError)
-//line app/vmalert/web.qtpl:158
+//line app/vmalert/web.qtpl:154
 					qw422016.N().S(`
                                             </div>
                                         </div>
                                         `)
-//line app/vmalert/web.qtpl:161
+//line app/vmalert/web.qtpl:157
 				}
-//line app/vmalert/web.qtpl:161
+//line app/vmalert/web.qtpl:157
 				qw422016.N().S(`
                                     </div>
                                 </td>
                                 <td class="text-center">`)
-//line app/vmalert/web.qtpl:164
+//line app/vmalert/web.qtpl:160
 				qw422016.N().D(r.LastSamples)
-//line app/vmalert/web.qtpl:164
+//line app/vmalert/web.qtpl:160
 				qw422016.N().S(`</td>
                                 <td class="text-center">`)
-//line app/vmalert/web.qtpl:165
+//line app/vmalert/web.qtpl:161
 				qw422016.N().FPrec(time.Since(r.LastEvaluation).Seconds(), 3)
-//line app/vmalert/web.qtpl:165
+//line app/vmalert/web.qtpl:161
 				qw422016.N().S(`s ago</td>
                             </tr>
                         `)
-//line app/vmalert/web.qtpl:167
+//line app/vmalert/web.qtpl:163
 			}
-//line app/vmalert/web.qtpl:167
+//line app/vmalert/web.qtpl:163
 			qw422016.N().S(`
                      </tbody>
                     </table>
                 </div>
             `)
-//line app/vmalert/web.qtpl:171
+//line app/vmalert/web.qtpl:167
 		}
-//line app/vmalert/web.qtpl:171
+//line app/vmalert/web.qtpl:167
 		qw422016.N().S(`
         `)
-//line app/vmalert/web.qtpl:172
+//line app/vmalert/web.qtpl:168
 	} else {
-//line app/vmalert/web.qtpl:172
+//line app/vmalert/web.qtpl:168
 		qw422016.N().S(`
             <div>
                 <p>No groups...</p>
             </div>
         `)
-//line app/vmalert/web.qtpl:176
+//line app/vmalert/web.qtpl:172
 	}
-//line app/vmalert/web.qtpl:176
+//line app/vmalert/web.qtpl:172
 	qw422016.N().S(`
 
     `)
-//line app/vmalert/web.qtpl:178
+//line app/vmalert/web.qtpl:174
 	tpl.StreamFooter(qw422016, r)
-//line app/vmalert/web.qtpl:178
+//line app/vmalert/web.qtpl:174
 	qw422016.N().S(`
 
 `)
-//line app/vmalert/web.qtpl:180
+//line app/vmalert/web.qtpl:176
 }
 
-//line app/vmalert/web.qtpl:180
+//line app/vmalert/web.qtpl:176
 func WriteListGroups(qq422016 qtio422016.Writer, r *http.Request, originGroups []apiGroup) {
-//line app/vmalert/web.qtpl:180
+//line app/vmalert/web.qtpl:176
 	qw422016 := qt422016.AcquireWriter(qq422016)
-//line app/vmalert/web.qtpl:180
+//line app/vmalert/web.qtpl:176
 	StreamListGroups(qw422016, r, originGroups)
-//line app/vmalert/web.qtpl:180
+//line app/vmalert/web.qtpl:176
 	qt422016.ReleaseWriter(qw422016)
-//line app/vmalert/web.qtpl:180
+//line app/vmalert/web.qtpl:176
 }
 
-//line app/vmalert/web.qtpl:180
+//line app/vmalert/web.qtpl:176
 func ListGroups(r *http.Request, originGroups []apiGroup) string {
-//line app/vmalert/web.qtpl:180
+//line app/vmalert/web.qtpl:176
 	qb422016 := qt422016.AcquireByteBuffer()
-//line app/vmalert/web.qtpl:180
+//line app/vmalert/web.qtpl:176
 	WriteListGroups(qb422016, r, originGroups)
-//line app/vmalert/web.qtpl:180
+//line app/vmalert/web.qtpl:176
 	qs422016 := string(qb422016.B)
-//line app/vmalert/web.qtpl:180
+//line app/vmalert/web.qtpl:176
 	qt422016.ReleaseByteBuffer(qb422016)
-//line app/vmalert/web.qtpl:180
+//line app/vmalert/web.qtpl:176
 	return qs422016
-//line app/vmalert/web.qtpl:180
+//line app/vmalert/web.qtpl:176
 }
 
-//line app/vmalert/web.qtpl:183
+//line app/vmalert/web.qtpl:179
 func StreamListAlerts(qw422016 *qt422016.Writer, r *http.Request, groupAlerts []groupAlerts) {
-//line app/vmalert/web.qtpl:183
+//line app/vmalert/web.qtpl:179
 	qw422016.N().S(`
     `)
-//line app/vmalert/web.qtpl:184
+//line app/vmalert/web.qtpl:180
 	prefix := utils.Prefix(r.URL.Path)
 
-//line app/vmalert/web.qtpl:184
+//line app/vmalert/web.qtpl:180
 	qw422016.N().S(`
     `)
-//line app/vmalert/web.qtpl:185
+//line app/vmalert/web.qtpl:181
 	tpl.StreamHeader(qw422016, r, navItems, "Alerts", getLastConfigError())
-//line app/vmalert/web.qtpl:185
+//line app/vmalert/web.qtpl:181
 	qw422016.N().S(`
     `)
-//line app/vmalert/web.qtpl:186
+//line app/vmalert/web.qtpl:182
 	if len(groupAlerts) > 0 {
-//line app/vmalert/web.qtpl:186
+//line app/vmalert/web.qtpl:182
 		qw422016.N().S(`
          <a class="btn btn-primary" role="button" onclick="collapseAll()">Collapse All</a>
          <a class="btn btn-primary" role="button" onclick="expandAll()">Expand All</a>
          `)
-//line app/vmalert/web.qtpl:189
+//line app/vmalert/web.qtpl:185
 		for _, ga := range groupAlerts {
-//line app/vmalert/web.qtpl:189
+//line app/vmalert/web.qtpl:185
 			qw422016.N().S(`
             `)
-//line app/vmalert/web.qtpl:190
+//line app/vmalert/web.qtpl:186
 			g := ga.Group
 
-//line app/vmalert/web.qtpl:190
+//line app/vmalert/web.qtpl:186
 			qw422016.N().S(`
             <div class="group-heading alert-danger" data-bs-target="rules-`)
-//line app/vmalert/web.qtpl:191
+//line app/vmalert/web.qtpl:187
 			qw422016.E().S(g.ID)
-//line app/vmalert/web.qtpl:191
+//line app/vmalert/web.qtpl:187
 			qw422016.N().S(`">
                 <span class="anchor" id="group-`)
-//line app/vmalert/web.qtpl:192
+//line app/vmalert/web.qtpl:188
 			qw422016.E().S(g.ID)
-//line app/vmalert/web.qtpl:192
+//line app/vmalert/web.qtpl:188
 			qw422016.N().S(`"></span>
                 <a href="#group-`)
-//line app/vmalert/web.qtpl:193
+//line app/vmalert/web.qtpl:189
 			qw422016.E().S(g.ID)
-//line app/vmalert/web.qtpl:193
+//line app/vmalert/web.qtpl:189
 			qw422016.N().S(`">`)
-//line app/vmalert/web.qtpl:193
+//line app/vmalert/web.qtpl:189
 			qw422016.E().S(g.Name)
-//line app/vmalert/web.qtpl:193
+//line app/vmalert/web.qtpl:189
 			if g.Type != "prometheus" {
-//line app/vmalert/web.qtpl:193
+//line app/vmalert/web.qtpl:189
 				qw422016.N().S(` (`)
-//line app/vmalert/web.qtpl:193
+//line app/vmalert/web.qtpl:189
 				qw422016.E().S(g.Type)
-//line app/vmalert/web.qtpl:193
+//line app/vmalert/web.qtpl:189
 				qw422016.N().S(`)`)
-//line app/vmalert/web.qtpl:193
+//line app/vmalert/web.qtpl:189
 			}
-//line app/vmalert/web.qtpl:193
+//line app/vmalert/web.qtpl:189
 			qw422016.N().S(`</a>
                 <span class="badge bg-danger" title="Number of active alerts">`)
-//line app/vmalert/web.qtpl:194
+//line app/vmalert/web.qtpl:190
 			qw422016.N().D(len(ga.Alerts))
-//line app/vmalert/web.qtpl:194
+//line app/vmalert/web.qtpl:190
 			qw422016.N().S(`</span>
                 <br>
                 <p class="fs-6 fw-lighter">`)
-//line app/vmalert/web.qtpl:196
+//line app/vmalert/web.qtpl:192
 			qw422016.E().S(g.File)
-//line app/vmalert/web.qtpl:196
+//line app/vmalert/web.qtpl:192
 			qw422016.N().S(`</p>
             </div>
             `)
-//line app/vmalert/web.qtpl:199
+//line app/vmalert/web.qtpl:195
 			var keys []string
 			alertsByRule := make(map[string][]*apiAlert)
 			for _, alert := range ga.Alerts {
@@ -747,20 +743,20 @@ func StreamListAlerts(qw422016 *qt422016.Writer, r *http.Request, groupAlerts []
 			}
 			sort.Strings(keys)
 
-//line app/vmalert/web.qtpl:208
+//line app/vmalert/web.qtpl:204
 			qw422016.N().S(`
             <div class="collapse" id="rules-`)
-//line app/vmalert/web.qtpl:209
+//line app/vmalert/web.qtpl:205
 			qw422016.E().S(g.ID)
-//line app/vmalert/web.qtpl:209
+//line app/vmalert/web.qtpl:205
 			qw422016.N().S(`">
                 `)
-//line app/vmalert/web.qtpl:210
+//line app/vmalert/web.qtpl:206
 			for _, ruleID := range keys {
-//line app/vmalert/web.qtpl:210
+//line app/vmalert/web.qtpl:206
 				qw422016.N().S(`
                     `)
-//line app/vmalert/web.qtpl:212
+//line app/vmalert/web.qtpl:208
 				defaultAR := alertsByRule[ruleID][0]
 				var labelKeys []string
 				for k := range defaultAR.Labels {
@@ -768,28 +764,28 @@ func StreamListAlerts(qw422016 *qt422016.Writer, r *http.Request, groupAlerts []
 				}
 				sort.Strings(labelKeys)
 
-//line app/vmalert/web.qtpl:218
+//line app/vmalert/web.qtpl:214
 				qw422016.N().S(`
                     <br>
                     <b>alert:</b> `)
-//line app/vmalert/web.qtpl:220
+//line app/vmalert/web.qtpl:216
 				qw422016.E().S(defaultAR.Name)
-//line app/vmalert/web.qtpl:220
+//line app/vmalert/web.qtpl:216
 				qw422016.N().S(` (`)
-//line app/vmalert/web.qtpl:220
+//line app/vmalert/web.qtpl:216
 				qw422016.N().D(len(alertsByRule[ruleID]))
-//line app/vmalert/web.qtpl:220
+//line app/vmalert/web.qtpl:216
 				qw422016.N().S(`)
                      | <span><a target="_blank" href="`)
-//line app/vmalert/web.qtpl:221
+//line app/vmalert/web.qtpl:217
 				qw422016.E().S(defaultAR.SourceLink)
-//line app/vmalert/web.qtpl:221
+//line app/vmalert/web.qtpl:217
 				qw422016.N().S(`">Source</a></span>
                     <br>
                     <b>expr:</b><code><pre>`)
-//line app/vmalert/web.qtpl:223
+//line app/vmalert/web.qtpl:219
 				qw422016.E().S(defaultAR.Expression)
-//line app/vmalert/web.qtpl:223
+//line app/vmalert/web.qtpl:219
 				qw422016.N().S(`</pre></code>
                     <table class="table table-striped table-hover table-sm">
                         <thead>
@@ -803,213 +799,213 @@ func StreamListAlerts(qw422016 *qt422016.Writer, r *http.Request, groupAlerts []
                         </thead>
                         <tbody>
                         `)
-//line app/vmalert/web.qtpl:235
+//line app/vmalert/web.qtpl:231
 				for _, ar := range alertsByRule[ruleID] {
-//line app/vmalert/web.qtpl:235
+//line app/vmalert/web.qtpl:231
 					qw422016.N().S(`
                             <tr>
                                 <td>
                                     `)
-//line app/vmalert/web.qtpl:238
+//line app/vmalert/web.qtpl:234
 					for _, k := range labelKeys {
-//line app/vmalert/web.qtpl:238
+//line app/vmalert/web.qtpl:234
 						qw422016.N().S(`
                                         <span class="ms-1 badge bg-primary">`)
-//line app/vmalert/web.qtpl:239
+//line app/vmalert/web.qtpl:235
 						qw422016.E().S(k)
-//line app/vmalert/web.qtpl:239
+//line app/vmalert/web.qtpl:235
 						qw422016.N().S(`=`)
-//line app/vmalert/web.qtpl:239
+//line app/vmalert/web.qtpl:235
 						qw422016.E().S(ar.Labels[k])
-//line app/vmalert/web.qtpl:239
+//line app/vmalert/web.qtpl:235
 						qw422016.N().S(`</span>
                                     `)
-//line app/vmalert/web.qtpl:240
+//line app/vmalert/web.qtpl:236
 					}
-//line app/vmalert/web.qtpl:240
+//line app/vmalert/web.qtpl:236
 					qw422016.N().S(`
                                 </td>
                                 <td>`)
-//line app/vmalert/web.qtpl:242
+//line app/vmalert/web.qtpl:238
 					streambadgeState(qw422016, ar.State)
-//line app/vmalert/web.qtpl:242
+//line app/vmalert/web.qtpl:238
 					qw422016.N().S(`</td>
                                 <td>
                                     `)
-//line app/vmalert/web.qtpl:244
+//line app/vmalert/web.qtpl:240
 					qw422016.E().S(ar.ActiveAt.Format("2006-01-02T15:04:05Z07:00"))
-//line app/vmalert/web.qtpl:244
+//line app/vmalert/web.qtpl:240
 					qw422016.N().S(`
                                     `)
-//line app/vmalert/web.qtpl:245
+//line app/vmalert/web.qtpl:241
 					if ar.Restored {
-//line app/vmalert/web.qtpl:245
+//line app/vmalert/web.qtpl:241
 						streambadgeRestored(qw422016)
-//line app/vmalert/web.qtpl:245
+//line app/vmalert/web.qtpl:241
 					}
-//line app/vmalert/web.qtpl:245
+//line app/vmalert/web.qtpl:241
 					qw422016.N().S(`
                                     `)
-//line app/vmalert/web.qtpl:246
+//line app/vmalert/web.qtpl:242
 					if ar.Stabilizing {
-//line app/vmalert/web.qtpl:246
+//line app/vmalert/web.qtpl:242
 						streambadgeStabilizing(qw422016)
-//line app/vmalert/web.qtpl:246
+//line app/vmalert/web.qtpl:242
 					}
-//line app/vmalert/web.qtpl:246
+//line app/vmalert/web.qtpl:242
 					qw422016.N().S(`
                                 </td>
                                 <td>`)
-//line app/vmalert/web.qtpl:248
+//line app/vmalert/web.qtpl:244
 					qw422016.E().S(ar.Value)
-//line app/vmalert/web.qtpl:248
+//line app/vmalert/web.qtpl:244
 					qw422016.N().S(`</td>
                                 <td>
                                     <a href="`)
-//line app/vmalert/web.qtpl:250
+//line app/vmalert/web.qtpl:246
 					qw422016.E().S(prefix + ar.WebLink())
-//line app/vmalert/web.qtpl:250
+//line app/vmalert/web.qtpl:246
 					qw422016.N().S(`">Details</a>
                                 </td>
                             </tr>
                         `)
-//line app/vmalert/web.qtpl:253
+//line app/vmalert/web.qtpl:249
 				}
-//line app/vmalert/web.qtpl:253
+//line app/vmalert/web.qtpl:249
 				qw422016.N().S(`
                      </tbody>
                     </table>
                 `)
-//line app/vmalert/web.qtpl:256
+//line app/vmalert/web.qtpl:252
 			}
-//line app/vmalert/web.qtpl:256
+//line app/vmalert/web.qtpl:252
 			qw422016.N().S(`
             </div>
             <br>
         `)
-//line app/vmalert/web.qtpl:259
+//line app/vmalert/web.qtpl:255
 		}
-//line app/vmalert/web.qtpl:259
+//line app/vmalert/web.qtpl:255
 		qw422016.N().S(`
 
     `)
-//line app/vmalert/web.qtpl:261
+//line app/vmalert/web.qtpl:257
 	} else {
-//line app/vmalert/web.qtpl:261
+//line app/vmalert/web.qtpl:257
 		qw422016.N().S(`
         <div>
             <p>No active alerts...</p>
         </div>
     `)
-//line app/vmalert/web.qtpl:265
+//line app/vmalert/web.qtpl:261
 	}
-//line app/vmalert/web.qtpl:265
+//line app/vmalert/web.qtpl:261
 	qw422016.N().S(`
 
     `)
-//line app/vmalert/web.qtpl:267
+//line app/vmalert/web.qtpl:263
 	tpl.StreamFooter(qw422016, r)
-//line app/vmalert/web.qtpl:267
+//line app/vmalert/web.qtpl:263
 	qw422016.N().S(`
 
 `)
-//line app/vmalert/web.qtpl:269
+//line app/vmalert/web.qtpl:265
 }
 
-//line app/vmalert/web.qtpl:269
+//line app/vmalert/web.qtpl:265
 func WriteListAlerts(qq422016 qtio422016.Writer, r *http.Request, groupAlerts []groupAlerts) {
-//line app/vmalert/web.qtpl:269
+//line app/vmalert/web.qtpl:265
 	qw422016 := qt422016.AcquireWriter(qq422016)
-//line app/vmalert/web.qtpl:269
+//line app/vmalert/web.qtpl:265
 	StreamListAlerts(qw422016, r, groupAlerts)
-//line app/vmalert/web.qtpl:269
+//line app/vmalert/web.qtpl:265
 	qt422016.ReleaseWriter(qw422016)
-//line app/vmalert/web.qtpl:269
+//line app/vmalert/web.qtpl:265
 }
 
-//line app/vmalert/web.qtpl:269
+//line app/vmalert/web.qtpl:265
 func ListAlerts(r *http.Request, groupAlerts []groupAlerts) string {
-//line app/vmalert/web.qtpl:269
+//line app/vmalert/web.qtpl:265
 	qb422016 := qt422016.AcquireByteBuffer()
-//line app/vmalert/web.qtpl:269
+//line app/vmalert/web.qtpl:265
 	WriteListAlerts(qb422016, r, groupAlerts)
-//line app/vmalert/web.qtpl:269
+//line app/vmalert/web.qtpl:265
 	qs422016 := string(qb422016.B)
-//line app/vmalert/web.qtpl:269
+//line app/vmalert/web.qtpl:265
 	qt422016.ReleaseByteBuffer(qb422016)
-//line app/vmalert/web.qtpl:269
+//line app/vmalert/web.qtpl:265
 	return qs422016
-//line app/vmalert/web.qtpl:269
+//line app/vmalert/web.qtpl:265
 }
 
-//line app/vmalert/web.qtpl:271
+//line app/vmalert/web.qtpl:267
 func StreamListTargets(qw422016 *qt422016.Writer, r *http.Request, targets map[notifier.TargetType][]notifier.Target) {
-//line app/vmalert/web.qtpl:271
+//line app/vmalert/web.qtpl:267
 	qw422016.N().S(`
     `)
-//line app/vmalert/web.qtpl:272
+//line app/vmalert/web.qtpl:268
 	tpl.StreamHeader(qw422016, r, navItems, "Notifiers", getLastConfigError())
-//line app/vmalert/web.qtpl:272
+//line app/vmalert/web.qtpl:268
 	qw422016.N().S(`
     `)
-//line app/vmalert/web.qtpl:273
+//line app/vmalert/web.qtpl:269
 	if len(targets) > 0 {
-//line app/vmalert/web.qtpl:273
+//line app/vmalert/web.qtpl:269
 		qw422016.N().S(`
          <a class="btn btn-primary" role="button" onclick="collapseAll()">Collapse All</a>
          <a class="btn btn-primary" role="button" onclick="expandAll()">Expand All</a>
 
          `)
-//line app/vmalert/web.qtpl:278
+//line app/vmalert/web.qtpl:274
 		var keys []string
 		for key := range targets {
 			keys = append(keys, string(key))
 		}
 		sort.Strings(keys)
 
-//line app/vmalert/web.qtpl:283
+//line app/vmalert/web.qtpl:279
 		qw422016.N().S(`
 
          `)
-//line app/vmalert/web.qtpl:285
+//line app/vmalert/web.qtpl:281
 		for i := range keys {
-//line app/vmalert/web.qtpl:285
+//line app/vmalert/web.qtpl:281
 			qw422016.N().S(`
            `)
-//line app/vmalert/web.qtpl:286
+//line app/vmalert/web.qtpl:282
 			typeK, ns := keys[i], targets[notifier.TargetType(keys[i])]
 			count := len(ns)
 
-//line app/vmalert/web.qtpl:288
+//line app/vmalert/web.qtpl:284
 			qw422016.N().S(`
            <div class="group-heading" data-bs-target="notifiers-`)
-//line app/vmalert/web.qtpl:289
+//line app/vmalert/web.qtpl:285
 			qw422016.E().S(typeK)
-//line app/vmalert/web.qtpl:289
+//line app/vmalert/web.qtpl:285
 			qw422016.N().S(`">
              <span class="anchor" id="group-`)
-//line app/vmalert/web.qtpl:290
+//line app/vmalert/web.qtpl:286
 			qw422016.E().S(typeK)
-//line app/vmalert/web.qtpl:290
+//line app/vmalert/web.qtpl:286
 			qw422016.N().S(`"></span>
              <a href="#group-`)
-//line app/vmalert/web.qtpl:291
+//line app/vmalert/web.qtpl:287
 			qw422016.E().S(typeK)
-//line app/vmalert/web.qtpl:291
+//line app/vmalert/web.qtpl:287
 			qw422016.N().S(`">`)
-//line app/vmalert/web.qtpl:291
+//line app/vmalert/web.qtpl:287
 			qw422016.E().S(typeK)
-//line app/vmalert/web.qtpl:291
+//line app/vmalert/web.qtpl:287
 			qw422016.N().S(` (`)
-//line app/vmalert/web.qtpl:291
+//line app/vmalert/web.qtpl:287
 			qw422016.N().D(count)
-//line app/vmalert/web.qtpl:291
+//line app/vmalert/web.qtpl:287
 			qw422016.N().S(`)</a>
          </div>
          <div class="collapse show" id="notifiers-`)
-//line app/vmalert/web.qtpl:293
+//line app/vmalert/web.qtpl:289
 			qw422016.E().S(typeK)
-//line app/vmalert/web.qtpl:293
+//line app/vmalert/web.qtpl:289
 			qw422016.N().S(`">
              <table class="table table-striped table-hover table-sm">
                  <thead>
@@ -1020,119 +1016,119 @@ func StreamListTargets(qw422016 *qt422016.Writer, r *http.Request, targets map[n
                  </thead>
                  <tbody>
                  `)
-//line app/vmalert/web.qtpl:302
+//line app/vmalert/web.qtpl:298
 			for _, n := range ns {
-//line app/vmalert/web.qtpl:302
+//line app/vmalert/web.qtpl:298
 				qw422016.N().S(`
                      <tr>
                          <td>
                               `)
-//line app/vmalert/web.qtpl:305
+//line app/vmalert/web.qtpl:301
 				for _, l := range n.Labels.GetLabels() {
-//line app/vmalert/web.qtpl:305
+//line app/vmalert/web.qtpl:301
 					qw422016.N().S(`
                                       <span class="ms-1 badge bg-primary">`)
-//line app/vmalert/web.qtpl:306
+//line app/vmalert/web.qtpl:302
 					qw422016.E().S(l.Name)
-//line app/vmalert/web.qtpl:306
+//line app/vmalert/web.qtpl:302
 					qw422016.N().S(`=`)
-//line app/vmalert/web.qtpl:306
+//line app/vmalert/web.qtpl:302
 					qw422016.E().S(l.Value)
-//line app/vmalert/web.qtpl:306
+//line app/vmalert/web.qtpl:302
 					qw422016.N().S(`</span>
                               `)
-//line app/vmalert/web.qtpl:307
+//line app/vmalert/web.qtpl:303
 				}
-//line app/vmalert/web.qtpl:307
+//line app/vmalert/web.qtpl:303
 				qw422016.N().S(`
                           </td>
                          <td>`)
-//line app/vmalert/web.qtpl:309
+//line app/vmalert/web.qtpl:305
 				qw422016.E().S(n.Notifier.Addr())
-//line app/vmalert/web.qtpl:309
+//line app/vmalert/web.qtpl:305
 				qw422016.N().S(`</td>
                      </tr>
                  `)
-//line app/vmalert/web.qtpl:311
+//line app/vmalert/web.qtpl:307
 			}
-//line app/vmalert/web.qtpl:311
+//line app/vmalert/web.qtpl:307
 			qw422016.N().S(`
               </tbody>
              </table>
          </div>
      `)
-//line app/vmalert/web.qtpl:315
+//line app/vmalert/web.qtpl:311
 		}
-//line app/vmalert/web.qtpl:315
+//line app/vmalert/web.qtpl:311
 		qw422016.N().S(`
 
     `)
-//line app/vmalert/web.qtpl:317
+//line app/vmalert/web.qtpl:313
 	} else {
-//line app/vmalert/web.qtpl:317
+//line app/vmalert/web.qtpl:313
 		qw422016.N().S(`
         <div>
             <p>No targets...</p>
         </div>
     `)
-//line app/vmalert/web.qtpl:321
+//line app/vmalert/web.qtpl:317
 	}
-//line app/vmalert/web.qtpl:321
+//line app/vmalert/web.qtpl:317
 	qw422016.N().S(`
 
     `)
-//line app/vmalert/web.qtpl:323
+//line app/vmalert/web.qtpl:319
 	tpl.StreamFooter(qw422016, r)
-//line app/vmalert/web.qtpl:323
+//line app/vmalert/web.qtpl:319
 	qw422016.N().S(`
 
 `)
-//line app/vmalert/web.qtpl:325
+//line app/vmalert/web.qtpl:321
 }
 
-//line app/vmalert/web.qtpl:325
+//line app/vmalert/web.qtpl:321
 func WriteListTargets(qq422016 qtio422016.Writer, r *http.Request, targets map[notifier.TargetType][]notifier.Target) {
-//line app/vmalert/web.qtpl:325
+//line app/vmalert/web.qtpl:321
 	qw422016 := qt422016.AcquireWriter(qq422016)
-//line app/vmalert/web.qtpl:325
+//line app/vmalert/web.qtpl:321
 	StreamListTargets(qw422016, r, targets)
-//line app/vmalert/web.qtpl:325
+//line app/vmalert/web.qtpl:321
 	qt422016.ReleaseWriter(qw422016)
-//line app/vmalert/web.qtpl:325
+//line app/vmalert/web.qtpl:321
 }
 
-//line app/vmalert/web.qtpl:325
+//line app/vmalert/web.qtpl:321
 func ListTargets(r *http.Request, targets map[notifier.TargetType][]notifier.Target) string {
-//line app/vmalert/web.qtpl:325
+//line app/vmalert/web.qtpl:321
 	qb422016 := qt422016.AcquireByteBuffer()
-//line app/vmalert/web.qtpl:325
+//line app/vmalert/web.qtpl:321
 	WriteListTargets(qb422016, r, targets)
-//line app/vmalert/web.qtpl:325
+//line app/vmalert/web.qtpl:321
 	qs422016 := string(qb422016.B)
-//line app/vmalert/web.qtpl:325
+//line app/vmalert/web.qtpl:321
 	qt422016.ReleaseByteBuffer(qb422016)
-//line app/vmalert/web.qtpl:325
+//line app/vmalert/web.qtpl:321
 	return qs422016
-//line app/vmalert/web.qtpl:325
+//line app/vmalert/web.qtpl:321
 }
 
-//line app/vmalert/web.qtpl:327
+//line app/vmalert/web.qtpl:323
 func StreamAlert(qw422016 *qt422016.Writer, r *http.Request, alert *apiAlert) {
-//line app/vmalert/web.qtpl:327
+//line app/vmalert/web.qtpl:323
 	qw422016.N().S(`
     `)
-//line app/vmalert/web.qtpl:328
+//line app/vmalert/web.qtpl:324
 	prefix := utils.Prefix(r.URL.Path)
 
-//line app/vmalert/web.qtpl:328
+//line app/vmalert/web.qtpl:324
 	qw422016.N().S(`
     `)
-//line app/vmalert/web.qtpl:329
+//line app/vmalert/web.qtpl:325
 	tpl.StreamHeader(qw422016, r, navItems, "", getLastConfigError())
-//line app/vmalert/web.qtpl:329
+//line app/vmalert/web.qtpl:325
 	qw422016.N().S(`
     `)
-//line app/vmalert/web.qtpl:331
+//line app/vmalert/web.qtpl:327
 	var labelKeys []string
 	for k := range alert.Labels {
 		labelKeys = append(labelKeys, k)
@@ -1145,28 +1141,28 @@ func StreamAlert(qw422016 *qt422016.Writer, r *http.Request, alert *apiAlert) {
 	}
 	sort.Strings(annotationKeys)
 
-//line app/vmalert/web.qtpl:342
+//line app/vmalert/web.qtpl:338
 	qw422016.N().S(`
     <div class="display-6 pb-3 mb-3">Alert: `)
-//line app/vmalert/web.qtpl:343
+//line app/vmalert/web.qtpl:339
 	qw422016.E().S(alert.Name)
-//line app/vmalert/web.qtpl:343
+//line app/vmalert/web.qtpl:339
 	qw422016.N().S(`<span class="ms-2 badge `)
-//line app/vmalert/web.qtpl:343
+//line app/vmalert/web.qtpl:339
 	if alert.State == "firing" {
-//line app/vmalert/web.qtpl:343
+//line app/vmalert/web.qtpl:339
 		qw422016.N().S(`bg-danger`)
-//line app/vmalert/web.qtpl:343
+//line app/vmalert/web.qtpl:339
 	} else {
-//line app/vmalert/web.qtpl:343
+//line app/vmalert/web.qtpl:339
 		qw422016.N().S(` bg-warning text-dark`)
-//line app/vmalert/web.qtpl:343
+//line app/vmalert/web.qtpl:339
 	}
-//line app/vmalert/web.qtpl:343
+//line app/vmalert/web.qtpl:339
 	qw422016.N().S(`">`)
-//line app/vmalert/web.qtpl:343
+//line app/vmalert/web.qtpl:339
 	qw422016.E().S(alert.State)
-//line app/vmalert/web.qtpl:343
+//line app/vmalert/web.qtpl:339
 	qw422016.N().S(`</span></div>
     <div class="container border-bottom p-2">
       <div class="row">
@@ -1175,9 +1171,9 @@ func StreamAlert(qw422016 *qt422016.Writer, r *http.Request, alert *apiAlert) {
         </div>
         <div class="col">
           `)
-//line app/vmalert/web.qtpl:350
+//line app/vmalert/web.qtpl:346
 	qw422016.E().S(alert.ActiveAt.Format("2006-01-02T15:04:05Z07:00"))
-//line app/vmalert/web.qtpl:350
+//line app/vmalert/web.qtpl:346
 	qw422016.N().S(`
         </div>
       </div>
@@ -1189,9 +1185,9 @@ func StreamAlert(qw422016 *qt422016.Writer, r *http.Request, alert *apiAlert) {
         </div>
         <div class="col">
           <code><pre>`)
-//line app/vmalert/web.qtpl:360
+//line app/vmalert/web.qtpl:356
 	qw422016.E().S(alert.Expression)
-//line app/vmalert/web.qtpl:360
+//line app/vmalert/web.qtpl:356
 	qw422016.N().S(`</pre></code>
         </div>
       </div>
@@ -1203,23 +1199,23 @@ func StreamAlert(qw422016 *qt422016.Writer, r *http.Request, alert *apiAlert) {
         </div>
         <div class="col">
            `)
-//line app/vmalert/web.qtpl:370
+//line app/vmalert/web.qtpl:366
 	for _, k := range labelKeys {
-//line app/vmalert/web.qtpl:370
+//line app/vmalert/web.qtpl:366
 		qw422016.N().S(`
                 <span class="m-1 badge bg-primary">`)
-//line app/vmalert/web.qtpl:371
+//line app/vmalert/web.qtpl:367
 		qw422016.E().S(k)
-//line app/vmalert/web.qtpl:371
+//line app/vmalert/web.qtpl:367
 		qw422016.N().S(`=`)
-//line app/vmalert/web.qtpl:371
+//line app/vmalert/web.qtpl:367
 		qw422016.E().S(alert.Labels[k])
-//line app/vmalert/web.qtpl:371
+//line app/vmalert/web.qtpl:367
 		qw422016.N().S(`</span>
           `)
-//line app/vmalert/web.qtpl:372
+//line app/vmalert/web.qtpl:368
 	}
-//line app/vmalert/web.qtpl:372
+//line app/vmalert/web.qtpl:368
 	qw422016.N().S(`
         </div>
       </div>
@@ -1231,24 +1227,24 @@ func StreamAlert(qw422016 *qt422016.Writer, r *http.Request, alert *apiAlert) {
         </div>
         <div class="col">
            `)
-//line app/vmalert/web.qtpl:382
+//line app/vmalert/web.qtpl:378
 	for _, k := range annotationKeys {
-//line app/vmalert/web.qtpl:382
+//line app/vmalert/web.qtpl:378
 		qw422016.N().S(`
                 <b>`)
-//line app/vmalert/web.qtpl:383
+//line app/vmalert/web.qtpl:379
 		qw422016.E().S(k)
-//line app/vmalert/web.qtpl:383
+//line app/vmalert/web.qtpl:379
 		qw422016.N().S(`:</b><br>
                 <p>`)
-//line app/vmalert/web.qtpl:384
+//line app/vmalert/web.qtpl:380
 		qw422016.E().S(alert.Annotations[k])
-//line app/vmalert/web.qtpl:384
+//line app/vmalert/web.qtpl:380
 		qw422016.N().S(`</p>
           `)
-//line app/vmalert/web.qtpl:385
+//line app/vmalert/web.qtpl:381
 	}
-//line app/vmalert/web.qtpl:385
+//line app/vmalert/web.qtpl:381
 	qw422016.N().S(`
         </div>
       </div>
@@ -1260,17 +1256,17 @@ func StreamAlert(qw422016 *qt422016.Writer, r *http.Request, alert *apiAlert) {
         </div>
         <div class="col">
            <a target="_blank" href="`)
-//line app/vmalert/web.qtpl:395
+//line app/vmalert/web.qtpl:391
 	qw422016.E().S(prefix)
-//line app/vmalert/web.qtpl:395
+//line app/vmalert/web.qtpl:391
 	qw422016.N().S(`groups#group-`)
-//line app/vmalert/web.qtpl:395
+//line app/vmalert/web.qtpl:391
 	qw422016.E().S(alert.GroupID)
-//line app/vmalert/web.qtpl:395
+//line app/vmalert/web.qtpl:391
 	qw422016.N().S(`">`)
-//line app/vmalert/web.qtpl:395
+//line app/vmalert/web.qtpl:391
 	qw422016.E().S(alert.GroupID)
-//line app/vmalert/web.qtpl:395
+//line app/vmalert/web.qtpl:391
 	qw422016.N().S(`</a>
         </div>
       </div>
@@ -1282,66 +1278,66 @@ func StreamAlert(qw422016 *qt422016.Writer, r *http.Request, alert *apiAlert) {
         </div>
         <div class="col">
            <a target="_blank" href="`)
-//line app/vmalert/web.qtpl:405
+//line app/vmalert/web.qtpl:401
 	qw422016.E().S(alert.SourceLink)
-//line app/vmalert/web.qtpl:405
+//line app/vmalert/web.qtpl:401
 	qw422016.N().S(`">Link</a>
         </div>
       </div>
     </div>
     `)
-//line app/vmalert/web.qtpl:409
+//line app/vmalert/web.qtpl:405
 	tpl.StreamFooter(qw422016, r)
-//line app/vmalert/web.qtpl:409
+//line app/vmalert/web.qtpl:405
 	qw422016.N().S(`
 
 `)
-//line app/vmalert/web.qtpl:411
+//line app/vmalert/web.qtpl:407
 }
 
-//line app/vmalert/web.qtpl:411
+//line app/vmalert/web.qtpl:407
 func WriteAlert(qq422016 qtio422016.Writer, r *http.Request, alert *apiAlert) {
-//line app/vmalert/web.qtpl:411
+//line app/vmalert/web.qtpl:407
 	qw422016 := qt422016.AcquireWriter(qq422016)
-//line app/vmalert/web.qtpl:411
+//line app/vmalert/web.qtpl:407
 	StreamAlert(qw422016, r, alert)
-//line app/vmalert/web.qtpl:411
+//line app/vmalert/web.qtpl:407
 	qt422016.ReleaseWriter(qw422016)
-//line app/vmalert/web.qtpl:411
+//line app/vmalert/web.qtpl:407
 }
 
-//line app/vmalert/web.qtpl:411
+//line app/vmalert/web.qtpl:407
 func Alert(r *http.Request, alert *apiAlert) string {
-//line app/vmalert/web.qtpl:411
+//line app/vmalert/web.qtpl:407
 	qb422016 := qt422016.AcquireByteBuffer()
-//line app/vmalert/web.qtpl:411
+//line app/vmalert/web.qtpl:407
 	WriteAlert(qb422016, r, alert)
-//line app/vmalert/web.qtpl:411
+//line app/vmalert/web.qtpl:407
 	qs422016 := string(qb422016.B)
-//line app/vmalert/web.qtpl:411
+//line app/vmalert/web.qtpl:407
 	qt422016.ReleaseByteBuffer(qb422016)
-//line app/vmalert/web.qtpl:411
+//line app/vmalert/web.qtpl:407
 	return qs422016
-//line app/vmalert/web.qtpl:411
+//line app/vmalert/web.qtpl:407
 }
 
-//line app/vmalert/web.qtpl:414
+//line app/vmalert/web.qtpl:410
 func StreamRuleDetails(qw422016 *qt422016.Writer, r *http.Request, rule apiRule) {
-//line app/vmalert/web.qtpl:414
+//line app/vmalert/web.qtpl:410
 	qw422016.N().S(`
     `)
-//line app/vmalert/web.qtpl:415
+//line app/vmalert/web.qtpl:411
 	prefix := utils.Prefix(r.URL.Path)
 
-//line app/vmalert/web.qtpl:415
+//line app/vmalert/web.qtpl:411
 	qw422016.N().S(`
     `)
-//line app/vmalert/web.qtpl:416
+//line app/vmalert/web.qtpl:412
 	tpl.StreamHeader(qw422016, r, navItems, "", getLastConfigError())
-//line app/vmalert/web.qtpl:416
+//line app/vmalert/web.qtpl:412
 	qw422016.N().S(`
     `)
-//line app/vmalert/web.qtpl:418
+//line app/vmalert/web.qtpl:414
 	var labelKeys []string
 	for k := range rule.Labels {
 		labelKeys = append(labelKeys, k)
@@ -1365,28 +1361,28 @@ func StreamRuleDetails(qw422016 *qt422016.Writer, r *http.Request, rule apiRule)
 		}
 	}
 
-//line app/vmalert/web.qtpl:441
+//line app/vmalert/web.qtpl:437
 	qw422016.N().S(`
     <div class="display-6 pb-3 mb-3">Rule: `)
-//line app/vmalert/web.qtpl:442
+//line app/vmalert/web.qtpl:438
 	qw422016.E().S(rule.Name)
-//line app/vmalert/web.qtpl:442
+//line app/vmalert/web.qtpl:438
 	qw422016.N().S(`<span class="ms-2 badge `)
-//line app/vmalert/web.qtpl:442
+//line app/vmalert/web.qtpl:438
 	if rule.Health != "ok" {
-//line app/vmalert/web.qtpl:442
+//line app/vmalert/web.qtpl:438
 		qw422016.N().S(`bg-danger`)
-//line app/vmalert/web.qtpl:442
+//line app/vmalert/web.qtpl:438
 	} else {
-//line app/vmalert/web.qtpl:442
+//line app/vmalert/web.qtpl:438
 		qw422016.N().S(` bg-success text-dark`)
-//line app/vmalert/web.qtpl:442
+//line app/vmalert/web.qtpl:438
 	}
-//line app/vmalert/web.qtpl:442
+//line app/vmalert/web.qtpl:438
 	qw422016.N().S(`">`)
-//line app/vmalert/web.qtpl:442
+//line app/vmalert/web.qtpl:438
 	qw422016.E().S(rule.Health)
-//line app/vmalert/web.qtpl:442
+//line app/vmalert/web.qtpl:438
 	qw422016.N().S(`</span></div>
     <div class="container border-bottom p-2">
       <div class="row">
@@ -1395,17 +1391,17 @@ func StreamRuleDetails(qw422016 *qt422016.Writer, r *http.Request, rule apiRule)
         </div>
         <div class="col">
           <code><pre>`)
-//line app/vmalert/web.qtpl:449
+//line app/vmalert/web.qtpl:445
 	qw422016.E().S(rule.Query)
-//line app/vmalert/web.qtpl:449
+//line app/vmalert/web.qtpl:445
 	qw422016.N().S(`</pre></code>
         </div>
       </div>
     </div>
     `)
-//line app/vmalert/web.qtpl:453
+//line app/vmalert/web.qtpl:449
 	if rule.Type == "alerting" {
-//line app/vmalert/web.qtpl:453
+//line app/vmalert/web.qtpl:449
 		qw422016.N().S(`
     <div class="container border-bottom p-2">
       <div class="row">
@@ -1414,17 +1410,17 @@ func StreamRuleDetails(qw422016 *qt422016.Writer, r *http.Request, rule apiRule)
         </div>
         <div class="col">
          `)
-//line app/vmalert/web.qtpl:460
+//line app/vmalert/web.qtpl:456
 		qw422016.E().V(rule.Duration)
-//line app/vmalert/web.qtpl:460
+//line app/vmalert/web.qtpl:456
 		qw422016.N().S(` seconds
         </div>
       </div>
     </div>
     `)
-//line app/vmalert/web.qtpl:464
+//line app/vmalert/web.qtpl:460
 		if rule.KeepFiringFor > 0 {
-//line app/vmalert/web.qtpl:464
+//line app/vmalert/web.qtpl:460
 			qw422016.N().S(`
     <div class="container border-bottom p-2">
       <div class="row">
@@ -1433,22 +1429,22 @@ func StreamRuleDetails(qw422016 *qt422016.Writer, r *http.Request, rule apiRule)
         </div>
         <div class="col">
          `)
-//line app/vmalert/web.qtpl:471
+//line app/vmalert/web.qtpl:467
 			qw422016.E().V(rule.KeepFiringFor)
-//line app/vmalert/web.qtpl:471
+//line app/vmalert/web.qtpl:467
 			qw422016.N().S(` seconds
         </div>
       </div>
     </div>
     `)
-//line app/vmalert/web.qtpl:475
+//line app/vmalert/web.qtpl:471
 		}
-//line app/vmalert/web.qtpl:475
+//line app/vmalert/web.qtpl:471
 		qw422016.N().S(`
     `)
-//line app/vmalert/web.qtpl:476
+//line app/vmalert/web.qtpl:472
 	}
-//line app/vmalert/web.qtpl:476
+//line app/vmalert/web.qtpl:472
 	qw422016.N().S(`
     <div class="container border-bottom p-2">
       <div class="row">
@@ -1457,31 +1453,31 @@ func StreamRuleDetails(qw422016 *qt422016.Writer, r *http.Request, rule apiRule)
         </div>
         <div class="col">
           `)
-//line app/vmalert/web.qtpl:483
+//line app/vmalert/web.qtpl:479
 	for _, k := range labelKeys {
-//line app/vmalert/web.qtpl:483
+//line app/vmalert/web.qtpl:479
 		qw422016.N().S(`
                 <span class="m-1 badge bg-primary">`)
-//line app/vmalert/web.qtpl:484
+//line app/vmalert/web.qtpl:480
 		qw422016.E().S(k)
-//line app/vmalert/web.qtpl:484
+//line app/vmalert/web.qtpl:480
 		qw422016.N().S(`=`)
-//line app/vmalert/web.qtpl:484
+//line app/vmalert/web.qtpl:480
 		qw422016.E().S(rule.Labels[k])
-//line app/vmalert/web.qtpl:484
+//line app/vmalert/web.qtpl:480
 		qw422016.N().S(`</span>
           `)
-//line app/vmalert/web.qtpl:485
+//line app/vmalert/web.qtpl:481
 	}
-//line app/vmalert/web.qtpl:485
+//line app/vmalert/web.qtpl:481
 	qw422016.N().S(`
         </div>
       </div>
     </div>
     `)
-//line app/vmalert/web.qtpl:489
+//line app/vmalert/web.qtpl:485
 	if rule.Type == "alerting" {
-//line app/vmalert/web.qtpl:489
+//line app/vmalert/web.qtpl:485
 		qw422016.N().S(`
     <div class="container border-bottom p-2">
       <div class="row">
@@ -1490,24 +1486,24 @@ func StreamRuleDetails(qw422016 *qt422016.Writer, r *http.Request, rule apiRule)
         </div>
         <div class="col">
           `)
-//line app/vmalert/web.qtpl:496
+//line app/vmalert/web.qtpl:492
 		for _, k := range annotationKeys {
-//line app/vmalert/web.qtpl:496
+//line app/vmalert/web.qtpl:492
 			qw422016.N().S(`
                 <b>`)
-//line app/vmalert/web.qtpl:497
+//line app/vmalert/web.qtpl:493
 			qw422016.E().S(k)
-//line app/vmalert/web.qtpl:497
+//line app/vmalert/web.qtpl:493
 			qw422016.N().S(`:</b><br>
                 <p>`)
-//line app/vmalert/web.qtpl:498
+//line app/vmalert/web.qtpl:494
 			qw422016.E().S(rule.Annotations[k])
-//line app/vmalert/web.qtpl:498
+//line app/vmalert/web.qtpl:494
 			qw422016.N().S(`</p>
           `)
-//line app/vmalert/web.qtpl:499
+//line app/vmalert/web.qtpl:495
 		}
-//line app/vmalert/web.qtpl:499
+//line app/vmalert/web.qtpl:495
 		qw422016.N().S(`
         </div>
       </div>
@@ -1519,17 +1515,17 @@ func StreamRuleDetails(qw422016 *qt422016.Writer, r *http.Request, rule apiRule)
         </div>
         <div class="col">
            `)
-//line app/vmalert/web.qtpl:509
+//line app/vmalert/web.qtpl:505
 		qw422016.E().V(rule.Debug)
-//line app/vmalert/web.qtpl:509
+//line app/vmalert/web.qtpl:505
 		qw422016.N().S(`
         </div>
       </div>
     </div>
     `)
-//line app/vmalert/web.qtpl:513
+//line app/vmalert/web.qtpl:509
 	}
-//line app/vmalert/web.qtpl:513
+//line app/vmalert/web.qtpl:509
 	qw422016.N().S(`
     <div class="container border-bottom p-2">
       <div class="row">
@@ -1538,17 +1534,17 @@ func StreamRuleDetails(qw422016 *qt422016.Writer, r *http.Request, rule apiRule)
         </div>
         <div class="col">
            <a target="_blank" href="`)
-//line app/vmalert/web.qtpl:520
+//line app/vmalert/web.qtpl:516
 	qw422016.E().S(prefix)
-//line app/vmalert/web.qtpl:520
+//line app/vmalert/web.qtpl:516
 	qw422016.N().S(`groups#group-`)
-//line app/vmalert/web.qtpl:520
+//line app/vmalert/web.qtpl:516
 	qw422016.E().S(rule.GroupID)
-//line app/vmalert/web.qtpl:520
+//line app/vmalert/web.qtpl:516
 	qw422016.N().S(`">`)
-//line app/vmalert/web.qtpl:520
+//line app/vmalert/web.qtpl:516
 	qw422016.E().S(rule.GroupID)
-//line app/vmalert/web.qtpl:520
+//line app/vmalert/web.qtpl:516
 	qw422016.N().S(`</a>
         </div>
       </div>
@@ -1556,9 +1552,9 @@ func StreamRuleDetails(qw422016 *qt422016.Writer, r *http.Request, rule apiRule)
 
     <br>
     `)
-//line app/vmalert/web.qtpl:526
+//line app/vmalert/web.qtpl:522
 	if seriesFetchedWarning {
-//line app/vmalert/web.qtpl:526
+//line app/vmalert/web.qtpl:522
 		qw422016.N().S(`
     <div class="alert alert-warning" role="alert">
        <strong>Warning:</strong> some of updates have "Series fetched" equal to 0.<br>
@@ -1572,18 +1568,18 @@ func StreamRuleDetails(qw422016 *qt422016.Writer, r *http.Request, rule apiRule)
        See more details about this detection <a target="_blank" href="https://github.com/VictoriaMetrics/VictoriaMetrics/issues/4039">here</a>.
     </div>
     `)
-//line app/vmalert/web.qtpl:538
+//line app/vmalert/web.qtpl:534
 	}
-//line app/vmalert/web.qtpl:538
+//line app/vmalert/web.qtpl:534
 	qw422016.N().S(`
     <div class="display-6 pb-3">Last `)
-//line app/vmalert/web.qtpl:539
+//line app/vmalert/web.qtpl:535
 	qw422016.N().D(len(rule.Updates))
-//line app/vmalert/web.qtpl:539
+//line app/vmalert/web.qtpl:535
 	qw422016.N().S(`/`)
-//line app/vmalert/web.qtpl:539
+//line app/vmalert/web.qtpl:535
 	qw422016.N().D(rule.MaxUpdates)
-//line app/vmalert/web.qtpl:539
+//line app/vmalert/web.qtpl:535
 	qw422016.N().S(` updates</span>:</div>
         <table class="table table-striped table-hover table-sm">
             <thead>
@@ -1591,13 +1587,13 @@ func StreamRuleDetails(qw422016 *qt422016.Writer, r *http.Request, rule apiRule)
                     <th scope="col" title="The time when event was created">Updated at</th>
                     <th scope="col" style="width: 10%" class="text-center" title="How many samples were returned">Samples</th>
                     `)
-//line app/vmalert/web.qtpl:545
+//line app/vmalert/web.qtpl:541
 	if seriesFetchedEnabled {
-//line app/vmalert/web.qtpl:545
+//line app/vmalert/web.qtpl:541
 		qw422016.N().S(`<th scope="col" style="width: 10%" class="text-center" title="How many series were scanned by datasource during the evaluation">Series fetched</th>`)
-//line app/vmalert/web.qtpl:545
+//line app/vmalert/web.qtpl:541
 	}
-//line app/vmalert/web.qtpl:545
+//line app/vmalert/web.qtpl:541
 	qw422016.N().S(`
                     <th scope="col" style="width: 10%" class="text-center" title="How many seconds request took">Duration</th>
                     <th scope="col" class="text-center" title="Time used for rule execution">Executed at</th>
@@ -1607,285 +1603,285 @@ func StreamRuleDetails(qw422016 *qt422016.Writer, r *http.Request, rule apiRule)
             <tbody>
 
      `)
-//line app/vmalert/web.qtpl:553
+//line app/vmalert/web.qtpl:549
 	for _, u := range rule.Updates {
-//line app/vmalert/web.qtpl:553
+//line app/vmalert/web.qtpl:549
 		qw422016.N().S(`
              <tr`)
-//line app/vmalert/web.qtpl:554
+//line app/vmalert/web.qtpl:550
 		if u.Err != nil {
-//line app/vmalert/web.qtpl:554
+//line app/vmalert/web.qtpl:550
 			qw422016.N().S(` class="alert-danger"`)
-//line app/vmalert/web.qtpl:554
+//line app/vmalert/web.qtpl:550
 		}
-//line app/vmalert/web.qtpl:554
+//line app/vmalert/web.qtpl:550
 		qw422016.N().S(`>
                  <td>
                     <span class="badge bg-primary rounded-pill me-3" title="Updated at">`)
-//line app/vmalert/web.qtpl:556
+//line app/vmalert/web.qtpl:552
 		qw422016.E().S(u.Time.Format(time.RFC3339))
-//line app/vmalert/web.qtpl:556
+//line app/vmalert/web.qtpl:552
 		qw422016.N().S(`</span>
                  </td>
                  <td class="text-center">`)
-//line app/vmalert/web.qtpl:558
+//line app/vmalert/web.qtpl:554
 		qw422016.N().D(u.Samples)
-//line app/vmalert/web.qtpl:558
+//line app/vmalert/web.qtpl:554
 		qw422016.N().S(`</td>
                  `)
-//line app/vmalert/web.qtpl:559
+//line app/vmalert/web.qtpl:555
 		if seriesFetchedEnabled {
-//line app/vmalert/web.qtpl:559
+//line app/vmalert/web.qtpl:555
 			qw422016.N().S(`<td class="text-center">`)
-//line app/vmalert/web.qtpl:559
+//line app/vmalert/web.qtpl:555
 			if u.SeriesFetched != nil {
-//line app/vmalert/web.qtpl:559
+//line app/vmalert/web.qtpl:555
 				qw422016.N().D(*u.SeriesFetched)
-//line app/vmalert/web.qtpl:559
+//line app/vmalert/web.qtpl:555
 			}
-//line app/vmalert/web.qtpl:559
+//line app/vmalert/web.qtpl:555
 			qw422016.N().S(`</td>`)
-//line app/vmalert/web.qtpl:559
+//line app/vmalert/web.qtpl:555
 		}
-//line app/vmalert/web.qtpl:559
+//line app/vmalert/web.qtpl:555
 		qw422016.N().S(`
                  <td class="text-center">`)
-//line app/vmalert/web.qtpl:560
+//line app/vmalert/web.qtpl:556
 		qw422016.N().FPrec(u.Duration.Seconds(), 3)
-//line app/vmalert/web.qtpl:560
+//line app/vmalert/web.qtpl:556
 		qw422016.N().S(`s</td>
                  <td class="text-center">`)
-//line app/vmalert/web.qtpl:561
+//line app/vmalert/web.qtpl:557
 		qw422016.E().S(u.At.Format(time.RFC3339))
-//line app/vmalert/web.qtpl:561
+//line app/vmalert/web.qtpl:557
 		qw422016.N().S(`</td>
                  <td>
                     <textarea class="curl-area" rows="1" onclick="this.focus();this.select()">`)
-//line app/vmalert/web.qtpl:563
+//line app/vmalert/web.qtpl:559
 		qw422016.E().S(u.Curl)
-//line app/vmalert/web.qtpl:563
+//line app/vmalert/web.qtpl:559
 		qw422016.N().S(`</textarea>
                 </td>
              </tr>
           </li>
           `)
-//line app/vmalert/web.qtpl:567
+//line app/vmalert/web.qtpl:563
 		if u.Err != nil {
-//line app/vmalert/web.qtpl:567
+//line app/vmalert/web.qtpl:563
 			qw422016.N().S(`
              <tr`)
-//line app/vmalert/web.qtpl:568
+//line app/vmalert/web.qtpl:564
 			if u.Err != nil {
-//line app/vmalert/web.qtpl:568
+//line app/vmalert/web.qtpl:564
 				qw422016.N().S(` class="alert-danger"`)
-//line app/vmalert/web.qtpl:568
+//line app/vmalert/web.qtpl:564
 			}
-//line app/vmalert/web.qtpl:568
+//line app/vmalert/web.qtpl:564
 			qw422016.N().S(`>
                <td colspan="`)
-//line app/vmalert/web.qtpl:569
+//line app/vmalert/web.qtpl:565
 			if seriesFetchedEnabled {
-//line app/vmalert/web.qtpl:569
+//line app/vmalert/web.qtpl:565
 				qw422016.N().S(`6`)
-//line app/vmalert/web.qtpl:569
+//line app/vmalert/web.qtpl:565
 			} else {
-//line app/vmalert/web.qtpl:569
+//line app/vmalert/web.qtpl:565
 				qw422016.N().S(`5`)
-//line app/vmalert/web.qtpl:569
+//line app/vmalert/web.qtpl:565
 			}
-//line app/vmalert/web.qtpl:569
+//line app/vmalert/web.qtpl:565
 			qw422016.N().S(`">
                    <span class="alert-danger">`)
-//line app/vmalert/web.qtpl:570
+//line app/vmalert/web.qtpl:566
 			qw422016.E().V(u.Err)
-//line app/vmalert/web.qtpl:570
+//line app/vmalert/web.qtpl:566
 			qw422016.N().S(`</span>
                </td>
              </tr>
           `)
-//line app/vmalert/web.qtpl:573
+//line app/vmalert/web.qtpl:569
 		}
-//line app/vmalert/web.qtpl:573
+//line app/vmalert/web.qtpl:569
 		qw422016.N().S(`
      `)
-//line app/vmalert/web.qtpl:574
+//line app/vmalert/web.qtpl:570
 	}
-//line app/vmalert/web.qtpl:574
+//line app/vmalert/web.qtpl:570
 	qw422016.N().S(`
 
     `)
-//line app/vmalert/web.qtpl:576
+//line app/vmalert/web.qtpl:572
 	tpl.StreamFooter(qw422016, r)
-//line app/vmalert/web.qtpl:576
+//line app/vmalert/web.qtpl:572
 	qw422016.N().S(`
 `)
-//line app/vmalert/web.qtpl:577
+//line app/vmalert/web.qtpl:573
 }
 
-//line app/vmalert/web.qtpl:577
+//line app/vmalert/web.qtpl:573
 func WriteRuleDetails(qq422016 qtio422016.Writer, r *http.Request, rule apiRule) {
-//line app/vmalert/web.qtpl:577
+//line app/vmalert/web.qtpl:573
 	qw422016 := qt422016.AcquireWriter(qq422016)
-//line app/vmalert/web.qtpl:577
+//line app/vmalert/web.qtpl:573
 	StreamRuleDetails(qw422016, r, rule)
-//line app/vmalert/web.qtpl:577
+//line app/vmalert/web.qtpl:573
 	qt422016.ReleaseWriter(qw422016)
-//line app/vmalert/web.qtpl:577
+//line app/vmalert/web.qtpl:573
 }
 
-//line app/vmalert/web.qtpl:577
+//line app/vmalert/web.qtpl:573
 func RuleDetails(r *http.Request, rule apiRule) string {
-//line app/vmalert/web.qtpl:577
+//line app/vmalert/web.qtpl:573
 	qb422016 := qt422016.AcquireByteBuffer()
-//line app/vmalert/web.qtpl:577
+//line app/vmalert/web.qtpl:573
 	WriteRuleDetails(qb422016, r, rule)
-//line app/vmalert/web.qtpl:577
+//line app/vmalert/web.qtpl:573
 	qs422016 := string(qb422016.B)
-//line app/vmalert/web.qtpl:577
+//line app/vmalert/web.qtpl:573
 	qt422016.ReleaseByteBuffer(qb422016)
-//line app/vmalert/web.qtpl:577
+//line app/vmalert/web.qtpl:573
 	return qs422016
-//line app/vmalert/web.qtpl:577
+//line app/vmalert/web.qtpl:573
 }
 
-//line app/vmalert/web.qtpl:581
+//line app/vmalert/web.qtpl:577
 func streambadgeState(qw422016 *qt422016.Writer, state string) {
-//line app/vmalert/web.qtpl:581
+//line app/vmalert/web.qtpl:577
 	qw422016.N().S(`
 `)
-//line app/vmalert/web.qtpl:583
+//line app/vmalert/web.qtpl:579
 	badgeClass := "bg-warning text-dark"
 	if state == "firing" {
 		badgeClass = "bg-danger"
 	}
 
-//line app/vmalert/web.qtpl:587
+//line app/vmalert/web.qtpl:583
 	qw422016.N().S(`
 <span class="badge `)
-//line app/vmalert/web.qtpl:588
+//line app/vmalert/web.qtpl:584
 	qw422016.E().S(badgeClass)
-//line app/vmalert/web.qtpl:588
+//line app/vmalert/web.qtpl:584
 	qw422016.N().S(`">`)
-//line app/vmalert/web.qtpl:588
+//line app/vmalert/web.qtpl:584
 	qw422016.E().S(state)
-//line app/vmalert/web.qtpl:588
+//line app/vmalert/web.qtpl:584
 	qw422016.N().S(`</span>
 `)
-//line app/vmalert/web.qtpl:589
+//line app/vmalert/web.qtpl:585
 }
 
-//line app/vmalert/web.qtpl:589
+//line app/vmalert/web.qtpl:585
 func writebadgeState(qq422016 qtio422016.Writer, state string) {
-//line app/vmalert/web.qtpl:589
+//line app/vmalert/web.qtpl:585
 	qw422016 := qt422016.AcquireWriter(qq422016)
-//line app/vmalert/web.qtpl:589
+//line app/vmalert/web.qtpl:585
 	streambadgeState(qw422016, state)
-//line app/vmalert/web.qtpl:589
+//line app/vmalert/web.qtpl:585
 	qt422016.ReleaseWriter(qw422016)
-//line app/vmalert/web.qtpl:589
+//line app/vmalert/web.qtpl:585
 }
 
-//line app/vmalert/web.qtpl:589
+//line app/vmalert/web.qtpl:585
 func badgeState(state string) string {
-//line app/vmalert/web.qtpl:589
+//line app/vmalert/web.qtpl:585
 	qb422016 := qt422016.AcquireByteBuffer()
-//line app/vmalert/web.qtpl:589
+//line app/vmalert/web.qtpl:585
 	writebadgeState(qb422016, state)
-//line app/vmalert/web.qtpl:589
+//line app/vmalert/web.qtpl:585
 	qs422016 := string(qb422016.B)
-//line app/vmalert/web.qtpl:589
+//line app/vmalert/web.qtpl:585
 	qt422016.ReleaseByteBuffer(qb422016)
-//line app/vmalert/web.qtpl:589
+//line app/vmalert/web.qtpl:585
 	return qs422016
-//line app/vmalert/web.qtpl:589
+//line app/vmalert/web.qtpl:585
 }
 
-//line app/vmalert/web.qtpl:591
+//line app/vmalert/web.qtpl:587
 func streambadgeRestored(qw422016 *qt422016.Writer) {
-//line app/vmalert/web.qtpl:591
+//line app/vmalert/web.qtpl:587
 	qw422016.N().S(`
 <span class="badge bg-warning text-dark" title="Alert state was restored after the service restart from remote storage">restored</span>
 `)
-//line app/vmalert/web.qtpl:593
+//line app/vmalert/web.qtpl:589
 }
 
-//line app/vmalert/web.qtpl:593
+//line app/vmalert/web.qtpl:589
 func writebadgeRestored(qq422016 qtio422016.Writer) {
-//line app/vmalert/web.qtpl:593
+//line app/vmalert/web.qtpl:589
 	qw422016 := qt422016.AcquireWriter(qq422016)
-//line app/vmalert/web.qtpl:593
+//line app/vmalert/web.qtpl:589
 	streambadgeRestored(qw422016)
-//line app/vmalert/web.qtpl:593
+//line app/vmalert/web.qtpl:589
 	qt422016.ReleaseWriter(qw422016)
-//line app/vmalert/web.qtpl:593
+//line app/vmalert/web.qtpl:589
 }
 
-//line app/vmalert/web.qtpl:593
+//line app/vmalert/web.qtpl:589
 func badgeRestored() string {
-//line app/vmalert/web.qtpl:593
+//line app/vmalert/web.qtpl:589
 	qb422016 := qt422016.AcquireByteBuffer()
-//line app/vmalert/web.qtpl:593
+//line app/vmalert/web.qtpl:589
 	writebadgeRestored(qb422016)
-//line app/vmalert/web.qtpl:593
+//line app/vmalert/web.qtpl:589
 	qs422016 := string(qb422016.B)
-//line app/vmalert/web.qtpl:593
+//line app/vmalert/web.qtpl:589
 	qt422016.ReleaseByteBuffer(qb422016)
-//line app/vmalert/web.qtpl:593
+//line app/vmalert/web.qtpl:589
 	return qs422016
-//line app/vmalert/web.qtpl:593
+//line app/vmalert/web.qtpl:589
 }
 
-//line app/vmalert/web.qtpl:595
+//line app/vmalert/web.qtpl:591
 func streambadgeStabilizing(qw422016 *qt422016.Writer) {
-//line app/vmalert/web.qtpl:595
+//line app/vmalert/web.qtpl:591
 	qw422016.N().S(`
 <span class="badge bg-warning text-dark" title="This firing state is kept because of `)
-//line app/vmalert/web.qtpl:595
+//line app/vmalert/web.qtpl:591
 	qw422016.N().S("`")
-//line app/vmalert/web.qtpl:595
+//line app/vmalert/web.qtpl:591
 	qw422016.N().S(`keep_firing_for`)
-//line app/vmalert/web.qtpl:595
+//line app/vmalert/web.qtpl:591
 	qw422016.N().S("`")
-//line app/vmalert/web.qtpl:595
+//line app/vmalert/web.qtpl:591
 	qw422016.N().S(`">stabilizing</span>
 `)
-//line app/vmalert/web.qtpl:597
+//line app/vmalert/web.qtpl:593
 }
 
-//line app/vmalert/web.qtpl:597
+//line app/vmalert/web.qtpl:593
 func writebadgeStabilizing(qq422016 qtio422016.Writer) {
-//line app/vmalert/web.qtpl:597
+//line app/vmalert/web.qtpl:593
 	qw422016 := qt422016.AcquireWriter(qq422016)
-//line app/vmalert/web.qtpl:597
+//line app/vmalert/web.qtpl:593
 	streambadgeStabilizing(qw422016)
-//line app/vmalert/web.qtpl:597
+//line app/vmalert/web.qtpl:593
 	qt422016.ReleaseWriter(qw422016)
-//line app/vmalert/web.qtpl:597
+//line app/vmalert/web.qtpl:593
 }
 
-//line app/vmalert/web.qtpl:597
+//line app/vmalert/web.qtpl:593
 func badgeStabilizing() string {
-//line app/vmalert/web.qtpl:597
+//line app/vmalert/web.qtpl:593
 	qb422016 := qt422016.AcquireByteBuffer()
-//line app/vmalert/web.qtpl:597
+//line app/vmalert/web.qtpl:593
 	writebadgeStabilizing(qb422016)
-//line app/vmalert/web.qtpl:597
+//line app/vmalert/web.qtpl:593
 	qs422016 := string(qb422016.B)
-//line app/vmalert/web.qtpl:597
+//line app/vmalert/web.qtpl:593
 	qt422016.ReleaseByteBuffer(qb422016)
-//line app/vmalert/web.qtpl:597
+//line app/vmalert/web.qtpl:593
 	return qs422016
-//line app/vmalert/web.qtpl:597
+//line app/vmalert/web.qtpl:593
 }
 
-//line app/vmalert/web.qtpl:599
+//line app/vmalert/web.qtpl:595
 func streamseriesFetchedWarn(qw422016 *qt422016.Writer, r apiRule) {
-//line app/vmalert/web.qtpl:599
+//line app/vmalert/web.qtpl:595
 	qw422016.N().S(`
 `)
-//line app/vmalert/web.qtpl:600
+//line app/vmalert/web.qtpl:596
 	if isNoMatch(r) {
-//line app/vmalert/web.qtpl:600
+//line app/vmalert/web.qtpl:596
 		qw422016.N().S(`
 <svg xmlns="http://www.w3.org/2000/svg"
     data-bs-toggle="tooltip"
@@ -1896,41 +1892,41 @@ func streamseriesFetchedWarn(qw422016 *qt422016.Writer, r apiRule) {
        <path d="M8 16A8 8 0 1 0 8 0a8 8 0 0 0 0 16zm.93-9.412-1 4.705c-.07.34.029.533.304.533.194 0 .487-.07.686-.246l-.088.416c-.287.346-.92.598-1.465.598-.703 0-1.002-.422-.808-1.319l.738-3.468c.064-.293.006-.399-.287-.47l-.451-.081.082-.381 2.29-.287zM8 5.5a1 1 0 1 1 0-2 1 1 0 0 1 0 2z"/>
 </svg>
 `)
-//line app/vmalert/web.qtpl:609
+//line app/vmalert/web.qtpl:605
 	}
-//line app/vmalert/web.qtpl:609
+//line app/vmalert/web.qtpl:605
 	qw422016.N().S(`
 `)
-//line app/vmalert/web.qtpl:610
+//line app/vmalert/web.qtpl:606
 }
 
-//line app/vmalert/web.qtpl:610
+//line app/vmalert/web.qtpl:606
 func writeseriesFetchedWarn(qq422016 qtio422016.Writer, r apiRule) {
-//line app/vmalert/web.qtpl:610
+//line app/vmalert/web.qtpl:606
 	qw422016 := qt422016.AcquireWriter(qq422016)
-//line app/vmalert/web.qtpl:610
+//line app/vmalert/web.qtpl:606
 	streamseriesFetchedWarn(qw422016, r)
-//line app/vmalert/web.qtpl:610
+//line app/vmalert/web.qtpl:606
 	qt422016.ReleaseWriter(qw422016)
-//line app/vmalert/web.qtpl:610
+//line app/vmalert/web.qtpl:606
 }
 
-//line app/vmalert/web.qtpl:610
+//line app/vmalert/web.qtpl:606
 func seriesFetchedWarn(r apiRule) string {
-//line app/vmalert/web.qtpl:610
+//line app/vmalert/web.qtpl:606
 	qb422016 := qt422016.AcquireByteBuffer()
-//line app/vmalert/web.qtpl:610
+//line app/vmalert/web.qtpl:606
 	writeseriesFetchedWarn(qb422016, r)
-//line app/vmalert/web.qtpl:610
+//line app/vmalert/web.qtpl:606
 	qs422016 := string(qb422016.B)
-//line app/vmalert/web.qtpl:610
+//line app/vmalert/web.qtpl:606
 	qt422016.ReleaseByteBuffer(qb422016)
-//line app/vmalert/web.qtpl:610
+//line app/vmalert/web.qtpl:606
 	return qs422016
-//line app/vmalert/web.qtpl:610
+//line app/vmalert/web.qtpl:606
 }
 
-//line app/vmalert/web.qtpl:613
+//line app/vmalert/web.qtpl:609
 func isNoMatch(r apiRule) bool {
 	return r.LastSamples == 0 && r.LastSeriesFetched != nil && *r.LastSeriesFetched == 0
 }

--- a/app/vmalert/web.qtpl.go
+++ b/app/vmalert/web.qtpl.go
@@ -242,175 +242,188 @@ func StreamListGroups(qw422016 *qt422016.Writer, r *http.Request, originGroups [
 
 //line app/vmalert/web.qtpl:72
 	qw422016.N().S(`
-         <a class="btn `)
-//line app/vmalert/web.qtpl:73
+        <div class="btn-toolbar mb-3" role="toolbar">
+          <div>
+            <a class="btn `)
+//line app/vmalert/web.qtpl:75
 	streambuttonActive(qw422016, filter, "")
-//line app/vmalert/web.qtpl:73
+//line app/vmalert/web.qtpl:75
 	qw422016.N().S(`" role="button" onclick="window.location = window.location.pathname">All</a>
-         <a class="btn btn-primary" role="button" onclick="collapseAll()">Collapse All</a>
-         <a class="btn btn-primary" role="button" onclick="expandAll()">Expand All</a>
-         <a class="btn `)
-//line app/vmalert/web.qtpl:76
+            <a class="btn btn-primary" role="button" onclick="collapseAll()">Collapse All</a>
+            <a class="btn btn-primary" role="button" onclick="expandAll()">Expand All</a>
+            <a class="btn `)
+//line app/vmalert/web.qtpl:78
 	streambuttonActive(qw422016, filter, "unhealthy")
-//line app/vmalert/web.qtpl:76
+//line app/vmalert/web.qtpl:78
 	qw422016.N().S(`" role="button" onclick="location.href='?filter=unhealthy'" title="Show only rules with errors">Unhealthy</a>
-         <a class="btn `)
-//line app/vmalert/web.qtpl:77
+            <a class="btn `)
+//line app/vmalert/web.qtpl:79
 	streambuttonActive(qw422016, filter, "noMatch")
-//line app/vmalert/web.qtpl:77
+//line app/vmalert/web.qtpl:79
 	qw422016.N().S(`" role="button" onclick="location.href='?filter=noMatch'" title="Show only rules matching no time series during last evaluation">NoMatch</a>
-         <input id="filter" class="input-group" role="input"></input>
+          </div>
+          <div class="col-md-4 col-lg-5">
+            <div class="px-3 input-group">
+              <div class="input-group-prepend">
+                <span class="input-group-text">
+                  <svg fill="#000000" height="25px" width="20px" version="1.1" id="Capa_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 490.4 490.4" xml:space="preserve"><g id="SVGRepo_bgCarrier" stroke-width="0"></g><g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"></g><g id="SVGRepo_iconCarrier"> <g> <path d="M484.1,454.796l-110.5-110.6c29.8-36.3,47.6-82.8,47.6-133.4c0-116.3-94.3-210.6-210.6-210.6S0,94.496,0,210.796 s94.3,210.6,210.6,210.6c50.8,0,97.4-18,133.8-48l110.5,110.5c12.9,11.8,25,4.2,29.2,0C492.5,475.596,492.5,463.096,484.1,454.796z M41.1,210.796c0-93.6,75.9-169.5,169.5-169.5s169.6,75.9,169.6,169.5s-75.9,169.5-169.5,169.5S41.1,304.396,41.1,210.796z"></path> </g> </g></svg>
+                </span>
+              </div>
+              <input id="filter" placeholder="Filter by group, rule or labels" type="text" class="form-control"/>
+            </div>
+          </div>
+        </div>
         `)
-//line app/vmalert/web.qtpl:79
+//line app/vmalert/web.qtpl:92
 	if len(groups) > 0 {
-//line app/vmalert/web.qtpl:79
+//line app/vmalert/web.qtpl:92
 		qw422016.N().S(`
             `)
-//line app/vmalert/web.qtpl:80
+//line app/vmalert/web.qtpl:93
 		for _, g := range groups {
-//line app/vmalert/web.qtpl:80
+//line app/vmalert/web.qtpl:93
 			qw422016.N().S(`
                   <div
                     class="group-heading`)
-//line app/vmalert/web.qtpl:82
+//line app/vmalert/web.qtpl:95
 			if rNotOk[g.ID] > 0 {
-//line app/vmalert/web.qtpl:82
+//line app/vmalert/web.qtpl:95
 				qw422016.N().S(` alert-danger`)
-//line app/vmalert/web.qtpl:82
+//line app/vmalert/web.qtpl:95
 			}
-//line app/vmalert/web.qtpl:82
+//line app/vmalert/web.qtpl:95
 			qw422016.N().S(`" data-bs-target="rules-`)
-//line app/vmalert/web.qtpl:82
+//line app/vmalert/web.qtpl:95
 			qw422016.E().S(g.ID)
-//line app/vmalert/web.qtpl:82
+//line app/vmalert/web.qtpl:95
 			qw422016.N().S(`" data-group-name="`)
-//line app/vmalert/web.qtpl:82
+//line app/vmalert/web.qtpl:95
 			qw422016.E().S(g.Name)
-//line app/vmalert/web.qtpl:82
+//line app/vmalert/web.qtpl:95
 			qw422016.N().S(`">
                     <span class="anchor" id="group-`)
-//line app/vmalert/web.qtpl:83
+//line app/vmalert/web.qtpl:96
 			qw422016.E().S(g.ID)
-//line app/vmalert/web.qtpl:83
+//line app/vmalert/web.qtpl:96
 			qw422016.N().S(`"></span>
                     <a href="#group-`)
-//line app/vmalert/web.qtpl:84
+//line app/vmalert/web.qtpl:97
 			qw422016.E().S(g.ID)
-//line app/vmalert/web.qtpl:84
+//line app/vmalert/web.qtpl:97
 			qw422016.N().S(`">`)
-//line app/vmalert/web.qtpl:84
+//line app/vmalert/web.qtpl:97
 			qw422016.E().S(g.Name)
-//line app/vmalert/web.qtpl:84
+//line app/vmalert/web.qtpl:97
 			if g.Type != "prometheus" {
-//line app/vmalert/web.qtpl:84
+//line app/vmalert/web.qtpl:97
 				qw422016.N().S(` (`)
-//line app/vmalert/web.qtpl:84
+//line app/vmalert/web.qtpl:97
 				qw422016.E().S(g.Type)
-//line app/vmalert/web.qtpl:84
+//line app/vmalert/web.qtpl:97
 				qw422016.N().S(`)`)
-//line app/vmalert/web.qtpl:84
+//line app/vmalert/web.qtpl:97
 			}
-//line app/vmalert/web.qtpl:84
+//line app/vmalert/web.qtpl:97
 			qw422016.N().S(` (every `)
-//line app/vmalert/web.qtpl:84
+//line app/vmalert/web.qtpl:97
 			qw422016.N().FPrec(g.Interval, 0)
-//line app/vmalert/web.qtpl:84
+//line app/vmalert/web.qtpl:97
 			qw422016.N().S(`s) #</a>
                      `)
-//line app/vmalert/web.qtpl:85
+//line app/vmalert/web.qtpl:98
 			if rNotOk[g.ID] > 0 {
-//line app/vmalert/web.qtpl:85
+//line app/vmalert/web.qtpl:98
 				qw422016.N().S(`<span class="badge bg-danger" title="Number of rules with status Error">`)
-//line app/vmalert/web.qtpl:85
+//line app/vmalert/web.qtpl:98
 				qw422016.N().D(rNotOk[g.ID])
-//line app/vmalert/web.qtpl:85
+//line app/vmalert/web.qtpl:98
 				qw422016.N().S(`</span> `)
-//line app/vmalert/web.qtpl:85
+//line app/vmalert/web.qtpl:98
 			}
-//line app/vmalert/web.qtpl:85
+//line app/vmalert/web.qtpl:98
 			qw422016.N().S(`
                      `)
-//line app/vmalert/web.qtpl:86
+//line app/vmalert/web.qtpl:99
 			if rNoMatch[g.ID] > 0 {
-//line app/vmalert/web.qtpl:86
+//line app/vmalert/web.qtpl:99
 				qw422016.N().S(`<span class="badge bg-warning" title="Number of rules with status NoMatch">`)
-//line app/vmalert/web.qtpl:86
+//line app/vmalert/web.qtpl:99
 				qw422016.N().D(rNoMatch[g.ID])
-//line app/vmalert/web.qtpl:86
+//line app/vmalert/web.qtpl:99
 				qw422016.N().S(`</span> `)
-//line app/vmalert/web.qtpl:86
+//line app/vmalert/web.qtpl:99
 			}
-//line app/vmalert/web.qtpl:86
+//line app/vmalert/web.qtpl:99
 			qw422016.N().S(`
                     <span class="badge bg-success" title="Number of rules withs status Ok">`)
-//line app/vmalert/web.qtpl:87
+//line app/vmalert/web.qtpl:100
 			qw422016.N().D(rOk[g.ID])
-//line app/vmalert/web.qtpl:87
+//line app/vmalert/web.qtpl:100
 			qw422016.N().S(`</span>
                     <p class="fs-6 fw-lighter">`)
-//line app/vmalert/web.qtpl:88
+//line app/vmalert/web.qtpl:101
 			qw422016.E().S(g.File)
-//line app/vmalert/web.qtpl:88
+//line app/vmalert/web.qtpl:101
 			qw422016.N().S(`</p>
                     `)
-//line app/vmalert/web.qtpl:89
+//line app/vmalert/web.qtpl:102
 			if len(g.Params) > 0 {
-//line app/vmalert/web.qtpl:89
+//line app/vmalert/web.qtpl:102
 				qw422016.N().S(`
                         <div class="fs-6 fw-lighter">Extra params
                         `)
-//line app/vmalert/web.qtpl:91
+//line app/vmalert/web.qtpl:104
 				for _, param := range g.Params {
-//line app/vmalert/web.qtpl:91
+//line app/vmalert/web.qtpl:104
 					qw422016.N().S(`
                                 <span class="float-left badge bg-primary">`)
-//line app/vmalert/web.qtpl:92
+//line app/vmalert/web.qtpl:105
 					qw422016.E().S(param)
-//line app/vmalert/web.qtpl:92
+//line app/vmalert/web.qtpl:105
 					qw422016.N().S(`</span>
                         `)
-//line app/vmalert/web.qtpl:93
+//line app/vmalert/web.qtpl:106
 				}
-//line app/vmalert/web.qtpl:93
+//line app/vmalert/web.qtpl:106
 				qw422016.N().S(`
                         </div>
                     `)
-//line app/vmalert/web.qtpl:95
+//line app/vmalert/web.qtpl:108
 			}
-//line app/vmalert/web.qtpl:95
+//line app/vmalert/web.qtpl:108
 			qw422016.N().S(`
                     `)
-//line app/vmalert/web.qtpl:96
+//line app/vmalert/web.qtpl:109
 			if len(g.Headers) > 0 {
-//line app/vmalert/web.qtpl:96
+//line app/vmalert/web.qtpl:109
 				qw422016.N().S(`
                         <div class="fs-6 fw-lighter">Extra headers
                         `)
-//line app/vmalert/web.qtpl:98
+//line app/vmalert/web.qtpl:111
 				for _, header := range g.Headers {
-//line app/vmalert/web.qtpl:98
+//line app/vmalert/web.qtpl:111
 					qw422016.N().S(`
                                 <span class="float-left badge bg-primary">`)
-//line app/vmalert/web.qtpl:99
+//line app/vmalert/web.qtpl:112
 					qw422016.E().S(header)
-//line app/vmalert/web.qtpl:99
+//line app/vmalert/web.qtpl:112
 					qw422016.N().S(`</span>
                         `)
-//line app/vmalert/web.qtpl:100
+//line app/vmalert/web.qtpl:113
 				}
-//line app/vmalert/web.qtpl:100
+//line app/vmalert/web.qtpl:113
 				qw422016.N().S(`
                         </div>
                     `)
-//line app/vmalert/web.qtpl:102
+//line app/vmalert/web.qtpl:115
 			}
-//line app/vmalert/web.qtpl:102
+//line app/vmalert/web.qtpl:115
 			qw422016.N().S(`
                 </div>
                 <div class="collapse rule-table" id="rules-`)
-//line app/vmalert/web.qtpl:104
+//line app/vmalert/web.qtpl:117
 			qw422016.E().S(g.ID)
-//line app/vmalert/web.qtpl:104
+//line app/vmalert/web.qtpl:117
 			qw422016.N().S(`">
                     <table class="table table-striped table-hover table-sm">
                         <thead>
@@ -422,308 +435,308 @@ func StreamListGroups(qw422016 *qt422016.Writer, r *http.Request, originGroups [
                         </thead>
                         <tbody>
                         `)
-//line app/vmalert/web.qtpl:114
+//line app/vmalert/web.qtpl:127
 			for _, r := range g.Rules {
-//line app/vmalert/web.qtpl:114
+//line app/vmalert/web.qtpl:127
 				qw422016.N().S(`
                             <tr class="rule`)
-//line app/vmalert/web.qtpl:115
+//line app/vmalert/web.qtpl:128
 				if r.LastError != "" {
-//line app/vmalert/web.qtpl:115
+//line app/vmalert/web.qtpl:128
 					qw422016.N().S(` alert-danger`)
-//line app/vmalert/web.qtpl:115
+//line app/vmalert/web.qtpl:128
 				}
-//line app/vmalert/web.qtpl:115
+//line app/vmalert/web.qtpl:128
 				qw422016.N().S(`" data-rule-name="`)
-//line app/vmalert/web.qtpl:115
+//line app/vmalert/web.qtpl:128
 				qw422016.E().S(r.Name)
-//line app/vmalert/web.qtpl:115
+//line app/vmalert/web.qtpl:128
 				qw422016.N().S(`" data-bs-target="`)
-//line app/vmalert/web.qtpl:115
+//line app/vmalert/web.qtpl:128
 				qw422016.E().S(g.ID)
-//line app/vmalert/web.qtpl:115
+//line app/vmalert/web.qtpl:128
 				qw422016.N().S(`">
                                 <td>
                                     <div class="row">
                                         <div class="col-12 mb-2">
                                             `)
-//line app/vmalert/web.qtpl:119
+//line app/vmalert/web.qtpl:132
 				if r.Type == "alerting" {
-//line app/vmalert/web.qtpl:119
+//line app/vmalert/web.qtpl:132
 					qw422016.N().S(`
                                             `)
-//line app/vmalert/web.qtpl:120
+//line app/vmalert/web.qtpl:133
 					if r.KeepFiringFor > 0 {
-//line app/vmalert/web.qtpl:120
+//line app/vmalert/web.qtpl:133
 						qw422016.N().S(`
                                             <b>alert:</b> `)
-//line app/vmalert/web.qtpl:121
+//line app/vmalert/web.qtpl:134
 						qw422016.E().S(r.Name)
-//line app/vmalert/web.qtpl:121
+//line app/vmalert/web.qtpl:134
 						qw422016.N().S(` (for: `)
-//line app/vmalert/web.qtpl:121
+//line app/vmalert/web.qtpl:134
 						qw422016.E().V(r.Duration)
-//line app/vmalert/web.qtpl:121
+//line app/vmalert/web.qtpl:134
 						qw422016.N().S(` seconds, keep_firing_for: `)
-//line app/vmalert/web.qtpl:121
+//line app/vmalert/web.qtpl:134
 						qw422016.E().V(r.KeepFiringFor)
-//line app/vmalert/web.qtpl:121
+//line app/vmalert/web.qtpl:134
 						qw422016.N().S(` seconds)
                                             `)
-//line app/vmalert/web.qtpl:122
+//line app/vmalert/web.qtpl:135
 					} else {
-//line app/vmalert/web.qtpl:122
+//line app/vmalert/web.qtpl:135
 						qw422016.N().S(`
                                             <b>alert:</b> `)
-//line app/vmalert/web.qtpl:123
+//line app/vmalert/web.qtpl:136
 						qw422016.E().S(r.Name)
-//line app/vmalert/web.qtpl:123
+//line app/vmalert/web.qtpl:136
 						qw422016.N().S(` (for: `)
-//line app/vmalert/web.qtpl:123
+//line app/vmalert/web.qtpl:136
 						qw422016.E().V(r.Duration)
-//line app/vmalert/web.qtpl:123
+//line app/vmalert/web.qtpl:136
 						qw422016.N().S(` seconds)
                                             `)
-//line app/vmalert/web.qtpl:124
+//line app/vmalert/web.qtpl:137
 					}
-//line app/vmalert/web.qtpl:124
+//line app/vmalert/web.qtpl:137
 					qw422016.N().S(`
                                             `)
-//line app/vmalert/web.qtpl:125
+//line app/vmalert/web.qtpl:138
 				} else {
-//line app/vmalert/web.qtpl:125
+//line app/vmalert/web.qtpl:138
 					qw422016.N().S(`
                                             <b>record:</b> `)
-//line app/vmalert/web.qtpl:126
+//line app/vmalert/web.qtpl:139
 					qw422016.E().S(r.Name)
-//line app/vmalert/web.qtpl:126
+//line app/vmalert/web.qtpl:139
 					qw422016.N().S(`
                                             `)
-//line app/vmalert/web.qtpl:127
+//line app/vmalert/web.qtpl:140
 				}
-//line app/vmalert/web.qtpl:127
+//line app/vmalert/web.qtpl:140
 				qw422016.N().S(`
                                             |
                                             `)
-//line app/vmalert/web.qtpl:129
+//line app/vmalert/web.qtpl:142
 				streamseriesFetchedWarn(qw422016, r)
-//line app/vmalert/web.qtpl:129
+//line app/vmalert/web.qtpl:142
 				qw422016.N().S(`
                                             <span><a target="_blank" href="`)
-//line app/vmalert/web.qtpl:130
+//line app/vmalert/web.qtpl:143
 				qw422016.E().S(prefix + r.WebLink())
-//line app/vmalert/web.qtpl:130
+//line app/vmalert/web.qtpl:143
 				qw422016.N().S(`">Details</a></span>
                                         </div>
                                         <div class="col-12">
                                             <code><pre>`)
-//line app/vmalert/web.qtpl:133
+//line app/vmalert/web.qtpl:146
 				qw422016.E().S(r.Query)
-//line app/vmalert/web.qtpl:133
+//line app/vmalert/web.qtpl:146
 				qw422016.N().S(`</pre></code>
                                         </div>
                                         <div class="col-12 mb-2">
                                             `)
-//line app/vmalert/web.qtpl:136
+//line app/vmalert/web.qtpl:149
 				if len(r.Labels) > 0 {
-//line app/vmalert/web.qtpl:136
+//line app/vmalert/web.qtpl:149
 					qw422016.N().S(` <b>Labels:</b>`)
-//line app/vmalert/web.qtpl:136
+//line app/vmalert/web.qtpl:149
 				}
-//line app/vmalert/web.qtpl:136
+//line app/vmalert/web.qtpl:149
 				qw422016.N().S(`
                                             `)
-//line app/vmalert/web.qtpl:137
+//line app/vmalert/web.qtpl:150
 				for k, v := range r.Labels {
-//line app/vmalert/web.qtpl:137
+//line app/vmalert/web.qtpl:150
 					qw422016.N().S(`
                                                     <span class="ms-1 badge bg-primary label">`)
-//line app/vmalert/web.qtpl:138
+//line app/vmalert/web.qtpl:151
 					qw422016.E().S(k)
-//line app/vmalert/web.qtpl:138
+//line app/vmalert/web.qtpl:151
 					qw422016.N().S(`=`)
-//line app/vmalert/web.qtpl:138
+//line app/vmalert/web.qtpl:151
 					qw422016.E().S(v)
-//line app/vmalert/web.qtpl:138
+//line app/vmalert/web.qtpl:151
 					qw422016.N().S(`</span>
                                             `)
-//line app/vmalert/web.qtpl:139
+//line app/vmalert/web.qtpl:152
 				}
-//line app/vmalert/web.qtpl:139
+//line app/vmalert/web.qtpl:152
 				qw422016.N().S(`
                                         </div>
                                         `)
-//line app/vmalert/web.qtpl:141
+//line app/vmalert/web.qtpl:154
 				if r.LastError != "" {
-//line app/vmalert/web.qtpl:141
+//line app/vmalert/web.qtpl:154
 					qw422016.N().S(`
                                         <div class="col-12">
                                             <b>Error:</b>
                                             <div class="error-cell">
                                             `)
-//line app/vmalert/web.qtpl:145
+//line app/vmalert/web.qtpl:158
 					qw422016.E().S(r.LastError)
-//line app/vmalert/web.qtpl:145
+//line app/vmalert/web.qtpl:158
 					qw422016.N().S(`
                                             </div>
                                         </div>
                                         `)
-//line app/vmalert/web.qtpl:148
+//line app/vmalert/web.qtpl:161
 				}
-//line app/vmalert/web.qtpl:148
+//line app/vmalert/web.qtpl:161
 				qw422016.N().S(`
                                     </div>
                                 </td>
                                 <td class="text-center">`)
-//line app/vmalert/web.qtpl:151
+//line app/vmalert/web.qtpl:164
 				qw422016.N().D(r.LastSamples)
-//line app/vmalert/web.qtpl:151
+//line app/vmalert/web.qtpl:164
 				qw422016.N().S(`</td>
                                 <td class="text-center">`)
-//line app/vmalert/web.qtpl:152
+//line app/vmalert/web.qtpl:165
 				qw422016.N().FPrec(time.Since(r.LastEvaluation).Seconds(), 3)
-//line app/vmalert/web.qtpl:152
+//line app/vmalert/web.qtpl:165
 				qw422016.N().S(`s ago</td>
                             </tr>
                         `)
-//line app/vmalert/web.qtpl:154
+//line app/vmalert/web.qtpl:167
 			}
-//line app/vmalert/web.qtpl:154
+//line app/vmalert/web.qtpl:167
 			qw422016.N().S(`
                      </tbody>
                     </table>
                 </div>
             `)
-//line app/vmalert/web.qtpl:158
+//line app/vmalert/web.qtpl:171
 		}
-//line app/vmalert/web.qtpl:158
+//line app/vmalert/web.qtpl:171
 		qw422016.N().S(`
         `)
-//line app/vmalert/web.qtpl:159
+//line app/vmalert/web.qtpl:172
 	} else {
-//line app/vmalert/web.qtpl:159
+//line app/vmalert/web.qtpl:172
 		qw422016.N().S(`
             <div>
                 <p>No groups...</p>
             </div>
         `)
-//line app/vmalert/web.qtpl:163
+//line app/vmalert/web.qtpl:176
 	}
-//line app/vmalert/web.qtpl:163
+//line app/vmalert/web.qtpl:176
 	qw422016.N().S(`
 
     `)
-//line app/vmalert/web.qtpl:165
+//line app/vmalert/web.qtpl:178
 	tpl.StreamFooter(qw422016, r)
-//line app/vmalert/web.qtpl:165
+//line app/vmalert/web.qtpl:178
 	qw422016.N().S(`
 
 `)
-//line app/vmalert/web.qtpl:167
+//line app/vmalert/web.qtpl:180
 }
 
-//line app/vmalert/web.qtpl:167
+//line app/vmalert/web.qtpl:180
 func WriteListGroups(qq422016 qtio422016.Writer, r *http.Request, originGroups []apiGroup) {
-//line app/vmalert/web.qtpl:167
+//line app/vmalert/web.qtpl:180
 	qw422016 := qt422016.AcquireWriter(qq422016)
-//line app/vmalert/web.qtpl:167
+//line app/vmalert/web.qtpl:180
 	StreamListGroups(qw422016, r, originGroups)
-//line app/vmalert/web.qtpl:167
+//line app/vmalert/web.qtpl:180
 	qt422016.ReleaseWriter(qw422016)
-//line app/vmalert/web.qtpl:167
+//line app/vmalert/web.qtpl:180
 }
 
-//line app/vmalert/web.qtpl:167
+//line app/vmalert/web.qtpl:180
 func ListGroups(r *http.Request, originGroups []apiGroup) string {
-//line app/vmalert/web.qtpl:167
+//line app/vmalert/web.qtpl:180
 	qb422016 := qt422016.AcquireByteBuffer()
-//line app/vmalert/web.qtpl:167
+//line app/vmalert/web.qtpl:180
 	WriteListGroups(qb422016, r, originGroups)
-//line app/vmalert/web.qtpl:167
+//line app/vmalert/web.qtpl:180
 	qs422016 := string(qb422016.B)
-//line app/vmalert/web.qtpl:167
+//line app/vmalert/web.qtpl:180
 	qt422016.ReleaseByteBuffer(qb422016)
-//line app/vmalert/web.qtpl:167
+//line app/vmalert/web.qtpl:180
 	return qs422016
-//line app/vmalert/web.qtpl:167
+//line app/vmalert/web.qtpl:180
 }
 
-//line app/vmalert/web.qtpl:170
+//line app/vmalert/web.qtpl:183
 func StreamListAlerts(qw422016 *qt422016.Writer, r *http.Request, groupAlerts []groupAlerts) {
-//line app/vmalert/web.qtpl:170
+//line app/vmalert/web.qtpl:183
 	qw422016.N().S(`
     `)
-//line app/vmalert/web.qtpl:171
+//line app/vmalert/web.qtpl:184
 	prefix := utils.Prefix(r.URL.Path)
 
-//line app/vmalert/web.qtpl:171
+//line app/vmalert/web.qtpl:184
 	qw422016.N().S(`
     `)
-//line app/vmalert/web.qtpl:172
+//line app/vmalert/web.qtpl:185
 	tpl.StreamHeader(qw422016, r, navItems, "Alerts", getLastConfigError())
-//line app/vmalert/web.qtpl:172
+//line app/vmalert/web.qtpl:185
 	qw422016.N().S(`
     `)
-//line app/vmalert/web.qtpl:173
+//line app/vmalert/web.qtpl:186
 	if len(groupAlerts) > 0 {
-//line app/vmalert/web.qtpl:173
+//line app/vmalert/web.qtpl:186
 		qw422016.N().S(`
          <a class="btn btn-primary" role="button" onclick="collapseAll()">Collapse All</a>
          <a class="btn btn-primary" role="button" onclick="expandAll()">Expand All</a>
          `)
-//line app/vmalert/web.qtpl:176
+//line app/vmalert/web.qtpl:189
 		for _, ga := range groupAlerts {
-//line app/vmalert/web.qtpl:176
+//line app/vmalert/web.qtpl:189
 			qw422016.N().S(`
             `)
-//line app/vmalert/web.qtpl:177
+//line app/vmalert/web.qtpl:190
 			g := ga.Group
 
-//line app/vmalert/web.qtpl:177
+//line app/vmalert/web.qtpl:190
 			qw422016.N().S(`
             <div class="group-heading alert-danger" data-bs-target="rules-`)
-//line app/vmalert/web.qtpl:178
+//line app/vmalert/web.qtpl:191
 			qw422016.E().S(g.ID)
-//line app/vmalert/web.qtpl:178
+//line app/vmalert/web.qtpl:191
 			qw422016.N().S(`">
                 <span class="anchor" id="group-`)
-//line app/vmalert/web.qtpl:179
+//line app/vmalert/web.qtpl:192
 			qw422016.E().S(g.ID)
-//line app/vmalert/web.qtpl:179
+//line app/vmalert/web.qtpl:192
 			qw422016.N().S(`"></span>
                 <a href="#group-`)
-//line app/vmalert/web.qtpl:180
+//line app/vmalert/web.qtpl:193
 			qw422016.E().S(g.ID)
-//line app/vmalert/web.qtpl:180
+//line app/vmalert/web.qtpl:193
 			qw422016.N().S(`">`)
-//line app/vmalert/web.qtpl:180
+//line app/vmalert/web.qtpl:193
 			qw422016.E().S(g.Name)
-//line app/vmalert/web.qtpl:180
+//line app/vmalert/web.qtpl:193
 			if g.Type != "prometheus" {
-//line app/vmalert/web.qtpl:180
+//line app/vmalert/web.qtpl:193
 				qw422016.N().S(` (`)
-//line app/vmalert/web.qtpl:180
+//line app/vmalert/web.qtpl:193
 				qw422016.E().S(g.Type)
-//line app/vmalert/web.qtpl:180
+//line app/vmalert/web.qtpl:193
 				qw422016.N().S(`)`)
-//line app/vmalert/web.qtpl:180
+//line app/vmalert/web.qtpl:193
 			}
-//line app/vmalert/web.qtpl:180
+//line app/vmalert/web.qtpl:193
 			qw422016.N().S(`</a>
                 <span class="badge bg-danger" title="Number of active alerts">`)
-//line app/vmalert/web.qtpl:181
+//line app/vmalert/web.qtpl:194
 			qw422016.N().D(len(ga.Alerts))
-//line app/vmalert/web.qtpl:181
+//line app/vmalert/web.qtpl:194
 			qw422016.N().S(`</span>
                 <br>
                 <p class="fs-6 fw-lighter">`)
-//line app/vmalert/web.qtpl:183
+//line app/vmalert/web.qtpl:196
 			qw422016.E().S(g.File)
-//line app/vmalert/web.qtpl:183
+//line app/vmalert/web.qtpl:196
 			qw422016.N().S(`</p>
             </div>
             `)
-//line app/vmalert/web.qtpl:186
+//line app/vmalert/web.qtpl:199
 			var keys []string
 			alertsByRule := make(map[string][]*apiAlert)
 			for _, alert := range ga.Alerts {
@@ -734,20 +747,20 @@ func StreamListAlerts(qw422016 *qt422016.Writer, r *http.Request, groupAlerts []
 			}
 			sort.Strings(keys)
 
-//line app/vmalert/web.qtpl:195
+//line app/vmalert/web.qtpl:208
 			qw422016.N().S(`
             <div class="collapse" id="rules-`)
-//line app/vmalert/web.qtpl:196
+//line app/vmalert/web.qtpl:209
 			qw422016.E().S(g.ID)
-//line app/vmalert/web.qtpl:196
+//line app/vmalert/web.qtpl:209
 			qw422016.N().S(`">
                 `)
-//line app/vmalert/web.qtpl:197
+//line app/vmalert/web.qtpl:210
 			for _, ruleID := range keys {
-//line app/vmalert/web.qtpl:197
+//line app/vmalert/web.qtpl:210
 				qw422016.N().S(`
                     `)
-//line app/vmalert/web.qtpl:199
+//line app/vmalert/web.qtpl:212
 				defaultAR := alertsByRule[ruleID][0]
 				var labelKeys []string
 				for k := range defaultAR.Labels {
@@ -755,28 +768,28 @@ func StreamListAlerts(qw422016 *qt422016.Writer, r *http.Request, groupAlerts []
 				}
 				sort.Strings(labelKeys)
 
-//line app/vmalert/web.qtpl:205
+//line app/vmalert/web.qtpl:218
 				qw422016.N().S(`
                     <br>
                     <b>alert:</b> `)
-//line app/vmalert/web.qtpl:207
+//line app/vmalert/web.qtpl:220
 				qw422016.E().S(defaultAR.Name)
-//line app/vmalert/web.qtpl:207
+//line app/vmalert/web.qtpl:220
 				qw422016.N().S(` (`)
-//line app/vmalert/web.qtpl:207
+//line app/vmalert/web.qtpl:220
 				qw422016.N().D(len(alertsByRule[ruleID]))
-//line app/vmalert/web.qtpl:207
+//line app/vmalert/web.qtpl:220
 				qw422016.N().S(`)
                      | <span><a target="_blank" href="`)
-//line app/vmalert/web.qtpl:208
+//line app/vmalert/web.qtpl:221
 				qw422016.E().S(defaultAR.SourceLink)
-//line app/vmalert/web.qtpl:208
+//line app/vmalert/web.qtpl:221
 				qw422016.N().S(`">Source</a></span>
                     <br>
                     <b>expr:</b><code><pre>`)
-//line app/vmalert/web.qtpl:210
+//line app/vmalert/web.qtpl:223
 				qw422016.E().S(defaultAR.Expression)
-//line app/vmalert/web.qtpl:210
+//line app/vmalert/web.qtpl:223
 				qw422016.N().S(`</pre></code>
                     <table class="table table-striped table-hover table-sm">
                         <thead>
@@ -790,213 +803,213 @@ func StreamListAlerts(qw422016 *qt422016.Writer, r *http.Request, groupAlerts []
                         </thead>
                         <tbody>
                         `)
-//line app/vmalert/web.qtpl:222
+//line app/vmalert/web.qtpl:235
 				for _, ar := range alertsByRule[ruleID] {
-//line app/vmalert/web.qtpl:222
+//line app/vmalert/web.qtpl:235
 					qw422016.N().S(`
                             <tr>
                                 <td>
                                     `)
-//line app/vmalert/web.qtpl:225
+//line app/vmalert/web.qtpl:238
 					for _, k := range labelKeys {
-//line app/vmalert/web.qtpl:225
+//line app/vmalert/web.qtpl:238
 						qw422016.N().S(`
                                         <span class="ms-1 badge bg-primary">`)
-//line app/vmalert/web.qtpl:226
+//line app/vmalert/web.qtpl:239
 						qw422016.E().S(k)
-//line app/vmalert/web.qtpl:226
+//line app/vmalert/web.qtpl:239
 						qw422016.N().S(`=`)
-//line app/vmalert/web.qtpl:226
+//line app/vmalert/web.qtpl:239
 						qw422016.E().S(ar.Labels[k])
-//line app/vmalert/web.qtpl:226
+//line app/vmalert/web.qtpl:239
 						qw422016.N().S(`</span>
                                     `)
-//line app/vmalert/web.qtpl:227
+//line app/vmalert/web.qtpl:240
 					}
-//line app/vmalert/web.qtpl:227
+//line app/vmalert/web.qtpl:240
 					qw422016.N().S(`
                                 </td>
                                 <td>`)
-//line app/vmalert/web.qtpl:229
+//line app/vmalert/web.qtpl:242
 					streambadgeState(qw422016, ar.State)
-//line app/vmalert/web.qtpl:229
+//line app/vmalert/web.qtpl:242
 					qw422016.N().S(`</td>
                                 <td>
                                     `)
-//line app/vmalert/web.qtpl:231
+//line app/vmalert/web.qtpl:244
 					qw422016.E().S(ar.ActiveAt.Format("2006-01-02T15:04:05Z07:00"))
-//line app/vmalert/web.qtpl:231
+//line app/vmalert/web.qtpl:244
 					qw422016.N().S(`
                                     `)
-//line app/vmalert/web.qtpl:232
+//line app/vmalert/web.qtpl:245
 					if ar.Restored {
-//line app/vmalert/web.qtpl:232
+//line app/vmalert/web.qtpl:245
 						streambadgeRestored(qw422016)
-//line app/vmalert/web.qtpl:232
+//line app/vmalert/web.qtpl:245
 					}
-//line app/vmalert/web.qtpl:232
+//line app/vmalert/web.qtpl:245
 					qw422016.N().S(`
                                     `)
-//line app/vmalert/web.qtpl:233
+//line app/vmalert/web.qtpl:246
 					if ar.Stabilizing {
-//line app/vmalert/web.qtpl:233
+//line app/vmalert/web.qtpl:246
 						streambadgeStabilizing(qw422016)
-//line app/vmalert/web.qtpl:233
+//line app/vmalert/web.qtpl:246
 					}
-//line app/vmalert/web.qtpl:233
+//line app/vmalert/web.qtpl:246
 					qw422016.N().S(`
                                 </td>
                                 <td>`)
-//line app/vmalert/web.qtpl:235
+//line app/vmalert/web.qtpl:248
 					qw422016.E().S(ar.Value)
-//line app/vmalert/web.qtpl:235
+//line app/vmalert/web.qtpl:248
 					qw422016.N().S(`</td>
                                 <td>
                                     <a href="`)
-//line app/vmalert/web.qtpl:237
+//line app/vmalert/web.qtpl:250
 					qw422016.E().S(prefix + ar.WebLink())
-//line app/vmalert/web.qtpl:237
+//line app/vmalert/web.qtpl:250
 					qw422016.N().S(`">Details</a>
                                 </td>
                             </tr>
                         `)
-//line app/vmalert/web.qtpl:240
+//line app/vmalert/web.qtpl:253
 				}
-//line app/vmalert/web.qtpl:240
+//line app/vmalert/web.qtpl:253
 				qw422016.N().S(`
                      </tbody>
                     </table>
                 `)
-//line app/vmalert/web.qtpl:243
+//line app/vmalert/web.qtpl:256
 			}
-//line app/vmalert/web.qtpl:243
+//line app/vmalert/web.qtpl:256
 			qw422016.N().S(`
             </div>
             <br>
         `)
-//line app/vmalert/web.qtpl:246
+//line app/vmalert/web.qtpl:259
 		}
-//line app/vmalert/web.qtpl:246
+//line app/vmalert/web.qtpl:259
 		qw422016.N().S(`
 
     `)
-//line app/vmalert/web.qtpl:248
+//line app/vmalert/web.qtpl:261
 	} else {
-//line app/vmalert/web.qtpl:248
+//line app/vmalert/web.qtpl:261
 		qw422016.N().S(`
         <div>
             <p>No active alerts...</p>
         </div>
     `)
-//line app/vmalert/web.qtpl:252
+//line app/vmalert/web.qtpl:265
 	}
-//line app/vmalert/web.qtpl:252
+//line app/vmalert/web.qtpl:265
 	qw422016.N().S(`
 
     `)
-//line app/vmalert/web.qtpl:254
+//line app/vmalert/web.qtpl:267
 	tpl.StreamFooter(qw422016, r)
-//line app/vmalert/web.qtpl:254
+//line app/vmalert/web.qtpl:267
 	qw422016.N().S(`
 
 `)
-//line app/vmalert/web.qtpl:256
+//line app/vmalert/web.qtpl:269
 }
 
-//line app/vmalert/web.qtpl:256
+//line app/vmalert/web.qtpl:269
 func WriteListAlerts(qq422016 qtio422016.Writer, r *http.Request, groupAlerts []groupAlerts) {
-//line app/vmalert/web.qtpl:256
+//line app/vmalert/web.qtpl:269
 	qw422016 := qt422016.AcquireWriter(qq422016)
-//line app/vmalert/web.qtpl:256
+//line app/vmalert/web.qtpl:269
 	StreamListAlerts(qw422016, r, groupAlerts)
-//line app/vmalert/web.qtpl:256
+//line app/vmalert/web.qtpl:269
 	qt422016.ReleaseWriter(qw422016)
-//line app/vmalert/web.qtpl:256
+//line app/vmalert/web.qtpl:269
 }
 
-//line app/vmalert/web.qtpl:256
+//line app/vmalert/web.qtpl:269
 func ListAlerts(r *http.Request, groupAlerts []groupAlerts) string {
-//line app/vmalert/web.qtpl:256
+//line app/vmalert/web.qtpl:269
 	qb422016 := qt422016.AcquireByteBuffer()
-//line app/vmalert/web.qtpl:256
+//line app/vmalert/web.qtpl:269
 	WriteListAlerts(qb422016, r, groupAlerts)
-//line app/vmalert/web.qtpl:256
+//line app/vmalert/web.qtpl:269
 	qs422016 := string(qb422016.B)
-//line app/vmalert/web.qtpl:256
+//line app/vmalert/web.qtpl:269
 	qt422016.ReleaseByteBuffer(qb422016)
-//line app/vmalert/web.qtpl:256
+//line app/vmalert/web.qtpl:269
 	return qs422016
-//line app/vmalert/web.qtpl:256
+//line app/vmalert/web.qtpl:269
 }
 
-//line app/vmalert/web.qtpl:258
+//line app/vmalert/web.qtpl:271
 func StreamListTargets(qw422016 *qt422016.Writer, r *http.Request, targets map[notifier.TargetType][]notifier.Target) {
-//line app/vmalert/web.qtpl:258
+//line app/vmalert/web.qtpl:271
 	qw422016.N().S(`
     `)
-//line app/vmalert/web.qtpl:259
+//line app/vmalert/web.qtpl:272
 	tpl.StreamHeader(qw422016, r, navItems, "Notifiers", getLastConfigError())
-//line app/vmalert/web.qtpl:259
+//line app/vmalert/web.qtpl:272
 	qw422016.N().S(`
     `)
-//line app/vmalert/web.qtpl:260
+//line app/vmalert/web.qtpl:273
 	if len(targets) > 0 {
-//line app/vmalert/web.qtpl:260
+//line app/vmalert/web.qtpl:273
 		qw422016.N().S(`
          <a class="btn btn-primary" role="button" onclick="collapseAll()">Collapse All</a>
          <a class="btn btn-primary" role="button" onclick="expandAll()">Expand All</a>
 
          `)
-//line app/vmalert/web.qtpl:265
+//line app/vmalert/web.qtpl:278
 		var keys []string
 		for key := range targets {
 			keys = append(keys, string(key))
 		}
 		sort.Strings(keys)
 
-//line app/vmalert/web.qtpl:270
+//line app/vmalert/web.qtpl:283
 		qw422016.N().S(`
 
          `)
-//line app/vmalert/web.qtpl:272
+//line app/vmalert/web.qtpl:285
 		for i := range keys {
-//line app/vmalert/web.qtpl:272
+//line app/vmalert/web.qtpl:285
 			qw422016.N().S(`
            `)
-//line app/vmalert/web.qtpl:273
+//line app/vmalert/web.qtpl:286
 			typeK, ns := keys[i], targets[notifier.TargetType(keys[i])]
 			count := len(ns)
 
-//line app/vmalert/web.qtpl:275
+//line app/vmalert/web.qtpl:288
 			qw422016.N().S(`
            <div class="group-heading" data-bs-target="notifiers-`)
-//line app/vmalert/web.qtpl:276
+//line app/vmalert/web.qtpl:289
 			qw422016.E().S(typeK)
-//line app/vmalert/web.qtpl:276
+//line app/vmalert/web.qtpl:289
 			qw422016.N().S(`">
              <span class="anchor" id="group-`)
-//line app/vmalert/web.qtpl:277
+//line app/vmalert/web.qtpl:290
 			qw422016.E().S(typeK)
-//line app/vmalert/web.qtpl:277
+//line app/vmalert/web.qtpl:290
 			qw422016.N().S(`"></span>
              <a href="#group-`)
-//line app/vmalert/web.qtpl:278
+//line app/vmalert/web.qtpl:291
 			qw422016.E().S(typeK)
-//line app/vmalert/web.qtpl:278
+//line app/vmalert/web.qtpl:291
 			qw422016.N().S(`">`)
-//line app/vmalert/web.qtpl:278
+//line app/vmalert/web.qtpl:291
 			qw422016.E().S(typeK)
-//line app/vmalert/web.qtpl:278
+//line app/vmalert/web.qtpl:291
 			qw422016.N().S(` (`)
-//line app/vmalert/web.qtpl:278
+//line app/vmalert/web.qtpl:291
 			qw422016.N().D(count)
-//line app/vmalert/web.qtpl:278
+//line app/vmalert/web.qtpl:291
 			qw422016.N().S(`)</a>
          </div>
          <div class="collapse show" id="notifiers-`)
-//line app/vmalert/web.qtpl:280
+//line app/vmalert/web.qtpl:293
 			qw422016.E().S(typeK)
-//line app/vmalert/web.qtpl:280
+//line app/vmalert/web.qtpl:293
 			qw422016.N().S(`">
              <table class="table table-striped table-hover table-sm">
                  <thead>
@@ -1007,119 +1020,119 @@ func StreamListTargets(qw422016 *qt422016.Writer, r *http.Request, targets map[n
                  </thead>
                  <tbody>
                  `)
-//line app/vmalert/web.qtpl:289
+//line app/vmalert/web.qtpl:302
 			for _, n := range ns {
-//line app/vmalert/web.qtpl:289
+//line app/vmalert/web.qtpl:302
 				qw422016.N().S(`
                      <tr>
                          <td>
                               `)
-//line app/vmalert/web.qtpl:292
+//line app/vmalert/web.qtpl:305
 				for _, l := range n.Labels.GetLabels() {
-//line app/vmalert/web.qtpl:292
+//line app/vmalert/web.qtpl:305
 					qw422016.N().S(`
                                       <span class="ms-1 badge bg-primary">`)
-//line app/vmalert/web.qtpl:293
+//line app/vmalert/web.qtpl:306
 					qw422016.E().S(l.Name)
-//line app/vmalert/web.qtpl:293
+//line app/vmalert/web.qtpl:306
 					qw422016.N().S(`=`)
-//line app/vmalert/web.qtpl:293
+//line app/vmalert/web.qtpl:306
 					qw422016.E().S(l.Value)
-//line app/vmalert/web.qtpl:293
+//line app/vmalert/web.qtpl:306
 					qw422016.N().S(`</span>
                               `)
-//line app/vmalert/web.qtpl:294
+//line app/vmalert/web.qtpl:307
 				}
-//line app/vmalert/web.qtpl:294
+//line app/vmalert/web.qtpl:307
 				qw422016.N().S(`
                           </td>
                          <td>`)
-//line app/vmalert/web.qtpl:296
+//line app/vmalert/web.qtpl:309
 				qw422016.E().S(n.Notifier.Addr())
-//line app/vmalert/web.qtpl:296
+//line app/vmalert/web.qtpl:309
 				qw422016.N().S(`</td>
                      </tr>
                  `)
-//line app/vmalert/web.qtpl:298
+//line app/vmalert/web.qtpl:311
 			}
-//line app/vmalert/web.qtpl:298
+//line app/vmalert/web.qtpl:311
 			qw422016.N().S(`
               </tbody>
              </table>
          </div>
      `)
-//line app/vmalert/web.qtpl:302
+//line app/vmalert/web.qtpl:315
 		}
-//line app/vmalert/web.qtpl:302
+//line app/vmalert/web.qtpl:315
 		qw422016.N().S(`
 
     `)
-//line app/vmalert/web.qtpl:304
+//line app/vmalert/web.qtpl:317
 	} else {
-//line app/vmalert/web.qtpl:304
+//line app/vmalert/web.qtpl:317
 		qw422016.N().S(`
         <div>
             <p>No targets...</p>
         </div>
     `)
-//line app/vmalert/web.qtpl:308
+//line app/vmalert/web.qtpl:321
 	}
-//line app/vmalert/web.qtpl:308
+//line app/vmalert/web.qtpl:321
 	qw422016.N().S(`
 
     `)
-//line app/vmalert/web.qtpl:310
+//line app/vmalert/web.qtpl:323
 	tpl.StreamFooter(qw422016, r)
-//line app/vmalert/web.qtpl:310
+//line app/vmalert/web.qtpl:323
 	qw422016.N().S(`
 
 `)
-//line app/vmalert/web.qtpl:312
+//line app/vmalert/web.qtpl:325
 }
 
-//line app/vmalert/web.qtpl:312
+//line app/vmalert/web.qtpl:325
 func WriteListTargets(qq422016 qtio422016.Writer, r *http.Request, targets map[notifier.TargetType][]notifier.Target) {
-//line app/vmalert/web.qtpl:312
+//line app/vmalert/web.qtpl:325
 	qw422016 := qt422016.AcquireWriter(qq422016)
-//line app/vmalert/web.qtpl:312
+//line app/vmalert/web.qtpl:325
 	StreamListTargets(qw422016, r, targets)
-//line app/vmalert/web.qtpl:312
+//line app/vmalert/web.qtpl:325
 	qt422016.ReleaseWriter(qw422016)
-//line app/vmalert/web.qtpl:312
+//line app/vmalert/web.qtpl:325
 }
 
-//line app/vmalert/web.qtpl:312
+//line app/vmalert/web.qtpl:325
 func ListTargets(r *http.Request, targets map[notifier.TargetType][]notifier.Target) string {
-//line app/vmalert/web.qtpl:312
+//line app/vmalert/web.qtpl:325
 	qb422016 := qt422016.AcquireByteBuffer()
-//line app/vmalert/web.qtpl:312
+//line app/vmalert/web.qtpl:325
 	WriteListTargets(qb422016, r, targets)
-//line app/vmalert/web.qtpl:312
+//line app/vmalert/web.qtpl:325
 	qs422016 := string(qb422016.B)
-//line app/vmalert/web.qtpl:312
+//line app/vmalert/web.qtpl:325
 	qt422016.ReleaseByteBuffer(qb422016)
-//line app/vmalert/web.qtpl:312
+//line app/vmalert/web.qtpl:325
 	return qs422016
-//line app/vmalert/web.qtpl:312
+//line app/vmalert/web.qtpl:325
 }
 
-//line app/vmalert/web.qtpl:314
+//line app/vmalert/web.qtpl:327
 func StreamAlert(qw422016 *qt422016.Writer, r *http.Request, alert *apiAlert) {
-//line app/vmalert/web.qtpl:314
+//line app/vmalert/web.qtpl:327
 	qw422016.N().S(`
     `)
-//line app/vmalert/web.qtpl:315
+//line app/vmalert/web.qtpl:328
 	prefix := utils.Prefix(r.URL.Path)
 
-//line app/vmalert/web.qtpl:315
+//line app/vmalert/web.qtpl:328
 	qw422016.N().S(`
     `)
-//line app/vmalert/web.qtpl:316
+//line app/vmalert/web.qtpl:329
 	tpl.StreamHeader(qw422016, r, navItems, "", getLastConfigError())
-//line app/vmalert/web.qtpl:316
+//line app/vmalert/web.qtpl:329
 	qw422016.N().S(`
     `)
-//line app/vmalert/web.qtpl:318
+//line app/vmalert/web.qtpl:331
 	var labelKeys []string
 	for k := range alert.Labels {
 		labelKeys = append(labelKeys, k)
@@ -1132,28 +1145,28 @@ func StreamAlert(qw422016 *qt422016.Writer, r *http.Request, alert *apiAlert) {
 	}
 	sort.Strings(annotationKeys)
 
-//line app/vmalert/web.qtpl:329
+//line app/vmalert/web.qtpl:342
 	qw422016.N().S(`
     <div class="display-6 pb-3 mb-3">Alert: `)
-//line app/vmalert/web.qtpl:330
+//line app/vmalert/web.qtpl:343
 	qw422016.E().S(alert.Name)
-//line app/vmalert/web.qtpl:330
+//line app/vmalert/web.qtpl:343
 	qw422016.N().S(`<span class="ms-2 badge `)
-//line app/vmalert/web.qtpl:330
+//line app/vmalert/web.qtpl:343
 	if alert.State == "firing" {
-//line app/vmalert/web.qtpl:330
+//line app/vmalert/web.qtpl:343
 		qw422016.N().S(`bg-danger`)
-//line app/vmalert/web.qtpl:330
+//line app/vmalert/web.qtpl:343
 	} else {
-//line app/vmalert/web.qtpl:330
+//line app/vmalert/web.qtpl:343
 		qw422016.N().S(` bg-warning text-dark`)
-//line app/vmalert/web.qtpl:330
+//line app/vmalert/web.qtpl:343
 	}
-//line app/vmalert/web.qtpl:330
+//line app/vmalert/web.qtpl:343
 	qw422016.N().S(`">`)
-//line app/vmalert/web.qtpl:330
+//line app/vmalert/web.qtpl:343
 	qw422016.E().S(alert.State)
-//line app/vmalert/web.qtpl:330
+//line app/vmalert/web.qtpl:343
 	qw422016.N().S(`</span></div>
     <div class="container border-bottom p-2">
       <div class="row">
@@ -1162,9 +1175,9 @@ func StreamAlert(qw422016 *qt422016.Writer, r *http.Request, alert *apiAlert) {
         </div>
         <div class="col">
           `)
-//line app/vmalert/web.qtpl:337
+//line app/vmalert/web.qtpl:350
 	qw422016.E().S(alert.ActiveAt.Format("2006-01-02T15:04:05Z07:00"))
-//line app/vmalert/web.qtpl:337
+//line app/vmalert/web.qtpl:350
 	qw422016.N().S(`
         </div>
       </div>
@@ -1176,9 +1189,9 @@ func StreamAlert(qw422016 *qt422016.Writer, r *http.Request, alert *apiAlert) {
         </div>
         <div class="col">
           <code><pre>`)
-//line app/vmalert/web.qtpl:347
+//line app/vmalert/web.qtpl:360
 	qw422016.E().S(alert.Expression)
-//line app/vmalert/web.qtpl:347
+//line app/vmalert/web.qtpl:360
 	qw422016.N().S(`</pre></code>
         </div>
       </div>
@@ -1190,23 +1203,23 @@ func StreamAlert(qw422016 *qt422016.Writer, r *http.Request, alert *apiAlert) {
         </div>
         <div class="col">
            `)
-//line app/vmalert/web.qtpl:357
+//line app/vmalert/web.qtpl:370
 	for _, k := range labelKeys {
-//line app/vmalert/web.qtpl:357
+//line app/vmalert/web.qtpl:370
 		qw422016.N().S(`
                 <span class="m-1 badge bg-primary">`)
-//line app/vmalert/web.qtpl:358
+//line app/vmalert/web.qtpl:371
 		qw422016.E().S(k)
-//line app/vmalert/web.qtpl:358
+//line app/vmalert/web.qtpl:371
 		qw422016.N().S(`=`)
-//line app/vmalert/web.qtpl:358
+//line app/vmalert/web.qtpl:371
 		qw422016.E().S(alert.Labels[k])
-//line app/vmalert/web.qtpl:358
+//line app/vmalert/web.qtpl:371
 		qw422016.N().S(`</span>
           `)
-//line app/vmalert/web.qtpl:359
+//line app/vmalert/web.qtpl:372
 	}
-//line app/vmalert/web.qtpl:359
+//line app/vmalert/web.qtpl:372
 	qw422016.N().S(`
         </div>
       </div>
@@ -1218,24 +1231,24 @@ func StreamAlert(qw422016 *qt422016.Writer, r *http.Request, alert *apiAlert) {
         </div>
         <div class="col">
            `)
-//line app/vmalert/web.qtpl:369
+//line app/vmalert/web.qtpl:382
 	for _, k := range annotationKeys {
-//line app/vmalert/web.qtpl:369
+//line app/vmalert/web.qtpl:382
 		qw422016.N().S(`
                 <b>`)
-//line app/vmalert/web.qtpl:370
+//line app/vmalert/web.qtpl:383
 		qw422016.E().S(k)
-//line app/vmalert/web.qtpl:370
+//line app/vmalert/web.qtpl:383
 		qw422016.N().S(`:</b><br>
                 <p>`)
-//line app/vmalert/web.qtpl:371
+//line app/vmalert/web.qtpl:384
 		qw422016.E().S(alert.Annotations[k])
-//line app/vmalert/web.qtpl:371
+//line app/vmalert/web.qtpl:384
 		qw422016.N().S(`</p>
           `)
-//line app/vmalert/web.qtpl:372
+//line app/vmalert/web.qtpl:385
 	}
-//line app/vmalert/web.qtpl:372
+//line app/vmalert/web.qtpl:385
 	qw422016.N().S(`
         </div>
       </div>
@@ -1247,17 +1260,17 @@ func StreamAlert(qw422016 *qt422016.Writer, r *http.Request, alert *apiAlert) {
         </div>
         <div class="col">
            <a target="_blank" href="`)
-//line app/vmalert/web.qtpl:382
+//line app/vmalert/web.qtpl:395
 	qw422016.E().S(prefix)
-//line app/vmalert/web.qtpl:382
+//line app/vmalert/web.qtpl:395
 	qw422016.N().S(`groups#group-`)
-//line app/vmalert/web.qtpl:382
+//line app/vmalert/web.qtpl:395
 	qw422016.E().S(alert.GroupID)
-//line app/vmalert/web.qtpl:382
+//line app/vmalert/web.qtpl:395
 	qw422016.N().S(`">`)
-//line app/vmalert/web.qtpl:382
+//line app/vmalert/web.qtpl:395
 	qw422016.E().S(alert.GroupID)
-//line app/vmalert/web.qtpl:382
+//line app/vmalert/web.qtpl:395
 	qw422016.N().S(`</a>
         </div>
       </div>
@@ -1269,66 +1282,66 @@ func StreamAlert(qw422016 *qt422016.Writer, r *http.Request, alert *apiAlert) {
         </div>
         <div class="col">
            <a target="_blank" href="`)
-//line app/vmalert/web.qtpl:392
+//line app/vmalert/web.qtpl:405
 	qw422016.E().S(alert.SourceLink)
-//line app/vmalert/web.qtpl:392
+//line app/vmalert/web.qtpl:405
 	qw422016.N().S(`">Link</a>
         </div>
       </div>
     </div>
     `)
-//line app/vmalert/web.qtpl:396
+//line app/vmalert/web.qtpl:409
 	tpl.StreamFooter(qw422016, r)
-//line app/vmalert/web.qtpl:396
+//line app/vmalert/web.qtpl:409
 	qw422016.N().S(`
 
 `)
-//line app/vmalert/web.qtpl:398
+//line app/vmalert/web.qtpl:411
 }
 
-//line app/vmalert/web.qtpl:398
+//line app/vmalert/web.qtpl:411
 func WriteAlert(qq422016 qtio422016.Writer, r *http.Request, alert *apiAlert) {
-//line app/vmalert/web.qtpl:398
+//line app/vmalert/web.qtpl:411
 	qw422016 := qt422016.AcquireWriter(qq422016)
-//line app/vmalert/web.qtpl:398
+//line app/vmalert/web.qtpl:411
 	StreamAlert(qw422016, r, alert)
-//line app/vmalert/web.qtpl:398
+//line app/vmalert/web.qtpl:411
 	qt422016.ReleaseWriter(qw422016)
-//line app/vmalert/web.qtpl:398
+//line app/vmalert/web.qtpl:411
 }
 
-//line app/vmalert/web.qtpl:398
+//line app/vmalert/web.qtpl:411
 func Alert(r *http.Request, alert *apiAlert) string {
-//line app/vmalert/web.qtpl:398
+//line app/vmalert/web.qtpl:411
 	qb422016 := qt422016.AcquireByteBuffer()
-//line app/vmalert/web.qtpl:398
+//line app/vmalert/web.qtpl:411
 	WriteAlert(qb422016, r, alert)
-//line app/vmalert/web.qtpl:398
+//line app/vmalert/web.qtpl:411
 	qs422016 := string(qb422016.B)
-//line app/vmalert/web.qtpl:398
+//line app/vmalert/web.qtpl:411
 	qt422016.ReleaseByteBuffer(qb422016)
-//line app/vmalert/web.qtpl:398
+//line app/vmalert/web.qtpl:411
 	return qs422016
-//line app/vmalert/web.qtpl:398
+//line app/vmalert/web.qtpl:411
 }
 
-//line app/vmalert/web.qtpl:401
+//line app/vmalert/web.qtpl:414
 func StreamRuleDetails(qw422016 *qt422016.Writer, r *http.Request, rule apiRule) {
-//line app/vmalert/web.qtpl:401
+//line app/vmalert/web.qtpl:414
 	qw422016.N().S(`
     `)
-//line app/vmalert/web.qtpl:402
+//line app/vmalert/web.qtpl:415
 	prefix := utils.Prefix(r.URL.Path)
 
-//line app/vmalert/web.qtpl:402
+//line app/vmalert/web.qtpl:415
 	qw422016.N().S(`
     `)
-//line app/vmalert/web.qtpl:403
+//line app/vmalert/web.qtpl:416
 	tpl.StreamHeader(qw422016, r, navItems, "", getLastConfigError())
-//line app/vmalert/web.qtpl:403
+//line app/vmalert/web.qtpl:416
 	qw422016.N().S(`
     `)
-//line app/vmalert/web.qtpl:405
+//line app/vmalert/web.qtpl:418
 	var labelKeys []string
 	for k := range rule.Labels {
 		labelKeys = append(labelKeys, k)
@@ -1352,28 +1365,28 @@ func StreamRuleDetails(qw422016 *qt422016.Writer, r *http.Request, rule apiRule)
 		}
 	}
 
-//line app/vmalert/web.qtpl:428
+//line app/vmalert/web.qtpl:441
 	qw422016.N().S(`
     <div class="display-6 pb-3 mb-3">Rule: `)
-//line app/vmalert/web.qtpl:429
+//line app/vmalert/web.qtpl:442
 	qw422016.E().S(rule.Name)
-//line app/vmalert/web.qtpl:429
+//line app/vmalert/web.qtpl:442
 	qw422016.N().S(`<span class="ms-2 badge `)
-//line app/vmalert/web.qtpl:429
+//line app/vmalert/web.qtpl:442
 	if rule.Health != "ok" {
-//line app/vmalert/web.qtpl:429
+//line app/vmalert/web.qtpl:442
 		qw422016.N().S(`bg-danger`)
-//line app/vmalert/web.qtpl:429
+//line app/vmalert/web.qtpl:442
 	} else {
-//line app/vmalert/web.qtpl:429
+//line app/vmalert/web.qtpl:442
 		qw422016.N().S(` bg-success text-dark`)
-//line app/vmalert/web.qtpl:429
+//line app/vmalert/web.qtpl:442
 	}
-//line app/vmalert/web.qtpl:429
+//line app/vmalert/web.qtpl:442
 	qw422016.N().S(`">`)
-//line app/vmalert/web.qtpl:429
+//line app/vmalert/web.qtpl:442
 	qw422016.E().S(rule.Health)
-//line app/vmalert/web.qtpl:429
+//line app/vmalert/web.qtpl:442
 	qw422016.N().S(`</span></div>
     <div class="container border-bottom p-2">
       <div class="row">
@@ -1382,17 +1395,17 @@ func StreamRuleDetails(qw422016 *qt422016.Writer, r *http.Request, rule apiRule)
         </div>
         <div class="col">
           <code><pre>`)
-//line app/vmalert/web.qtpl:436
+//line app/vmalert/web.qtpl:449
 	qw422016.E().S(rule.Query)
-//line app/vmalert/web.qtpl:436
+//line app/vmalert/web.qtpl:449
 	qw422016.N().S(`</pre></code>
         </div>
       </div>
     </div>
     `)
-//line app/vmalert/web.qtpl:440
+//line app/vmalert/web.qtpl:453
 	if rule.Type == "alerting" {
-//line app/vmalert/web.qtpl:440
+//line app/vmalert/web.qtpl:453
 		qw422016.N().S(`
     <div class="container border-bottom p-2">
       <div class="row">
@@ -1401,17 +1414,17 @@ func StreamRuleDetails(qw422016 *qt422016.Writer, r *http.Request, rule apiRule)
         </div>
         <div class="col">
          `)
-//line app/vmalert/web.qtpl:447
+//line app/vmalert/web.qtpl:460
 		qw422016.E().V(rule.Duration)
-//line app/vmalert/web.qtpl:447
+//line app/vmalert/web.qtpl:460
 		qw422016.N().S(` seconds
         </div>
       </div>
     </div>
     `)
-//line app/vmalert/web.qtpl:451
+//line app/vmalert/web.qtpl:464
 		if rule.KeepFiringFor > 0 {
-//line app/vmalert/web.qtpl:451
+//line app/vmalert/web.qtpl:464
 			qw422016.N().S(`
     <div class="container border-bottom p-2">
       <div class="row">
@@ -1420,22 +1433,22 @@ func StreamRuleDetails(qw422016 *qt422016.Writer, r *http.Request, rule apiRule)
         </div>
         <div class="col">
          `)
-//line app/vmalert/web.qtpl:458
+//line app/vmalert/web.qtpl:471
 			qw422016.E().V(rule.KeepFiringFor)
-//line app/vmalert/web.qtpl:458
+//line app/vmalert/web.qtpl:471
 			qw422016.N().S(` seconds
         </div>
       </div>
     </div>
     `)
-//line app/vmalert/web.qtpl:462
+//line app/vmalert/web.qtpl:475
 		}
-//line app/vmalert/web.qtpl:462
+//line app/vmalert/web.qtpl:475
 		qw422016.N().S(`
     `)
-//line app/vmalert/web.qtpl:463
+//line app/vmalert/web.qtpl:476
 	}
-//line app/vmalert/web.qtpl:463
+//line app/vmalert/web.qtpl:476
 	qw422016.N().S(`
     <div class="container border-bottom p-2">
       <div class="row">
@@ -1444,31 +1457,31 @@ func StreamRuleDetails(qw422016 *qt422016.Writer, r *http.Request, rule apiRule)
         </div>
         <div class="col">
           `)
-//line app/vmalert/web.qtpl:470
+//line app/vmalert/web.qtpl:483
 	for _, k := range labelKeys {
-//line app/vmalert/web.qtpl:470
+//line app/vmalert/web.qtpl:483
 		qw422016.N().S(`
                 <span class="m-1 badge bg-primary">`)
-//line app/vmalert/web.qtpl:471
+//line app/vmalert/web.qtpl:484
 		qw422016.E().S(k)
-//line app/vmalert/web.qtpl:471
+//line app/vmalert/web.qtpl:484
 		qw422016.N().S(`=`)
-//line app/vmalert/web.qtpl:471
+//line app/vmalert/web.qtpl:484
 		qw422016.E().S(rule.Labels[k])
-//line app/vmalert/web.qtpl:471
+//line app/vmalert/web.qtpl:484
 		qw422016.N().S(`</span>
           `)
-//line app/vmalert/web.qtpl:472
+//line app/vmalert/web.qtpl:485
 	}
-//line app/vmalert/web.qtpl:472
+//line app/vmalert/web.qtpl:485
 	qw422016.N().S(`
         </div>
       </div>
     </div>
     `)
-//line app/vmalert/web.qtpl:476
+//line app/vmalert/web.qtpl:489
 	if rule.Type == "alerting" {
-//line app/vmalert/web.qtpl:476
+//line app/vmalert/web.qtpl:489
 		qw422016.N().S(`
     <div class="container border-bottom p-2">
       <div class="row">
@@ -1477,24 +1490,24 @@ func StreamRuleDetails(qw422016 *qt422016.Writer, r *http.Request, rule apiRule)
         </div>
         <div class="col">
           `)
-//line app/vmalert/web.qtpl:483
+//line app/vmalert/web.qtpl:496
 		for _, k := range annotationKeys {
-//line app/vmalert/web.qtpl:483
+//line app/vmalert/web.qtpl:496
 			qw422016.N().S(`
                 <b>`)
-//line app/vmalert/web.qtpl:484
+//line app/vmalert/web.qtpl:497
 			qw422016.E().S(k)
-//line app/vmalert/web.qtpl:484
+//line app/vmalert/web.qtpl:497
 			qw422016.N().S(`:</b><br>
                 <p>`)
-//line app/vmalert/web.qtpl:485
+//line app/vmalert/web.qtpl:498
 			qw422016.E().S(rule.Annotations[k])
-//line app/vmalert/web.qtpl:485
+//line app/vmalert/web.qtpl:498
 			qw422016.N().S(`</p>
           `)
-//line app/vmalert/web.qtpl:486
+//line app/vmalert/web.qtpl:499
 		}
-//line app/vmalert/web.qtpl:486
+//line app/vmalert/web.qtpl:499
 		qw422016.N().S(`
         </div>
       </div>
@@ -1506,17 +1519,17 @@ func StreamRuleDetails(qw422016 *qt422016.Writer, r *http.Request, rule apiRule)
         </div>
         <div class="col">
            `)
-//line app/vmalert/web.qtpl:496
+//line app/vmalert/web.qtpl:509
 		qw422016.E().V(rule.Debug)
-//line app/vmalert/web.qtpl:496
+//line app/vmalert/web.qtpl:509
 		qw422016.N().S(`
         </div>
       </div>
     </div>
     `)
-//line app/vmalert/web.qtpl:500
+//line app/vmalert/web.qtpl:513
 	}
-//line app/vmalert/web.qtpl:500
+//line app/vmalert/web.qtpl:513
 	qw422016.N().S(`
     <div class="container border-bottom p-2">
       <div class="row">
@@ -1525,17 +1538,17 @@ func StreamRuleDetails(qw422016 *qt422016.Writer, r *http.Request, rule apiRule)
         </div>
         <div class="col">
            <a target="_blank" href="`)
-//line app/vmalert/web.qtpl:507
+//line app/vmalert/web.qtpl:520
 	qw422016.E().S(prefix)
-//line app/vmalert/web.qtpl:507
+//line app/vmalert/web.qtpl:520
 	qw422016.N().S(`groups#group-`)
-//line app/vmalert/web.qtpl:507
+//line app/vmalert/web.qtpl:520
 	qw422016.E().S(rule.GroupID)
-//line app/vmalert/web.qtpl:507
+//line app/vmalert/web.qtpl:520
 	qw422016.N().S(`">`)
-//line app/vmalert/web.qtpl:507
+//line app/vmalert/web.qtpl:520
 	qw422016.E().S(rule.GroupID)
-//line app/vmalert/web.qtpl:507
+//line app/vmalert/web.qtpl:520
 	qw422016.N().S(`</a>
         </div>
       </div>
@@ -1543,9 +1556,9 @@ func StreamRuleDetails(qw422016 *qt422016.Writer, r *http.Request, rule apiRule)
 
     <br>
     `)
-//line app/vmalert/web.qtpl:513
+//line app/vmalert/web.qtpl:526
 	if seriesFetchedWarning {
-//line app/vmalert/web.qtpl:513
+//line app/vmalert/web.qtpl:526
 		qw422016.N().S(`
     <div class="alert alert-warning" role="alert">
        <strong>Warning:</strong> some of updates have "Series fetched" equal to 0.<br>
@@ -1559,18 +1572,18 @@ func StreamRuleDetails(qw422016 *qt422016.Writer, r *http.Request, rule apiRule)
        See more details about this detection <a target="_blank" href="https://github.com/VictoriaMetrics/VictoriaMetrics/issues/4039">here</a>.
     </div>
     `)
-//line app/vmalert/web.qtpl:525
+//line app/vmalert/web.qtpl:538
 	}
-//line app/vmalert/web.qtpl:525
+//line app/vmalert/web.qtpl:538
 	qw422016.N().S(`
     <div class="display-6 pb-3">Last `)
-//line app/vmalert/web.qtpl:526
+//line app/vmalert/web.qtpl:539
 	qw422016.N().D(len(rule.Updates))
-//line app/vmalert/web.qtpl:526
+//line app/vmalert/web.qtpl:539
 	qw422016.N().S(`/`)
-//line app/vmalert/web.qtpl:526
+//line app/vmalert/web.qtpl:539
 	qw422016.N().D(rule.MaxUpdates)
-//line app/vmalert/web.qtpl:526
+//line app/vmalert/web.qtpl:539
 	qw422016.N().S(` updates</span>:</div>
         <table class="table table-striped table-hover table-sm">
             <thead>
@@ -1578,13 +1591,13 @@ func StreamRuleDetails(qw422016 *qt422016.Writer, r *http.Request, rule apiRule)
                     <th scope="col" title="The time when event was created">Updated at</th>
                     <th scope="col" style="width: 10%" class="text-center" title="How many samples were returned">Samples</th>
                     `)
-//line app/vmalert/web.qtpl:532
+//line app/vmalert/web.qtpl:545
 	if seriesFetchedEnabled {
-//line app/vmalert/web.qtpl:532
+//line app/vmalert/web.qtpl:545
 		qw422016.N().S(`<th scope="col" style="width: 10%" class="text-center" title="How many series were scanned by datasource during the evaluation">Series fetched</th>`)
-//line app/vmalert/web.qtpl:532
+//line app/vmalert/web.qtpl:545
 	}
-//line app/vmalert/web.qtpl:532
+//line app/vmalert/web.qtpl:545
 	qw422016.N().S(`
                     <th scope="col" style="width: 10%" class="text-center" title="How many seconds request took">Duration</th>
                     <th scope="col" class="text-center" title="Time used for rule execution">Executed at</th>
@@ -1594,285 +1607,285 @@ func StreamRuleDetails(qw422016 *qt422016.Writer, r *http.Request, rule apiRule)
             <tbody>
 
      `)
-//line app/vmalert/web.qtpl:540
+//line app/vmalert/web.qtpl:553
 	for _, u := range rule.Updates {
-//line app/vmalert/web.qtpl:540
+//line app/vmalert/web.qtpl:553
 		qw422016.N().S(`
              <tr`)
-//line app/vmalert/web.qtpl:541
+//line app/vmalert/web.qtpl:554
 		if u.Err != nil {
-//line app/vmalert/web.qtpl:541
+//line app/vmalert/web.qtpl:554
 			qw422016.N().S(` class="alert-danger"`)
-//line app/vmalert/web.qtpl:541
+//line app/vmalert/web.qtpl:554
 		}
-//line app/vmalert/web.qtpl:541
+//line app/vmalert/web.qtpl:554
 		qw422016.N().S(`>
                  <td>
                     <span class="badge bg-primary rounded-pill me-3" title="Updated at">`)
-//line app/vmalert/web.qtpl:543
+//line app/vmalert/web.qtpl:556
 		qw422016.E().S(u.Time.Format(time.RFC3339))
-//line app/vmalert/web.qtpl:543
+//line app/vmalert/web.qtpl:556
 		qw422016.N().S(`</span>
                  </td>
                  <td class="text-center">`)
-//line app/vmalert/web.qtpl:545
+//line app/vmalert/web.qtpl:558
 		qw422016.N().D(u.Samples)
-//line app/vmalert/web.qtpl:545
+//line app/vmalert/web.qtpl:558
 		qw422016.N().S(`</td>
                  `)
-//line app/vmalert/web.qtpl:546
+//line app/vmalert/web.qtpl:559
 		if seriesFetchedEnabled {
-//line app/vmalert/web.qtpl:546
+//line app/vmalert/web.qtpl:559
 			qw422016.N().S(`<td class="text-center">`)
-//line app/vmalert/web.qtpl:546
+//line app/vmalert/web.qtpl:559
 			if u.SeriesFetched != nil {
-//line app/vmalert/web.qtpl:546
+//line app/vmalert/web.qtpl:559
 				qw422016.N().D(*u.SeriesFetched)
-//line app/vmalert/web.qtpl:546
+//line app/vmalert/web.qtpl:559
 			}
-//line app/vmalert/web.qtpl:546
+//line app/vmalert/web.qtpl:559
 			qw422016.N().S(`</td>`)
-//line app/vmalert/web.qtpl:546
+//line app/vmalert/web.qtpl:559
 		}
-//line app/vmalert/web.qtpl:546
+//line app/vmalert/web.qtpl:559
 		qw422016.N().S(`
                  <td class="text-center">`)
-//line app/vmalert/web.qtpl:547
+//line app/vmalert/web.qtpl:560
 		qw422016.N().FPrec(u.Duration.Seconds(), 3)
-//line app/vmalert/web.qtpl:547
+//line app/vmalert/web.qtpl:560
 		qw422016.N().S(`s</td>
                  <td class="text-center">`)
-//line app/vmalert/web.qtpl:548
+//line app/vmalert/web.qtpl:561
 		qw422016.E().S(u.At.Format(time.RFC3339))
-//line app/vmalert/web.qtpl:548
+//line app/vmalert/web.qtpl:561
 		qw422016.N().S(`</td>
                  <td>
                     <textarea class="curl-area" rows="1" onclick="this.focus();this.select()">`)
-//line app/vmalert/web.qtpl:550
+//line app/vmalert/web.qtpl:563
 		qw422016.E().S(u.Curl)
-//line app/vmalert/web.qtpl:550
+//line app/vmalert/web.qtpl:563
 		qw422016.N().S(`</textarea>
                 </td>
              </tr>
           </li>
           `)
-//line app/vmalert/web.qtpl:554
+//line app/vmalert/web.qtpl:567
 		if u.Err != nil {
-//line app/vmalert/web.qtpl:554
+//line app/vmalert/web.qtpl:567
 			qw422016.N().S(`
              <tr`)
-//line app/vmalert/web.qtpl:555
+//line app/vmalert/web.qtpl:568
 			if u.Err != nil {
-//line app/vmalert/web.qtpl:555
+//line app/vmalert/web.qtpl:568
 				qw422016.N().S(` class="alert-danger"`)
-//line app/vmalert/web.qtpl:555
+//line app/vmalert/web.qtpl:568
 			}
-//line app/vmalert/web.qtpl:555
+//line app/vmalert/web.qtpl:568
 			qw422016.N().S(`>
                <td colspan="`)
-//line app/vmalert/web.qtpl:556
+//line app/vmalert/web.qtpl:569
 			if seriesFetchedEnabled {
-//line app/vmalert/web.qtpl:556
+//line app/vmalert/web.qtpl:569
 				qw422016.N().S(`6`)
-//line app/vmalert/web.qtpl:556
+//line app/vmalert/web.qtpl:569
 			} else {
-//line app/vmalert/web.qtpl:556
+//line app/vmalert/web.qtpl:569
 				qw422016.N().S(`5`)
-//line app/vmalert/web.qtpl:556
+//line app/vmalert/web.qtpl:569
 			}
-//line app/vmalert/web.qtpl:556
+//line app/vmalert/web.qtpl:569
 			qw422016.N().S(`">
                    <span class="alert-danger">`)
-//line app/vmalert/web.qtpl:557
+//line app/vmalert/web.qtpl:570
 			qw422016.E().V(u.Err)
-//line app/vmalert/web.qtpl:557
+//line app/vmalert/web.qtpl:570
 			qw422016.N().S(`</span>
                </td>
              </tr>
           `)
-//line app/vmalert/web.qtpl:560
+//line app/vmalert/web.qtpl:573
 		}
-//line app/vmalert/web.qtpl:560
+//line app/vmalert/web.qtpl:573
 		qw422016.N().S(`
      `)
-//line app/vmalert/web.qtpl:561
+//line app/vmalert/web.qtpl:574
 	}
-//line app/vmalert/web.qtpl:561
+//line app/vmalert/web.qtpl:574
 	qw422016.N().S(`
 
     `)
-//line app/vmalert/web.qtpl:563
+//line app/vmalert/web.qtpl:576
 	tpl.StreamFooter(qw422016, r)
-//line app/vmalert/web.qtpl:563
+//line app/vmalert/web.qtpl:576
 	qw422016.N().S(`
 `)
-//line app/vmalert/web.qtpl:564
+//line app/vmalert/web.qtpl:577
 }
 
-//line app/vmalert/web.qtpl:564
+//line app/vmalert/web.qtpl:577
 func WriteRuleDetails(qq422016 qtio422016.Writer, r *http.Request, rule apiRule) {
-//line app/vmalert/web.qtpl:564
+//line app/vmalert/web.qtpl:577
 	qw422016 := qt422016.AcquireWriter(qq422016)
-//line app/vmalert/web.qtpl:564
+//line app/vmalert/web.qtpl:577
 	StreamRuleDetails(qw422016, r, rule)
-//line app/vmalert/web.qtpl:564
+//line app/vmalert/web.qtpl:577
 	qt422016.ReleaseWriter(qw422016)
-//line app/vmalert/web.qtpl:564
+//line app/vmalert/web.qtpl:577
 }
 
-//line app/vmalert/web.qtpl:564
+//line app/vmalert/web.qtpl:577
 func RuleDetails(r *http.Request, rule apiRule) string {
-//line app/vmalert/web.qtpl:564
+//line app/vmalert/web.qtpl:577
 	qb422016 := qt422016.AcquireByteBuffer()
-//line app/vmalert/web.qtpl:564
+//line app/vmalert/web.qtpl:577
 	WriteRuleDetails(qb422016, r, rule)
-//line app/vmalert/web.qtpl:564
+//line app/vmalert/web.qtpl:577
 	qs422016 := string(qb422016.B)
-//line app/vmalert/web.qtpl:564
+//line app/vmalert/web.qtpl:577
 	qt422016.ReleaseByteBuffer(qb422016)
-//line app/vmalert/web.qtpl:564
+//line app/vmalert/web.qtpl:577
 	return qs422016
-//line app/vmalert/web.qtpl:564
+//line app/vmalert/web.qtpl:577
 }
 
-//line app/vmalert/web.qtpl:568
+//line app/vmalert/web.qtpl:581
 func streambadgeState(qw422016 *qt422016.Writer, state string) {
-//line app/vmalert/web.qtpl:568
+//line app/vmalert/web.qtpl:581
 	qw422016.N().S(`
 `)
-//line app/vmalert/web.qtpl:570
+//line app/vmalert/web.qtpl:583
 	badgeClass := "bg-warning text-dark"
 	if state == "firing" {
 		badgeClass = "bg-danger"
 	}
 
-//line app/vmalert/web.qtpl:574
+//line app/vmalert/web.qtpl:587
 	qw422016.N().S(`
 <span class="badge `)
-//line app/vmalert/web.qtpl:575
+//line app/vmalert/web.qtpl:588
 	qw422016.E().S(badgeClass)
-//line app/vmalert/web.qtpl:575
+//line app/vmalert/web.qtpl:588
 	qw422016.N().S(`">`)
-//line app/vmalert/web.qtpl:575
+//line app/vmalert/web.qtpl:588
 	qw422016.E().S(state)
-//line app/vmalert/web.qtpl:575
+//line app/vmalert/web.qtpl:588
 	qw422016.N().S(`</span>
 `)
-//line app/vmalert/web.qtpl:576
+//line app/vmalert/web.qtpl:589
 }
 
-//line app/vmalert/web.qtpl:576
+//line app/vmalert/web.qtpl:589
 func writebadgeState(qq422016 qtio422016.Writer, state string) {
-//line app/vmalert/web.qtpl:576
+//line app/vmalert/web.qtpl:589
 	qw422016 := qt422016.AcquireWriter(qq422016)
-//line app/vmalert/web.qtpl:576
+//line app/vmalert/web.qtpl:589
 	streambadgeState(qw422016, state)
-//line app/vmalert/web.qtpl:576
+//line app/vmalert/web.qtpl:589
 	qt422016.ReleaseWriter(qw422016)
-//line app/vmalert/web.qtpl:576
+//line app/vmalert/web.qtpl:589
 }
 
-//line app/vmalert/web.qtpl:576
+//line app/vmalert/web.qtpl:589
 func badgeState(state string) string {
-//line app/vmalert/web.qtpl:576
+//line app/vmalert/web.qtpl:589
 	qb422016 := qt422016.AcquireByteBuffer()
-//line app/vmalert/web.qtpl:576
+//line app/vmalert/web.qtpl:589
 	writebadgeState(qb422016, state)
-//line app/vmalert/web.qtpl:576
+//line app/vmalert/web.qtpl:589
 	qs422016 := string(qb422016.B)
-//line app/vmalert/web.qtpl:576
+//line app/vmalert/web.qtpl:589
 	qt422016.ReleaseByteBuffer(qb422016)
-//line app/vmalert/web.qtpl:576
+//line app/vmalert/web.qtpl:589
 	return qs422016
-//line app/vmalert/web.qtpl:576
+//line app/vmalert/web.qtpl:589
 }
 
-//line app/vmalert/web.qtpl:578
+//line app/vmalert/web.qtpl:591
 func streambadgeRestored(qw422016 *qt422016.Writer) {
-//line app/vmalert/web.qtpl:578
+//line app/vmalert/web.qtpl:591
 	qw422016.N().S(`
 <span class="badge bg-warning text-dark" title="Alert state was restored after the service restart from remote storage">restored</span>
 `)
-//line app/vmalert/web.qtpl:580
+//line app/vmalert/web.qtpl:593
 }
 
-//line app/vmalert/web.qtpl:580
+//line app/vmalert/web.qtpl:593
 func writebadgeRestored(qq422016 qtio422016.Writer) {
-//line app/vmalert/web.qtpl:580
+//line app/vmalert/web.qtpl:593
 	qw422016 := qt422016.AcquireWriter(qq422016)
-//line app/vmalert/web.qtpl:580
+//line app/vmalert/web.qtpl:593
 	streambadgeRestored(qw422016)
-//line app/vmalert/web.qtpl:580
+//line app/vmalert/web.qtpl:593
 	qt422016.ReleaseWriter(qw422016)
-//line app/vmalert/web.qtpl:580
+//line app/vmalert/web.qtpl:593
 }
 
-//line app/vmalert/web.qtpl:580
+//line app/vmalert/web.qtpl:593
 func badgeRestored() string {
-//line app/vmalert/web.qtpl:580
+//line app/vmalert/web.qtpl:593
 	qb422016 := qt422016.AcquireByteBuffer()
-//line app/vmalert/web.qtpl:580
+//line app/vmalert/web.qtpl:593
 	writebadgeRestored(qb422016)
-//line app/vmalert/web.qtpl:580
+//line app/vmalert/web.qtpl:593
 	qs422016 := string(qb422016.B)
-//line app/vmalert/web.qtpl:580
+//line app/vmalert/web.qtpl:593
 	qt422016.ReleaseByteBuffer(qb422016)
-//line app/vmalert/web.qtpl:580
+//line app/vmalert/web.qtpl:593
 	return qs422016
-//line app/vmalert/web.qtpl:580
+//line app/vmalert/web.qtpl:593
 }
 
-//line app/vmalert/web.qtpl:582
+//line app/vmalert/web.qtpl:595
 func streambadgeStabilizing(qw422016 *qt422016.Writer) {
-//line app/vmalert/web.qtpl:582
+//line app/vmalert/web.qtpl:595
 	qw422016.N().S(`
 <span class="badge bg-warning text-dark" title="This firing state is kept because of `)
-//line app/vmalert/web.qtpl:582
+//line app/vmalert/web.qtpl:595
 	qw422016.N().S("`")
-//line app/vmalert/web.qtpl:582
+//line app/vmalert/web.qtpl:595
 	qw422016.N().S(`keep_firing_for`)
-//line app/vmalert/web.qtpl:582
+//line app/vmalert/web.qtpl:595
 	qw422016.N().S("`")
-//line app/vmalert/web.qtpl:582
+//line app/vmalert/web.qtpl:595
 	qw422016.N().S(`">stabilizing</span>
 `)
-//line app/vmalert/web.qtpl:584
+//line app/vmalert/web.qtpl:597
 }
 
-//line app/vmalert/web.qtpl:584
+//line app/vmalert/web.qtpl:597
 func writebadgeStabilizing(qq422016 qtio422016.Writer) {
-//line app/vmalert/web.qtpl:584
+//line app/vmalert/web.qtpl:597
 	qw422016 := qt422016.AcquireWriter(qq422016)
-//line app/vmalert/web.qtpl:584
+//line app/vmalert/web.qtpl:597
 	streambadgeStabilizing(qw422016)
-//line app/vmalert/web.qtpl:584
+//line app/vmalert/web.qtpl:597
 	qt422016.ReleaseWriter(qw422016)
-//line app/vmalert/web.qtpl:584
+//line app/vmalert/web.qtpl:597
 }
 
-//line app/vmalert/web.qtpl:584
+//line app/vmalert/web.qtpl:597
 func badgeStabilizing() string {
-//line app/vmalert/web.qtpl:584
+//line app/vmalert/web.qtpl:597
 	qb422016 := qt422016.AcquireByteBuffer()
-//line app/vmalert/web.qtpl:584
+//line app/vmalert/web.qtpl:597
 	writebadgeStabilizing(qb422016)
-//line app/vmalert/web.qtpl:584
+//line app/vmalert/web.qtpl:597
 	qs422016 := string(qb422016.B)
-//line app/vmalert/web.qtpl:584
+//line app/vmalert/web.qtpl:597
 	qt422016.ReleaseByteBuffer(qb422016)
-//line app/vmalert/web.qtpl:584
+//line app/vmalert/web.qtpl:597
 	return qs422016
-//line app/vmalert/web.qtpl:584
+//line app/vmalert/web.qtpl:597
 }
 
-//line app/vmalert/web.qtpl:586
+//line app/vmalert/web.qtpl:599
 func streamseriesFetchedWarn(qw422016 *qt422016.Writer, r apiRule) {
-//line app/vmalert/web.qtpl:586
+//line app/vmalert/web.qtpl:599
 	qw422016.N().S(`
 `)
-//line app/vmalert/web.qtpl:587
+//line app/vmalert/web.qtpl:600
 	if isNoMatch(r) {
-//line app/vmalert/web.qtpl:587
+//line app/vmalert/web.qtpl:600
 		qw422016.N().S(`
 <svg xmlns="http://www.w3.org/2000/svg"
     data-bs-toggle="tooltip"
@@ -1883,41 +1896,41 @@ func streamseriesFetchedWarn(qw422016 *qt422016.Writer, r apiRule) {
        <path d="M8 16A8 8 0 1 0 8 0a8 8 0 0 0 0 16zm.93-9.412-1 4.705c-.07.34.029.533.304.533.194 0 .487-.07.686-.246l-.088.416c-.287.346-.92.598-1.465.598-.703 0-1.002-.422-.808-1.319l.738-3.468c.064-.293.006-.399-.287-.47l-.451-.081.082-.381 2.29-.287zM8 5.5a1 1 0 1 1 0-2 1 1 0 0 1 0 2z"/>
 </svg>
 `)
-//line app/vmalert/web.qtpl:596
+//line app/vmalert/web.qtpl:609
 	}
-//line app/vmalert/web.qtpl:596
+//line app/vmalert/web.qtpl:609
 	qw422016.N().S(`
 `)
-//line app/vmalert/web.qtpl:597
+//line app/vmalert/web.qtpl:610
 }
 
-//line app/vmalert/web.qtpl:597
+//line app/vmalert/web.qtpl:610
 func writeseriesFetchedWarn(qq422016 qtio422016.Writer, r apiRule) {
-//line app/vmalert/web.qtpl:597
+//line app/vmalert/web.qtpl:610
 	qw422016 := qt422016.AcquireWriter(qq422016)
-//line app/vmalert/web.qtpl:597
+//line app/vmalert/web.qtpl:610
 	streamseriesFetchedWarn(qw422016, r)
-//line app/vmalert/web.qtpl:597
+//line app/vmalert/web.qtpl:610
 	qt422016.ReleaseWriter(qw422016)
-//line app/vmalert/web.qtpl:597
+//line app/vmalert/web.qtpl:610
 }
 
-//line app/vmalert/web.qtpl:597
+//line app/vmalert/web.qtpl:610
 func seriesFetchedWarn(r apiRule) string {
-//line app/vmalert/web.qtpl:597
+//line app/vmalert/web.qtpl:610
 	qb422016 := qt422016.AcquireByteBuffer()
-//line app/vmalert/web.qtpl:597
+//line app/vmalert/web.qtpl:610
 	writeseriesFetchedWarn(qb422016, r)
-//line app/vmalert/web.qtpl:597
+//line app/vmalert/web.qtpl:610
 	qs422016 := string(qb422016.B)
-//line app/vmalert/web.qtpl:597
+//line app/vmalert/web.qtpl:610
 	qt422016.ReleaseByteBuffer(qb422016)
-//line app/vmalert/web.qtpl:597
+//line app/vmalert/web.qtpl:610
 	return qs422016
-//line app/vmalert/web.qtpl:597
+//line app/vmalert/web.qtpl:610
 }
 
-//line app/vmalert/web.qtpl:600
+//line app/vmalert/web.qtpl:613
 func isNoMatch(r apiRule) bool {
 	return r.LastSamples == 0 && r.LastSeriesFetched != nil && *r.LastSeriesFetched == 0
 }

--- a/app/vmalert/web.qtpl.go
+++ b/app/vmalert/web.qtpl.go
@@ -259,165 +259,158 @@ func StreamListGroups(qw422016 *qt422016.Writer, r *http.Request, originGroups [
 	streambuttonActive(qw422016, filter, "noMatch")
 //line app/vmalert/web.qtpl:77
 	qw422016.N().S(`" role="button" onclick="location.href='?filter=noMatch'" title="Show only rules matching no time series during last evaluation">NoMatch</a>
-         <p>
-          <input id="filter" class="input-group" role="input"></input>
-            <a class="btn btn-primary" role="button" onclick="filter()">Filter</a>
-            <form>
-              <input type="radio" name="filterType" id="groups" role="input" checked>By Group Name</input>
-              <input type="radio" name="filterType" id="rules" role="input">By Rule Name</input>
-            </form>
-        </p>
+         <input id="filter" class="input-group" role="input"></input>
         `)
-//line app/vmalert/web.qtpl:86
+//line app/vmalert/web.qtpl:79
 	if len(groups) > 0 {
-//line app/vmalert/web.qtpl:86
+//line app/vmalert/web.qtpl:79
 		qw422016.N().S(`
             `)
-//line app/vmalert/web.qtpl:87
+//line app/vmalert/web.qtpl:80
 		for _, g := range groups {
-//line app/vmalert/web.qtpl:87
+//line app/vmalert/web.qtpl:80
 			qw422016.N().S(`
                   <div
                     class="group-heading`)
-//line app/vmalert/web.qtpl:89
+//line app/vmalert/web.qtpl:82
 			if rNotOk[g.ID] > 0 {
-//line app/vmalert/web.qtpl:89
+//line app/vmalert/web.qtpl:82
 				qw422016.N().S(` alert-danger`)
-//line app/vmalert/web.qtpl:89
+//line app/vmalert/web.qtpl:82
 			}
-//line app/vmalert/web.qtpl:89
+//line app/vmalert/web.qtpl:82
 			qw422016.N().S(`" data-bs-target="rules-`)
-//line app/vmalert/web.qtpl:89
+//line app/vmalert/web.qtpl:82
 			qw422016.E().S(g.ID)
-//line app/vmalert/web.qtpl:89
+//line app/vmalert/web.qtpl:82
 			qw422016.N().S(`" data-group-name="`)
-//line app/vmalert/web.qtpl:89
+//line app/vmalert/web.qtpl:82
 			qw422016.E().S(g.Name)
-//line app/vmalert/web.qtpl:89
+//line app/vmalert/web.qtpl:82
 			qw422016.N().S(`">
                     <span class="anchor" id="group-`)
-//line app/vmalert/web.qtpl:90
+//line app/vmalert/web.qtpl:83
 			qw422016.E().S(g.ID)
-//line app/vmalert/web.qtpl:90
+//line app/vmalert/web.qtpl:83
 			qw422016.N().S(`"></span>
                     <a href="#group-`)
-//line app/vmalert/web.qtpl:91
+//line app/vmalert/web.qtpl:84
 			qw422016.E().S(g.ID)
-//line app/vmalert/web.qtpl:91
+//line app/vmalert/web.qtpl:84
 			qw422016.N().S(`">`)
-//line app/vmalert/web.qtpl:91
+//line app/vmalert/web.qtpl:84
 			qw422016.E().S(g.Name)
-//line app/vmalert/web.qtpl:91
+//line app/vmalert/web.qtpl:84
 			if g.Type != "prometheus" {
-//line app/vmalert/web.qtpl:91
+//line app/vmalert/web.qtpl:84
 				qw422016.N().S(` (`)
-//line app/vmalert/web.qtpl:91
+//line app/vmalert/web.qtpl:84
 				qw422016.E().S(g.Type)
-//line app/vmalert/web.qtpl:91
+//line app/vmalert/web.qtpl:84
 				qw422016.N().S(`)`)
-//line app/vmalert/web.qtpl:91
+//line app/vmalert/web.qtpl:84
 			}
-//line app/vmalert/web.qtpl:91
+//line app/vmalert/web.qtpl:84
 			qw422016.N().S(` (every `)
-//line app/vmalert/web.qtpl:91
+//line app/vmalert/web.qtpl:84
 			qw422016.N().FPrec(g.Interval, 0)
-//line app/vmalert/web.qtpl:91
+//line app/vmalert/web.qtpl:84
 			qw422016.N().S(`s) #</a>
                      `)
-//line app/vmalert/web.qtpl:92
+//line app/vmalert/web.qtpl:85
 			if rNotOk[g.ID] > 0 {
-//line app/vmalert/web.qtpl:92
+//line app/vmalert/web.qtpl:85
 				qw422016.N().S(`<span class="badge bg-danger" title="Number of rules with status Error">`)
-//line app/vmalert/web.qtpl:92
+//line app/vmalert/web.qtpl:85
 				qw422016.N().D(rNotOk[g.ID])
-//line app/vmalert/web.qtpl:92
+//line app/vmalert/web.qtpl:85
 				qw422016.N().S(`</span> `)
-//line app/vmalert/web.qtpl:92
+//line app/vmalert/web.qtpl:85
 			}
-//line app/vmalert/web.qtpl:92
+//line app/vmalert/web.qtpl:85
 			qw422016.N().S(`
                      `)
-//line app/vmalert/web.qtpl:93
+//line app/vmalert/web.qtpl:86
 			if rNoMatch[g.ID] > 0 {
-//line app/vmalert/web.qtpl:93
+//line app/vmalert/web.qtpl:86
 				qw422016.N().S(`<span class="badge bg-warning" title="Number of rules with status NoMatch">`)
-//line app/vmalert/web.qtpl:93
+//line app/vmalert/web.qtpl:86
 				qw422016.N().D(rNoMatch[g.ID])
-//line app/vmalert/web.qtpl:93
+//line app/vmalert/web.qtpl:86
 				qw422016.N().S(`</span> `)
-//line app/vmalert/web.qtpl:93
+//line app/vmalert/web.qtpl:86
 			}
-//line app/vmalert/web.qtpl:93
+//line app/vmalert/web.qtpl:86
 			qw422016.N().S(`
                     <span class="badge bg-success" title="Number of rules withs status Ok">`)
-//line app/vmalert/web.qtpl:94
+//line app/vmalert/web.qtpl:87
 			qw422016.N().D(rOk[g.ID])
-//line app/vmalert/web.qtpl:94
+//line app/vmalert/web.qtpl:87
 			qw422016.N().S(`</span>
                     <p class="fs-6 fw-lighter">`)
-//line app/vmalert/web.qtpl:95
+//line app/vmalert/web.qtpl:88
 			qw422016.E().S(g.File)
-//line app/vmalert/web.qtpl:95
+//line app/vmalert/web.qtpl:88
 			qw422016.N().S(`</p>
                     `)
-//line app/vmalert/web.qtpl:96
+//line app/vmalert/web.qtpl:89
 			if len(g.Params) > 0 {
-//line app/vmalert/web.qtpl:96
+//line app/vmalert/web.qtpl:89
 				qw422016.N().S(`
                         <div class="fs-6 fw-lighter">Extra params
                         `)
-//line app/vmalert/web.qtpl:98
+//line app/vmalert/web.qtpl:91
 				for _, param := range g.Params {
-//line app/vmalert/web.qtpl:98
+//line app/vmalert/web.qtpl:91
 					qw422016.N().S(`
                                 <span class="float-left badge bg-primary">`)
-//line app/vmalert/web.qtpl:99
+//line app/vmalert/web.qtpl:92
 					qw422016.E().S(param)
-//line app/vmalert/web.qtpl:99
+//line app/vmalert/web.qtpl:92
 					qw422016.N().S(`</span>
                         `)
-//line app/vmalert/web.qtpl:100
+//line app/vmalert/web.qtpl:93
 				}
-//line app/vmalert/web.qtpl:100
+//line app/vmalert/web.qtpl:93
 				qw422016.N().S(`
                         </div>
                     `)
-//line app/vmalert/web.qtpl:102
+//line app/vmalert/web.qtpl:95
 			}
-//line app/vmalert/web.qtpl:102
+//line app/vmalert/web.qtpl:95
 			qw422016.N().S(`
                     `)
-//line app/vmalert/web.qtpl:103
+//line app/vmalert/web.qtpl:96
 			if len(g.Headers) > 0 {
-//line app/vmalert/web.qtpl:103
+//line app/vmalert/web.qtpl:96
 				qw422016.N().S(`
                         <div class="fs-6 fw-lighter">Extra headers
                         `)
-//line app/vmalert/web.qtpl:105
+//line app/vmalert/web.qtpl:98
 				for _, header := range g.Headers {
-//line app/vmalert/web.qtpl:105
+//line app/vmalert/web.qtpl:98
 					qw422016.N().S(`
                                 <span class="float-left badge bg-primary">`)
-//line app/vmalert/web.qtpl:106
+//line app/vmalert/web.qtpl:99
 					qw422016.E().S(header)
-//line app/vmalert/web.qtpl:106
+//line app/vmalert/web.qtpl:99
 					qw422016.N().S(`</span>
                         `)
-//line app/vmalert/web.qtpl:107
+//line app/vmalert/web.qtpl:100
 				}
-//line app/vmalert/web.qtpl:107
+//line app/vmalert/web.qtpl:100
 				qw422016.N().S(`
                         </div>
                     `)
-//line app/vmalert/web.qtpl:109
+//line app/vmalert/web.qtpl:102
 			}
-//line app/vmalert/web.qtpl:109
+//line app/vmalert/web.qtpl:102
 			qw422016.N().S(`
                 </div>
                 <div class="collapse rule-table" id="rules-`)
-//line app/vmalert/web.qtpl:111
+//line app/vmalert/web.qtpl:104
 			qw422016.E().S(g.ID)
-//line app/vmalert/web.qtpl:111
+//line app/vmalert/web.qtpl:104
 			qw422016.N().S(`">
                     <table class="table table-striped table-hover table-sm">
                         <thead>
@@ -429,308 +422,308 @@ func StreamListGroups(qw422016 *qt422016.Writer, r *http.Request, originGroups [
                         </thead>
                         <tbody>
                         `)
-//line app/vmalert/web.qtpl:121
+//line app/vmalert/web.qtpl:114
 			for _, r := range g.Rules {
-//line app/vmalert/web.qtpl:121
+//line app/vmalert/web.qtpl:114
 				qw422016.N().S(`
                             <tr class="rule`)
-//line app/vmalert/web.qtpl:122
+//line app/vmalert/web.qtpl:115
 				if r.LastError != "" {
-//line app/vmalert/web.qtpl:122
+//line app/vmalert/web.qtpl:115
 					qw422016.N().S(` alert-danger`)
-//line app/vmalert/web.qtpl:122
+//line app/vmalert/web.qtpl:115
 				}
-//line app/vmalert/web.qtpl:122
+//line app/vmalert/web.qtpl:115
 				qw422016.N().S(`" data-rule-name="`)
-//line app/vmalert/web.qtpl:122
+//line app/vmalert/web.qtpl:115
 				qw422016.E().S(r.Name)
-//line app/vmalert/web.qtpl:122
+//line app/vmalert/web.qtpl:115
 				qw422016.N().S(`" data-bs-target="`)
-//line app/vmalert/web.qtpl:122
+//line app/vmalert/web.qtpl:115
 				qw422016.E().S(g.ID)
-//line app/vmalert/web.qtpl:122
+//line app/vmalert/web.qtpl:115
 				qw422016.N().S(`">
                                 <td>
                                     <div class="row">
                                         <div class="col-12 mb-2">
                                             `)
-//line app/vmalert/web.qtpl:126
+//line app/vmalert/web.qtpl:119
 				if r.Type == "alerting" {
-//line app/vmalert/web.qtpl:126
+//line app/vmalert/web.qtpl:119
 					qw422016.N().S(`
                                             `)
-//line app/vmalert/web.qtpl:127
+//line app/vmalert/web.qtpl:120
 					if r.KeepFiringFor > 0 {
-//line app/vmalert/web.qtpl:127
+//line app/vmalert/web.qtpl:120
 						qw422016.N().S(`
                                             <b>alert:</b> `)
-//line app/vmalert/web.qtpl:128
+//line app/vmalert/web.qtpl:121
 						qw422016.E().S(r.Name)
-//line app/vmalert/web.qtpl:128
+//line app/vmalert/web.qtpl:121
 						qw422016.N().S(` (for: `)
-//line app/vmalert/web.qtpl:128
+//line app/vmalert/web.qtpl:121
 						qw422016.E().V(r.Duration)
-//line app/vmalert/web.qtpl:128
+//line app/vmalert/web.qtpl:121
 						qw422016.N().S(` seconds, keep_firing_for: `)
-//line app/vmalert/web.qtpl:128
+//line app/vmalert/web.qtpl:121
 						qw422016.E().V(r.KeepFiringFor)
-//line app/vmalert/web.qtpl:128
+//line app/vmalert/web.qtpl:121
 						qw422016.N().S(` seconds)
                                             `)
-//line app/vmalert/web.qtpl:129
+//line app/vmalert/web.qtpl:122
 					} else {
-//line app/vmalert/web.qtpl:129
+//line app/vmalert/web.qtpl:122
 						qw422016.N().S(`
                                             <b>alert:</b> `)
-//line app/vmalert/web.qtpl:130
+//line app/vmalert/web.qtpl:123
 						qw422016.E().S(r.Name)
-//line app/vmalert/web.qtpl:130
+//line app/vmalert/web.qtpl:123
 						qw422016.N().S(` (for: `)
-//line app/vmalert/web.qtpl:130
+//line app/vmalert/web.qtpl:123
 						qw422016.E().V(r.Duration)
-//line app/vmalert/web.qtpl:130
+//line app/vmalert/web.qtpl:123
 						qw422016.N().S(` seconds)
                                             `)
-//line app/vmalert/web.qtpl:131
+//line app/vmalert/web.qtpl:124
 					}
-//line app/vmalert/web.qtpl:131
+//line app/vmalert/web.qtpl:124
 					qw422016.N().S(`
                                             `)
-//line app/vmalert/web.qtpl:132
+//line app/vmalert/web.qtpl:125
 				} else {
-//line app/vmalert/web.qtpl:132
+//line app/vmalert/web.qtpl:125
 					qw422016.N().S(`
                                             <b>record:</b> `)
-//line app/vmalert/web.qtpl:133
+//line app/vmalert/web.qtpl:126
 					qw422016.E().S(r.Name)
-//line app/vmalert/web.qtpl:133
+//line app/vmalert/web.qtpl:126
 					qw422016.N().S(`
                                             `)
-//line app/vmalert/web.qtpl:134
+//line app/vmalert/web.qtpl:127
 				}
-//line app/vmalert/web.qtpl:134
+//line app/vmalert/web.qtpl:127
 				qw422016.N().S(`
                                             |
                                             `)
-//line app/vmalert/web.qtpl:136
+//line app/vmalert/web.qtpl:129
 				streamseriesFetchedWarn(qw422016, r)
-//line app/vmalert/web.qtpl:136
+//line app/vmalert/web.qtpl:129
 				qw422016.N().S(`
                                             <span><a target="_blank" href="`)
-//line app/vmalert/web.qtpl:137
+//line app/vmalert/web.qtpl:130
 				qw422016.E().S(prefix + r.WebLink())
-//line app/vmalert/web.qtpl:137
+//line app/vmalert/web.qtpl:130
 				qw422016.N().S(`">Details</a></span>
                                         </div>
                                         <div class="col-12">
                                             <code><pre>`)
-//line app/vmalert/web.qtpl:140
+//line app/vmalert/web.qtpl:133
 				qw422016.E().S(r.Query)
-//line app/vmalert/web.qtpl:140
+//line app/vmalert/web.qtpl:133
 				qw422016.N().S(`</pre></code>
                                         </div>
                                         <div class="col-12 mb-2">
                                             `)
-//line app/vmalert/web.qtpl:143
+//line app/vmalert/web.qtpl:136
 				if len(r.Labels) > 0 {
-//line app/vmalert/web.qtpl:143
+//line app/vmalert/web.qtpl:136
 					qw422016.N().S(` <b>Labels:</b>`)
-//line app/vmalert/web.qtpl:143
+//line app/vmalert/web.qtpl:136
 				}
-//line app/vmalert/web.qtpl:143
+//line app/vmalert/web.qtpl:136
 				qw422016.N().S(`
                                             `)
-//line app/vmalert/web.qtpl:144
+//line app/vmalert/web.qtpl:137
 				for k, v := range r.Labels {
-//line app/vmalert/web.qtpl:144
+//line app/vmalert/web.qtpl:137
 					qw422016.N().S(`
-                                                    <span class="ms-1 badge bg-primary">`)
-//line app/vmalert/web.qtpl:145
+                                                    <span class="ms-1 badge bg-primary label">`)
+//line app/vmalert/web.qtpl:138
 					qw422016.E().S(k)
-//line app/vmalert/web.qtpl:145
+//line app/vmalert/web.qtpl:138
 					qw422016.N().S(`=`)
-//line app/vmalert/web.qtpl:145
+//line app/vmalert/web.qtpl:138
 					qw422016.E().S(v)
-//line app/vmalert/web.qtpl:145
+//line app/vmalert/web.qtpl:138
 					qw422016.N().S(`</span>
                                             `)
-//line app/vmalert/web.qtpl:146
+//line app/vmalert/web.qtpl:139
 				}
-//line app/vmalert/web.qtpl:146
+//line app/vmalert/web.qtpl:139
 				qw422016.N().S(`
                                         </div>
                                         `)
-//line app/vmalert/web.qtpl:148
+//line app/vmalert/web.qtpl:141
 				if r.LastError != "" {
-//line app/vmalert/web.qtpl:148
+//line app/vmalert/web.qtpl:141
 					qw422016.N().S(`
                                         <div class="col-12">
                                             <b>Error:</b>
                                             <div class="error-cell">
                                             `)
-//line app/vmalert/web.qtpl:152
+//line app/vmalert/web.qtpl:145
 					qw422016.E().S(r.LastError)
-//line app/vmalert/web.qtpl:152
+//line app/vmalert/web.qtpl:145
 					qw422016.N().S(`
                                             </div>
                                         </div>
                                         `)
-//line app/vmalert/web.qtpl:155
+//line app/vmalert/web.qtpl:148
 				}
-//line app/vmalert/web.qtpl:155
+//line app/vmalert/web.qtpl:148
 				qw422016.N().S(`
                                     </div>
                                 </td>
                                 <td class="text-center">`)
-//line app/vmalert/web.qtpl:158
+//line app/vmalert/web.qtpl:151
 				qw422016.N().D(r.LastSamples)
-//line app/vmalert/web.qtpl:158
+//line app/vmalert/web.qtpl:151
 				qw422016.N().S(`</td>
                                 <td class="text-center">`)
-//line app/vmalert/web.qtpl:159
+//line app/vmalert/web.qtpl:152
 				qw422016.N().FPrec(time.Since(r.LastEvaluation).Seconds(), 3)
-//line app/vmalert/web.qtpl:159
+//line app/vmalert/web.qtpl:152
 				qw422016.N().S(`s ago</td>
                             </tr>
                         `)
-//line app/vmalert/web.qtpl:161
+//line app/vmalert/web.qtpl:154
 			}
-//line app/vmalert/web.qtpl:161
+//line app/vmalert/web.qtpl:154
 			qw422016.N().S(`
                      </tbody>
                     </table>
                 </div>
             `)
-//line app/vmalert/web.qtpl:165
+//line app/vmalert/web.qtpl:158
 		}
-//line app/vmalert/web.qtpl:165
+//line app/vmalert/web.qtpl:158
 		qw422016.N().S(`
         `)
-//line app/vmalert/web.qtpl:166
+//line app/vmalert/web.qtpl:159
 	} else {
-//line app/vmalert/web.qtpl:166
+//line app/vmalert/web.qtpl:159
 		qw422016.N().S(`
             <div>
                 <p>No groups...</p>
             </div>
         `)
-//line app/vmalert/web.qtpl:170
+//line app/vmalert/web.qtpl:163
 	}
-//line app/vmalert/web.qtpl:170
+//line app/vmalert/web.qtpl:163
 	qw422016.N().S(`
 
     `)
-//line app/vmalert/web.qtpl:172
+//line app/vmalert/web.qtpl:165
 	tpl.StreamFooter(qw422016, r)
-//line app/vmalert/web.qtpl:172
+//line app/vmalert/web.qtpl:165
 	qw422016.N().S(`
 
 `)
-//line app/vmalert/web.qtpl:174
+//line app/vmalert/web.qtpl:167
 }
 
-//line app/vmalert/web.qtpl:174
+//line app/vmalert/web.qtpl:167
 func WriteListGroups(qq422016 qtio422016.Writer, r *http.Request, originGroups []apiGroup) {
-//line app/vmalert/web.qtpl:174
+//line app/vmalert/web.qtpl:167
 	qw422016 := qt422016.AcquireWriter(qq422016)
-//line app/vmalert/web.qtpl:174
+//line app/vmalert/web.qtpl:167
 	StreamListGroups(qw422016, r, originGroups)
-//line app/vmalert/web.qtpl:174
+//line app/vmalert/web.qtpl:167
 	qt422016.ReleaseWriter(qw422016)
-//line app/vmalert/web.qtpl:174
+//line app/vmalert/web.qtpl:167
 }
 
-//line app/vmalert/web.qtpl:174
+//line app/vmalert/web.qtpl:167
 func ListGroups(r *http.Request, originGroups []apiGroup) string {
-//line app/vmalert/web.qtpl:174
+//line app/vmalert/web.qtpl:167
 	qb422016 := qt422016.AcquireByteBuffer()
-//line app/vmalert/web.qtpl:174
+//line app/vmalert/web.qtpl:167
 	WriteListGroups(qb422016, r, originGroups)
-//line app/vmalert/web.qtpl:174
+//line app/vmalert/web.qtpl:167
 	qs422016 := string(qb422016.B)
-//line app/vmalert/web.qtpl:174
+//line app/vmalert/web.qtpl:167
 	qt422016.ReleaseByteBuffer(qb422016)
-//line app/vmalert/web.qtpl:174
+//line app/vmalert/web.qtpl:167
 	return qs422016
-//line app/vmalert/web.qtpl:174
+//line app/vmalert/web.qtpl:167
 }
 
-//line app/vmalert/web.qtpl:177
+//line app/vmalert/web.qtpl:170
 func StreamListAlerts(qw422016 *qt422016.Writer, r *http.Request, groupAlerts []groupAlerts) {
-//line app/vmalert/web.qtpl:177
+//line app/vmalert/web.qtpl:170
 	qw422016.N().S(`
     `)
-//line app/vmalert/web.qtpl:178
+//line app/vmalert/web.qtpl:171
 	prefix := utils.Prefix(r.URL.Path)
 
-//line app/vmalert/web.qtpl:178
+//line app/vmalert/web.qtpl:171
 	qw422016.N().S(`
     `)
-//line app/vmalert/web.qtpl:179
+//line app/vmalert/web.qtpl:172
 	tpl.StreamHeader(qw422016, r, navItems, "Alerts", getLastConfigError())
-//line app/vmalert/web.qtpl:179
+//line app/vmalert/web.qtpl:172
 	qw422016.N().S(`
     `)
-//line app/vmalert/web.qtpl:180
+//line app/vmalert/web.qtpl:173
 	if len(groupAlerts) > 0 {
-//line app/vmalert/web.qtpl:180
+//line app/vmalert/web.qtpl:173
 		qw422016.N().S(`
          <a class="btn btn-primary" role="button" onclick="collapseAll()">Collapse All</a>
          <a class="btn btn-primary" role="button" onclick="expandAll()">Expand All</a>
          `)
-//line app/vmalert/web.qtpl:183
+//line app/vmalert/web.qtpl:176
 		for _, ga := range groupAlerts {
-//line app/vmalert/web.qtpl:183
+//line app/vmalert/web.qtpl:176
 			qw422016.N().S(`
             `)
-//line app/vmalert/web.qtpl:184
+//line app/vmalert/web.qtpl:177
 			g := ga.Group
 
-//line app/vmalert/web.qtpl:184
+//line app/vmalert/web.qtpl:177
 			qw422016.N().S(`
             <div class="group-heading alert-danger" data-bs-target="rules-`)
-//line app/vmalert/web.qtpl:185
+//line app/vmalert/web.qtpl:178
 			qw422016.E().S(g.ID)
-//line app/vmalert/web.qtpl:185
+//line app/vmalert/web.qtpl:178
 			qw422016.N().S(`">
                 <span class="anchor" id="group-`)
-//line app/vmalert/web.qtpl:186
+//line app/vmalert/web.qtpl:179
 			qw422016.E().S(g.ID)
-//line app/vmalert/web.qtpl:186
+//line app/vmalert/web.qtpl:179
 			qw422016.N().S(`"></span>
                 <a href="#group-`)
-//line app/vmalert/web.qtpl:187
+//line app/vmalert/web.qtpl:180
 			qw422016.E().S(g.ID)
-//line app/vmalert/web.qtpl:187
+//line app/vmalert/web.qtpl:180
 			qw422016.N().S(`">`)
-//line app/vmalert/web.qtpl:187
+//line app/vmalert/web.qtpl:180
 			qw422016.E().S(g.Name)
-//line app/vmalert/web.qtpl:187
+//line app/vmalert/web.qtpl:180
 			if g.Type != "prometheus" {
-//line app/vmalert/web.qtpl:187
+//line app/vmalert/web.qtpl:180
 				qw422016.N().S(` (`)
-//line app/vmalert/web.qtpl:187
+//line app/vmalert/web.qtpl:180
 				qw422016.E().S(g.Type)
-//line app/vmalert/web.qtpl:187
+//line app/vmalert/web.qtpl:180
 				qw422016.N().S(`)`)
-//line app/vmalert/web.qtpl:187
+//line app/vmalert/web.qtpl:180
 			}
-//line app/vmalert/web.qtpl:187
+//line app/vmalert/web.qtpl:180
 			qw422016.N().S(`</a>
                 <span class="badge bg-danger" title="Number of active alerts">`)
-//line app/vmalert/web.qtpl:188
+//line app/vmalert/web.qtpl:181
 			qw422016.N().D(len(ga.Alerts))
-//line app/vmalert/web.qtpl:188
+//line app/vmalert/web.qtpl:181
 			qw422016.N().S(`</span>
                 <br>
                 <p class="fs-6 fw-lighter">`)
-//line app/vmalert/web.qtpl:190
+//line app/vmalert/web.qtpl:183
 			qw422016.E().S(g.File)
-//line app/vmalert/web.qtpl:190
+//line app/vmalert/web.qtpl:183
 			qw422016.N().S(`</p>
             </div>
             `)
-//line app/vmalert/web.qtpl:193
+//line app/vmalert/web.qtpl:186
 			var keys []string
 			alertsByRule := make(map[string][]*apiAlert)
 			for _, alert := range ga.Alerts {
@@ -741,20 +734,20 @@ func StreamListAlerts(qw422016 *qt422016.Writer, r *http.Request, groupAlerts []
 			}
 			sort.Strings(keys)
 
-//line app/vmalert/web.qtpl:202
+//line app/vmalert/web.qtpl:195
 			qw422016.N().S(`
             <div class="collapse" id="rules-`)
-//line app/vmalert/web.qtpl:203
+//line app/vmalert/web.qtpl:196
 			qw422016.E().S(g.ID)
-//line app/vmalert/web.qtpl:203
+//line app/vmalert/web.qtpl:196
 			qw422016.N().S(`">
                 `)
-//line app/vmalert/web.qtpl:204
+//line app/vmalert/web.qtpl:197
 			for _, ruleID := range keys {
-//line app/vmalert/web.qtpl:204
+//line app/vmalert/web.qtpl:197
 				qw422016.N().S(`
                     `)
-//line app/vmalert/web.qtpl:206
+//line app/vmalert/web.qtpl:199
 				defaultAR := alertsByRule[ruleID][0]
 				var labelKeys []string
 				for k := range defaultAR.Labels {
@@ -762,28 +755,28 @@ func StreamListAlerts(qw422016 *qt422016.Writer, r *http.Request, groupAlerts []
 				}
 				sort.Strings(labelKeys)
 
-//line app/vmalert/web.qtpl:212
+//line app/vmalert/web.qtpl:205
 				qw422016.N().S(`
                     <br>
                     <b>alert:</b> `)
-//line app/vmalert/web.qtpl:214
+//line app/vmalert/web.qtpl:207
 				qw422016.E().S(defaultAR.Name)
-//line app/vmalert/web.qtpl:214
+//line app/vmalert/web.qtpl:207
 				qw422016.N().S(` (`)
-//line app/vmalert/web.qtpl:214
+//line app/vmalert/web.qtpl:207
 				qw422016.N().D(len(alertsByRule[ruleID]))
-//line app/vmalert/web.qtpl:214
+//line app/vmalert/web.qtpl:207
 				qw422016.N().S(`)
                      | <span><a target="_blank" href="`)
-//line app/vmalert/web.qtpl:215
+//line app/vmalert/web.qtpl:208
 				qw422016.E().S(defaultAR.SourceLink)
-//line app/vmalert/web.qtpl:215
+//line app/vmalert/web.qtpl:208
 				qw422016.N().S(`">Source</a></span>
                     <br>
                     <b>expr:</b><code><pre>`)
-//line app/vmalert/web.qtpl:217
+//line app/vmalert/web.qtpl:210
 				qw422016.E().S(defaultAR.Expression)
-//line app/vmalert/web.qtpl:217
+//line app/vmalert/web.qtpl:210
 				qw422016.N().S(`</pre></code>
                     <table class="table table-striped table-hover table-sm">
                         <thead>
@@ -797,213 +790,213 @@ func StreamListAlerts(qw422016 *qt422016.Writer, r *http.Request, groupAlerts []
                         </thead>
                         <tbody>
                         `)
-//line app/vmalert/web.qtpl:229
+//line app/vmalert/web.qtpl:222
 				for _, ar := range alertsByRule[ruleID] {
-//line app/vmalert/web.qtpl:229
+//line app/vmalert/web.qtpl:222
 					qw422016.N().S(`
                             <tr>
                                 <td>
                                     `)
-//line app/vmalert/web.qtpl:232
+//line app/vmalert/web.qtpl:225
 					for _, k := range labelKeys {
-//line app/vmalert/web.qtpl:232
+//line app/vmalert/web.qtpl:225
 						qw422016.N().S(`
                                         <span class="ms-1 badge bg-primary">`)
-//line app/vmalert/web.qtpl:233
+//line app/vmalert/web.qtpl:226
 						qw422016.E().S(k)
-//line app/vmalert/web.qtpl:233
+//line app/vmalert/web.qtpl:226
 						qw422016.N().S(`=`)
-//line app/vmalert/web.qtpl:233
+//line app/vmalert/web.qtpl:226
 						qw422016.E().S(ar.Labels[k])
-//line app/vmalert/web.qtpl:233
+//line app/vmalert/web.qtpl:226
 						qw422016.N().S(`</span>
                                     `)
-//line app/vmalert/web.qtpl:234
+//line app/vmalert/web.qtpl:227
 					}
-//line app/vmalert/web.qtpl:234
+//line app/vmalert/web.qtpl:227
 					qw422016.N().S(`
                                 </td>
                                 <td>`)
-//line app/vmalert/web.qtpl:236
+//line app/vmalert/web.qtpl:229
 					streambadgeState(qw422016, ar.State)
-//line app/vmalert/web.qtpl:236
+//line app/vmalert/web.qtpl:229
 					qw422016.N().S(`</td>
                                 <td>
                                     `)
-//line app/vmalert/web.qtpl:238
+//line app/vmalert/web.qtpl:231
 					qw422016.E().S(ar.ActiveAt.Format("2006-01-02T15:04:05Z07:00"))
-//line app/vmalert/web.qtpl:238
+//line app/vmalert/web.qtpl:231
 					qw422016.N().S(`
                                     `)
-//line app/vmalert/web.qtpl:239
+//line app/vmalert/web.qtpl:232
 					if ar.Restored {
-//line app/vmalert/web.qtpl:239
+//line app/vmalert/web.qtpl:232
 						streambadgeRestored(qw422016)
-//line app/vmalert/web.qtpl:239
+//line app/vmalert/web.qtpl:232
 					}
-//line app/vmalert/web.qtpl:239
+//line app/vmalert/web.qtpl:232
 					qw422016.N().S(`
                                     `)
-//line app/vmalert/web.qtpl:240
+//line app/vmalert/web.qtpl:233
 					if ar.Stabilizing {
-//line app/vmalert/web.qtpl:240
+//line app/vmalert/web.qtpl:233
 						streambadgeStabilizing(qw422016)
-//line app/vmalert/web.qtpl:240
+//line app/vmalert/web.qtpl:233
 					}
-//line app/vmalert/web.qtpl:240
+//line app/vmalert/web.qtpl:233
 					qw422016.N().S(`
                                 </td>
                                 <td>`)
-//line app/vmalert/web.qtpl:242
+//line app/vmalert/web.qtpl:235
 					qw422016.E().S(ar.Value)
-//line app/vmalert/web.qtpl:242
+//line app/vmalert/web.qtpl:235
 					qw422016.N().S(`</td>
                                 <td>
                                     <a href="`)
-//line app/vmalert/web.qtpl:244
+//line app/vmalert/web.qtpl:237
 					qw422016.E().S(prefix + ar.WebLink())
-//line app/vmalert/web.qtpl:244
+//line app/vmalert/web.qtpl:237
 					qw422016.N().S(`">Details</a>
                                 </td>
                             </tr>
                         `)
-//line app/vmalert/web.qtpl:247
+//line app/vmalert/web.qtpl:240
 				}
-//line app/vmalert/web.qtpl:247
+//line app/vmalert/web.qtpl:240
 				qw422016.N().S(`
                      </tbody>
                     </table>
                 `)
-//line app/vmalert/web.qtpl:250
+//line app/vmalert/web.qtpl:243
 			}
-//line app/vmalert/web.qtpl:250
+//line app/vmalert/web.qtpl:243
 			qw422016.N().S(`
             </div>
             <br>
         `)
-//line app/vmalert/web.qtpl:253
+//line app/vmalert/web.qtpl:246
 		}
-//line app/vmalert/web.qtpl:253
+//line app/vmalert/web.qtpl:246
 		qw422016.N().S(`
 
     `)
-//line app/vmalert/web.qtpl:255
+//line app/vmalert/web.qtpl:248
 	} else {
-//line app/vmalert/web.qtpl:255
+//line app/vmalert/web.qtpl:248
 		qw422016.N().S(`
         <div>
             <p>No active alerts...</p>
         </div>
     `)
-//line app/vmalert/web.qtpl:259
+//line app/vmalert/web.qtpl:252
 	}
-//line app/vmalert/web.qtpl:259
+//line app/vmalert/web.qtpl:252
 	qw422016.N().S(`
 
     `)
-//line app/vmalert/web.qtpl:261
+//line app/vmalert/web.qtpl:254
 	tpl.StreamFooter(qw422016, r)
-//line app/vmalert/web.qtpl:261
+//line app/vmalert/web.qtpl:254
 	qw422016.N().S(`
 
 `)
-//line app/vmalert/web.qtpl:263
+//line app/vmalert/web.qtpl:256
 }
 
-//line app/vmalert/web.qtpl:263
+//line app/vmalert/web.qtpl:256
 func WriteListAlerts(qq422016 qtio422016.Writer, r *http.Request, groupAlerts []groupAlerts) {
-//line app/vmalert/web.qtpl:263
+//line app/vmalert/web.qtpl:256
 	qw422016 := qt422016.AcquireWriter(qq422016)
-//line app/vmalert/web.qtpl:263
+//line app/vmalert/web.qtpl:256
 	StreamListAlerts(qw422016, r, groupAlerts)
-//line app/vmalert/web.qtpl:263
+//line app/vmalert/web.qtpl:256
 	qt422016.ReleaseWriter(qw422016)
-//line app/vmalert/web.qtpl:263
+//line app/vmalert/web.qtpl:256
 }
 
-//line app/vmalert/web.qtpl:263
+//line app/vmalert/web.qtpl:256
 func ListAlerts(r *http.Request, groupAlerts []groupAlerts) string {
-//line app/vmalert/web.qtpl:263
+//line app/vmalert/web.qtpl:256
 	qb422016 := qt422016.AcquireByteBuffer()
-//line app/vmalert/web.qtpl:263
+//line app/vmalert/web.qtpl:256
 	WriteListAlerts(qb422016, r, groupAlerts)
-//line app/vmalert/web.qtpl:263
+//line app/vmalert/web.qtpl:256
 	qs422016 := string(qb422016.B)
-//line app/vmalert/web.qtpl:263
+//line app/vmalert/web.qtpl:256
 	qt422016.ReleaseByteBuffer(qb422016)
-//line app/vmalert/web.qtpl:263
+//line app/vmalert/web.qtpl:256
 	return qs422016
-//line app/vmalert/web.qtpl:263
+//line app/vmalert/web.qtpl:256
 }
 
-//line app/vmalert/web.qtpl:265
+//line app/vmalert/web.qtpl:258
 func StreamListTargets(qw422016 *qt422016.Writer, r *http.Request, targets map[notifier.TargetType][]notifier.Target) {
-//line app/vmalert/web.qtpl:265
+//line app/vmalert/web.qtpl:258
 	qw422016.N().S(`
     `)
-//line app/vmalert/web.qtpl:266
+//line app/vmalert/web.qtpl:259
 	tpl.StreamHeader(qw422016, r, navItems, "Notifiers", getLastConfigError())
-//line app/vmalert/web.qtpl:266
+//line app/vmalert/web.qtpl:259
 	qw422016.N().S(`
     `)
-//line app/vmalert/web.qtpl:267
+//line app/vmalert/web.qtpl:260
 	if len(targets) > 0 {
-//line app/vmalert/web.qtpl:267
+//line app/vmalert/web.qtpl:260
 		qw422016.N().S(`
          <a class="btn btn-primary" role="button" onclick="collapseAll()">Collapse All</a>
          <a class="btn btn-primary" role="button" onclick="expandAll()">Expand All</a>
 
          `)
-//line app/vmalert/web.qtpl:272
+//line app/vmalert/web.qtpl:265
 		var keys []string
 		for key := range targets {
 			keys = append(keys, string(key))
 		}
 		sort.Strings(keys)
 
-//line app/vmalert/web.qtpl:277
+//line app/vmalert/web.qtpl:270
 		qw422016.N().S(`
 
          `)
-//line app/vmalert/web.qtpl:279
+//line app/vmalert/web.qtpl:272
 		for i := range keys {
-//line app/vmalert/web.qtpl:279
+//line app/vmalert/web.qtpl:272
 			qw422016.N().S(`
            `)
-//line app/vmalert/web.qtpl:280
+//line app/vmalert/web.qtpl:273
 			typeK, ns := keys[i], targets[notifier.TargetType(keys[i])]
 			count := len(ns)
 
-//line app/vmalert/web.qtpl:282
+//line app/vmalert/web.qtpl:275
 			qw422016.N().S(`
            <div class="group-heading" data-bs-target="notifiers-`)
-//line app/vmalert/web.qtpl:283
+//line app/vmalert/web.qtpl:276
 			qw422016.E().S(typeK)
-//line app/vmalert/web.qtpl:283
+//line app/vmalert/web.qtpl:276
 			qw422016.N().S(`">
              <span class="anchor" id="group-`)
-//line app/vmalert/web.qtpl:284
+//line app/vmalert/web.qtpl:277
 			qw422016.E().S(typeK)
-//line app/vmalert/web.qtpl:284
+//line app/vmalert/web.qtpl:277
 			qw422016.N().S(`"></span>
              <a href="#group-`)
-//line app/vmalert/web.qtpl:285
+//line app/vmalert/web.qtpl:278
 			qw422016.E().S(typeK)
-//line app/vmalert/web.qtpl:285
+//line app/vmalert/web.qtpl:278
 			qw422016.N().S(`">`)
-//line app/vmalert/web.qtpl:285
+//line app/vmalert/web.qtpl:278
 			qw422016.E().S(typeK)
-//line app/vmalert/web.qtpl:285
+//line app/vmalert/web.qtpl:278
 			qw422016.N().S(` (`)
-//line app/vmalert/web.qtpl:285
+//line app/vmalert/web.qtpl:278
 			qw422016.N().D(count)
-//line app/vmalert/web.qtpl:285
+//line app/vmalert/web.qtpl:278
 			qw422016.N().S(`)</a>
          </div>
          <div class="collapse show" id="notifiers-`)
-//line app/vmalert/web.qtpl:287
+//line app/vmalert/web.qtpl:280
 			qw422016.E().S(typeK)
-//line app/vmalert/web.qtpl:287
+//line app/vmalert/web.qtpl:280
 			qw422016.N().S(`">
              <table class="table table-striped table-hover table-sm">
                  <thead>
@@ -1014,119 +1007,119 @@ func StreamListTargets(qw422016 *qt422016.Writer, r *http.Request, targets map[n
                  </thead>
                  <tbody>
                  `)
-//line app/vmalert/web.qtpl:296
+//line app/vmalert/web.qtpl:289
 			for _, n := range ns {
-//line app/vmalert/web.qtpl:296
+//line app/vmalert/web.qtpl:289
 				qw422016.N().S(`
                      <tr>
                          <td>
                               `)
-//line app/vmalert/web.qtpl:299
+//line app/vmalert/web.qtpl:292
 				for _, l := range n.Labels.GetLabels() {
-//line app/vmalert/web.qtpl:299
+//line app/vmalert/web.qtpl:292
 					qw422016.N().S(`
                                       <span class="ms-1 badge bg-primary">`)
-//line app/vmalert/web.qtpl:300
+//line app/vmalert/web.qtpl:293
 					qw422016.E().S(l.Name)
-//line app/vmalert/web.qtpl:300
+//line app/vmalert/web.qtpl:293
 					qw422016.N().S(`=`)
-//line app/vmalert/web.qtpl:300
+//line app/vmalert/web.qtpl:293
 					qw422016.E().S(l.Value)
-//line app/vmalert/web.qtpl:300
+//line app/vmalert/web.qtpl:293
 					qw422016.N().S(`</span>
                               `)
-//line app/vmalert/web.qtpl:301
+//line app/vmalert/web.qtpl:294
 				}
-//line app/vmalert/web.qtpl:301
+//line app/vmalert/web.qtpl:294
 				qw422016.N().S(`
                           </td>
                          <td>`)
-//line app/vmalert/web.qtpl:303
+//line app/vmalert/web.qtpl:296
 				qw422016.E().S(n.Notifier.Addr())
-//line app/vmalert/web.qtpl:303
+//line app/vmalert/web.qtpl:296
 				qw422016.N().S(`</td>
                      </tr>
                  `)
-//line app/vmalert/web.qtpl:305
+//line app/vmalert/web.qtpl:298
 			}
-//line app/vmalert/web.qtpl:305
+//line app/vmalert/web.qtpl:298
 			qw422016.N().S(`
               </tbody>
              </table>
          </div>
      `)
-//line app/vmalert/web.qtpl:309
+//line app/vmalert/web.qtpl:302
 		}
-//line app/vmalert/web.qtpl:309
+//line app/vmalert/web.qtpl:302
 		qw422016.N().S(`
 
     `)
-//line app/vmalert/web.qtpl:311
+//line app/vmalert/web.qtpl:304
 	} else {
-//line app/vmalert/web.qtpl:311
+//line app/vmalert/web.qtpl:304
 		qw422016.N().S(`
         <div>
             <p>No targets...</p>
         </div>
     `)
-//line app/vmalert/web.qtpl:315
+//line app/vmalert/web.qtpl:308
 	}
-//line app/vmalert/web.qtpl:315
+//line app/vmalert/web.qtpl:308
 	qw422016.N().S(`
 
     `)
-//line app/vmalert/web.qtpl:317
+//line app/vmalert/web.qtpl:310
 	tpl.StreamFooter(qw422016, r)
-//line app/vmalert/web.qtpl:317
+//line app/vmalert/web.qtpl:310
 	qw422016.N().S(`
 
 `)
-//line app/vmalert/web.qtpl:319
+//line app/vmalert/web.qtpl:312
 }
 
-//line app/vmalert/web.qtpl:319
+//line app/vmalert/web.qtpl:312
 func WriteListTargets(qq422016 qtio422016.Writer, r *http.Request, targets map[notifier.TargetType][]notifier.Target) {
-//line app/vmalert/web.qtpl:319
+//line app/vmalert/web.qtpl:312
 	qw422016 := qt422016.AcquireWriter(qq422016)
-//line app/vmalert/web.qtpl:319
+//line app/vmalert/web.qtpl:312
 	StreamListTargets(qw422016, r, targets)
-//line app/vmalert/web.qtpl:319
+//line app/vmalert/web.qtpl:312
 	qt422016.ReleaseWriter(qw422016)
-//line app/vmalert/web.qtpl:319
+//line app/vmalert/web.qtpl:312
 }
 
-//line app/vmalert/web.qtpl:319
+//line app/vmalert/web.qtpl:312
 func ListTargets(r *http.Request, targets map[notifier.TargetType][]notifier.Target) string {
-//line app/vmalert/web.qtpl:319
+//line app/vmalert/web.qtpl:312
 	qb422016 := qt422016.AcquireByteBuffer()
-//line app/vmalert/web.qtpl:319
+//line app/vmalert/web.qtpl:312
 	WriteListTargets(qb422016, r, targets)
-//line app/vmalert/web.qtpl:319
+//line app/vmalert/web.qtpl:312
 	qs422016 := string(qb422016.B)
-//line app/vmalert/web.qtpl:319
+//line app/vmalert/web.qtpl:312
 	qt422016.ReleaseByteBuffer(qb422016)
-//line app/vmalert/web.qtpl:319
+//line app/vmalert/web.qtpl:312
 	return qs422016
-//line app/vmalert/web.qtpl:319
+//line app/vmalert/web.qtpl:312
 }
 
-//line app/vmalert/web.qtpl:321
+//line app/vmalert/web.qtpl:314
 func StreamAlert(qw422016 *qt422016.Writer, r *http.Request, alert *apiAlert) {
-//line app/vmalert/web.qtpl:321
+//line app/vmalert/web.qtpl:314
 	qw422016.N().S(`
     `)
-//line app/vmalert/web.qtpl:322
+//line app/vmalert/web.qtpl:315
 	prefix := utils.Prefix(r.URL.Path)
 
-//line app/vmalert/web.qtpl:322
+//line app/vmalert/web.qtpl:315
 	qw422016.N().S(`
     `)
-//line app/vmalert/web.qtpl:323
+//line app/vmalert/web.qtpl:316
 	tpl.StreamHeader(qw422016, r, navItems, "", getLastConfigError())
-//line app/vmalert/web.qtpl:323
+//line app/vmalert/web.qtpl:316
 	qw422016.N().S(`
     `)
-//line app/vmalert/web.qtpl:325
+//line app/vmalert/web.qtpl:318
 	var labelKeys []string
 	for k := range alert.Labels {
 		labelKeys = append(labelKeys, k)
@@ -1139,28 +1132,28 @@ func StreamAlert(qw422016 *qt422016.Writer, r *http.Request, alert *apiAlert) {
 	}
 	sort.Strings(annotationKeys)
 
-//line app/vmalert/web.qtpl:336
+//line app/vmalert/web.qtpl:329
 	qw422016.N().S(`
     <div class="display-6 pb-3 mb-3">Alert: `)
-//line app/vmalert/web.qtpl:337
+//line app/vmalert/web.qtpl:330
 	qw422016.E().S(alert.Name)
-//line app/vmalert/web.qtpl:337
+//line app/vmalert/web.qtpl:330
 	qw422016.N().S(`<span class="ms-2 badge `)
-//line app/vmalert/web.qtpl:337
+//line app/vmalert/web.qtpl:330
 	if alert.State == "firing" {
-//line app/vmalert/web.qtpl:337
+//line app/vmalert/web.qtpl:330
 		qw422016.N().S(`bg-danger`)
-//line app/vmalert/web.qtpl:337
+//line app/vmalert/web.qtpl:330
 	} else {
-//line app/vmalert/web.qtpl:337
+//line app/vmalert/web.qtpl:330
 		qw422016.N().S(` bg-warning text-dark`)
-//line app/vmalert/web.qtpl:337
+//line app/vmalert/web.qtpl:330
 	}
-//line app/vmalert/web.qtpl:337
+//line app/vmalert/web.qtpl:330
 	qw422016.N().S(`">`)
-//line app/vmalert/web.qtpl:337
+//line app/vmalert/web.qtpl:330
 	qw422016.E().S(alert.State)
-//line app/vmalert/web.qtpl:337
+//line app/vmalert/web.qtpl:330
 	qw422016.N().S(`</span></div>
     <div class="container border-bottom p-2">
       <div class="row">
@@ -1169,9 +1162,9 @@ func StreamAlert(qw422016 *qt422016.Writer, r *http.Request, alert *apiAlert) {
         </div>
         <div class="col">
           `)
-//line app/vmalert/web.qtpl:344
+//line app/vmalert/web.qtpl:337
 	qw422016.E().S(alert.ActiveAt.Format("2006-01-02T15:04:05Z07:00"))
-//line app/vmalert/web.qtpl:344
+//line app/vmalert/web.qtpl:337
 	qw422016.N().S(`
         </div>
       </div>
@@ -1183,9 +1176,9 @@ func StreamAlert(qw422016 *qt422016.Writer, r *http.Request, alert *apiAlert) {
         </div>
         <div class="col">
           <code><pre>`)
-//line app/vmalert/web.qtpl:354
+//line app/vmalert/web.qtpl:347
 	qw422016.E().S(alert.Expression)
-//line app/vmalert/web.qtpl:354
+//line app/vmalert/web.qtpl:347
 	qw422016.N().S(`</pre></code>
         </div>
       </div>
@@ -1197,23 +1190,23 @@ func StreamAlert(qw422016 *qt422016.Writer, r *http.Request, alert *apiAlert) {
         </div>
         <div class="col">
            `)
-//line app/vmalert/web.qtpl:364
+//line app/vmalert/web.qtpl:357
 	for _, k := range labelKeys {
-//line app/vmalert/web.qtpl:364
+//line app/vmalert/web.qtpl:357
 		qw422016.N().S(`
                 <span class="m-1 badge bg-primary">`)
-//line app/vmalert/web.qtpl:365
+//line app/vmalert/web.qtpl:358
 		qw422016.E().S(k)
-//line app/vmalert/web.qtpl:365
+//line app/vmalert/web.qtpl:358
 		qw422016.N().S(`=`)
-//line app/vmalert/web.qtpl:365
+//line app/vmalert/web.qtpl:358
 		qw422016.E().S(alert.Labels[k])
-//line app/vmalert/web.qtpl:365
+//line app/vmalert/web.qtpl:358
 		qw422016.N().S(`</span>
           `)
-//line app/vmalert/web.qtpl:366
+//line app/vmalert/web.qtpl:359
 	}
-//line app/vmalert/web.qtpl:366
+//line app/vmalert/web.qtpl:359
 	qw422016.N().S(`
         </div>
       </div>
@@ -1225,24 +1218,24 @@ func StreamAlert(qw422016 *qt422016.Writer, r *http.Request, alert *apiAlert) {
         </div>
         <div class="col">
            `)
-//line app/vmalert/web.qtpl:376
+//line app/vmalert/web.qtpl:369
 	for _, k := range annotationKeys {
-//line app/vmalert/web.qtpl:376
+//line app/vmalert/web.qtpl:369
 		qw422016.N().S(`
                 <b>`)
-//line app/vmalert/web.qtpl:377
+//line app/vmalert/web.qtpl:370
 		qw422016.E().S(k)
-//line app/vmalert/web.qtpl:377
+//line app/vmalert/web.qtpl:370
 		qw422016.N().S(`:</b><br>
                 <p>`)
-//line app/vmalert/web.qtpl:378
+//line app/vmalert/web.qtpl:371
 		qw422016.E().S(alert.Annotations[k])
-//line app/vmalert/web.qtpl:378
+//line app/vmalert/web.qtpl:371
 		qw422016.N().S(`</p>
           `)
-//line app/vmalert/web.qtpl:379
+//line app/vmalert/web.qtpl:372
 	}
-//line app/vmalert/web.qtpl:379
+//line app/vmalert/web.qtpl:372
 	qw422016.N().S(`
         </div>
       </div>
@@ -1254,17 +1247,17 @@ func StreamAlert(qw422016 *qt422016.Writer, r *http.Request, alert *apiAlert) {
         </div>
         <div class="col">
            <a target="_blank" href="`)
-//line app/vmalert/web.qtpl:389
+//line app/vmalert/web.qtpl:382
 	qw422016.E().S(prefix)
-//line app/vmalert/web.qtpl:389
+//line app/vmalert/web.qtpl:382
 	qw422016.N().S(`groups#group-`)
-//line app/vmalert/web.qtpl:389
+//line app/vmalert/web.qtpl:382
 	qw422016.E().S(alert.GroupID)
-//line app/vmalert/web.qtpl:389
+//line app/vmalert/web.qtpl:382
 	qw422016.N().S(`">`)
-//line app/vmalert/web.qtpl:389
+//line app/vmalert/web.qtpl:382
 	qw422016.E().S(alert.GroupID)
-//line app/vmalert/web.qtpl:389
+//line app/vmalert/web.qtpl:382
 	qw422016.N().S(`</a>
         </div>
       </div>
@@ -1276,66 +1269,66 @@ func StreamAlert(qw422016 *qt422016.Writer, r *http.Request, alert *apiAlert) {
         </div>
         <div class="col">
            <a target="_blank" href="`)
-//line app/vmalert/web.qtpl:399
+//line app/vmalert/web.qtpl:392
 	qw422016.E().S(alert.SourceLink)
-//line app/vmalert/web.qtpl:399
+//line app/vmalert/web.qtpl:392
 	qw422016.N().S(`">Link</a>
         </div>
       </div>
     </div>
     `)
-//line app/vmalert/web.qtpl:403
+//line app/vmalert/web.qtpl:396
 	tpl.StreamFooter(qw422016, r)
-//line app/vmalert/web.qtpl:403
+//line app/vmalert/web.qtpl:396
 	qw422016.N().S(`
 
 `)
-//line app/vmalert/web.qtpl:405
+//line app/vmalert/web.qtpl:398
 }
 
-//line app/vmalert/web.qtpl:405
+//line app/vmalert/web.qtpl:398
 func WriteAlert(qq422016 qtio422016.Writer, r *http.Request, alert *apiAlert) {
-//line app/vmalert/web.qtpl:405
+//line app/vmalert/web.qtpl:398
 	qw422016 := qt422016.AcquireWriter(qq422016)
-//line app/vmalert/web.qtpl:405
+//line app/vmalert/web.qtpl:398
 	StreamAlert(qw422016, r, alert)
-//line app/vmalert/web.qtpl:405
+//line app/vmalert/web.qtpl:398
 	qt422016.ReleaseWriter(qw422016)
-//line app/vmalert/web.qtpl:405
+//line app/vmalert/web.qtpl:398
 }
 
-//line app/vmalert/web.qtpl:405
+//line app/vmalert/web.qtpl:398
 func Alert(r *http.Request, alert *apiAlert) string {
-//line app/vmalert/web.qtpl:405
+//line app/vmalert/web.qtpl:398
 	qb422016 := qt422016.AcquireByteBuffer()
-//line app/vmalert/web.qtpl:405
+//line app/vmalert/web.qtpl:398
 	WriteAlert(qb422016, r, alert)
-//line app/vmalert/web.qtpl:405
+//line app/vmalert/web.qtpl:398
 	qs422016 := string(qb422016.B)
-//line app/vmalert/web.qtpl:405
+//line app/vmalert/web.qtpl:398
 	qt422016.ReleaseByteBuffer(qb422016)
-//line app/vmalert/web.qtpl:405
+//line app/vmalert/web.qtpl:398
 	return qs422016
-//line app/vmalert/web.qtpl:405
+//line app/vmalert/web.qtpl:398
 }
 
-//line app/vmalert/web.qtpl:408
+//line app/vmalert/web.qtpl:401
 func StreamRuleDetails(qw422016 *qt422016.Writer, r *http.Request, rule apiRule) {
-//line app/vmalert/web.qtpl:408
+//line app/vmalert/web.qtpl:401
 	qw422016.N().S(`
     `)
-//line app/vmalert/web.qtpl:409
+//line app/vmalert/web.qtpl:402
 	prefix := utils.Prefix(r.URL.Path)
 
-//line app/vmalert/web.qtpl:409
+//line app/vmalert/web.qtpl:402
 	qw422016.N().S(`
     `)
-//line app/vmalert/web.qtpl:410
+//line app/vmalert/web.qtpl:403
 	tpl.StreamHeader(qw422016, r, navItems, "", getLastConfigError())
-//line app/vmalert/web.qtpl:410
+//line app/vmalert/web.qtpl:403
 	qw422016.N().S(`
     `)
-//line app/vmalert/web.qtpl:412
+//line app/vmalert/web.qtpl:405
 	var labelKeys []string
 	for k := range rule.Labels {
 		labelKeys = append(labelKeys, k)
@@ -1359,28 +1352,28 @@ func StreamRuleDetails(qw422016 *qt422016.Writer, r *http.Request, rule apiRule)
 		}
 	}
 
-//line app/vmalert/web.qtpl:435
+//line app/vmalert/web.qtpl:428
 	qw422016.N().S(`
     <div class="display-6 pb-3 mb-3">Rule: `)
-//line app/vmalert/web.qtpl:436
+//line app/vmalert/web.qtpl:429
 	qw422016.E().S(rule.Name)
-//line app/vmalert/web.qtpl:436
+//line app/vmalert/web.qtpl:429
 	qw422016.N().S(`<span class="ms-2 badge `)
-//line app/vmalert/web.qtpl:436
+//line app/vmalert/web.qtpl:429
 	if rule.Health != "ok" {
-//line app/vmalert/web.qtpl:436
+//line app/vmalert/web.qtpl:429
 		qw422016.N().S(`bg-danger`)
-//line app/vmalert/web.qtpl:436
+//line app/vmalert/web.qtpl:429
 	} else {
-//line app/vmalert/web.qtpl:436
+//line app/vmalert/web.qtpl:429
 		qw422016.N().S(` bg-success text-dark`)
-//line app/vmalert/web.qtpl:436
+//line app/vmalert/web.qtpl:429
 	}
-//line app/vmalert/web.qtpl:436
+//line app/vmalert/web.qtpl:429
 	qw422016.N().S(`">`)
-//line app/vmalert/web.qtpl:436
+//line app/vmalert/web.qtpl:429
 	qw422016.E().S(rule.Health)
-//line app/vmalert/web.qtpl:436
+//line app/vmalert/web.qtpl:429
 	qw422016.N().S(`</span></div>
     <div class="container border-bottom p-2">
       <div class="row">
@@ -1389,17 +1382,17 @@ func StreamRuleDetails(qw422016 *qt422016.Writer, r *http.Request, rule apiRule)
         </div>
         <div class="col">
           <code><pre>`)
-//line app/vmalert/web.qtpl:443
+//line app/vmalert/web.qtpl:436
 	qw422016.E().S(rule.Query)
-//line app/vmalert/web.qtpl:443
+//line app/vmalert/web.qtpl:436
 	qw422016.N().S(`</pre></code>
         </div>
       </div>
     </div>
     `)
-//line app/vmalert/web.qtpl:447
+//line app/vmalert/web.qtpl:440
 	if rule.Type == "alerting" {
-//line app/vmalert/web.qtpl:447
+//line app/vmalert/web.qtpl:440
 		qw422016.N().S(`
     <div class="container border-bottom p-2">
       <div class="row">
@@ -1408,17 +1401,17 @@ func StreamRuleDetails(qw422016 *qt422016.Writer, r *http.Request, rule apiRule)
         </div>
         <div class="col">
          `)
-//line app/vmalert/web.qtpl:454
+//line app/vmalert/web.qtpl:447
 		qw422016.E().V(rule.Duration)
-//line app/vmalert/web.qtpl:454
+//line app/vmalert/web.qtpl:447
 		qw422016.N().S(` seconds
         </div>
       </div>
     </div>
     `)
-//line app/vmalert/web.qtpl:458
+//line app/vmalert/web.qtpl:451
 		if rule.KeepFiringFor > 0 {
-//line app/vmalert/web.qtpl:458
+//line app/vmalert/web.qtpl:451
 			qw422016.N().S(`
     <div class="container border-bottom p-2">
       <div class="row">
@@ -1427,22 +1420,22 @@ func StreamRuleDetails(qw422016 *qt422016.Writer, r *http.Request, rule apiRule)
         </div>
         <div class="col">
          `)
-//line app/vmalert/web.qtpl:465
+//line app/vmalert/web.qtpl:458
 			qw422016.E().V(rule.KeepFiringFor)
-//line app/vmalert/web.qtpl:465
+//line app/vmalert/web.qtpl:458
 			qw422016.N().S(` seconds
         </div>
       </div>
     </div>
     `)
-//line app/vmalert/web.qtpl:469
+//line app/vmalert/web.qtpl:462
 		}
-//line app/vmalert/web.qtpl:469
+//line app/vmalert/web.qtpl:462
 		qw422016.N().S(`
     `)
-//line app/vmalert/web.qtpl:470
+//line app/vmalert/web.qtpl:463
 	}
-//line app/vmalert/web.qtpl:470
+//line app/vmalert/web.qtpl:463
 	qw422016.N().S(`
     <div class="container border-bottom p-2">
       <div class="row">
@@ -1451,31 +1444,31 @@ func StreamRuleDetails(qw422016 *qt422016.Writer, r *http.Request, rule apiRule)
         </div>
         <div class="col">
           `)
-//line app/vmalert/web.qtpl:477
+//line app/vmalert/web.qtpl:470
 	for _, k := range labelKeys {
-//line app/vmalert/web.qtpl:477
+//line app/vmalert/web.qtpl:470
 		qw422016.N().S(`
                 <span class="m-1 badge bg-primary">`)
-//line app/vmalert/web.qtpl:478
+//line app/vmalert/web.qtpl:471
 		qw422016.E().S(k)
-//line app/vmalert/web.qtpl:478
+//line app/vmalert/web.qtpl:471
 		qw422016.N().S(`=`)
-//line app/vmalert/web.qtpl:478
+//line app/vmalert/web.qtpl:471
 		qw422016.E().S(rule.Labels[k])
-//line app/vmalert/web.qtpl:478
+//line app/vmalert/web.qtpl:471
 		qw422016.N().S(`</span>
           `)
-//line app/vmalert/web.qtpl:479
+//line app/vmalert/web.qtpl:472
 	}
-//line app/vmalert/web.qtpl:479
+//line app/vmalert/web.qtpl:472
 	qw422016.N().S(`
         </div>
       </div>
     </div>
     `)
-//line app/vmalert/web.qtpl:483
+//line app/vmalert/web.qtpl:476
 	if rule.Type == "alerting" {
-//line app/vmalert/web.qtpl:483
+//line app/vmalert/web.qtpl:476
 		qw422016.N().S(`
     <div class="container border-bottom p-2">
       <div class="row">
@@ -1484,24 +1477,24 @@ func StreamRuleDetails(qw422016 *qt422016.Writer, r *http.Request, rule apiRule)
         </div>
         <div class="col">
           `)
-//line app/vmalert/web.qtpl:490
+//line app/vmalert/web.qtpl:483
 		for _, k := range annotationKeys {
-//line app/vmalert/web.qtpl:490
+//line app/vmalert/web.qtpl:483
 			qw422016.N().S(`
                 <b>`)
-//line app/vmalert/web.qtpl:491
+//line app/vmalert/web.qtpl:484
 			qw422016.E().S(k)
-//line app/vmalert/web.qtpl:491
+//line app/vmalert/web.qtpl:484
 			qw422016.N().S(`:</b><br>
                 <p>`)
-//line app/vmalert/web.qtpl:492
+//line app/vmalert/web.qtpl:485
 			qw422016.E().S(rule.Annotations[k])
-//line app/vmalert/web.qtpl:492
+//line app/vmalert/web.qtpl:485
 			qw422016.N().S(`</p>
           `)
-//line app/vmalert/web.qtpl:493
+//line app/vmalert/web.qtpl:486
 		}
-//line app/vmalert/web.qtpl:493
+//line app/vmalert/web.qtpl:486
 		qw422016.N().S(`
         </div>
       </div>
@@ -1513,17 +1506,17 @@ func StreamRuleDetails(qw422016 *qt422016.Writer, r *http.Request, rule apiRule)
         </div>
         <div class="col">
            `)
-//line app/vmalert/web.qtpl:503
+//line app/vmalert/web.qtpl:496
 		qw422016.E().V(rule.Debug)
-//line app/vmalert/web.qtpl:503
+//line app/vmalert/web.qtpl:496
 		qw422016.N().S(`
         </div>
       </div>
     </div>
     `)
-//line app/vmalert/web.qtpl:507
+//line app/vmalert/web.qtpl:500
 	}
-//line app/vmalert/web.qtpl:507
+//line app/vmalert/web.qtpl:500
 	qw422016.N().S(`
     <div class="container border-bottom p-2">
       <div class="row">
@@ -1532,17 +1525,17 @@ func StreamRuleDetails(qw422016 *qt422016.Writer, r *http.Request, rule apiRule)
         </div>
         <div class="col">
            <a target="_blank" href="`)
-//line app/vmalert/web.qtpl:514
+//line app/vmalert/web.qtpl:507
 	qw422016.E().S(prefix)
-//line app/vmalert/web.qtpl:514
+//line app/vmalert/web.qtpl:507
 	qw422016.N().S(`groups#group-`)
-//line app/vmalert/web.qtpl:514
+//line app/vmalert/web.qtpl:507
 	qw422016.E().S(rule.GroupID)
-//line app/vmalert/web.qtpl:514
+//line app/vmalert/web.qtpl:507
 	qw422016.N().S(`">`)
-//line app/vmalert/web.qtpl:514
+//line app/vmalert/web.qtpl:507
 	qw422016.E().S(rule.GroupID)
-//line app/vmalert/web.qtpl:514
+//line app/vmalert/web.qtpl:507
 	qw422016.N().S(`</a>
         </div>
       </div>
@@ -1550,9 +1543,9 @@ func StreamRuleDetails(qw422016 *qt422016.Writer, r *http.Request, rule apiRule)
 
     <br>
     `)
-//line app/vmalert/web.qtpl:520
+//line app/vmalert/web.qtpl:513
 	if seriesFetchedWarning {
-//line app/vmalert/web.qtpl:520
+//line app/vmalert/web.qtpl:513
 		qw422016.N().S(`
     <div class="alert alert-warning" role="alert">
        <strong>Warning:</strong> some of updates have "Series fetched" equal to 0.<br>
@@ -1566,18 +1559,18 @@ func StreamRuleDetails(qw422016 *qt422016.Writer, r *http.Request, rule apiRule)
        See more details about this detection <a target="_blank" href="https://github.com/VictoriaMetrics/VictoriaMetrics/issues/4039">here</a>.
     </div>
     `)
-//line app/vmalert/web.qtpl:532
+//line app/vmalert/web.qtpl:525
 	}
-//line app/vmalert/web.qtpl:532
+//line app/vmalert/web.qtpl:525
 	qw422016.N().S(`
     <div class="display-6 pb-3">Last `)
-//line app/vmalert/web.qtpl:533
+//line app/vmalert/web.qtpl:526
 	qw422016.N().D(len(rule.Updates))
-//line app/vmalert/web.qtpl:533
+//line app/vmalert/web.qtpl:526
 	qw422016.N().S(`/`)
-//line app/vmalert/web.qtpl:533
+//line app/vmalert/web.qtpl:526
 	qw422016.N().D(rule.MaxUpdates)
-//line app/vmalert/web.qtpl:533
+//line app/vmalert/web.qtpl:526
 	qw422016.N().S(` updates</span>:</div>
         <table class="table table-striped table-hover table-sm">
             <thead>
@@ -1585,13 +1578,13 @@ func StreamRuleDetails(qw422016 *qt422016.Writer, r *http.Request, rule apiRule)
                     <th scope="col" title="The time when event was created">Updated at</th>
                     <th scope="col" style="width: 10%" class="text-center" title="How many samples were returned">Samples</th>
                     `)
-//line app/vmalert/web.qtpl:539
+//line app/vmalert/web.qtpl:532
 	if seriesFetchedEnabled {
-//line app/vmalert/web.qtpl:539
+//line app/vmalert/web.qtpl:532
 		qw422016.N().S(`<th scope="col" style="width: 10%" class="text-center" title="How many series were scanned by datasource during the evaluation">Series fetched</th>`)
-//line app/vmalert/web.qtpl:539
+//line app/vmalert/web.qtpl:532
 	}
-//line app/vmalert/web.qtpl:539
+//line app/vmalert/web.qtpl:532
 	qw422016.N().S(`
                     <th scope="col" style="width: 10%" class="text-center" title="How many seconds request took">Duration</th>
                     <th scope="col" class="text-center" title="Time used for rule execution">Executed at</th>
@@ -1601,285 +1594,285 @@ func StreamRuleDetails(qw422016 *qt422016.Writer, r *http.Request, rule apiRule)
             <tbody>
 
      `)
-//line app/vmalert/web.qtpl:547
+//line app/vmalert/web.qtpl:540
 	for _, u := range rule.Updates {
-//line app/vmalert/web.qtpl:547
+//line app/vmalert/web.qtpl:540
 		qw422016.N().S(`
              <tr`)
-//line app/vmalert/web.qtpl:548
+//line app/vmalert/web.qtpl:541
 		if u.Err != nil {
-//line app/vmalert/web.qtpl:548
+//line app/vmalert/web.qtpl:541
 			qw422016.N().S(` class="alert-danger"`)
-//line app/vmalert/web.qtpl:548
+//line app/vmalert/web.qtpl:541
 		}
-//line app/vmalert/web.qtpl:548
+//line app/vmalert/web.qtpl:541
 		qw422016.N().S(`>
                  <td>
                     <span class="badge bg-primary rounded-pill me-3" title="Updated at">`)
-//line app/vmalert/web.qtpl:550
+//line app/vmalert/web.qtpl:543
 		qw422016.E().S(u.Time.Format(time.RFC3339))
-//line app/vmalert/web.qtpl:550
+//line app/vmalert/web.qtpl:543
 		qw422016.N().S(`</span>
                  </td>
                  <td class="text-center">`)
-//line app/vmalert/web.qtpl:552
+//line app/vmalert/web.qtpl:545
 		qw422016.N().D(u.Samples)
-//line app/vmalert/web.qtpl:552
+//line app/vmalert/web.qtpl:545
 		qw422016.N().S(`</td>
                  `)
-//line app/vmalert/web.qtpl:553
+//line app/vmalert/web.qtpl:546
 		if seriesFetchedEnabled {
-//line app/vmalert/web.qtpl:553
+//line app/vmalert/web.qtpl:546
 			qw422016.N().S(`<td class="text-center">`)
-//line app/vmalert/web.qtpl:553
+//line app/vmalert/web.qtpl:546
 			if u.SeriesFetched != nil {
-//line app/vmalert/web.qtpl:553
+//line app/vmalert/web.qtpl:546
 				qw422016.N().D(*u.SeriesFetched)
-//line app/vmalert/web.qtpl:553
+//line app/vmalert/web.qtpl:546
 			}
-//line app/vmalert/web.qtpl:553
+//line app/vmalert/web.qtpl:546
 			qw422016.N().S(`</td>`)
-//line app/vmalert/web.qtpl:553
+//line app/vmalert/web.qtpl:546
 		}
-//line app/vmalert/web.qtpl:553
+//line app/vmalert/web.qtpl:546
 		qw422016.N().S(`
                  <td class="text-center">`)
-//line app/vmalert/web.qtpl:554
+//line app/vmalert/web.qtpl:547
 		qw422016.N().FPrec(u.Duration.Seconds(), 3)
-//line app/vmalert/web.qtpl:554
+//line app/vmalert/web.qtpl:547
 		qw422016.N().S(`s</td>
                  <td class="text-center">`)
-//line app/vmalert/web.qtpl:555
+//line app/vmalert/web.qtpl:548
 		qw422016.E().S(u.At.Format(time.RFC3339))
-//line app/vmalert/web.qtpl:555
+//line app/vmalert/web.qtpl:548
 		qw422016.N().S(`</td>
                  <td>
                     <textarea class="curl-area" rows="1" onclick="this.focus();this.select()">`)
-//line app/vmalert/web.qtpl:557
+//line app/vmalert/web.qtpl:550
 		qw422016.E().S(u.Curl)
-//line app/vmalert/web.qtpl:557
+//line app/vmalert/web.qtpl:550
 		qw422016.N().S(`</textarea>
                 </td>
              </tr>
           </li>
           `)
-//line app/vmalert/web.qtpl:561
+//line app/vmalert/web.qtpl:554
 		if u.Err != nil {
-//line app/vmalert/web.qtpl:561
+//line app/vmalert/web.qtpl:554
 			qw422016.N().S(`
              <tr`)
-//line app/vmalert/web.qtpl:562
+//line app/vmalert/web.qtpl:555
 			if u.Err != nil {
-//line app/vmalert/web.qtpl:562
+//line app/vmalert/web.qtpl:555
 				qw422016.N().S(` class="alert-danger"`)
-//line app/vmalert/web.qtpl:562
+//line app/vmalert/web.qtpl:555
 			}
-//line app/vmalert/web.qtpl:562
+//line app/vmalert/web.qtpl:555
 			qw422016.N().S(`>
                <td colspan="`)
-//line app/vmalert/web.qtpl:563
+//line app/vmalert/web.qtpl:556
 			if seriesFetchedEnabled {
-//line app/vmalert/web.qtpl:563
+//line app/vmalert/web.qtpl:556
 				qw422016.N().S(`6`)
-//line app/vmalert/web.qtpl:563
+//line app/vmalert/web.qtpl:556
 			} else {
-//line app/vmalert/web.qtpl:563
+//line app/vmalert/web.qtpl:556
 				qw422016.N().S(`5`)
-//line app/vmalert/web.qtpl:563
+//line app/vmalert/web.qtpl:556
 			}
-//line app/vmalert/web.qtpl:563
+//line app/vmalert/web.qtpl:556
 			qw422016.N().S(`">
                    <span class="alert-danger">`)
-//line app/vmalert/web.qtpl:564
+//line app/vmalert/web.qtpl:557
 			qw422016.E().V(u.Err)
-//line app/vmalert/web.qtpl:564
+//line app/vmalert/web.qtpl:557
 			qw422016.N().S(`</span>
                </td>
              </tr>
           `)
-//line app/vmalert/web.qtpl:567
+//line app/vmalert/web.qtpl:560
 		}
-//line app/vmalert/web.qtpl:567
+//line app/vmalert/web.qtpl:560
 		qw422016.N().S(`
      `)
-//line app/vmalert/web.qtpl:568
+//line app/vmalert/web.qtpl:561
 	}
-//line app/vmalert/web.qtpl:568
+//line app/vmalert/web.qtpl:561
 	qw422016.N().S(`
 
     `)
-//line app/vmalert/web.qtpl:570
+//line app/vmalert/web.qtpl:563
 	tpl.StreamFooter(qw422016, r)
-//line app/vmalert/web.qtpl:570
+//line app/vmalert/web.qtpl:563
 	qw422016.N().S(`
 `)
-//line app/vmalert/web.qtpl:571
+//line app/vmalert/web.qtpl:564
 }
 
-//line app/vmalert/web.qtpl:571
+//line app/vmalert/web.qtpl:564
 func WriteRuleDetails(qq422016 qtio422016.Writer, r *http.Request, rule apiRule) {
-//line app/vmalert/web.qtpl:571
+//line app/vmalert/web.qtpl:564
 	qw422016 := qt422016.AcquireWriter(qq422016)
-//line app/vmalert/web.qtpl:571
+//line app/vmalert/web.qtpl:564
 	StreamRuleDetails(qw422016, r, rule)
-//line app/vmalert/web.qtpl:571
+//line app/vmalert/web.qtpl:564
 	qt422016.ReleaseWriter(qw422016)
-//line app/vmalert/web.qtpl:571
+//line app/vmalert/web.qtpl:564
 }
 
-//line app/vmalert/web.qtpl:571
+//line app/vmalert/web.qtpl:564
 func RuleDetails(r *http.Request, rule apiRule) string {
-//line app/vmalert/web.qtpl:571
+//line app/vmalert/web.qtpl:564
 	qb422016 := qt422016.AcquireByteBuffer()
-//line app/vmalert/web.qtpl:571
+//line app/vmalert/web.qtpl:564
 	WriteRuleDetails(qb422016, r, rule)
-//line app/vmalert/web.qtpl:571
+//line app/vmalert/web.qtpl:564
 	qs422016 := string(qb422016.B)
-//line app/vmalert/web.qtpl:571
+//line app/vmalert/web.qtpl:564
 	qt422016.ReleaseByteBuffer(qb422016)
-//line app/vmalert/web.qtpl:571
+//line app/vmalert/web.qtpl:564
 	return qs422016
-//line app/vmalert/web.qtpl:571
+//line app/vmalert/web.qtpl:564
 }
 
-//line app/vmalert/web.qtpl:575
+//line app/vmalert/web.qtpl:568
 func streambadgeState(qw422016 *qt422016.Writer, state string) {
-//line app/vmalert/web.qtpl:575
+//line app/vmalert/web.qtpl:568
 	qw422016.N().S(`
 `)
-//line app/vmalert/web.qtpl:577
+//line app/vmalert/web.qtpl:570
 	badgeClass := "bg-warning text-dark"
 	if state == "firing" {
 		badgeClass = "bg-danger"
 	}
 
-//line app/vmalert/web.qtpl:581
+//line app/vmalert/web.qtpl:574
 	qw422016.N().S(`
 <span class="badge `)
-//line app/vmalert/web.qtpl:582
+//line app/vmalert/web.qtpl:575
 	qw422016.E().S(badgeClass)
-//line app/vmalert/web.qtpl:582
+//line app/vmalert/web.qtpl:575
 	qw422016.N().S(`">`)
-//line app/vmalert/web.qtpl:582
+//line app/vmalert/web.qtpl:575
 	qw422016.E().S(state)
-//line app/vmalert/web.qtpl:582
+//line app/vmalert/web.qtpl:575
 	qw422016.N().S(`</span>
 `)
-//line app/vmalert/web.qtpl:583
+//line app/vmalert/web.qtpl:576
 }
 
-//line app/vmalert/web.qtpl:583
+//line app/vmalert/web.qtpl:576
 func writebadgeState(qq422016 qtio422016.Writer, state string) {
-//line app/vmalert/web.qtpl:583
+//line app/vmalert/web.qtpl:576
 	qw422016 := qt422016.AcquireWriter(qq422016)
-//line app/vmalert/web.qtpl:583
+//line app/vmalert/web.qtpl:576
 	streambadgeState(qw422016, state)
-//line app/vmalert/web.qtpl:583
+//line app/vmalert/web.qtpl:576
 	qt422016.ReleaseWriter(qw422016)
-//line app/vmalert/web.qtpl:583
+//line app/vmalert/web.qtpl:576
 }
 
-//line app/vmalert/web.qtpl:583
+//line app/vmalert/web.qtpl:576
 func badgeState(state string) string {
-//line app/vmalert/web.qtpl:583
+//line app/vmalert/web.qtpl:576
 	qb422016 := qt422016.AcquireByteBuffer()
-//line app/vmalert/web.qtpl:583
+//line app/vmalert/web.qtpl:576
 	writebadgeState(qb422016, state)
-//line app/vmalert/web.qtpl:583
+//line app/vmalert/web.qtpl:576
 	qs422016 := string(qb422016.B)
-//line app/vmalert/web.qtpl:583
+//line app/vmalert/web.qtpl:576
 	qt422016.ReleaseByteBuffer(qb422016)
-//line app/vmalert/web.qtpl:583
+//line app/vmalert/web.qtpl:576
 	return qs422016
-//line app/vmalert/web.qtpl:583
+//line app/vmalert/web.qtpl:576
 }
 
-//line app/vmalert/web.qtpl:585
+//line app/vmalert/web.qtpl:578
 func streambadgeRestored(qw422016 *qt422016.Writer) {
-//line app/vmalert/web.qtpl:585
+//line app/vmalert/web.qtpl:578
 	qw422016.N().S(`
 <span class="badge bg-warning text-dark" title="Alert state was restored after the service restart from remote storage">restored</span>
 `)
-//line app/vmalert/web.qtpl:587
+//line app/vmalert/web.qtpl:580
 }
 
-//line app/vmalert/web.qtpl:587
+//line app/vmalert/web.qtpl:580
 func writebadgeRestored(qq422016 qtio422016.Writer) {
-//line app/vmalert/web.qtpl:587
+//line app/vmalert/web.qtpl:580
 	qw422016 := qt422016.AcquireWriter(qq422016)
-//line app/vmalert/web.qtpl:587
+//line app/vmalert/web.qtpl:580
 	streambadgeRestored(qw422016)
-//line app/vmalert/web.qtpl:587
+//line app/vmalert/web.qtpl:580
 	qt422016.ReleaseWriter(qw422016)
-//line app/vmalert/web.qtpl:587
+//line app/vmalert/web.qtpl:580
 }
 
-//line app/vmalert/web.qtpl:587
+//line app/vmalert/web.qtpl:580
 func badgeRestored() string {
-//line app/vmalert/web.qtpl:587
+//line app/vmalert/web.qtpl:580
 	qb422016 := qt422016.AcquireByteBuffer()
-//line app/vmalert/web.qtpl:587
+//line app/vmalert/web.qtpl:580
 	writebadgeRestored(qb422016)
-//line app/vmalert/web.qtpl:587
+//line app/vmalert/web.qtpl:580
 	qs422016 := string(qb422016.B)
-//line app/vmalert/web.qtpl:587
+//line app/vmalert/web.qtpl:580
 	qt422016.ReleaseByteBuffer(qb422016)
-//line app/vmalert/web.qtpl:587
+//line app/vmalert/web.qtpl:580
 	return qs422016
-//line app/vmalert/web.qtpl:587
+//line app/vmalert/web.qtpl:580
 }
 
-//line app/vmalert/web.qtpl:589
+//line app/vmalert/web.qtpl:582
 func streambadgeStabilizing(qw422016 *qt422016.Writer) {
-//line app/vmalert/web.qtpl:589
+//line app/vmalert/web.qtpl:582
 	qw422016.N().S(`
 <span class="badge bg-warning text-dark" title="This firing state is kept because of `)
-//line app/vmalert/web.qtpl:589
+//line app/vmalert/web.qtpl:582
 	qw422016.N().S("`")
-//line app/vmalert/web.qtpl:589
+//line app/vmalert/web.qtpl:582
 	qw422016.N().S(`keep_firing_for`)
-//line app/vmalert/web.qtpl:589
+//line app/vmalert/web.qtpl:582
 	qw422016.N().S("`")
-//line app/vmalert/web.qtpl:589
+//line app/vmalert/web.qtpl:582
 	qw422016.N().S(`">stabilizing</span>
 `)
-//line app/vmalert/web.qtpl:591
+//line app/vmalert/web.qtpl:584
 }
 
-//line app/vmalert/web.qtpl:591
+//line app/vmalert/web.qtpl:584
 func writebadgeStabilizing(qq422016 qtio422016.Writer) {
-//line app/vmalert/web.qtpl:591
+//line app/vmalert/web.qtpl:584
 	qw422016 := qt422016.AcquireWriter(qq422016)
-//line app/vmalert/web.qtpl:591
+//line app/vmalert/web.qtpl:584
 	streambadgeStabilizing(qw422016)
-//line app/vmalert/web.qtpl:591
+//line app/vmalert/web.qtpl:584
 	qt422016.ReleaseWriter(qw422016)
-//line app/vmalert/web.qtpl:591
+//line app/vmalert/web.qtpl:584
 }
 
-//line app/vmalert/web.qtpl:591
+//line app/vmalert/web.qtpl:584
 func badgeStabilizing() string {
-//line app/vmalert/web.qtpl:591
+//line app/vmalert/web.qtpl:584
 	qb422016 := qt422016.AcquireByteBuffer()
-//line app/vmalert/web.qtpl:591
+//line app/vmalert/web.qtpl:584
 	writebadgeStabilizing(qb422016)
-//line app/vmalert/web.qtpl:591
+//line app/vmalert/web.qtpl:584
 	qs422016 := string(qb422016.B)
-//line app/vmalert/web.qtpl:591
+//line app/vmalert/web.qtpl:584
 	qt422016.ReleaseByteBuffer(qb422016)
-//line app/vmalert/web.qtpl:591
+//line app/vmalert/web.qtpl:584
 	return qs422016
-//line app/vmalert/web.qtpl:591
+//line app/vmalert/web.qtpl:584
 }
 
-//line app/vmalert/web.qtpl:593
+//line app/vmalert/web.qtpl:586
 func streamseriesFetchedWarn(qw422016 *qt422016.Writer, r apiRule) {
-//line app/vmalert/web.qtpl:593
+//line app/vmalert/web.qtpl:586
 	qw422016.N().S(`
 `)
-//line app/vmalert/web.qtpl:594
+//line app/vmalert/web.qtpl:587
 	if isNoMatch(r) {
-//line app/vmalert/web.qtpl:594
+//line app/vmalert/web.qtpl:587
 		qw422016.N().S(`
 <svg xmlns="http://www.w3.org/2000/svg"
     data-bs-toggle="tooltip"
@@ -1890,41 +1883,41 @@ func streamseriesFetchedWarn(qw422016 *qt422016.Writer, r apiRule) {
        <path d="M8 16A8 8 0 1 0 8 0a8 8 0 0 0 0 16zm.93-9.412-1 4.705c-.07.34.029.533.304.533.194 0 .487-.07.686-.246l-.088.416c-.287.346-.92.598-1.465.598-.703 0-1.002-.422-.808-1.319l.738-3.468c.064-.293.006-.399-.287-.47l-.451-.081.082-.381 2.29-.287zM8 5.5a1 1 0 1 1 0-2 1 1 0 0 1 0 2z"/>
 </svg>
 `)
-//line app/vmalert/web.qtpl:603
+//line app/vmalert/web.qtpl:596
 	}
-//line app/vmalert/web.qtpl:603
+//line app/vmalert/web.qtpl:596
 	qw422016.N().S(`
 `)
-//line app/vmalert/web.qtpl:604
+//line app/vmalert/web.qtpl:597
 }
 
-//line app/vmalert/web.qtpl:604
+//line app/vmalert/web.qtpl:597
 func writeseriesFetchedWarn(qq422016 qtio422016.Writer, r apiRule) {
-//line app/vmalert/web.qtpl:604
+//line app/vmalert/web.qtpl:597
 	qw422016 := qt422016.AcquireWriter(qq422016)
-//line app/vmalert/web.qtpl:604
+//line app/vmalert/web.qtpl:597
 	streamseriesFetchedWarn(qw422016, r)
-//line app/vmalert/web.qtpl:604
+//line app/vmalert/web.qtpl:597
 	qt422016.ReleaseWriter(qw422016)
-//line app/vmalert/web.qtpl:604
+//line app/vmalert/web.qtpl:597
 }
 
-//line app/vmalert/web.qtpl:604
+//line app/vmalert/web.qtpl:597
 func seriesFetchedWarn(r apiRule) string {
-//line app/vmalert/web.qtpl:604
+//line app/vmalert/web.qtpl:597
 	qb422016 := qt422016.AcquireByteBuffer()
-//line app/vmalert/web.qtpl:604
+//line app/vmalert/web.qtpl:597
 	writeseriesFetchedWarn(qb422016, r)
-//line app/vmalert/web.qtpl:604
+//line app/vmalert/web.qtpl:597
 	qs422016 := string(qb422016.B)
-//line app/vmalert/web.qtpl:604
+//line app/vmalert/web.qtpl:597
 	qt422016.ReleaseByteBuffer(qb422016)
-//line app/vmalert/web.qtpl:604
+//line app/vmalert/web.qtpl:597
 	return qs422016
-//line app/vmalert/web.qtpl:604
+//line app/vmalert/web.qtpl:597
 }
 
-//line app/vmalert/web.qtpl:607
+//line app/vmalert/web.qtpl:600
 func isNoMatch(r apiRule) bool {
 	return r.LastSamples == 0 && r.LastSeriesFetched != nil && *r.LastSeriesFetched == 0
 }


### PR DESCRIPTION
### Is your feature request related to a problem? Please describe

At my company we run hundreds of alerts in different groups and to search for them in the vmalert UI sometimes is tough task.  

### Describe the solution you'd like

I'm proposing here a filter at UI level by Group or Rule names and by Labels. The idea is just to show Groups that match its name with the filter and hide the others. For Rule name, I want to filter them and show theirs groups and already show the rules row opened. For labels, I want to filter by its key or its value.

Example:
No filter applied:

<img width="550" alt="Screenshot 2024-02-09 at 14 51 54" src="https://github.com/VictoriaMetrics/VictoriaMetrics/assets/1914482/2319450a-becb-4952-a6c4-652d88546a44">

Filter by group name `1abc`:

<img width="509" alt="Screenshot 2024-02-09 at 14 52 18" src="https://github.com/VictoriaMetrics/VictoriaMetrics/assets/1914482/079ac96c-4f6d-43a2-9e61-a3dc23a2297f">

Just changing the query to `2abc`:

<img width="532" alt="Screenshot 2024-02-09 at 14 52 57" src="https://github.com/VictoriaMetrics/VictoriaMetrics/assets/1914482/4bfb668e-93a9-4262-943b-f1cae75a3c11">

Now, changing to filter by rule name and querying `1234`:

<img width="679" alt="Screenshot 2024-02-09 at 14 53 22" src="https://github.com/VictoriaMetrics/VictoriaMetrics/assets/1914482/a8b2e520-3859-4018-b514-90daaa68c508">

Changing the query to `5678`:

<img width="697" alt="Screenshot 2024-02-09 at 14 53 48" src="https://github.com/VictoriaMetrics/VictoriaMetrics/assets/1914482/ed3637b2-c40b-49f2-82b0-3ec0dcfd5298">

Changing the query to `service1` which is a value of a label:

<img width="710" alt="Screenshot 2024-02-09 at 14 54 28" src="https://github.com/VictoriaMetrics/VictoriaMetrics/assets/1914482/0c5dac04-2583-49de-bac9-dcf772c246ee">

Changing the query to `raw_name=alert_cba`:

<img width="726" alt="Screenshot 2024-02-09 at 14 55 24" src="https://github.com/VictoriaMetrics/VictoriaMetrics/assets/1914482/f0901823-0802-4655-8776-14ce6412d4c5">

Other case:
- Any blank filter will show all groups
- Every new query show all groups and rules, to ensure we are not hiding wrong elements

Sample alerts used: https://gist.github.com/victoramsantos/1f231ecf879a77e4c4ac181a9113ada2

### Describe alternatives you've considered

I though to run the filter for every letter typed but I think for huge list of groups or rules this could be bad, so I just leave the `Filter` button.

### Additional information

I'm not good with CSS so if someone could help me to beautify the UI would be good 😊 

**Any feedback is welcome 😊** 