### PR TITLE
dashboards/victoria-metrics-single: allow selecting multiple instance values

### DIFF
--- a/dashboards/victoriametrics.json
+++ b/dashboards/victoriametrics.json
@@ -967,7 +967,7 @@
           "refId": "A"
         }
       ],
-      "title": "Datapoints ingestion rate ($instance)",
+      "title": "Datapoints ingestion rate",
       "type": "timeseries"
     },
     {
@@ -1077,7 +1077,7 @@
           "refId": "A"
         }
       ],
-      "title": "Requests rate ($instance)",
+      "title": "Requests rate",
       "type": "timeseries"
     },
     {
@@ -1190,7 +1190,7 @@
           "refId": "A"
         }
       ],
-      "title": "Active time series ($instance)",
+      "title": "Active time series",
       "type": "timeseries"
     },
     {
@@ -1299,7 +1299,7 @@
           "refId": "A"
         }
       ],
-      "title": "Query duration 0.99 quantile ($instance)",
+      "title": "Query duration 0.99 quantile",
       "type": "timeseries"
     },
     {
@@ -1403,7 +1403,7 @@
           "refId": "A"
         }
       ],
-      "title": "Requests error rate ($instance)",
+      "title": "Requests error rate",
       "type": "timeseries"
     },
     {
@@ -1625,7 +1625,7 @@
               "refId": "A"
             }
           ],
-          "title": "RSS memory % usage ($instance)",
+          "title": "RSS memory % usage",
           "type": "timeseries"
         },
         {
@@ -1794,7 +1794,7 @@
               "refId": "E"
             }
           ],
-          "title": "Memory usage ($instance)",
+          "title": "Memory usage",
           "type": "timeseries"
         },
         {
@@ -1903,7 +1903,7 @@
               "refId": "A"
             }
           ],
-          "title": "RSS anonymous memory % usage ($instance)",
+          "title": "RSS anonymous memory % usage",
           "type": "timeseries"
         },
         {
@@ -2013,7 +2013,7 @@
               "refId": "A"
             }
           ],
-          "title": "CPU % usage ($instance)",
+          "title": "CPU % usage",
           "type": "timeseries"
         },
         {
@@ -2141,7 +2141,7 @@
               "refId": "A"
             }
           ],
-          "title": "Open FDs ($instance)",
+          "title": "Open FDs",
           "type": "timeseries"
         },
         {
@@ -2279,7 +2279,7 @@
               "refId": "B"
             }
           ],
-          "title": "CPU ($instance)",
+          "title": "CPU",
           "type": "timeseries"
         },
         {
@@ -2388,7 +2388,7 @@
               "refId": "A"
             }
           ],
-          "title": "Goroutines ($instance)",
+          "title": "Goroutines",
           "type": "timeseries"
         },
         {
@@ -2526,7 +2526,7 @@
               "refId": "B"
             }
           ],
-          "title": "Disk writes/reads ($instance)",
+          "title": "Disk writes/reads",
           "type": "timeseries"
         },
         {
@@ -2635,7 +2635,7 @@
               "refId": "A"
             }
           ],
-          "title": "Threads ($instance)",
+          "title": "Threads",
           "type": "timeseries"
         },
         {
@@ -2773,7 +2773,7 @@
               "refId": "B"
             }
           ],
-          "title": "Disk write/read calls ($instance)",
+          "title": "Disk write/read calls",
           "type": "timeseries"
         },
         {
@@ -2883,7 +2883,7 @@
               "refId": "A"
             }
           ],
-          "title": "TCP connections rate ($instance)",
+          "title": "TCP connections rate",
           "type": "timeseries"
         },
         {
@@ -2993,7 +2993,7 @@
               "refId": "A"
             }
           ],
-          "title": "TCP connections ($instance)",
+          "title": "TCP connections",
           "type": "timeseries"
         },
         {
@@ -3102,7 +3102,7 @@
               "refId": "A"
             }
           ],
-          "title": "CPU spent on GC ($instance)",
+          "title": "CPU spent on GC",
           "type": "timeseries"
         }
       ],
@@ -3244,7 +3244,7 @@
               "refId": "B"
             }
           ],
-          "title": "Churn rate ($instance)",
+          "title": "Churn rate",
           "type": "timeseries"
         },
         {
@@ -3352,7 +3352,7 @@
               "refId": "A"
             }
           ],
-          "title": "Slow inserts ($instance)",
+          "title": "Slow inserts",
           "type": "timeseries"
         },
         {
@@ -3457,7 +3457,7 @@
               "refId": "A"
             }
           ],
-          "title": "Assisted merges ($instance)",
+          "title": "Assisted merges",
           "type": "timeseries"
         },
         {
@@ -3563,7 +3563,7 @@
               "refId": "A"
             }
           ],
-          "title": "Slow queries rate ($instance)",
+          "title": "Slow queries rate",
           "type": "timeseries"
         },
         {
@@ -3665,7 +3665,7 @@
               "refId": "A"
             }
           ],
-          "title": "Cache usage % by type ($instance)",
+          "title": "Cache usage % by type",
           "type": "timeseries"
         },
         {
@@ -3774,7 +3774,7 @@
               "refId": "A"
             }
           ],
-          "title": "Cache miss ratio ($instance)",
+          "title": "Cache miss ratio",
           "type": "timeseries"
         },
         {
@@ -4004,7 +4004,7 @@
               "refId": "A"
             }
           ],
-          "title": "Labels limit exceeded ($instance)",
+          "title": "Labels limit exceeded",
           "type": "timeseries"
         }
       ],
@@ -4137,7 +4137,7 @@
               "refId": "A"
             }
           ],
-          "title": "Datapoints ingestion rate ($instance)",
+          "title": "Datapoints ingestion rate",
           "type": "timeseries"
         },
         {
@@ -4244,7 +4244,7 @@
               "refId": "A"
             }
           ],
-          "title": "Storage full ETA ($instance)",
+          "title": "Storage full ETA",
           "type": "timeseries"
         },
         {
@@ -4378,7 +4378,7 @@
               "refId": "C"
             }
           ],
-          "title": "Disk space usage - datapoints ($instance)",
+          "title": "Disk space usage - datapoints",
           "type": "timeseries"
         },
         {
@@ -4513,7 +4513,7 @@
               "refId": "B"
             }
           ],
-          "title": "Pending datapoints ($instance)",
+          "title": "Pending datapoints",
           "type": "timeseries"
         },
         {
@@ -4650,7 +4650,7 @@
               "refId": "B"
             }
           ],
-          "title": "Datapoints ($instance)",
+          "title": "Datapoints",
           "type": "timeseries"
         },
         {
@@ -4754,7 +4754,7 @@
               "refId": "A"
             }
           ],
-          "title": "LSM parts ($instance)",
+          "title": "LSM parts",
           "type": "timeseries"
         },
         {
@@ -4860,7 +4860,7 @@
               "refId": "A"
             }
           ],
-          "title": "Rows ignored for last 1h ($instance)",
+          "title": "Rows ignored for last 1h",
           "type": "timeseries"
         },
         {
@@ -4961,7 +4961,7 @@
               "refId": "A"
             }
           ],
-          "title": "Active merges ($instance)",
+          "title": "Active merges",
           "type": "timeseries"
         },
         {
@@ -5094,7 +5094,7 @@
               "refId": "B"
             }
           ],
-          "title": "Concurrent flushes on disk ($instance)",
+          "title": "Concurrent flushes on disk",
           "type": "timeseries"
         },
         {
@@ -5197,7 +5197,7 @@
               "refId": "A"
             }
           ],
-          "title": "Merge speed ($instance)",
+          "title": "Merge speed",
           "type": "timeseries"
         },
         {
@@ -5304,7 +5304,7 @@
               "refId": "A"
             }
           ],
-          "title": "Series read per query ($instance)",
+          "title": "Series read per query",
           "type": "timeseries"
         },
         {
@@ -5411,7 +5411,7 @@
               "refId": "A"
             }
           ],
-          "title": "Datapoints read per series ($instance)",
+          "title": "Datapoints read per series",
           "type": "timeseries"
         },
         {
@@ -5518,7 +5518,7 @@
               "refId": "A"
             }
           ],
-          "title": "Datapoints read per query ($instance)",
+          "title": "Datapoints read per query",
           "type": "timeseries"
         },
         {
@@ -5625,7 +5625,7 @@
               "refId": "A"
             }
           ],
-          "title": "Datapoints scanned per query ($instance)",
+          "title": "Datapoints scanned per query",
           "type": "timeseries"
         }
       ],

--- a/dashboards/victoriametrics.json
+++ b/dashboards/victoriametrics.json
@@ -958,11 +958,11 @@
             "uid": "$ds"
           },
           "editorMode": "code",
-          "expr": "sum(rate(vm_rows_inserted_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (type) > 0",
+          "expr": "sum(rate(vm_rows_inserted_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (type, instance) > 0",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
-          "legendFormat": "__auto",
+          "legendFormat": "{{instance}} - {{type}}",
           "range": true,
           "refId": "A"
         }
@@ -1068,11 +1068,11 @@
             "uid": "$ds"
           },
           "editorMode": "code",
-          "expr": "sum(rate(vm_http_requests_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (path) > 0",
+          "expr": "sum(rate(vm_http_requests_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (path, instance) > 0",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "{{path}}",
+          "legendFormat": "{{instance}} - {{path}}",
           "range": true,
           "refId": "A"
         }
@@ -1181,10 +1181,12 @@
             "type": "prometheus",
             "uid": "$ds"
           },
+          "editorMode": "code",
           "expr": "vm_cache_entries{job=~\"$job\", instance=~\"$instance\", type=\"storage/hour_metric_ids\"}",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "Active time series",
+          "legendFormat": "{{instance}} - Active time series",
+          "range": true,
           "refId": "A"
         }
       ],
@@ -1289,10 +1291,10 @@
             "uid": "$ds"
           },
           "editorMode": "code",
-          "expr": "max(vm_request_duration_seconds{job=~\"$job\", instance=~\"$instance\", quantile=\"0.99\"}) by (path) > 0",
+          "expr": "max(vm_request_duration_seconds{job=~\"$job\", instance=~\"$instance\", quantile=\"0.99\"}) by (instance, path) > 0",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "__auto",
+          "legendFormat": "{{instance}} - {{path}}",
           "range": true,
           "refId": "A"
         }
@@ -1392,11 +1394,11 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum(rate(vm_http_request_errors_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (path) > 0",
+          "expr": "sum(rate(vm_http_request_errors_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (instance, path) > 0",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "__auto",
+          "legendFormat": "{{instance}} - {{path}}",
           "range": true,
           "refId": "A"
         }
@@ -1493,9 +1495,9 @@
             "uid": "$ds"
           },
           "editorMode": "code",
-          "expr": "sum(rate(vm_log_messages_total{job=~\"$job\", instance=~\"$instance\", level!=\"info\"}[$__rate_interval])) by (level, location) > 0",
+          "expr": "sum(rate(vm_log_messages_total{job=~\"$job\", instance=~\"$instance\", level!=\"info\"}[$__rate_interval])) by (instance, level, location) > 0",
           "interval": "5m",
-          "legendFormat": "{{level}}: {{location}}",
+          "legendFormat": "{{instance}} - {{level}}: {{location}}",
           "range": true,
           "refId": "A"
         }
@@ -1723,11 +1725,13 @@
                 "type": "prometheus",
                 "uid": "$ds"
               },
-              "expr": "sum(go_memstats_sys_bytes{job=~\"$job\", instance=~\"$instance\"}) + sum(vm_cache_size_bytes{job=~\"$job\", instance=~\"$instance\"})",
+              "editorMode": "code",
+              "expr": "sum(go_memstats_sys_bytes{job=~\"$job\", instance=~\"$instance\"}) by (instance) + sum(vm_cache_size_bytes{job=~\"$job\", instance=~\"$instance\"}) by (instance)",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
-              "legendFormat": "requested from system",
+              "legendFormat": "{{instance}} - requested from system",
+              "range": true,
               "refId": "A"
             },
             {
@@ -1735,11 +1739,13 @@
                 "type": "prometheus",
                 "uid": "$ds"
               },
-              "expr": "sum(go_memstats_heap_inuse_bytes{job=~\"$job\", instance=~\"$instance\"}) + sum(vm_cache_size_bytes{job=~\"$job\", instance=~\"$instance\"})",
+              "editorMode": "code",
+              "expr": "sum(go_memstats_heap_inuse_bytes{job=~\"$job\", instance=~\"$instance\"}) by (instance) + sum(vm_cache_size_bytes{job=~\"$job\", instance=~\"$instance\"}) by (instance)",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
-              "legendFormat": "heap inuse",
+              "legendFormat": "{{instance}} - heap inuse",
+              "range": true,
               "refId": "B"
             },
             {
@@ -1747,11 +1753,13 @@
                 "type": "prometheus",
                 "uid": "$ds"
               },
-              "expr": "sum(go_memstats_stack_inuse_bytes{job=~\"$job\", instance=~\"$instance\"})",
+              "editorMode": "code",
+              "expr": "sum(go_memstats_stack_inuse_bytes{job=~\"$job\", instance=~\"$instance\"}) by (instance)",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
-              "legendFormat": "stack inuse",
+              "legendFormat": "{{instance}} - stack inuse",
+              "range": true,
               "refId": "C"
             },
             {
@@ -1759,12 +1767,14 @@
                 "type": "prometheus",
                 "uid": "$ds"
               },
-              "expr": "sum(process_resident_memory_bytes{job=~\"$job\", instance=~\"$instance\"})",
+              "editorMode": "code",
+              "expr": "sum(process_resident_memory_bytes{job=~\"$job\", instance=~\"$instance\"}) by (instance)",
               "format": "time_series",
               "hide": false,
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "resident",
+              "legendFormat": "{{instance}} - resident",
+              "range": true,
               "refId": "D"
             },
             {
@@ -1772,13 +1782,15 @@
                 "type": "prometheus",
                 "uid": "$ds"
               },
+              "editorMode": "code",
               "exemplar": false,
-              "expr": "sum(process_resident_memory_anon_bytes{job=~\"$job\", instance=~\"$instance\"})",
+              "expr": "sum(process_resident_memory_anon_bytes{job=~\"$job\", instance=~\"$instance\"}) by (instance)",
               "format": "time_series",
               "hide": false,
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "resident anonymous",
+              "legendFormat": "{{instance}} - resident anonymous",
+              "range": true,
               "refId": "E"
             }
           ],
@@ -2488,12 +2500,14 @@
                 "type": "prometheus",
                 "uid": "$ds"
               },
-              "expr": "sum(rate(process_io_storage_read_bytes_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
+              "editorMode": "code",
+              "expr": "sum(rate(process_io_storage_read_bytes_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (instance)",
               "format": "time_series",
               "hide": false,
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "read",
+              "legendFormat": "{{instance}} - read",
+              "range": true,
               "refId": "A"
             },
             {
@@ -2501,12 +2515,14 @@
                 "type": "prometheus",
                 "uid": "$ds"
               },
-              "expr": "sum(rate(process_io_storage_written_bytes_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
+              "editorMode": "code",
+              "expr": "sum(rate(process_io_storage_written_bytes_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (instance)",
               "format": "time_series",
               "hide": false,
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "write",
+              "legendFormat": "{{instance}} - write",
+              "range": true,
               "refId": "B"
             }
           ],
@@ -2732,12 +2748,12 @@
                 "uid": "$ds"
               },
               "editorMode": "code",
-              "expr": "sum(rate(process_io_read_syscalls_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
+              "expr": "sum(rate(process_io_read_syscalls_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (instance)",
               "format": "time_series",
               "hide": false,
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "read calls",
+              "legendFormat": "{{instance}} - read calls",
               "range": true,
               "refId": "A"
             },
@@ -2747,12 +2763,12 @@
                 "uid": "$ds"
               },
               "editorMode": "code",
-              "expr": "sum(rate(process_io_write_syscalls_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
+              "expr": "sum(rate(process_io_write_syscalls_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (instance)",
               "format": "time_series",
               "hide": false,
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "write calls",
+              "legendFormat": "{{instance}} - write calls",
               "range": true,
               "refId": "B"
             }
@@ -3208,9 +3224,11 @@
                 "type": "prometheus",
                 "uid": "$ds"
               },
-              "expr": "sum(rate(vm_new_timeseries_created_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
+              "editorMode": "code",
+              "expr": "sum(rate(vm_new_timeseries_created_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (instance)",
               "interval": "",
-              "legendFormat": "churn rate",
+              "legendFormat": "{{instance}} - churn rate",
+              "range": true,
               "refId": "A"
             },
             {
@@ -3218,9 +3236,11 @@
                 "type": "prometheus",
                 "uid": "$ds"
               },
-              "expr": "sum(increase(vm_new_timeseries_created_total{job=~\"$job\", instance=~\"$instance\"}[24h]))",
+              "editorMode": "code",
+              "expr": "sum(increase(vm_new_timeseries_created_total{job=~\"$job\", instance=~\"$instance\"}[24h])) by (instance)",
               "interval": "",
-              "legendFormat": "new series over 24h",
+              "legendFormat": "{{instance}} - new series over 24h",
+              "range": true,
               "refId": "B"
             }
           ],
@@ -3322,12 +3342,12 @@
                 "uid": "$ds"
               },
               "editorMode": "code",
-              "expr": "max(\n    rate(vm_slow_row_inserts_total{job=~\"$job\"}[$__rate_interval]) \n    / rate(vm_rows_added_to_storage_total{job=~\"$job\"}[$__rate_interval])\n)",
+              "expr": "max(\n    rate(vm_slow_row_inserts_total{job=~\"$job\"}[$__rate_interval]) \n    / rate(vm_rows_added_to_storage_total{job=~\"$job\"}[$__rate_interval])\n) by (instance)",
               "format": "time_series",
               "hide": false,
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "slow inserts percentage",
+              "legendFormat": "{{instance}} - slow inserts percentage",
               "range": true,
               "refId": "A"
             }
@@ -3428,11 +3448,11 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "sum(increase(vm_assisted_merges_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by(type) > 0",
+              "expr": "sum(increase(vm_assisted_merges_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by(instance, type) > 0",
               "format": "time_series",
               "interval": "5m",
               "intervalFactor": 1,
-              "legendFormat": "__auto",
+              "legendFormat": "{{instance}} - {{type}}",
               "range": true,
               "refId": "A"
             }
@@ -3533,11 +3553,13 @@
                 "type": "prometheus",
                 "uid": "$ds"
               },
-              "expr": "sum(rate(vm_slow_queries_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
+              "editorMode": "code",
+              "expr": "sum(rate(vm_slow_queries_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (instance)",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
-              "legendFormat": "slow queries rate",
+              "legendFormat": "{{instance}} - slow queries rate",
+              "range": true,
               "refId": "A"
             }
           ],
@@ -3638,7 +3660,7 @@
               "exemplar": false,
               "expr": "vm_cache_size_bytes{job=~\"$job\", instance=~\"$instance\"} / vm_cache_size_max_bytes{job=~\"$job\", instance=~\"$instance\"}",
               "interval": "",
-              "legendFormat": "{{type}}",
+              "legendFormat": "{{instance}} - {{type}}",
               "range": true,
               "refId": "A"
             }
@@ -3747,7 +3769,7 @@
               "hide": false,
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "{{type}}",
+              "legendFormat": "{{instance}} - {{type}}",
               "range": true,
               "refId": "A"
             }
@@ -3972,12 +3994,13 @@
                 "uid": "$ds"
               },
               "exemplar": false,
-              "expr": "sum(increase(vm_metrics_with_dropped_labels_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
+              "expr": "sum(increase(vm_metrics_with_dropped_labels_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (instance)",
               "format": "time_series",
               "hide": false,
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "limit exceeded",
+              "legendFormat": "{{instance}} - limit exceeded",
+              "range": true,
               "refId": "A"
             }
           ],
@@ -4105,11 +4128,11 @@
                 "uid": "$ds"
               },
               "editorMode": "code",
-              "expr": "sum(rate(vm_rows_inserted_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (type) > 0",
+              "expr": "sum(rate(vm_rows_inserted_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (instance, type) > 0",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
-              "legendFormat": "{{type}}",
+              "legendFormat": "{{instance}} - {{type}}",
               "range": true,
               "refId": "A"
             }
@@ -4318,11 +4341,11 @@
                 "uid": "$ds"
               },
               "editorMode": "code",
-              "expr": "sum(vm_data_size_bytes{job=~\"$job\", instance=~\"$instance\", type!~\"indexdb.*\"})",
+              "expr": "sum(vm_data_size_bytes{job=~\"$job\", instance=~\"$instance\", type!~\"indexdb.*\"}) by (instance)",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "Used (datapoints)",
+              "legendFormat": "{{instance}} - Used (datapoints)",
               "range": true,
               "refId": "A"
             },
@@ -4335,7 +4358,8 @@
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "Free",
+              "legendFormat": "{{instance}} - Free",
+              "range": true,
               "refId": "B"
             },
             {
@@ -4344,12 +4368,12 @@
                 "uid": "$ds"
               },
               "editorMode": "code",
-              "expr": "sum(vm_data_size_bytes{job=~\"$job\", instance=~\"$instance\", type=~\"indexdb.*\"})",
+              "expr": "sum(vm_data_size_bytes{job=~\"$job\", instance=~\"$instance\", type=~\"indexdb.*\"}) by (instance)",
               "format": "time_series",
               "hide": false,
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "Used (index)",
+              "legendFormat": "{{instance}} - Used (index)",
               "range": true,
               "refId": "C"
             }
@@ -4471,7 +4495,8 @@
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
-              "legendFormat": "pending datapoints",
+              "legendFormat": "{{instance}} - pending datapoints",
+              "range": true,
               "refId": "A"
             },
             {
@@ -4483,7 +4508,8 @@
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
-              "legendFormat": "pending index entries",
+              "legendFormat": "{{instance}} - pending index entries",
+              "range": true,
               "refId": "B"
             }
           ],
@@ -4600,11 +4626,13 @@
                 "type": "prometheus",
                 "uid": "$ds"
               },
-              "expr": "sum(vm_rows{job=~\"$job\", instance=~\"$instance\", type!~\"indexdb.*\"})",
+              "editorMode": "code",
+              "expr": "sum(vm_rows{job=~\"$job\", instance=~\"$instance\", type!~\"indexdb.*\"}) by (instance)",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "total datapoints",
+              "legendFormat": "{{instance}} - total datapoints",
+              "range": true,
               "refId": "A"
             },
             {
@@ -4613,11 +4641,11 @@
                 "uid": "$ds"
               },
               "editorMode": "code",
-              "expr": "sum(vm_data_size_bytes{job=~\"$job\", instance=~\"$instance\"}) \n/ sum(vm_rows{job=~\"$job\", instance=~\"$instance\", type!~\"indexdb.*\"})",
+              "expr": "sum(vm_data_size_bytes{job=~\"$job\", instance=~\"$instance\"}) by (instance)\n/ sum(vm_rows{job=~\"$job\", instance=~\"$instance\", type!~\"indexdb.*\"}) by (instance)",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "bytes-per-datapoint",
+              "legendFormat": "{{instance}} - bytes-per-datapoint",
               "range": true,
               "refId": "B"
             }
@@ -4717,10 +4745,12 @@
                 "type": "prometheus",
                 "uid": "$ds"
               },
-              "expr": "sum(vm_parts{job=~\"$job\", instance=~\"$instance\"}) by (type)",
+              "editorMode": "code",
+              "expr": "sum(vm_parts{job=~\"$job\", instance=~\"$instance\"}) by (instance, type)",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "{{type}}",
+              "legendFormat": "{{instance}} - {{type}}",
+              "range": true,
               "refId": "A"
             }
           ],
@@ -4820,12 +4850,12 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "sum(increase(vm_rows_ignored_total{job=~\"$job\", instance=~\"$instance\"}[1h])) by (reason)",
+              "expr": "sum(increase(vm_rows_ignored_total{job=~\"$job\", instance=~\"$instance\"}[1h])) by (instance, reason)",
               "format": "time_series",
               "hide": false,
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "{{reason}}",
+              "legendFormat": "{{instance}} - {{reason}}",
               "range": true,
               "refId": "A"
             }
@@ -4924,8 +4954,10 @@
                 "type": "prometheus",
                 "uid": "$ds"
               },
-              "expr": "sum(vm_active_merges{job=~\"$job\", instance=~\"$instance\"}) by(type)",
-              "legendFormat": "{{type}}",
+              "editorMode": "code",
+              "expr": "sum(vm_active_merges{job=~\"$job\", instance=~\"$instance\"}) by(instance, type)",
+              "legendFormat": "{{instance}} - {{type}}",
+              "range": true,
               "refId": "A"
             }
           ],
@@ -5044,7 +5076,7 @@
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "max",
+              "legendFormat": "{{instance}} - max",
               "range": true,
               "refId": "A"
             },
@@ -5053,10 +5085,12 @@
                 "type": "prometheus",
                 "uid": "$ds"
               },
-              "expr": "sum(vm_concurrent_insert_current{job=~\"$job\", instance=~\"$instance\"})",
+              "editorMode": "code",
+              "expr": "sum(vm_concurrent_insert_current{job=~\"$job\", instance=~\"$instance\"}) by (instance)",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "current",
+              "legendFormat": "{{instance}} - current",
+              "range": true,
               "refId": "B"
             }
           ],
@@ -5156,8 +5190,10 @@
                 "type": "prometheus",
                 "uid": "$ds"
               },
-              "expr": "sum(rate(vm_rows_merged_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by(type)",
-              "legendFormat": "{{type}}",
+              "editorMode": "code",
+              "expr": "sum(rate(vm_rows_merged_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by(instance, type)",
+              "legendFormat": "{{instance}} - {{type}}",
+              "range": true,
               "refId": "A"
             }
           ],

--- a/dashboards/victoriametrics.json
+++ b/dashboards/victoriametrics.json
@@ -240,6 +240,7 @@
             "type": "prometheus",
             "uid": "$ds"
           },
+          "editorMode": "code",
           "exemplar": false,
           "expr": "sum(vm_rows{job=~\"$job\", instance=~\"$instance\", type!~\"indexdb.*\"})",
           "format": "time_series",
@@ -537,7 +538,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "vm_app_uptime_seconds{job=~\"$job\", instance=~\"$instance\"}",
+          "expr": "min(vm_app_uptime_seconds{job=~\"$job\", instance=~\"$instance\"})",
           "instant": true,
           "interval": "",
           "legendFormat": "",
@@ -606,8 +607,9 @@
             "type": "prometheus",
             "uid": "$ds"
           },
+          "editorMode": "code",
           "exemplar": false,
-          "expr": "vm_cache_entries{job=~\"$job\", instance=~\"$instance\", type=\"storage/hour_metric_ids\"}",
+          "expr": "sum(vm_cache_entries{job=~\"$job\", instance=~\"$instance\", type=\"storage/hour_metric_ids\"})",
           "format": "time_series",
           "instant": true,
           "interval": "",
@@ -753,7 +755,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum(vm_data_size_bytes{job=~\"$job\", instance=~\"$instance\"}) / sum(vm_rows{job=~\"$job\", instance=~\"$instance\"})",
+          "expr": "max(sum(vm_data_size_bytes{job=~\"$job\", instance=~\"$instance\"}) / sum(vm_rows{job=~\"$job\", instance=~\"$instance\"}))",
           "format": "time_series",
           "instant": true,
           "interval": "",
@@ -1185,7 +1187,7 @@
           "expr": "vm_cache_entries{job=~\"$job\", instance=~\"$instance\", type=\"storage/hour_metric_ids\"}",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "{{instance}} - Active time series",
+          "legendFormat": "{{instance}}",
           "range": true,
           "refId": "A"
         }
@@ -1314,6 +1316,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
@@ -1327,6 +1330,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -1350,7 +1354,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -1358,7 +1363,8 @@
               }
             ]
           },
-          "unit": "short"
+          "unit": "short",
+          "unitScale": true
         },
         "overrides": []
       },
@@ -1418,6 +1424,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
@@ -1431,6 +1438,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -1452,14 +1460,16 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
                 "value": 80
               }
             ]
-          }
+          },
+          "unitScale": true
         },
         "overrides": []
       },
@@ -1587,7 +1597,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 3
+            "y": 15
           },
           "id": 112,
           "links": [],
@@ -1696,7 +1706,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 3
+            "y": 15
           },
           "id": 44,
           "links": [],
@@ -1865,7 +1875,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 11
+            "y": 23
           },
           "id": 123,
           "links": [],
@@ -1973,7 +1983,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 11
+            "y": 23
           },
           "id": 114,
           "links": [],
@@ -2101,7 +2111,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 19
+            "y": 31
           },
           "id": 75,
           "links": [],
@@ -2149,7 +2159,7 @@
             "type": "prometheus",
             "uid": "$ds"
           },
-          "description": "",
+          "description": "CPU cores used by instance",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -2228,7 +2238,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 19
+            "y": 31
           },
           "id": 57,
           "links": [],
@@ -2257,11 +2267,13 @@
                 "type": "prometheus",
                 "uid": "$ds"
               },
+              "editorMode": "code",
               "expr": "rate(process_cpu_seconds_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "CPU cores used",
+              "legendFormat": "{{instance}}",
+              "range": true,
               "refId": "A"
             },
             {
@@ -2269,13 +2281,15 @@
                 "type": "prometheus",
                 "uid": "$ds"
               },
+              "editorMode": "code",
               "exemplar": false,
-              "expr": "process_cpu_cores_available{job=~\"$job\", instance=~\"$instance\"}",
+              "expr": "min(process_cpu_cores_available{job=~\"$job\", instance=~\"$instance\"})",
               "format": "time_series",
               "hide": false,
               "interval": "",
               "intervalFactor": 1,
               "legendFormat": "Limit",
+              "range": true,
               "refId": "B"
             }
           ],
@@ -2350,7 +2364,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 27
+            "y": 39
           },
           "id": 47,
           "links": [],
@@ -2455,8 +2469,8 @@
             "overrides": [
               {
                 "matcher": {
-                  "id": "byName",
-                  "options": "read"
+                  "id": "byRegexp",
+                  "options": "/.*read/"
                 },
                 "properties": [
                   {
@@ -2471,7 +2485,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 27
+            "y": 39
           },
           "id": 76,
           "links": [],
@@ -2597,7 +2611,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 35
+            "y": 47
           },
           "id": 48,
           "links": [],
@@ -2702,8 +2716,8 @@
             "overrides": [
               {
                 "matcher": {
-                  "id": "byName",
-                  "options": "read calls"
+                  "id": "byRegexp",
+                  "options": "/.*read.*/"
                 },
                 "properties": [
                   {
@@ -2718,7 +2732,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 35
+            "y": 47
           },
           "id": 124,
           "links": [],
@@ -2844,7 +2858,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 43
+            "y": 55
           },
           "id": 49,
           "links": [],
@@ -2954,7 +2968,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 43
+            "y": 55
           },
           "id": 37,
           "links": [],
@@ -3065,7 +3079,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 51
+            "y": 63
           },
           "id": 125,
           "links": [],
@@ -3144,6 +3158,7 @@
                 "mode": "palette-classic"
               },
               "custom": {
+                "axisBorderShow": false,
                 "axisCenteredZero": false,
                 "axisColorMode": "text",
                 "axisLabel": "",
@@ -3157,6 +3172,7 @@
                   "tooltip": false,
                   "viz": false
                 },
+                "insertNulls": false,
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
                 "pointSize": 5,
@@ -3180,7 +3196,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -3188,7 +3205,8 @@
                   }
                 ]
               },
-              "unit": "short"
+              "unit": "short",
+              "unitScale": true
             },
             "overrides": []
           },
@@ -3196,7 +3214,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 16
+            "y": 4
           },
           "id": 66,
           "options": {
@@ -3259,6 +3277,7 @@
                 "mode": "palette-classic"
               },
               "custom": {
+                "axisBorderShow": false,
                 "axisCenteredZero": false,
                 "axisColorMode": "text",
                 "axisLabel": "",
@@ -3272,6 +3291,7 @@
                   "tooltip": false,
                   "viz": false
                 },
+                "insertNulls": false,
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
                 "pointSize": 5,
@@ -3296,7 +3316,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "transparent"
+                    "color": "transparent",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -3304,7 +3325,8 @@
                   }
                 ]
               },
-              "unit": "percentunit"
+              "unit": "percentunit",
+              "unitScale": true
             },
             "overrides": []
           },
@@ -3312,7 +3334,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 16
+            "y": 4
           },
           "id": 68,
           "links": [],
@@ -3347,12 +3369,12 @@
               "hide": false,
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "{{instance}} - slow inserts percentage",
+              "legendFormat": "{{instance}}",
               "range": true,
               "refId": "A"
             }
           ],
-          "title": "Slow inserts",
+          "title": "Slow inserts %",
           "type": "timeseries"
         },
         {
@@ -3367,6 +3389,7 @@
                 "mode": "palette-classic"
               },
               "custom": {
+                "axisBorderShow": false,
                 "axisCenteredZero": false,
                 "axisColorMode": "text",
                 "axisLabel": "",
@@ -3380,6 +3403,7 @@
                   "tooltip": false,
                   "viz": false
                 },
+                "insertNulls": false,
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
                 "pointSize": 5,
@@ -3403,7 +3427,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -3411,7 +3436,8 @@
                   }
                 ]
               },
-              "unit": "short"
+              "unit": "short",
+              "unitScale": true
             },
             "overrides": []
           },
@@ -3419,7 +3445,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 24
+            "y": 12
           },
           "id": 116,
           "links": [],
@@ -3472,6 +3498,7 @@
                 "mode": "palette-classic"
               },
               "custom": {
+                "axisBorderShow": false,
                 "axisCenteredZero": false,
                 "axisColorMode": "text",
                 "axisLabel": "",
@@ -3485,6 +3512,7 @@
                   "tooltip": false,
                   "viz": false
                 },
+                "insertNulls": false,
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
                 "pointSize": 5,
@@ -3508,7 +3536,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -3516,7 +3545,8 @@
                   }
                 ]
               },
-              "unit": "short"
+              "unit": "short",
+              "unitScale": true
             },
             "overrides": []
           },
@@ -3524,7 +3554,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 24
+            "y": 12
           },
           "id": 60,
           "links": [],
@@ -3558,7 +3588,7 @@
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
-              "legendFormat": "{{instance}} - slow queries rate",
+              "legendFormat": "{{instance}}",
               "range": true,
               "refId": "A"
             }
@@ -3578,6 +3608,7 @@
                 "mode": "palette-classic"
               },
               "custom": {
+                "axisBorderShow": false,
                 "axisCenteredZero": false,
                 "axisColorMode": "text",
                 "axisLabel": "",
@@ -3591,6 +3622,7 @@
                   "tooltip": false,
                   "viz": false
                 },
+                "insertNulls": false,
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
                 "pointSize": 5,
@@ -3612,7 +3644,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -3620,7 +3653,8 @@
                   }
                 ]
               },
-              "unit": "percentunit"
+              "unit": "percentunit",
+              "unitScale": true
             },
             "overrides": []
           },
@@ -3628,7 +3662,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 32
+            "y": 20
           },
           "id": 90,
           "options": {
@@ -3680,6 +3714,7 @@
                 "mode": "palette-classic"
               },
               "custom": {
+                "axisBorderShow": false,
                 "axisCenteredZero": false,
                 "axisColorMode": "text",
                 "axisLabel": "",
@@ -3693,6 +3728,7 @@
                   "tooltip": false,
                   "viz": false
                 },
+                "insertNulls": false,
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
                 "pointSize": 5,
@@ -3717,7 +3753,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -3725,7 +3762,8 @@
                   }
                 ]
               },
-              "unit": "percentunit"
+              "unit": "percentunit",
+              "unitScale": true
             },
             "overrides": []
           },
@@ -3733,7 +3771,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 32
+            "y": 20
           },
           "id": 118,
           "links": [],
@@ -3782,6 +3820,7 @@
             "type": "prometheus",
             "uid": "$ds"
           },
+          "description": "Flags explicitly set to non-default values",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -3799,16 +3838,30 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
                     "value": 80
                   }
                 ]
-              }
+              },
+              "unitScale": true
             },
             "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Time"
+                },
+                "properties": [
+                  {
+                    "id": "custom.hidden",
+                    "value": true
+                  }
+                ]
+              },
               {
                 "matcher": {
                   "id": "byName",
@@ -3824,7 +3877,7 @@
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "Time"
+                  "options": "job"
                 },
                 "properties": [
                   {
@@ -3839,26 +3892,22 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 41
+            "y": 29
           },
-          "id": 120,
+          "id": 126,
           "options": {
+            "cellHeight": "sm",
             "footer": {
+              "countRows": false,
               "fields": "",
               "reducer": [
                 "sum"
               ],
               "show": false
             },
-            "showHeader": true,
-            "sortBy": [
-              {
-                "desc": true,
-                "displayName": "job"
-              }
-            ]
+            "showHeader": true
           },
-          "pluginVersion": "9.1.0",
+          "pluginVersion": "10.3.1",
           "targets": [
             {
               "datasource": {
@@ -3876,29 +3925,6 @@
             }
           ],
           "title": "Non-default flags",
-          "transformations": [
-            {
-              "id": "groupBy",
-              "options": {
-                "fields": {
-                  "instance": {
-                    "aggregations": []
-                  },
-                  "job": {
-                    "aggregations": []
-                  },
-                  "name": {
-                    "aggregations": [],
-                    "operation": "groupby"
-                  },
-                  "value": {
-                    "aggregations": [],
-                    "operation": "groupby"
-                  }
-                }
-              }
-            }
-          ],
           "type": "table"
         },
         {
@@ -3913,6 +3939,7 @@
                 "mode": "palette-classic"
               },
               "custom": {
+                "axisBorderShow": false,
                 "axisCenteredZero": false,
                 "axisColorMode": "text",
                 "axisLabel": "",
@@ -3926,6 +3953,7 @@
                   "tooltip": false,
                   "viz": false
                 },
+                "insertNulls": false,
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
                 "pointSize": 5,
@@ -3950,7 +3978,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -3958,7 +3987,8 @@
                   }
                 ]
               },
-              "unit": "short"
+              "unit": "short",
+              "unitScale": true
             },
             "overrides": []
           },
@@ -3966,7 +3996,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 41
+            "y": 29
           },
           "id": 74,
           "links": [],
@@ -4046,6 +4076,7 @@
                 "mode": "palette-classic"
               },
               "custom": {
+                "axisBorderShow": false,
                 "axisCenteredZero": false,
                 "axisColorMode": "text",
                 "axisLabel": "",
@@ -4059,6 +4090,7 @@
                   "tooltip": false,
                   "viz": false
                 },
+                "insertNulls": false,
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
                 "pointSize": 5,
@@ -4082,7 +4114,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -4090,7 +4123,8 @@
                   }
                 ]
               },
-              "unit": "short"
+              "unit": "short",
+              "unitScale": true
             },
             "overrides": []
           },
@@ -4098,7 +4132,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 41
+            "y": 5
           },
           "id": 10,
           "links": [],
@@ -4152,6 +4186,7 @@
                 "mode": "palette-classic"
               },
               "custom": {
+                "axisBorderShow": false,
                 "axisCenteredZero": false,
                 "axisColorMode": "text",
                 "axisLabel": "",
@@ -4165,6 +4200,7 @@
                   "tooltip": false,
                   "viz": false
                 },
+                "insertNulls": false,
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
                 "pointSize": 5,
@@ -4188,7 +4224,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -4196,7 +4233,8 @@
                   }
                 ]
               },
-              "unit": "s"
+              "unit": "s",
+              "unitScale": true
             },
             "overrides": []
           },
@@ -4204,7 +4242,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 41
+            "y": 5
           },
           "id": 73,
           "links": [],
@@ -4259,6 +4297,7 @@
                 "mode": "palette-classic"
               },
               "custom": {
+                "axisBorderShow": false,
                 "axisCenteredZero": false,
                 "axisColorMode": "text",
                 "axisLabel": "",
@@ -4272,6 +4311,7 @@
                   "tooltip": false,
                   "viz": false
                 },
+                "insertNulls": false,
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
                 "pointSize": 5,
@@ -4295,7 +4335,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -4303,7 +4344,8 @@
                   }
                 ]
               },
-              "unit": "bytes"
+              "unit": "bytes",
+              "unitScale": true
             },
             "overrides": []
           },
@@ -4311,7 +4353,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 49
+            "y": 13
           },
           "id": 53,
           "links": [],
@@ -4393,6 +4435,7 @@
                 "mode": "palette-classic"
               },
               "custom": {
+                "axisBorderShow": false,
                 "axisCenteredZero": false,
                 "axisColorMode": "text",
                 "axisLabel": "",
@@ -4406,6 +4449,7 @@
                   "tooltip": false,
                   "viz": false
                 },
+                "insertNulls": false,
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
                 "pointSize": 5,
@@ -4429,7 +4473,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -4437,7 +4482,8 @@
                   }
                 ]
               },
-              "unit": "short"
+              "unit": "short",
+              "unitScale": true
             },
             "overrides": [
               {
@@ -4462,7 +4508,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 49
+            "y": 13
           },
           "id": 34,
           "links": [],
@@ -4528,6 +4574,7 @@
                 "mode": "palette-classic"
               },
               "custom": {
+                "axisBorderShow": false,
                 "axisCenteredZero": false,
                 "axisColorMode": "text",
                 "axisLabel": "",
@@ -4541,6 +4588,7 @@
                   "tooltip": false,
                   "viz": false
                 },
+                "insertNulls": false,
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
                 "pointSize": 5,
@@ -4564,7 +4612,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -4572,7 +4621,8 @@
                   }
                 ]
               },
-              "unit": "short"
+              "unit": "short",
+              "unitScale": true
             },
             "overrides": [
               {
@@ -4597,7 +4647,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 57
+            "y": 21
           },
           "id": 30,
           "links": [],
@@ -4664,6 +4714,7 @@
                 "mode": "palette-classic"
               },
               "custom": {
+                "axisBorderShow": false,
                 "axisCenteredZero": false,
                 "axisColorMode": "text",
                 "axisLabel": "",
@@ -4677,6 +4728,7 @@
                   "tooltip": false,
                   "viz": false
                 },
+                "insertNulls": false,
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
                 "pointSize": 5,
@@ -4700,7 +4752,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -4708,7 +4761,8 @@
                   }
                 ]
               },
-              "unit": "short"
+              "unit": "short",
+              "unitScale": true
             },
             "overrides": []
           },
@@ -4716,7 +4770,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 57
+            "y": 21
           },
           "id": 36,
           "links": [],
@@ -4769,6 +4823,7 @@
                 "mode": "palette-classic"
               },
               "custom": {
+                "axisBorderShow": false,
                 "axisCenteredZero": false,
                 "axisColorMode": "text",
                 "axisLabel": "",
@@ -4782,6 +4837,7 @@
                   "tooltip": false,
                   "viz": false
                 },
+                "insertNulls": false,
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
                 "pointSize": 5,
@@ -4805,7 +4861,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -4813,7 +4870,8 @@
                   }
                 ]
               },
-              "unit": "short"
+              "unit": "short",
+              "unitScale": true
             },
             "overrides": []
           },
@@ -4821,7 +4879,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 65
+            "y": 29
           },
           "id": 58,
           "links": [],
@@ -4875,6 +4933,7 @@
                 "mode": "palette-classic"
               },
               "custom": {
+                "axisBorderShow": false,
                 "axisCenteredZero": false,
                 "axisColorMode": "text",
                 "axisLabel": "",
@@ -4888,6 +4947,7 @@
                   "tooltip": false,
                   "viz": false
                 },
+                "insertNulls": false,
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
                 "pointSize": 5,
@@ -4912,7 +4972,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -4920,7 +4981,8 @@
                   }
                 ]
               },
-              "unit": "short"
+              "unit": "short",
+              "unitScale": true
             },
             "overrides": []
           },
@@ -4928,7 +4990,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 65
+            "y": 29
           },
           "id": 62,
           "options": {
@@ -4976,6 +5038,7 @@
                 "mode": "palette-classic"
               },
               "custom": {
+                "axisBorderShow": false,
                 "axisCenteredZero": false,
                 "axisColorMode": "text",
                 "axisLabel": "",
@@ -4989,6 +5052,7 @@
                   "tooltip": false,
                   "viz": false
                 },
+                "insertNulls": false,
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
                 "pointSize": 5,
@@ -5013,7 +5077,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -5021,7 +5086,8 @@
                   }
                 ]
               },
-              "unit": "short"
+              "unit": "short",
+              "unitScale": true
             },
             "overrides": [
               {
@@ -5045,7 +5111,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 73
+            "y": 37
           },
           "id": 59,
           "links": [],
@@ -5109,6 +5175,7 @@
                 "mode": "palette-classic"
               },
               "custom": {
+                "axisBorderShow": false,
                 "axisCenteredZero": false,
                 "axisColorMode": "text",
                 "axisLabel": "",
@@ -5122,6 +5189,7 @@
                   "tooltip": false,
                   "viz": false
                 },
+                "insertNulls": false,
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
                 "pointSize": 5,
@@ -5146,7 +5214,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -5154,7 +5223,8 @@
                   }
                 ]
               },
-              "unit": "short"
+              "unit": "short",
+              "unitScale": true
             },
             "overrides": []
           },
@@ -5162,7 +5232,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 73
+            "y": 37
           },
           "id": 64,
           "options": {
@@ -5212,6 +5282,7 @@
                 "mode": "palette-classic"
               },
               "custom": {
+                "axisBorderShow": false,
                 "axisCenteredZero": false,
                 "axisColorMode": "text",
                 "axisLabel": "",
@@ -5225,6 +5296,7 @@
                   "tooltip": false,
                   "viz": false
                 },
+                "insertNulls": false,
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
                 "pointSize": 5,
@@ -5249,7 +5321,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -5257,7 +5330,8 @@
                   }
                 ]
               },
-              "unit": "short"
+              "unit": "short",
+              "unitScale": true
             },
             "overrides": []
           },
@@ -5265,7 +5339,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 81
+            "y": 45
           },
           "id": 99,
           "links": [],
@@ -5319,6 +5393,7 @@
                 "mode": "palette-classic"
               },
               "custom": {
+                "axisBorderShow": false,
                 "axisCenteredZero": false,
                 "axisColorMode": "text",
                 "axisLabel": "",
@@ -5332,6 +5407,7 @@
                   "tooltip": false,
                   "viz": false
                 },
+                "insertNulls": false,
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
                 "pointSize": 5,
@@ -5356,7 +5432,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -5364,7 +5441,8 @@
                   }
                 ]
               },
-              "unit": "short"
+              "unit": "short",
+              "unitScale": true
             },
             "overrides": []
           },
@@ -5372,7 +5450,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 81
+            "y": 45
           },
           "id": 103,
           "links": [],
@@ -5426,6 +5504,7 @@
                 "mode": "palette-classic"
               },
               "custom": {
+                "axisBorderShow": false,
                 "axisCenteredZero": false,
                 "axisColorMode": "text",
                 "axisLabel": "",
@@ -5439,6 +5518,7 @@
                   "tooltip": false,
                   "viz": false
                 },
+                "insertNulls": false,
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
                 "pointSize": 5,
@@ -5463,7 +5543,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -5471,7 +5552,8 @@
                   }
                 ]
               },
-              "unit": "short"
+              "unit": "short",
+              "unitScale": true
             },
             "overrides": []
           },
@@ -5479,7 +5561,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 89
+            "y": 53
           },
           "id": 122,
           "links": [],
@@ -5533,6 +5615,7 @@
                 "mode": "palette-classic"
               },
               "custom": {
+                "axisBorderShow": false,
                 "axisCenteredZero": false,
                 "axisColorMode": "text",
                 "axisLabel": "",
@@ -5546,6 +5629,7 @@
                   "tooltip": false,
                   "viz": false
                 },
+                "insertNulls": false,
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
                 "pointSize": 5,
@@ -5570,7 +5654,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -5578,7 +5663,8 @@
                   }
                 ]
               },
-              "unit": "short"
+              "unit": "short",
+              "unitScale": true
             },
             "overrides": []
           },
@@ -5586,7 +5672,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 89
+            "y": 53
           },
           "id": 105,
           "links": [],

--- a/dashboards/victoriametrics.json
+++ b/dashboards/victoriametrics.json
@@ -5683,6 +5683,7 @@
         "useTags": false
       },
       {
+        "allValue": ".*",
         "current": {},
         "datasource": {
           "type": "prometheus",
@@ -5690,8 +5691,8 @@
         },
         "definition": "label_values(vm_app_version{job=~\"$job\"}, instance)",
         "hide": 0,
-        "includeAll": false,
-        "multi": false,
+        "includeAll": true,
+        "multi": true,
         "name": "instance",
         "options": [],
         "query": {

--- a/dashboards/vm/victoriametrics.json
+++ b/dashboards/vm/victoriametrics.json
@@ -959,11 +959,11 @@
             "uid": "$ds"
           },
           "editorMode": "code",
-          "expr": "sum(rate(vm_rows_inserted_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (type) > 0",
+          "expr": "sum(rate(vm_rows_inserted_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (type, instance) > 0",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
-          "legendFormat": "__auto",
+          "legendFormat": "{{instance}} - {{type}}",
           "range": true,
           "refId": "A"
         }
@@ -1069,11 +1069,11 @@
             "uid": "$ds"
           },
           "editorMode": "code",
-          "expr": "sum(rate(vm_http_requests_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (path) > 0",
+          "expr": "sum(rate(vm_http_requests_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (path, instance) > 0",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "{{path}}",
+          "legendFormat": "{{instance}} - {{path}}",
           "range": true,
           "refId": "A"
         }
@@ -1182,10 +1182,12 @@
             "type": "victoriametrics-datasource",
             "uid": "$ds"
           },
+          "editorMode": "code",
           "expr": "vm_cache_entries{job=~\"$job\", instance=~\"$instance\", type=\"storage/hour_metric_ids\"}",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "Active time series",
+          "legendFormat": "{{instance}} - Active time series",
+          "range": true,
           "refId": "A"
         }
       ],
@@ -1290,10 +1292,10 @@
             "uid": "$ds"
           },
           "editorMode": "code",
-          "expr": "max(vm_request_duration_seconds{job=~\"$job\", instance=~\"$instance\", quantile=\"0.99\"}) by (path) > 0",
+          "expr": "max(vm_request_duration_seconds{job=~\"$job\", instance=~\"$instance\", quantile=\"0.99\"}) by (instance, path) > 0",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "__auto",
+          "legendFormat": "{{instance}} - {{path}}",
           "range": true,
           "refId": "A"
         }
@@ -1393,11 +1395,11 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum(rate(vm_http_request_errors_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (path) > 0",
+          "expr": "sum(rate(vm_http_request_errors_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (instance, path) > 0",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "__auto",
+          "legendFormat": "{{instance}} - {{path}}",
           "range": true,
           "refId": "A"
         }
@@ -1494,9 +1496,9 @@
             "uid": "$ds"
           },
           "editorMode": "code",
-          "expr": "sum(rate(vm_log_messages_total{job=~\"$job\", instance=~\"$instance\", level!=\"info\"}[$__rate_interval])) by (level, location) > 0",
+          "expr": "sum(rate(vm_log_messages_total{job=~\"$job\", instance=~\"$instance\", level!=\"info\"}[$__rate_interval])) by (instance, level, location) > 0",
           "interval": "5m",
-          "legendFormat": "{{level}}: {{location}}",
+          "legendFormat": "{{instance}} - {{level}}: {{location}}",
           "range": true,
           "refId": "A"
         }
@@ -1724,11 +1726,13 @@
                 "type": "victoriametrics-datasource",
                 "uid": "$ds"
               },
-              "expr": "sum(go_memstats_sys_bytes{job=~\"$job\", instance=~\"$instance\"}) + sum(vm_cache_size_bytes{job=~\"$job\", instance=~\"$instance\"})",
+              "editorMode": "code",
+              "expr": "sum(go_memstats_sys_bytes{job=~\"$job\", instance=~\"$instance\"}) by (instance) + sum(vm_cache_size_bytes{job=~\"$job\", instance=~\"$instance\"}) by (instance)",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
-              "legendFormat": "requested from system",
+              "legendFormat": "{{instance}} - requested from system",
+              "range": true,
               "refId": "A"
             },
             {
@@ -1736,11 +1740,13 @@
                 "type": "victoriametrics-datasource",
                 "uid": "$ds"
               },
-              "expr": "sum(go_memstats_heap_inuse_bytes{job=~\"$job\", instance=~\"$instance\"}) + sum(vm_cache_size_bytes{job=~\"$job\", instance=~\"$instance\"})",
+              "editorMode": "code",
+              "expr": "sum(go_memstats_heap_inuse_bytes{job=~\"$job\", instance=~\"$instance\"}) by (instance) + sum(vm_cache_size_bytes{job=~\"$job\", instance=~\"$instance\"}) by (instance)",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
-              "legendFormat": "heap inuse",
+              "legendFormat": "{{instance}} - heap inuse",
+              "range": true,
               "refId": "B"
             },
             {
@@ -1748,11 +1754,13 @@
                 "type": "victoriametrics-datasource",
                 "uid": "$ds"
               },
-              "expr": "sum(go_memstats_stack_inuse_bytes{job=~\"$job\", instance=~\"$instance\"})",
+              "editorMode": "code",
+              "expr": "sum(go_memstats_stack_inuse_bytes{job=~\"$job\", instance=~\"$instance\"}) by (instance)",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
-              "legendFormat": "stack inuse",
+              "legendFormat": "{{instance}} - stack inuse",
+              "range": true,
               "refId": "C"
             },
             {
@@ -1760,12 +1768,14 @@
                 "type": "victoriametrics-datasource",
                 "uid": "$ds"
               },
-              "expr": "sum(process_resident_memory_bytes{job=~\"$job\", instance=~\"$instance\"})",
+              "editorMode": "code",
+              "expr": "sum(process_resident_memory_bytes{job=~\"$job\", instance=~\"$instance\"}) by (instance)",
               "format": "time_series",
               "hide": false,
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "resident",
+              "legendFormat": "{{instance}} - resident",
+              "range": true,
               "refId": "D"
             },
             {
@@ -1773,13 +1783,15 @@
                 "type": "victoriametrics-datasource",
                 "uid": "$ds"
               },
+              "editorMode": "code",
               "exemplar": false,
-              "expr": "sum(process_resident_memory_anon_bytes{job=~\"$job\", instance=~\"$instance\"})",
+              "expr": "sum(process_resident_memory_anon_bytes{job=~\"$job\", instance=~\"$instance\"}) by (instance)",
               "format": "time_series",
               "hide": false,
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "resident anonymous",
+              "legendFormat": "{{instance}} - resident anonymous",
+              "range": true,
               "refId": "E"
             }
           ],
@@ -2489,12 +2501,14 @@
                 "type": "victoriametrics-datasource",
                 "uid": "$ds"
               },
-              "expr": "sum(rate(process_io_storage_read_bytes_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
+              "editorMode": "code",
+              "expr": "sum(rate(process_io_storage_read_bytes_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (instance)",
               "format": "time_series",
               "hide": false,
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "read",
+              "legendFormat": "{{instance}} - read",
+              "range": true,
               "refId": "A"
             },
             {
@@ -2502,12 +2516,14 @@
                 "type": "victoriametrics-datasource",
                 "uid": "$ds"
               },
-              "expr": "sum(rate(process_io_storage_written_bytes_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
+              "editorMode": "code",
+              "expr": "sum(rate(process_io_storage_written_bytes_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (instance)",
               "format": "time_series",
               "hide": false,
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "write",
+              "legendFormat": "{{instance}} - write",
+              "range": true,
               "refId": "B"
             }
           ],
@@ -2733,12 +2749,12 @@
                 "uid": "$ds"
               },
               "editorMode": "code",
-              "expr": "sum(rate(process_io_read_syscalls_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
+              "expr": "sum(rate(process_io_read_syscalls_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (instance)",
               "format": "time_series",
               "hide": false,
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "read calls",
+              "legendFormat": "{{instance}} - read calls",
               "range": true,
               "refId": "A"
             },
@@ -2748,12 +2764,12 @@
                 "uid": "$ds"
               },
               "editorMode": "code",
-              "expr": "sum(rate(process_io_write_syscalls_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
+              "expr": "sum(rate(process_io_write_syscalls_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (instance)",
               "format": "time_series",
               "hide": false,
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "write calls",
+              "legendFormat": "{{instance}} - write calls",
               "range": true,
               "refId": "B"
             }
@@ -3209,9 +3225,11 @@
                 "type": "victoriametrics-datasource",
                 "uid": "$ds"
               },
-              "expr": "sum(rate(vm_new_timeseries_created_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
+              "editorMode": "code",
+              "expr": "sum(rate(vm_new_timeseries_created_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (instance)",
               "interval": "",
-              "legendFormat": "churn rate",
+              "legendFormat": "{{instance}} - churn rate",
+              "range": true,
               "refId": "A"
             },
             {
@@ -3219,9 +3237,11 @@
                 "type": "victoriametrics-datasource",
                 "uid": "$ds"
               },
-              "expr": "sum(increase(vm_new_timeseries_created_total{job=~\"$job\", instance=~\"$instance\"}[24h]))",
+              "editorMode": "code",
+              "expr": "sum(increase(vm_new_timeseries_created_total{job=~\"$job\", instance=~\"$instance\"}[24h])) by (instance)",
               "interval": "",
-              "legendFormat": "new series over 24h",
+              "legendFormat": "{{instance}} - new series over 24h",
+              "range": true,
               "refId": "B"
             }
           ],
@@ -3323,12 +3343,12 @@
                 "uid": "$ds"
               },
               "editorMode": "code",
-              "expr": "max(\n    rate(vm_slow_row_inserts_total{job=~\"$job\"}[$__rate_interval]) \n    / rate(vm_rows_added_to_storage_total{job=~\"$job\"}[$__rate_interval])\n)",
+              "expr": "max(\n    rate(vm_slow_row_inserts_total{job=~\"$job\"}[$__rate_interval]) \n    / rate(vm_rows_added_to_storage_total{job=~\"$job\"}[$__rate_interval])\n) by (instance)",
               "format": "time_series",
               "hide": false,
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "slow inserts percentage",
+              "legendFormat": "{{instance}} - slow inserts percentage",
               "range": true,
               "refId": "A"
             }
@@ -3429,11 +3449,11 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "sum(increase(vm_assisted_merges_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by(type) > 0",
+              "expr": "sum(increase(vm_assisted_merges_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by(instance, type) > 0",
               "format": "time_series",
               "interval": "5m",
               "intervalFactor": 1,
-              "legendFormat": "__auto",
+              "legendFormat": "{{instance}} - {{type}}",
               "range": true,
               "refId": "A"
             }
@@ -3534,11 +3554,13 @@
                 "type": "victoriametrics-datasource",
                 "uid": "$ds"
               },
-              "expr": "sum(rate(vm_slow_queries_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
+              "editorMode": "code",
+              "expr": "sum(rate(vm_slow_queries_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (instance)",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
-              "legendFormat": "slow queries rate",
+              "legendFormat": "{{instance}} - slow queries rate",
+              "range": true,
               "refId": "A"
             }
           ],
@@ -3639,7 +3661,7 @@
               "exemplar": false,
               "expr": "vm_cache_size_bytes{job=~\"$job\", instance=~\"$instance\"} / vm_cache_size_max_bytes{job=~\"$job\", instance=~\"$instance\"}",
               "interval": "",
-              "legendFormat": "{{type}}",
+              "legendFormat": "{{instance}} - {{type}}",
               "range": true,
               "refId": "A"
             }
@@ -3748,7 +3770,7 @@
               "hide": false,
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "{{type}}",
+              "legendFormat": "{{instance}} - {{type}}",
               "range": true,
               "refId": "A"
             }
@@ -3973,12 +3995,13 @@
                 "uid": "$ds"
               },
               "exemplar": false,
-              "expr": "sum(increase(vm_metrics_with_dropped_labels_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
+              "expr": "sum(increase(vm_metrics_with_dropped_labels_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (instance)",
               "format": "time_series",
               "hide": false,
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "limit exceeded",
+              "legendFormat": "{{instance}} - limit exceeded",
+              "range": true,
               "refId": "A"
             }
           ],
@@ -4106,11 +4129,11 @@
                 "uid": "$ds"
               },
               "editorMode": "code",
-              "expr": "sum(rate(vm_rows_inserted_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (type) > 0",
+              "expr": "sum(rate(vm_rows_inserted_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (instance, type) > 0",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
-              "legendFormat": "{{type}}",
+              "legendFormat": "{{instance}} - {{type}}",
               "range": true,
               "refId": "A"
             }
@@ -4319,11 +4342,11 @@
                 "uid": "$ds"
               },
               "editorMode": "code",
-              "expr": "sum(vm_data_size_bytes{job=~\"$job\", instance=~\"$instance\", type!~\"indexdb.*\"})",
+              "expr": "sum(vm_data_size_bytes{job=~\"$job\", instance=~\"$instance\", type!~\"indexdb.*\"}) by (instance)",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "Used (datapoints)",
+              "legendFormat": "{{instance}} - Used (datapoints)",
               "range": true,
               "refId": "A"
             },
@@ -4336,7 +4359,8 @@
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "Free",
+              "legendFormat": "{{instance}} - Free",
+              "range": true,
               "refId": "B"
             },
             {
@@ -4345,12 +4369,12 @@
                 "uid": "$ds"
               },
               "editorMode": "code",
-              "expr": "sum(vm_data_size_bytes{job=~\"$job\", instance=~\"$instance\", type=~\"indexdb.*\"})",
+              "expr": "sum(vm_data_size_bytes{job=~\"$job\", instance=~\"$instance\", type=~\"indexdb.*\"}) by (instance)",
               "format": "time_series",
               "hide": false,
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "Used (index)",
+              "legendFormat": "{{instance}} - Used (index)",
               "range": true,
               "refId": "C"
             }
@@ -4472,7 +4496,8 @@
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
-              "legendFormat": "pending datapoints",
+              "legendFormat": "{{instance}} - pending datapoints",
+              "range": true,
               "refId": "A"
             },
             {
@@ -4484,7 +4509,8 @@
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
-              "legendFormat": "pending index entries",
+              "legendFormat": "{{instance}} - pending index entries",
+              "range": true,
               "refId": "B"
             }
           ],
@@ -4601,11 +4627,13 @@
                 "type": "victoriametrics-datasource",
                 "uid": "$ds"
               },
-              "expr": "sum(vm_rows{job=~\"$job\", instance=~\"$instance\", type!~\"indexdb.*\"})",
+              "editorMode": "code",
+              "expr": "sum(vm_rows{job=~\"$job\", instance=~\"$instance\", type!~\"indexdb.*\"}) by (instance)",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "total datapoints",
+              "legendFormat": "{{instance}} - total datapoints",
+              "range": true,
               "refId": "A"
             },
             {
@@ -4614,11 +4642,11 @@
                 "uid": "$ds"
               },
               "editorMode": "code",
-              "expr": "sum(vm_data_size_bytes{job=~\"$job\", instance=~\"$instance\"}) \n/ sum(vm_rows{job=~\"$job\", instance=~\"$instance\", type!~\"indexdb.*\"})",
+              "expr": "sum(vm_data_size_bytes{job=~\"$job\", instance=~\"$instance\"}) by (instance)\n/ sum(vm_rows{job=~\"$job\", instance=~\"$instance\", type!~\"indexdb.*\"}) by (instance)",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "bytes-per-datapoint",
+              "legendFormat": "{{instance}} - bytes-per-datapoint",
               "range": true,
               "refId": "B"
             }
@@ -4718,10 +4746,12 @@
                 "type": "victoriametrics-datasource",
                 "uid": "$ds"
               },
-              "expr": "sum(vm_parts{job=~\"$job\", instance=~\"$instance\"}) by (type)",
+              "editorMode": "code",
+              "expr": "sum(vm_parts{job=~\"$job\", instance=~\"$instance\"}) by (instance, type)",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "{{type}}",
+              "legendFormat": "{{instance}} - {{type}}",
+              "range": true,
               "refId": "A"
             }
           ],
@@ -4821,12 +4851,12 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "sum(increase(vm_rows_ignored_total{job=~\"$job\", instance=~\"$instance\"}[1h])) by (reason)",
+              "expr": "sum(increase(vm_rows_ignored_total{job=~\"$job\", instance=~\"$instance\"}[1h])) by (instance, reason)",
               "format": "time_series",
               "hide": false,
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "{{reason}}",
+              "legendFormat": "{{instance}} - {{reason}}",
               "range": true,
               "refId": "A"
             }
@@ -4925,8 +4955,10 @@
                 "type": "victoriametrics-datasource",
                 "uid": "$ds"
               },
-              "expr": "sum(vm_active_merges{job=~\"$job\", instance=~\"$instance\"}) by(type)",
-              "legendFormat": "{{type}}",
+              "editorMode": "code",
+              "expr": "sum(vm_active_merges{job=~\"$job\", instance=~\"$instance\"}) by(instance, type)",
+              "legendFormat": "{{instance}} - {{type}}",
+              "range": true,
               "refId": "A"
             }
           ],
@@ -5045,7 +5077,7 @@
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "max",
+              "legendFormat": "{{instance}} - max",
               "range": true,
               "refId": "A"
             },
@@ -5054,10 +5086,12 @@
                 "type": "victoriametrics-datasource",
                 "uid": "$ds"
               },
-              "expr": "sum(vm_concurrent_insert_current{job=~\"$job\", instance=~\"$instance\"})",
+              "editorMode": "code",
+              "expr": "sum(vm_concurrent_insert_current{job=~\"$job\", instance=~\"$instance\"}) by (instance)",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "current",
+              "legendFormat": "{{instance}} - current",
+              "range": true,
               "refId": "B"
             }
           ],
@@ -5157,8 +5191,10 @@
                 "type": "victoriametrics-datasource",
                 "uid": "$ds"
               },
-              "expr": "sum(rate(vm_rows_merged_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by(type)",
-              "legendFormat": "{{type}}",
+              "editorMode": "code",
+              "expr": "sum(rate(vm_rows_merged_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by(instance, type)",
+              "legendFormat": "{{instance}} - {{type}}",
+              "range": true,
               "refId": "A"
             }
           ],
@@ -5684,6 +5720,7 @@
         "useTags": false
       },
       {
+        "allValue": ".*",
         "current": {},
         "datasource": {
           "type": "victoriametrics-datasource",
@@ -5691,8 +5728,8 @@
         },
         "definition": "label_values(vm_app_version{job=~\"$job\"}, instance)",
         "hide": 0,
-        "includeAll": false,
-        "multi": false,
+        "includeAll": true,
+        "multi": true,
         "name": "instance",
         "options": [],
         "query": {

--- a/dashboards/vm/victoriametrics.json
+++ b/dashboards/vm/victoriametrics.json
@@ -241,6 +241,7 @@
             "type": "victoriametrics-datasource",
             "uid": "$ds"
           },
+          "editorMode": "code",
           "exemplar": false,
           "expr": "sum(vm_rows{job=~\"$job\", instance=~\"$instance\", type!~\"indexdb.*\"})",
           "format": "time_series",
@@ -538,7 +539,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "vm_app_uptime_seconds{job=~\"$job\", instance=~\"$instance\"}",
+          "expr": "min(vm_app_uptime_seconds{job=~\"$job\", instance=~\"$instance\"})",
           "instant": true,
           "interval": "",
           "legendFormat": "",
@@ -607,8 +608,9 @@
             "type": "victoriametrics-datasource",
             "uid": "$ds"
           },
+          "editorMode": "code",
           "exemplar": false,
-          "expr": "vm_cache_entries{job=~\"$job\", instance=~\"$instance\", type=\"storage/hour_metric_ids\"}",
+          "expr": "sum(vm_cache_entries{job=~\"$job\", instance=~\"$instance\", type=\"storage/hour_metric_ids\"})",
           "format": "time_series",
           "instant": true,
           "interval": "",
@@ -754,7 +756,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum(vm_data_size_bytes{job=~\"$job\", instance=~\"$instance\"}) / sum(vm_rows{job=~\"$job\", instance=~\"$instance\"})",
+          "expr": "max(sum(vm_data_size_bytes{job=~\"$job\", instance=~\"$instance\"}) / sum(vm_rows{job=~\"$job\", instance=~\"$instance\"}))",
           "format": "time_series",
           "instant": true,
           "interval": "",
@@ -968,7 +970,7 @@
           "refId": "A"
         }
       ],
-      "title": "Datapoints ingestion rate ($instance)",
+      "title": "Datapoints ingestion rate",
       "type": "timeseries"
     },
     {
@@ -1078,7 +1080,7 @@
           "refId": "A"
         }
       ],
-      "title": "Requests rate ($instance)",
+      "title": "Requests rate",
       "type": "timeseries"
     },
     {
@@ -1186,12 +1188,12 @@
           "expr": "vm_cache_entries{job=~\"$job\", instance=~\"$instance\", type=\"storage/hour_metric_ids\"}",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "{{instance}} - Active time series",
+          "legendFormat": "{{instance}}",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Active time series ($instance)",
+      "title": "Active time series",
       "type": "timeseries"
     },
     {
@@ -1300,7 +1302,7 @@
           "refId": "A"
         }
       ],
-      "title": "Query duration 0.99 quantile ($instance)",
+      "title": "Query duration 0.99 quantile",
       "type": "timeseries"
     },
     {
@@ -1315,6 +1317,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
@@ -1328,6 +1331,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -1351,7 +1355,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -1359,7 +1364,8 @@
               }
             ]
           },
-          "unit": "short"
+          "unit": "short",
+          "unitScale": true
         },
         "overrides": []
       },
@@ -1404,7 +1410,7 @@
           "refId": "A"
         }
       ],
-      "title": "Requests error rate ($instance)",
+      "title": "Requests error rate",
       "type": "timeseries"
     },
     {
@@ -1419,6 +1425,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
@@ -1432,6 +1439,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -1453,14 +1461,16 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
                 "value": 80
               }
             ]
-          }
+          },
+          "unitScale": true
         },
         "overrides": []
       },
@@ -1588,7 +1598,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 3
+            "y": 15
           },
           "id": 112,
           "links": [],
@@ -1626,7 +1636,7 @@
               "refId": "A"
             }
           ],
-          "title": "RSS memory % usage ($instance)",
+          "title": "RSS memory % usage",
           "type": "timeseries"
         },
         {
@@ -1697,7 +1707,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 3
+            "y": 15
           },
           "id": 44,
           "links": [],
@@ -1795,7 +1805,7 @@
               "refId": "E"
             }
           ],
-          "title": "Memory usage ($instance)",
+          "title": "Memory usage",
           "type": "timeseries"
         },
         {
@@ -1866,7 +1876,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 11
+            "y": 23
           },
           "id": 123,
           "links": [],
@@ -1904,7 +1914,7 @@
               "refId": "A"
             }
           ],
-          "title": "RSS anonymous memory % usage ($instance)",
+          "title": "RSS anonymous memory % usage",
           "type": "timeseries"
         },
         {
@@ -1974,7 +1984,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 11
+            "y": 23
           },
           "id": 114,
           "links": [],
@@ -2014,7 +2024,7 @@
               "refId": "A"
             }
           ],
-          "title": "CPU % usage ($instance)",
+          "title": "CPU % usage",
           "type": "timeseries"
         },
         {
@@ -2102,7 +2112,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 19
+            "y": 31
           },
           "id": 75,
           "links": [],
@@ -2142,7 +2152,7 @@
               "refId": "A"
             }
           ],
-          "title": "Open FDs ($instance)",
+          "title": "Open FDs",
           "type": "timeseries"
         },
         {
@@ -2150,7 +2160,7 @@
             "type": "victoriametrics-datasource",
             "uid": "$ds"
           },
-          "description": "",
+          "description": "CPU cores used by instance",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -2229,7 +2239,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 19
+            "y": 31
           },
           "id": 57,
           "links": [],
@@ -2258,11 +2268,13 @@
                 "type": "victoriametrics-datasource",
                 "uid": "$ds"
               },
+              "editorMode": "code",
               "expr": "rate(process_cpu_seconds_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "CPU cores used",
+              "legendFormat": "{{instance}}",
+              "range": true,
               "refId": "A"
             },
             {
@@ -2270,17 +2282,19 @@
                 "type": "victoriametrics-datasource",
                 "uid": "$ds"
               },
+              "editorMode": "code",
               "exemplar": false,
-              "expr": "process_cpu_cores_available{job=~\"$job\", instance=~\"$instance\"}",
+              "expr": "min(process_cpu_cores_available{job=~\"$job\", instance=~\"$instance\"})",
               "format": "time_series",
               "hide": false,
               "interval": "",
               "intervalFactor": 1,
               "legendFormat": "Limit",
+              "range": true,
               "refId": "B"
             }
           ],
-          "title": "CPU ($instance)",
+          "title": "CPU",
           "type": "timeseries"
         },
         {
@@ -2351,7 +2365,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 27
+            "y": 39
           },
           "id": 47,
           "links": [],
@@ -2389,7 +2403,7 @@
               "refId": "A"
             }
           ],
-          "title": "Goroutines ($instance)",
+          "title": "Goroutines",
           "type": "timeseries"
         },
         {
@@ -2456,8 +2470,8 @@
             "overrides": [
               {
                 "matcher": {
-                  "id": "byName",
-                  "options": "read"
+                  "id": "byRegexp",
+                  "options": "/.*read/"
                 },
                 "properties": [
                   {
@@ -2472,7 +2486,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 27
+            "y": 39
           },
           "id": 76,
           "links": [],
@@ -2527,7 +2541,7 @@
               "refId": "B"
             }
           ],
-          "title": "Disk writes/reads ($instance)",
+          "title": "Disk writes/reads",
           "type": "timeseries"
         },
         {
@@ -2598,7 +2612,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 35
+            "y": 47
           },
           "id": 48,
           "links": [],
@@ -2636,7 +2650,7 @@
               "refId": "A"
             }
           ],
-          "title": "Threads ($instance)",
+          "title": "Threads",
           "type": "timeseries"
         },
         {
@@ -2703,8 +2717,8 @@
             "overrides": [
               {
                 "matcher": {
-                  "id": "byName",
-                  "options": "read calls"
+                  "id": "byRegexp",
+                  "options": "/.*read.*/"
                 },
                 "properties": [
                   {
@@ -2719,7 +2733,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 35
+            "y": 47
           },
           "id": 124,
           "links": [],
@@ -2774,7 +2788,7 @@
               "refId": "B"
             }
           ],
-          "title": "Disk write/read calls ($instance)",
+          "title": "Disk write/read calls",
           "type": "timeseries"
         },
         {
@@ -2845,7 +2859,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 43
+            "y": 55
           },
           "id": 49,
           "links": [],
@@ -2884,7 +2898,7 @@
               "refId": "A"
             }
           ],
-          "title": "TCP connections rate ($instance)",
+          "title": "TCP connections rate",
           "type": "timeseries"
         },
         {
@@ -2955,7 +2969,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 43
+            "y": 55
           },
           "id": 37,
           "links": [],
@@ -2994,7 +3008,7 @@
               "refId": "A"
             }
           ],
-          "title": "TCP connections ($instance)",
+          "title": "TCP connections",
           "type": "timeseries"
         },
         {
@@ -3066,7 +3080,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 51
+            "y": 63
           },
           "id": 125,
           "links": [],
@@ -3103,7 +3117,7 @@
               "refId": "A"
             }
           ],
-          "title": "CPU spent on GC ($instance)",
+          "title": "CPU spent on GC",
           "type": "timeseries"
         }
       ],
@@ -3145,6 +3159,7 @@
                 "mode": "palette-classic"
               },
               "custom": {
+                "axisBorderShow": false,
                 "axisCenteredZero": false,
                 "axisColorMode": "text",
                 "axisLabel": "",
@@ -3158,6 +3173,7 @@
                   "tooltip": false,
                   "viz": false
                 },
+                "insertNulls": false,
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
                 "pointSize": 5,
@@ -3181,7 +3197,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -3189,7 +3206,8 @@
                   }
                 ]
               },
-              "unit": "short"
+              "unit": "short",
+              "unitScale": true
             },
             "overrides": []
           },
@@ -3197,7 +3215,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 16
+            "y": 4
           },
           "id": 66,
           "options": {
@@ -3245,7 +3263,7 @@
               "refId": "B"
             }
           ],
-          "title": "Churn rate ($instance)",
+          "title": "Churn rate",
           "type": "timeseries"
         },
         {
@@ -3260,6 +3278,7 @@
                 "mode": "palette-classic"
               },
               "custom": {
+                "axisBorderShow": false,
                 "axisCenteredZero": false,
                 "axisColorMode": "text",
                 "axisLabel": "",
@@ -3273,6 +3292,7 @@
                   "tooltip": false,
                   "viz": false
                 },
+                "insertNulls": false,
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
                 "pointSize": 5,
@@ -3297,7 +3317,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "transparent"
+                    "color": "transparent",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -3305,7 +3326,8 @@
                   }
                 ]
               },
-              "unit": "percentunit"
+              "unit": "percentunit",
+              "unitScale": true
             },
             "overrides": []
           },
@@ -3313,7 +3335,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 16
+            "y": 4
           },
           "id": 68,
           "links": [],
@@ -3348,12 +3370,12 @@
               "hide": false,
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "{{instance}} - slow inserts percentage",
+              "legendFormat": "{{instance}}",
               "range": true,
               "refId": "A"
             }
           ],
-          "title": "Slow inserts ($instance)",
+          "title": "Slow inserts %",
           "type": "timeseries"
         },
         {
@@ -3368,6 +3390,7 @@
                 "mode": "palette-classic"
               },
               "custom": {
+                "axisBorderShow": false,
                 "axisCenteredZero": false,
                 "axisColorMode": "text",
                 "axisLabel": "",
@@ -3381,6 +3404,7 @@
                   "tooltip": false,
                   "viz": false
                 },
+                "insertNulls": false,
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
                 "pointSize": 5,
@@ -3404,7 +3428,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -3412,7 +3437,8 @@
                   }
                 ]
               },
-              "unit": "short"
+              "unit": "short",
+              "unitScale": true
             },
             "overrides": []
           },
@@ -3420,7 +3446,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 24
+            "y": 12
           },
           "id": 116,
           "links": [],
@@ -3458,7 +3484,7 @@
               "refId": "A"
             }
           ],
-          "title": "Assisted merges ($instance)",
+          "title": "Assisted merges",
           "type": "timeseries"
         },
         {
@@ -3473,6 +3499,7 @@
                 "mode": "palette-classic"
               },
               "custom": {
+                "axisBorderShow": false,
                 "axisCenteredZero": false,
                 "axisColorMode": "text",
                 "axisLabel": "",
@@ -3486,6 +3513,7 @@
                   "tooltip": false,
                   "viz": false
                 },
+                "insertNulls": false,
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
                 "pointSize": 5,
@@ -3509,7 +3537,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -3517,7 +3546,8 @@
                   }
                 ]
               },
-              "unit": "short"
+              "unit": "short",
+              "unitScale": true
             },
             "overrides": []
           },
@@ -3525,7 +3555,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 24
+            "y": 12
           },
           "id": 60,
           "links": [],
@@ -3559,12 +3589,12 @@
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
-              "legendFormat": "{{instance}} - slow queries rate",
+              "legendFormat": "{{instance}}",
               "range": true,
               "refId": "A"
             }
           ],
-          "title": "Slow queries rate ($instance)",
+          "title": "Slow queries rate",
           "type": "timeseries"
         },
         {
@@ -3579,6 +3609,7 @@
                 "mode": "palette-classic"
               },
               "custom": {
+                "axisBorderShow": false,
                 "axisCenteredZero": false,
                 "axisColorMode": "text",
                 "axisLabel": "",
@@ -3592,6 +3623,7 @@
                   "tooltip": false,
                   "viz": false
                 },
+                "insertNulls": false,
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
                 "pointSize": 5,
@@ -3613,7 +3645,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -3621,7 +3654,8 @@
                   }
                 ]
               },
-              "unit": "percentunit"
+              "unit": "percentunit",
+              "unitScale": true
             },
             "overrides": []
           },
@@ -3629,7 +3663,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 32
+            "y": 20
           },
           "id": 90,
           "options": {
@@ -3666,7 +3700,7 @@
               "refId": "A"
             }
           ],
-          "title": "Cache usage % by type ($instance)",
+          "title": "Cache usage % by type",
           "type": "timeseries"
         },
         {
@@ -3681,6 +3715,7 @@
                 "mode": "palette-classic"
               },
               "custom": {
+                "axisBorderShow": false,
                 "axisCenteredZero": false,
                 "axisColorMode": "text",
                 "axisLabel": "",
@@ -3694,6 +3729,7 @@
                   "tooltip": false,
                   "viz": false
                 },
+                "insertNulls": false,
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
                 "pointSize": 5,
@@ -3718,7 +3754,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -3726,7 +3763,8 @@
                   }
                 ]
               },
-              "unit": "percentunit"
+              "unit": "percentunit",
+              "unitScale": true
             },
             "overrides": []
           },
@@ -3734,7 +3772,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 32
+            "y": 20
           },
           "id": 118,
           "links": [],
@@ -3775,7 +3813,7 @@
               "refId": "A"
             }
           ],
-          "title": "Cache miss ratio ($instance)",
+          "title": "Cache miss ratio",
           "type": "timeseries"
         },
         {
@@ -3783,6 +3821,7 @@
             "type": "victoriametrics-datasource",
             "uid": "$ds"
           },
+          "description": "Flags explicitly set to non-default values",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -3800,16 +3839,30 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
                     "value": 80
                   }
                 ]
-              }
+              },
+              "unitScale": true
             },
             "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Time"
+                },
+                "properties": [
+                  {
+                    "id": "custom.hidden",
+                    "value": true
+                  }
+                ]
+              },
               {
                 "matcher": {
                   "id": "byName",
@@ -3825,7 +3878,7 @@
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "Time"
+                  "options": "job"
                 },
                 "properties": [
                   {
@@ -3840,26 +3893,22 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 41
+            "y": 29
           },
-          "id": 120,
+          "id": 126,
           "options": {
+            "cellHeight": "sm",
             "footer": {
+              "countRows": false,
               "fields": "",
               "reducer": [
                 "sum"
               ],
               "show": false
             },
-            "showHeader": true,
-            "sortBy": [
-              {
-                "desc": true,
-                "displayName": "job"
-              }
-            ]
+            "showHeader": true
           },
-          "pluginVersion": "9.1.0",
+          "pluginVersion": "10.3.1",
           "targets": [
             {
               "datasource": {
@@ -3877,29 +3926,6 @@
             }
           ],
           "title": "Non-default flags",
-          "transformations": [
-            {
-              "id": "groupBy",
-              "options": {
-                "fields": {
-                  "instance": {
-                    "aggregations": []
-                  },
-                  "job": {
-                    "aggregations": []
-                  },
-                  "name": {
-                    "aggregations": [],
-                    "operation": "groupby"
-                  },
-                  "value": {
-                    "aggregations": [],
-                    "operation": "groupby"
-                  }
-                }
-              }
-            }
-          ],
           "type": "table"
         },
         {
@@ -3914,6 +3940,7 @@
                 "mode": "palette-classic"
               },
               "custom": {
+                "axisBorderShow": false,
                 "axisCenteredZero": false,
                 "axisColorMode": "text",
                 "axisLabel": "",
@@ -3927,6 +3954,7 @@
                   "tooltip": false,
                   "viz": false
                 },
+                "insertNulls": false,
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
                 "pointSize": 5,
@@ -3951,7 +3979,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -3959,7 +3988,8 @@
                   }
                 ]
               },
-              "unit": "short"
+              "unit": "short",
+              "unitScale": true
             },
             "overrides": []
           },
@@ -3967,7 +3997,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 41
+            "y": 29
           },
           "id": 74,
           "links": [],
@@ -4005,7 +4035,7 @@
               "refId": "A"
             }
           ],
-          "title": "Labels limit exceeded ($instance)",
+          "title": "Labels limit exceeded",
           "type": "timeseries"
         }
       ],
@@ -4047,6 +4077,7 @@
                 "mode": "palette-classic"
               },
               "custom": {
+                "axisBorderShow": false,
                 "axisCenteredZero": false,
                 "axisColorMode": "text",
                 "axisLabel": "",
@@ -4060,6 +4091,7 @@
                   "tooltip": false,
                   "viz": false
                 },
+                "insertNulls": false,
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
                 "pointSize": 5,
@@ -4083,7 +4115,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -4091,7 +4124,8 @@
                   }
                 ]
               },
-              "unit": "short"
+              "unit": "short",
+              "unitScale": true
             },
             "overrides": []
           },
@@ -4099,7 +4133,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 41
+            "y": 5
           },
           "id": 10,
           "links": [],
@@ -4138,7 +4172,7 @@
               "refId": "A"
             }
           ],
-          "title": "Datapoints ingestion rate ($instance)",
+          "title": "Datapoints ingestion rate",
           "type": "timeseries"
         },
         {
@@ -4153,6 +4187,7 @@
                 "mode": "palette-classic"
               },
               "custom": {
+                "axisBorderShow": false,
                 "axisCenteredZero": false,
                 "axisColorMode": "text",
                 "axisLabel": "",
@@ -4166,6 +4201,7 @@
                   "tooltip": false,
                   "viz": false
                 },
+                "insertNulls": false,
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
                 "pointSize": 5,
@@ -4189,7 +4225,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -4197,7 +4234,8 @@
                   }
                 ]
               },
-              "unit": "s"
+              "unit": "s",
+              "unitScale": true
             },
             "overrides": []
           },
@@ -4205,7 +4243,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 41
+            "y": 5
           },
           "id": 73,
           "links": [],
@@ -4245,7 +4283,7 @@
               "refId": "A"
             }
           ],
-          "title": "Storage full ETA ($instance)",
+          "title": "Storage full ETA",
           "type": "timeseries"
         },
         {
@@ -4260,6 +4298,7 @@
                 "mode": "palette-classic"
               },
               "custom": {
+                "axisBorderShow": false,
                 "axisCenteredZero": false,
                 "axisColorMode": "text",
                 "axisLabel": "",
@@ -4273,6 +4312,7 @@
                   "tooltip": false,
                   "viz": false
                 },
+                "insertNulls": false,
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
                 "pointSize": 5,
@@ -4296,7 +4336,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -4304,7 +4345,8 @@
                   }
                 ]
               },
-              "unit": "bytes"
+              "unit": "bytes",
+              "unitScale": true
             },
             "overrides": []
           },
@@ -4312,7 +4354,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 49
+            "y": 13
           },
           "id": 53,
           "links": [],
@@ -4379,7 +4421,7 @@
               "refId": "C"
             }
           ],
-          "title": "Disk space usage - datapoints ($instance)",
+          "title": "Disk space usage - datapoints",
           "type": "timeseries"
         },
         {
@@ -4394,6 +4436,7 @@
                 "mode": "palette-classic"
               },
               "custom": {
+                "axisBorderShow": false,
                 "axisCenteredZero": false,
                 "axisColorMode": "text",
                 "axisLabel": "",
@@ -4407,6 +4450,7 @@
                   "tooltip": false,
                   "viz": false
                 },
+                "insertNulls": false,
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
                 "pointSize": 5,
@@ -4430,7 +4474,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -4438,7 +4483,8 @@
                   }
                 ]
               },
-              "unit": "short"
+              "unit": "short",
+              "unitScale": true
             },
             "overrides": [
               {
@@ -4463,7 +4509,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 49
+            "y": 13
           },
           "id": 34,
           "links": [],
@@ -4514,7 +4560,7 @@
               "refId": "B"
             }
           ],
-          "title": "Pending datapoints ($instance)",
+          "title": "Pending datapoints",
           "type": "timeseries"
         },
         {
@@ -4529,6 +4575,7 @@
                 "mode": "palette-classic"
               },
               "custom": {
+                "axisBorderShow": false,
                 "axisCenteredZero": false,
                 "axisColorMode": "text",
                 "axisLabel": "",
@@ -4542,6 +4589,7 @@
                   "tooltip": false,
                   "viz": false
                 },
+                "insertNulls": false,
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
                 "pointSize": 5,
@@ -4565,7 +4613,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -4573,7 +4622,8 @@
                   }
                 ]
               },
-              "unit": "short"
+              "unit": "short",
+              "unitScale": true
             },
             "overrides": [
               {
@@ -4598,7 +4648,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 57
+            "y": 21
           },
           "id": 30,
           "links": [],
@@ -4651,7 +4701,7 @@
               "refId": "B"
             }
           ],
-          "title": "Datapoints ($instance)",
+          "title": "Datapoints",
           "type": "timeseries"
         },
         {
@@ -4665,6 +4715,7 @@
                 "mode": "palette-classic"
               },
               "custom": {
+                "axisBorderShow": false,
                 "axisCenteredZero": false,
                 "axisColorMode": "text",
                 "axisLabel": "",
@@ -4678,6 +4729,7 @@
                   "tooltip": false,
                   "viz": false
                 },
+                "insertNulls": false,
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
                 "pointSize": 5,
@@ -4701,7 +4753,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -4709,7 +4762,8 @@
                   }
                 ]
               },
-              "unit": "short"
+              "unit": "short",
+              "unitScale": true
             },
             "overrides": []
           },
@@ -4717,7 +4771,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 57
+            "y": 21
           },
           "id": 36,
           "links": [],
@@ -4755,7 +4809,7 @@
               "refId": "A"
             }
           ],
-          "title": "LSM parts ($instance)",
+          "title": "LSM parts",
           "type": "timeseries"
         },
         {
@@ -4770,6 +4824,7 @@
                 "mode": "palette-classic"
               },
               "custom": {
+                "axisBorderShow": false,
                 "axisCenteredZero": false,
                 "axisColorMode": "text",
                 "axisLabel": "",
@@ -4783,6 +4838,7 @@
                   "tooltip": false,
                   "viz": false
                 },
+                "insertNulls": false,
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
                 "pointSize": 5,
@@ -4806,7 +4862,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -4814,7 +4871,8 @@
                   }
                 ]
               },
-              "unit": "short"
+              "unit": "short",
+              "unitScale": true
             },
             "overrides": []
           },
@@ -4822,7 +4880,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 65
+            "y": 29
           },
           "id": 58,
           "links": [],
@@ -4861,7 +4919,7 @@
               "refId": "A"
             }
           ],
-          "title": "Rows ignored for last 1h ($instance)",
+          "title": "Rows ignored for last 1h",
           "type": "timeseries"
         },
         {
@@ -4876,6 +4934,7 @@
                 "mode": "palette-classic"
               },
               "custom": {
+                "axisBorderShow": false,
                 "axisCenteredZero": false,
                 "axisColorMode": "text",
                 "axisLabel": "",
@@ -4889,6 +4948,7 @@
                   "tooltip": false,
                   "viz": false
                 },
+                "insertNulls": false,
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
                 "pointSize": 5,
@@ -4913,7 +4973,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -4921,7 +4982,8 @@
                   }
                 ]
               },
-              "unit": "short"
+              "unit": "short",
+              "unitScale": true
             },
             "overrides": []
           },
@@ -4929,7 +4991,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 65
+            "y": 29
           },
           "id": 62,
           "options": {
@@ -4962,7 +5024,7 @@
               "refId": "A"
             }
           ],
-          "title": "Active merges ($instance)",
+          "title": "Active merges",
           "type": "timeseries"
         },
         {
@@ -4977,6 +5039,7 @@
                 "mode": "palette-classic"
               },
               "custom": {
+                "axisBorderShow": false,
                 "axisCenteredZero": false,
                 "axisColorMode": "text",
                 "axisLabel": "",
@@ -4990,6 +5053,7 @@
                   "tooltip": false,
                   "viz": false
                 },
+                "insertNulls": false,
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
                 "pointSize": 5,
@@ -5014,7 +5078,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -5022,7 +5087,8 @@
                   }
                 ]
               },
-              "unit": "short"
+              "unit": "short",
+              "unitScale": true
             },
             "overrides": [
               {
@@ -5046,7 +5112,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 73
+            "y": 37
           },
           "id": 59,
           "links": [],
@@ -5095,7 +5161,7 @@
               "refId": "B"
             }
           ],
-          "title": "Concurrent flushes on disk ($instance)",
+          "title": "Concurrent flushes on disk",
           "type": "timeseries"
         },
         {
@@ -5110,6 +5176,7 @@
                 "mode": "palette-classic"
               },
               "custom": {
+                "axisBorderShow": false,
                 "axisCenteredZero": false,
                 "axisColorMode": "text",
                 "axisLabel": "",
@@ -5123,6 +5190,7 @@
                   "tooltip": false,
                   "viz": false
                 },
+                "insertNulls": false,
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
                 "pointSize": 5,
@@ -5147,7 +5215,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -5155,7 +5224,8 @@
                   }
                 ]
               },
-              "unit": "short"
+              "unit": "short",
+              "unitScale": true
             },
             "overrides": []
           },
@@ -5163,7 +5233,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 73
+            "y": 37
           },
           "id": 64,
           "options": {
@@ -5198,7 +5268,7 @@
               "refId": "A"
             }
           ],
-          "title": "Merge speed ($instance)",
+          "title": "Merge speed",
           "type": "timeseries"
         },
         {
@@ -5213,6 +5283,7 @@
                 "mode": "palette-classic"
               },
               "custom": {
+                "axisBorderShow": false,
                 "axisCenteredZero": false,
                 "axisColorMode": "text",
                 "axisLabel": "",
@@ -5226,6 +5297,7 @@
                   "tooltip": false,
                   "viz": false
                 },
+                "insertNulls": false,
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
                 "pointSize": 5,
@@ -5250,7 +5322,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -5258,7 +5331,8 @@
                   }
                 ]
               },
-              "unit": "short"
+              "unit": "short",
+              "unitScale": true
             },
             "overrides": []
           },
@@ -5266,7 +5340,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 81
+            "y": 45
           },
           "id": 99,
           "links": [],
@@ -5305,7 +5379,7 @@
               "refId": "A"
             }
           ],
-          "title": "Series read per query ($instance)",
+          "title": "Series read per query",
           "type": "timeseries"
         },
         {
@@ -5320,6 +5394,7 @@
                 "mode": "palette-classic"
               },
               "custom": {
+                "axisBorderShow": false,
                 "axisCenteredZero": false,
                 "axisColorMode": "text",
                 "axisLabel": "",
@@ -5333,6 +5408,7 @@
                   "tooltip": false,
                   "viz": false
                 },
+                "insertNulls": false,
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
                 "pointSize": 5,
@@ -5357,7 +5433,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -5365,7 +5442,8 @@
                   }
                 ]
               },
-              "unit": "short"
+              "unit": "short",
+              "unitScale": true
             },
             "overrides": []
           },
@@ -5373,7 +5451,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 81
+            "y": 45
           },
           "id": 103,
           "links": [],
@@ -5412,7 +5490,7 @@
               "refId": "A"
             }
           ],
-          "title": "Datapoints read per series ($instance)",
+          "title": "Datapoints read per series",
           "type": "timeseries"
         },
         {
@@ -5427,6 +5505,7 @@
                 "mode": "palette-classic"
               },
               "custom": {
+                "axisBorderShow": false,
                 "axisCenteredZero": false,
                 "axisColorMode": "text",
                 "axisLabel": "",
@@ -5440,6 +5519,7 @@
                   "tooltip": false,
                   "viz": false
                 },
+                "insertNulls": false,
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
                 "pointSize": 5,
@@ -5464,7 +5544,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -5472,7 +5553,8 @@
                   }
                 ]
               },
-              "unit": "short"
+              "unit": "short",
+              "unitScale": true
             },
             "overrides": []
           },
@@ -5480,7 +5562,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 89
+            "y": 53
           },
           "id": 122,
           "links": [],
@@ -5519,7 +5601,7 @@
               "refId": "A"
             }
           ],
-          "title": "Datapoints read per query ($instance)",
+          "title": "Datapoints read per query",
           "type": "timeseries"
         },
         {
@@ -5534,6 +5616,7 @@
                 "mode": "palette-classic"
               },
               "custom": {
+                "axisBorderShow": false,
                 "axisCenteredZero": false,
                 "axisColorMode": "text",
                 "axisLabel": "",
@@ -5547,6 +5630,7 @@
                   "tooltip": false,
                   "viz": false
                 },
+                "insertNulls": false,
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
                 "pointSize": 5,
@@ -5571,7 +5655,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -5579,7 +5664,8 @@
                   }
                 ]
               },
-              "unit": "short"
+              "unit": "short",
+              "unitScale": true
             },
             "overrides": []
           },
@@ -5587,7 +5673,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 89
+            "y": 53
           },
           "id": 105,
           "links": [],
@@ -5626,7 +5712,7 @@
               "refId": "A"
             }
           ],
-          "title": "Datapoints scanned per query ($instance)",
+          "title": "Datapoints scanned per query",
           "type": "timeseries"
         }
       ],

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -30,6 +30,9 @@ See also [LTS releases](https://docs.victoriametrics.com/lts-releases/).
 
 ## tip
 
+* FEATURE: [dashboards/single](https://grafana.com/grafana/dashboards/10229): support selecting of multiple instances on the dashboard. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/5869) for details.
+
+
 ## [v1.101.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.101.0)
 
 Released at 2024-04-26


### PR DESCRIPTION
Allowing to select multiple instance IPs makes it much easier to view metrics for longer periods of time in dynamic environments such as Kubernetes. In k8s update will also cause IP to change making it harder to use dashboard to check the status.

See: https://github.com/VictoriaMetrics/VictoriaMetrics/issues/5869