### PR TITLE
vmui: fix permission issue for `make vmui-build` command

### DIFF
--- a/app/vmui/Dockerfile-build
+++ b/app/vmui/Dockerfile-build
@@ -1,5 +1,8 @@
 FROM node:18-alpine3.17
 
+# Sets a custom location for the npm cache, preventing access errors in system directories
+ENV NPM_CONFIG_CACHE=/build/.npm
+
 RUN apk update && apk upgrade
 RUN apk add --no-cache bash bash-doc bash-completion libtool autoconf automake nasm pkgconfig libpng gcc make g++ zlib-dev gawk
 


### PR DESCRIPTION
**Problem:**
When attempting to execute the `make vmui-build` command on macOS, the process fails with an `npm` error related to permissions. Specifically, the error message is as follows:

```
npm ERR! code EACCES
npm ERR! syscall mkdir
npm ERR! path /.npm
npm ERR! errno -13
npm ERR! Your cache folder contains root-owned files, due to a bug in
npm ERR! previous versions of npm which has since been addressed.
npm ERR! To permanently fix this problem, please run:
npm ERR!   sudo chown -R 501:20 "/.npm"
```

This issue arises because `npm` attempts to access a cache directory that has incorrect ownership, leading to a permission denied error.

**Solution:**
To resolve this issue, an environment variable `NPM_CONFIG_CACHE` is introduced. This change specifies a custom location for the npm cache that is accessible by the current user, thus avoiding permission issues with the default cache directory. The `NPM_CONFIG_CACHE` environment variable is set to `/build/.npm`, ensuring that npm uses this directory for caching.