### PR TITLE
remotewrite: Use TLS ServerName as Host in all requests

### DIFF
--- a/app/vmagent/remotewrite/client.go
+++ b/app/vmagent/remotewrite/client.go
@@ -367,6 +367,9 @@ func (c *client) newRequest(url string, body []byte) (*http.Request, error) {
 	if err != nil {
 		logger.Panicf("BUG: unexpected error from http.NewRequest(%q): %s", url, err)
 	}
+	if tlsCfg, err := c.authCfg.NewTLSConfig(); err == nil && tlsCfg != nil {
+		req.Host = tlsCfg.ServerName
+	}
 	err = c.authCfg.SetHeaders(req, true)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This change modifies HTTP requests made via remote-write to set the `Host` field to the TLS config's `ServerName`, when a TLS config is present. Otherwise, the empty default is maintained, and the Go stdlib will fall back to using the host component of the URL.

This is useful to work around a somewhat-unfortunate setup we are currently dealing with, involving:

* a client machine that has limited ability to resolve DNS queries (so we must point to our reverse-proxy instance via IP)
* a reverse proxy that proxies based on the request's target host

We can almost get this to work by passing both `-remoteWrite.url` and `-remoteWrite.tlsServerName`; however, the host will still be the host specified in the former and not the latter, which our reverse proxy mappings will not be able to handle.

With this tweak, we are able to successfully ingest metrics.

---

This PR as-is is likely not production-worthy:

* this may not be the best place/way to get the TLS config and set the Host field
* more similar instances may need to be modified across the codebase for consistency

With this PR, I'm looking to get feedback on:

* which behavior is the most correct/useful (Host field comes from URL vs Host field comes from TLS ServerName)
* if this change is desired, then particulars on how would be appreciated!