### PR TITLE
lib/promscrape: properly set Host header when sending requests

### DIFF
--- a/lib/promauth/config.go
+++ b/lib/promauth/config.go
@@ -346,6 +346,11 @@ func (ac *Config) SetHeaders(req *http.Request, setAuthHeader bool) error {
 			reqHeaders.Set("Authorization", ah)
 		}
 	}
+	// Headers must be set first, so we get canonical header naming
+	hostHeader := reqHeaders.Get("Host")
+	if hostHeader != "" {
+		req.Host = hostHeader
+	}
 	return nil
 }
 


### PR DESCRIPTION
Fixes #5969 

I see that there's also an old issue related to the host header in proxied requests, though I didn't test how this behaves when using a proxy yet. Maybe @jtorkkel could test this?