### PR TITLE
lib/bytesutil: Optimize ToUnsafeBytes to make it leaner, more standards-compliant and slightly faster

### DIFF
--- a/lib/bytesutil/bytesutil.go
+++ b/lib/bytesutil/bytesutil.go
@@ -2,7 +2,6 @@ package bytesutil
 
 import (
 	"math/bits"
-	"reflect"
 	"unsafe"
 )
 
@@ -72,10 +71,5 @@ func ToUnsafeString(b []byte) string {
 //
 // The returned byte slice is valid only until s is reachable and unmodified.
 func ToUnsafeBytes(s string) (b []byte) {
-	sh := (*reflect.StringHeader)(unsafe.Pointer(&s))
-	slh := (*reflect.SliceHeader)(unsafe.Pointer(&b))
-	slh.Data = sh.Data
-	slh.Len = sh.Len
-	slh.Cap = sh.Len
-	return b
+	return unsafe.Slice(unsafe.StringData(s), len(s))
 }


### PR DESCRIPTION
Benchmark test results (To Unsafe Bytes2 here is after I optimized it)

```bash
go test -bench='ToUnsafeBytes' ./lib/bytesutil/ -benchtime=10s
goos: darwin
goarch: arm64
pkg: github.com/VictoriaMetrics/VictoriaMetrics/lib/bytesutil
BenchmarkToUnsafeBytes-8        1000000000               2.974 ns/op    8069.32 MB/s           0 B/op          0 allocs/op
BenchmarkToUnsafeBytes2-8       1000000000               2.721 ns/op    8819.26 MB/s           0 B/op          0 allocs/op
PASS
ok      github.com/VictoriaMetrics/VictoriaMetrics/lib/bytesutil        6.458s
```

In addition, I also tried to rewrite ToUnsafeString, from the benchmark test results (here ToUnsafeString2 is after I optimized it) will become a little bit slower, I do not know if this change is OK, because I did not submit it together with the pull request.

```go
func ToUnsafeString2(b []byte) string {
	return unsafe.String(unsafe.SliceData(b), len(b))
}
```

```bash
go test -bench='ToUnsafeString' ./lib/bytesutil/ -benchtime=10s
goos: darwin
goarch: arm64
pkg: github.com/VictoriaMetrics/VictoriaMetrics/lib/bytesutil
BenchmarkToUnsafeString-8       1000000000               1.408 ns/op    17041.92 MB/s          0 B/op          0 allocs/op
BenchmarkToUnsafeString2-8      1000000000               1.751 ns/op    13703.31 MB/s          0 B/op          0 allocs/op
PASS
ok      github.com/VictoriaMetrics/VictoriaMetrics/lib/bytesutil        4.564s
```
