### PR TITLE
lib/storage: fix aligning

### DIFF
--- a/lib/storage/partition.go
+++ b/lib/storage/partition.go
@@ -421,10 +421,9 @@ func (pt *partition) AddRows(rows []rawRow) {
 var isDebug = false
 
 type rawRowsShards struct {
+	shardIdx uint32
 	// Put flushDeadlineMs to the top in order to avoid unaligned memory access on 32-bit architectures:w
 	flushDeadlineMs int64
-
-	shardIdx uint32
 
 	// Shards reduce lock contention when adding rows on multi-CPU systems.
 	shards []rawRowsShard


### PR DESCRIPTION
This PR is fiixing the problem with data aligning 
```
--- FAIL: TestIndexDBRepopulateAfterRotation (0.09s)
panic: unaligned 64-bit atomic operation [recovered]
	panic: unaligned 64-bit atomic operation
```

Please check the tests on master branch 

Signed-off-by: dmitryk-dk [d.kozlov@victoriametrics.com](mailto:d.kozlov@victoriametrics.com)