### PR TITLE
app/vmselect: properly init filterss from match[] arg

### DIFF
--- a/app/vmselect/prometheus/prometheus.go
+++ b/app/vmselect/prometheus/prometheus.go
@@ -1182,17 +1182,16 @@ func getCommonParamsInternal(r *http.Request, startTime time.Time, requireNonEmp
 		return nil, fmt.Errorf("missing `match[]` arg")
 	}
 
-	var filterss [][]storage.TagFilter
+	filterss, err := getTagFilterssFromMatches(matches)
+	if err != nil {
+		return nil, err
+	}
 	if !isLabelsAPI || !*ignoreExtraFiltersAtLabelsAPI {
-		tagFilterss, err := getTagFilterssFromMatches(matches)
-		if err != nil {
-			return nil, err
-		}
 		etfs, err := searchutils.GetExtraTagFilters(r)
 		if err != nil {
 			return nil, err
 		}
-		filterss = searchutils.JoinTagFilterss(tagFilterss, etfs)
+		filterss = searchutils.JoinTagFilterss(filterss, etfs)
 	}
 
 	cp := &commonParams{

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -30,6 +30,7 @@ See also [LTS releases](https://docs.victoriametrics.com/lts-releases/).
 
 ## tip
 
+* BUGFIX: [vmselect](https://docs.victoriametrics.com/): properly initialize filters for `/api/v1/series` API requests with enabled command-line flag `-search.ignoreExtraFiltersAtLabelsAPI`.
 * FEATURE: [stream aggregation](https://docs.victoriametrics.com/stream-aggregation/): reduce memory usage by up to 5x when aggregating over big number of unique [time series](https://docs.victoriametrics.com/keyconcepts/#time-series). The memory usage reduction is most visible when [stream deduplication](https://docs.victoriametrics.com/stream-aggregation/#deduplication) is enabled. The downside is increased CPU usage by up to 30%.
 * FEATURE: [stream aggregation](https://docs.victoriametrics.com/stream-aggregation/): add `dedup_interval` option, which allows configuring individual [deduplication intervals](https://docs.victoriametrics.com/stream-aggregation/#deduplication) per each [stream aggregation config](https://docs.victoriametrics.com/stream-aggregation/#stream-aggregation-config).
 * FEATURE: [stream aggregation](https://docs.victoriametrics.com/stream-aggregation/): add `keep_metric_names` option, which can be set at [stream aggregation config](https://docs.victoriametrics.com/stream-aggregation/#stream-aggregation-config) in order to keep the original metric names in the output aggregated samples instead of using [the default output metric naming scheme](https://docs.victoriametrics.com/stream-aggregation/#output-metric-names).


### PR DESCRIPTION
previously it was ignored for /api/v1/series requests with enabled flag -search.ignoreExtraFiltersAtLabelsAPI follow-up after 0b7a23a91d5f29535c3c485f0c1d92f87ae91fef