### PR TITLE
[metricsql] fix `start` / `end` / `running_` time interval calculation in subqueries

### DIFF
--- a/app/vmselect/promql/eval.go
+++ b/app/vmselect/promql/eval.go
@@ -111,6 +111,11 @@ type EvalConfig struct {
 	End   int64
 	Step  int64
 
+	// RealStart contains the original start of the interval when executed in subqueries (because Start can be changed  for subqueries)
+	RealStart int64
+	// RealEnd contains the original end of the interval when executed in subqueries (because End can be changed for subqueries)
+	RealEnd int64
+
 	// MaxSeries is the maximum number of time series, which can be scanned by the query.
 	// Zero means 'no limit'
 	MaxSeries int
@@ -152,7 +157,17 @@ type EvalConfig struct {
 func copyEvalConfig(src *EvalConfig) *EvalConfig {
 	var ec EvalConfig
 	ec.Start = src.Start
+	if ec.RealStart > 0 {
+		ec.RealStart = src.RealStart
+	} else {
+		ec.RealStart = src.Start
+	}
 	ec.End = src.End
+	if ec.RealEnd > 0 {
+		ec.RealEnd = src.RealEnd
+	} else {
+		ec.RealEnd = src.End
+	}
 	ec.Step = src.Step
 	ec.MaxSeries = src.MaxSeries
 	ec.MaxPointsPerSeries = src.MaxPointsPerSeries

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -41,6 +41,7 @@ See also [LTS releases](https://docs.victoriametrics.com/LTS-releases.html).
 * BUGFIX: fix the misleading error `0ms is out of allowed range [0 ...` when passing `step=0` to [/api/v1/query](https://docs.victoriametrics.com/keyconcepts/#instant-query)
   or [/api/v1/query_range](https://docs.victoriametrics.com/keyconcepts/#range-query). See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/5795).
 * BUGFIX: [vmalert](https://docs.victoriametrics.com/#vmalert): consistently sort groups by name and filename on `/groups` page in UI. This should prevent non-deterministic sorting for groups with identical names.
+* BUGFIX: [MetricsQL](https://docs.victoriametrics.com/MetricsQL.html): For subqueries fix behavior of functions that use query time range in their logic (like `start`, `end`, and `running_*`), from now on when using in subqueries they respect time range from query parameters. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/5794) for details.
 
 ## [v1.98.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.98.0)
 


### PR DESCRIPTION
for subqueries fixed behavior of functions that use query time range in their logic (like `start`, `end`, and `running_*`), from now on when using in subqueries they respect time range from query parameters (#5794)