### PR TITLE
lib/logstorage: avoid panic when parsing regex with stream filter

### DIFF
--- a/lib/logstorage/parser.go
+++ b/lib/logstorage/parser.go
@@ -12,6 +12,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/promutils"
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/regexutil"
 )
 
 type lexer struct {
@@ -1069,6 +1070,13 @@ func parseStreamTagFilter(lex *lexer) (*streamTagFilter, error) {
 		tagName: tagName,
 		op:      op,
 		value:   value,
+	}
+	if op == "=~" || op == "!~" {
+		re, err := regexutil.NewPromRegex(value)
+		if err != nil {
+			return nil, fmt.Errorf("invalid regexp %q for stream filter: %w", value, err)
+		}
+		stf.regexp = re
 	}
 	return stf, nil
 }

--- a/lib/logstorage/stream_filter.go
+++ b/lib/logstorage/stream_filter.go
@@ -3,11 +3,9 @@ package logstorage
 import (
 	"strconv"
 	"strings"
-	"sync"
 
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/bytesutil"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/encoding"
-	"github.com/VictoriaMetrics/VictoriaMetrics/lib/logger"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/regexutil"
 )
 
@@ -68,21 +66,11 @@ type streamTagFilter struct {
 	// value is the value
 	value string
 
-	regexpOnce sync.Once
-	regexp     *regexutil.PromRegex
+	regexp *regexutil.PromRegex
 }
 
 func (tf *streamTagFilter) getRegexp() *regexutil.PromRegex {
-	tf.regexpOnce.Do(tf.initRegexp)
 	return tf.regexp
-}
-
-func (tf *streamTagFilter) initRegexp() {
-	re, err := regexutil.NewPromRegex(tf.value)
-	if err != nil {
-		logger.Panicf("BUG: cannot parse regexp %q: %s", tf.value, err)
-	}
-	tf.regexp = re
 }
 
 func (tf *streamTagFilter) String() string {


### PR DESCRIPTION
We meet a panic when typing in an invalid regex with the stream filter. I think it can be avoided at the `ParseQuery`.

reproduce:

logsql: `_stream: {path=~"*debug.log"}`

```
panic: BUG: cannot parse regexp "*debug.log": error parsing regexp: missing argument to repetition operator: `*`

goroutine 5112 [running]:
github.com/VictoriaMetrics/VictoriaMetrics/lib/httpserver.handlerWrapper.func1()
        github.com/VictoriaMetrics/VictoriaMetrics/lib/httpserver/httpserver.go:289 +0x5b
panic({0x845320?, 0xc001002740?})
        runtime/panic.go:770 +0x132
github.com/VictoriaMetrics/VictoriaMetrics/lib/logger.logMessage({0x8c006c, 0x5}, {0xc004a89650, 0x69}, 0x4)
        github.com/VictoriaMetrics/VictoriaMetrics/lib/logger/logger.go:301 +0xa74
github.com/VictoriaMetrics/VictoriaMetrics/lib/logger.logLevelSkipframes(0x1, {0x8c006c, 0x5}, {0x8ce82d?, 0x42a220?}, {0xc050dd4bc8?, 0x3?, 0xc050dd4b88?})
        github.com/VictoriaMetrics/VictoriaMetrics/lib/logger/logger.go:141 +0x1a5
github.com/VictoriaMetrics/VictoriaMetrics/lib/logger.logLevel(...)
        github.com/VictoriaMetrics/VictoriaMetrics/lib/logger/logger.go:133
github.com/VictoriaMetrics/VictoriaMetrics/lib/logger.Panicf(...)
        github.com/VictoriaMetrics/VictoriaMetrics/lib/logger/logger.go:129
github.com/VictoriaMetrics/VictoriaMetrics/lib/logstorage.(*streamTagFilter).initRegexp(0xc0537fc4b0)
        github.com/VictoriaMetrics/VictoriaMetrics/lib/logstorage/stream_filter.go:83 +0xce
sync.(*Once).doSlow(0xc050dd4cb0?, 0x423965?)
        sync/once.go:74 +0xc2
sync.(*Once).Do(...)
        sync/once.go:65
github.com/VictoriaMetrics/VictoriaMetrics/lib/logstorage.(*streamTagFilter).getRegexp(...)
        github.com/VictoriaMetrics/VictoriaMetrics/lib/logstorage/stream_filter.go:76
github.com/VictoriaMetrics/VictoriaMetrics/lib/logstorage.(*indexSearch).getStreamIDsForTagFilter(0xc03101a5a0, {0x854780?, 0x0?}, 0xc0537fc4b0)
        github.com/VictoriaMetrics/VictoriaMetrics/lib/logstorage/indexdb.go:270 +0x2d5
github.com/VictoriaMetrics/VictoriaMetrics/lib/logstorage.(*indexSearch).updateStreamIDs(0xc03101a5a0, 0xc002767010, {0x1?, 0x0?}, 0x1?)
        github.com/VictoriaMetrics/VictoriaMetrics/lib/logstorage/indexdb.go:223 +0xa5
github.com/VictoriaMetrics/VictoriaMetrics/lib/logstorage.(*indexdb).searchStreamIDs(0xc00013a230, {0xc004b29208, 0x1, 0x1}, 0xc000b1adc8)
        github.com/VictoriaMetrics/VictoriaMetrics/lib/logstorage/indexdb.go:196 +0x368
github.com/VictoriaMetrics/VictoriaMetrics/lib/logstorage.(*partition).search(0xc0015e1180, {0x0, 0x0, 0x0}, 0xc00122c460, 0xc0004a8d80?, {0xa7d568, 0xc000b1b500}, 0xc0027672d8, 0xc054cc42a0, ...)
        github.com/VictoriaMetrics/VictoriaMetrics/lib/logstorage/storage_search.go:205 +0x90
github.com/VictoriaMetrics/VictoriaMetrics/lib/logstorage.(*Storage).search(0xc0000229a0, 0x40, 0xc0027672d8, 0xc002a01b60, 0xc0004a8d80)
        github.com/VictoriaMetrics/VictoriaMetrics/lib/logstorage/storage_search.go:179 +0x4d3
github.com/VictoriaMetrics/VictoriaMetrics/lib/logstorage.(*Storage).RunQuery(0xc0000229a0, {0xc004b29208, 0x1, 0x1}, 0xc001002650, 0xc002a01b60, 0xc00122c520)
        github.com/VictoriaMetrics/VictoriaMetrics/lib/logstorage/storage_search.go:56 +0x16d
github.com/VictoriaMetrics/VictoriaMetrics/app/vlstorage.RunQuery(...)
        github.com/VictoriaMetrics/VictoriaMetrics/app/vlstorage/main.go:104
github.com/VictoriaMetrics/VictoriaMetrics/app/vlselect/logsql.ProcessQueryRequest({0xa7d238, 0xc000b1ad50}, 0xc0186850e0, 0xc002a01b60, 0xc001002550)
        github.com/VictoriaMetrics/VictoriaMetrics/app/vlselect/logsql/logsql.go:51 +0x4f0
github.com/VictoriaMetrics/VictoriaMetrics/app/vlselect.RequestHandler({0xa7d238, 0xc000b1ad50}, 0xc0186850e0)
        github.com/VictoriaMetrics/VictoriaMetrics/app/vlselect/main.go:152 +0x952
main.requestHandler({0xa7d238, 0xc000b1ad50}, 0xc0186850e0)
        github.com/VictoriaMetrics/VictoriaMetrics/app/victoria-logs/main.go:92 +0x195
github.com/VictoriaMetrics/VictoriaMetrics/lib/httpserver.handlerWrapper(0xc00122a4c0, {0xa7dbc8, 0xc036162000}, 0xc0186850e0, 0x9fcf18)
        github.com/VictoriaMetrics/VictoriaMetrics/lib/httpserver/httpserver.go:414 +0x1003
github.com/VictoriaMetrics/VictoriaMetrics/lib/httpserver.gzipHandler.func1({0xa7dbc8?, 0xc036162000?}, 0xc036162000?)
        github.com/VictoriaMetrics/VictoriaMetrics/lib/httpserver/httpserver.go:248 +0x31
net/http.HandlerFunc.ServeHTTP(0xd2d430?, {0xa7dbc8?, 0xc036162000?}, 0x4?)
        net/http/server.go:2166 +0x29
github.com/klauspost/compress/gzhttp.NewWrapper.func1.1({0xa7d118, 0xc02935e7e0}, 0xc0186850e0)
        github.com/klauspost/compress@v1.17.6/gzhttp/compress.go:495 +0x54f
net/http.HandlerFunc.ServeHTTP(0x40e9a5?, {0xa7d118?, 0xc02935e7e0?}, 0xc02935e701?)
        net/http/server.go:2166 +0x29
net/http.serverHandler.ServeHTTP({0xa7c200?}, {0xa7d118?, 0xc02935e7e0?}, 0x6?)
        net/http/server.go:3137 +0x8e
net/http.(*conn).serve(0xc048711560, {0xa7e868, 0xc000fa1710})
        net/http/server.go:2039 +0x5e8
created by net/http.(*Server).Serve in goroutine 4209
        net/http/server.go:3285 +0x4b4
```

