### PR TITLE
deployment/docker: clean up loading of victoriametrics-datasource

### DIFF
--- a/deployment/docker/vm-datasource/docker-compose-cluster.yml
+++ b/deployment/docker/vm-datasource/docker-compose-cluster.yml
@@ -19,6 +19,5 @@ services:
       - ./../../dashboards/vm/vmalert.json:/var/lib/grafana/dashboards/vmalert.json
       - ./vm-datasource/download.sh:/download.sh
     environment:
-      - "GF_ALLOW_LOADING_UNSIGNED_PLUGINS=victoriametrics-datasource"
-      - "GF_DEFAULT_APP_MODE=development"
+      - "GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS=victoriametrics-datasource"
     restart: always

--- a/deployment/docker/vm-datasource/docker-compose.yml
+++ b/deployment/docker/vm-datasource/docker-compose.yml
@@ -19,8 +19,7 @@ services:
       - ./../../dashboards/vm/vmalert.json:/var/lib/grafana/dashboards/vmalert.json
       - ./vm-datasource/download.sh:/download.sh
     environment:
-      - "GF_ALLOW_LOADING_UNSIGNED_PLUGINS=victoriametrics-datasource"
-      - "GF_DEFAULT_APP_MODE=development"
+      - "GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS=victoriametrics-datasource"
     networks:
       - vm_net
     restart: always


### PR DESCRIPTION
Currently the docker-compose examples for loading `victoriametrics-datasource` uses 2 environment variables:
-  `GF_ALLOW_LOADING_UNSIGNED_PLUGINS`
- `GF_DEFAULT_APP_MODE`

I believe both of the env vars are trying to achieve the same thing. 
- `GF_DEFAULT_APP_MODE` disables code signing for all plugins -
- `GF_ALLOW_LOADING_UNSIGNED_PLUGINS` intends to disable code signing for just `victoriametrics-datasource`. 

In my opinion, keeping the scope narrowed to just `victoriametrics-datasource` would be preferable in this case.

Unfortunately `GF_ALLOW_LOADING_UNSIGNED_PLUGINS` is misspelled. According to [grafana docs](https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/#override-configuration-with-environment-variables), the format is supposed to be `GF_<SectionName>_<KeyName>`. In other words the current env var is missing the SectionName.

This PR proposes to:
1. fix the typo
2. remove the global disablement of code signing

Alternatively, if you prefer to keep codesigning disabled globally, please remove `GF_ALLOW_LOADING_UNSIGNED_PLUGINS` env var as it confuses things