### PR TITLE
Exemplar support

### DIFF
--- a/app/vmagent/remotewrite/pendingseries.go
+++ b/app/vmagent/remotewrite/pendingseries.go
@@ -123,12 +123,7 @@ func (wr *writeRequest) reset() {
 
 	wr.wr.Timeseries = nil
 
-	for i := range wr.tss {
-		ts := &wr.tss[i]
-		ts.Labels = nil
-		ts.Samples = nil
-		ts.Exemplars = nil
-	}
+	clear(wr.tss)
 	wr.tss = wr.tss[:0]
 
 	promrelabel.CleanLabels(wr.labels)

--- a/app/vmagent/remotewrite/pendingseries.go
+++ b/app/vmagent/remotewrite/pendingseries.go
@@ -295,6 +295,7 @@ func tryPushWriteRequest(wr *prompbmarshal.WriteRequest, tryPushBlock func(block
 
 		if !tryPushWriteRequest(wr, tryPushBlock, isVMRemoteWrite) {
 			wr.Timeseries[0].Samples = samples
+			wr.Timeseries[0].Exemplars = exemplars
 			return false
 		}
 		wr.Timeseries[0].Samples = samples

--- a/app/vmagent/remotewrite/pendingseries.go
+++ b/app/vmagent/remotewrite/pendingseries.go
@@ -225,7 +225,7 @@ func (wr *writeRequest) copyTimeSeries(dst, src *prompbmarshal.TimeSeries) {
 	dst.Samples = samplesDst[len(samplesDst)-len(src.Samples):]
 
 	exemplarsDst = append(exemplarsDst, src.Exemplars...)
-	dst.Exemplars = exemplarsDst
+	dst.Exemplars = exemplarsDst[len(exemplarsDst)-len(src.Exemplars):]
 
 	wr.samples = samplesDst
 	wr.labels = labelsDst

--- a/app/vmagent/remotewrite/pendingseries_test.go
+++ b/app/vmagent/remotewrite/pendingseries_test.go
@@ -10,8 +10,8 @@ import (
 
 func TestPushWriteRequest(t *testing.T) {
 	rowsCounts := []int{1, 10, 100, 1e3, 1e4}
-	expectedBlockLensProm := []int{216, 1848, 16424, 169882, 1757876}
-	expectedBlockLensVM := []int{138, 492, 3927, 34995, 288476}
+	expectedBlockLensProm := []int{230, 1952, 17433, 180381, 1861994}
+	expectedBlockLensVM := []int{138, 575, 4748, 44936, 367096}
 	for i, rowsCount := range rowsCounts {
 		expectedBlockLenProm := expectedBlockLensProm[i]
 		expectedBlockLenVM := expectedBlockLensVM[i]
@@ -59,6 +59,16 @@ func newTestWriteRequest(seriesCount, labelsCount int) *prompbmarshal.WriteReque
 				Value: fmt.Sprintf("value_%d_%d", i, j),
 			})
 		}
+		exemplar := prompbmarshal.Exemplar{
+			Labels: []prompbmarshal.Label{
+				{
+					Name:  "trace_id",
+					Value: "123456",
+				},
+			},
+			Value:     float64(i),
+			Timestamp: 1000 * int64(i),
+		}
 		wr.Timeseries = append(wr.Timeseries, prompbmarshal.TimeSeries{
 			Labels: labels,
 			Samples: []prompbmarshal.Sample{
@@ -66,6 +76,10 @@ func newTestWriteRequest(seriesCount, labelsCount int) *prompbmarshal.WriteReque
 					Value:     float64(i),
 					Timestamp: 1000 * int64(i),
 				},
+			},
+
+			Exemplars: []prompbmarshal.Exemplar{
+				exemplar,
 			},
 		})
 	}

--- a/app/vmagent/remotewrite/pendingseries_test.go
+++ b/app/vmagent/remotewrite/pendingseries_test.go
@@ -10,8 +10,8 @@ import (
 
 func TestPushWriteRequest(t *testing.T) {
 	rowsCounts := []int{1, 10, 100, 1e3, 1e4}
-	expectedBlockLensProm := []int{230, 1952, 17433, 180381, 1861994}
-	expectedBlockLensVM := []int{138, 575, 4748, 44936, 367096}
+	expectedBlockLensProm := []int{248, 1952, 17433, 180381, 1861994}
+	expectedBlockLensVM := []int{170, 575, 4748, 44936, 367096}
 	for i, rowsCount := range rowsCounts {
 		expectedBlockLenProm := expectedBlockLensProm[i]
 		expectedBlockLenVM := expectedBlockLensVM[i]
@@ -64,6 +64,10 @@ func newTestWriteRequest(seriesCount, labelsCount int) *prompbmarshal.WriteReque
 				{
 					Name:  "trace_id",
 					Value: "123456",
+				},
+				{
+					Name:  "log_id",
+					Value: "987654",
 				},
 			},
 			Value:     float64(i),

--- a/lib/prompb/prompb.go
+++ b/lib/prompb/prompb.go
@@ -36,6 +36,15 @@ func (wr *WriteRequest) Reset() {
 	wr.samplesPool = samplesPool[:0]
 }
 
+/*
+Exemplar Support
+
+Labels: a list of labels that uniquely identifies exemplar
+
+Value: the value of the exemplar
+
+Timestamp: the time the exemplar was recorded
+*/
 type Exemplar struct {
 	// Optional, can be empty.
 	Labels []Label

--- a/lib/prompb/prompb.go
+++ b/lib/prompb/prompb.go
@@ -9,10 +9,11 @@ import (
 // WriteRequest represents Prometheus remote write API request.
 type WriteRequest struct {
 	// Timeseries is a list of time series in the given WriteRequest
-	Timeseries    []TimeSeries
-	labelsPool    []Label
-	samplesPool   []Sample
-	exemplarsPool []Exemplar
+	Timeseries         []TimeSeries
+	labelsPool         []Label
+	exemplarLabelsPool []Label
+	samplesPool        []Sample
+	exemplarsPool      []Exemplar
 }
 
 // Reset resets wr for subsequent re-use.
@@ -29,6 +30,11 @@ func (wr *WriteRequest) Reset() {
 	}
 	wr.labelsPool = labelsPool[:0]
 
+	exemplarLabelsPool := wr.exemplarLabelsPool
+	for i := range exemplarLabelsPool {
+		exemplarLabelsPool[i] = Label{}
+	}
+	wr.labelsPool = labelsPool[:0]
 	samplesPool := wr.samplesPool
 	for i := range samplesPool {
 		samplesPool[i] = Sample{}
@@ -50,8 +56,7 @@ type Exemplar struct {
 	Value float64
 	// timestamp is in ms format, see model/timestamp/timestamp.go for
 	// conversion from time.Time to Prometheus timestamp.
-	Timestamp  int64
-	labelsPool []Label
+	Timestamp int64
 }
 
 // TimeSeries is a timeseries.
@@ -93,6 +98,7 @@ func (wr *WriteRequest) UnmarshalProtobuf(src []byte) (err error) {
 	// }
 	tss := wr.Timeseries
 	labelsPool := wr.labelsPool
+	exemplarLabelsPool := wr.exemplarLabelsPool
 	samplesPool := wr.samplesPool
 	exemplarsPool := wr.exemplarsPool
 
@@ -114,7 +120,7 @@ func (wr *WriteRequest) UnmarshalProtobuf(src []byte) (err error) {
 				tss = append(tss, TimeSeries{})
 			}
 			ts := &tss[len(tss)-1]
-			labelsPool, samplesPool, exemplarsPool, err = ts.unmarshalProtobuf(data, labelsPool, samplesPool, exemplarsPool)
+			labelsPool, exemplarLabelsPool, samplesPool, exemplarsPool, err = ts.unmarshalProtobuf(data, labelsPool, exemplarLabelsPool, samplesPool, exemplarsPool)
 			if err != nil {
 				return fmt.Errorf("cannot unmarshal timeseries: %w", err)
 			}
@@ -127,7 +133,7 @@ func (wr *WriteRequest) UnmarshalProtobuf(src []byte) (err error) {
 	return nil
 }
 
-func (ts *TimeSeries) unmarshalProtobuf(src []byte, labelsPool []Label, samplesPool []Sample, exemplarsPool []Exemplar) ([]Label, []Sample, []Exemplar, error) {
+func (ts *TimeSeries) unmarshalProtobuf(src []byte, labelsPool []Label, exemplarLabelsPool []Label, samplesPool []Sample, exemplarsPool []Exemplar) ([]Label, []Label, []Sample, []Exemplar, error) {
 	// message TimeSeries {
 	//   repeated Label labels   = 1;
 	//   repeated Sample samples = 2;
@@ -141,13 +147,13 @@ func (ts *TimeSeries) unmarshalProtobuf(src []byte, labelsPool []Label, samplesP
 		var err error
 		src, err = fc.NextField(src)
 		if err != nil {
-			return labelsPool, samplesPool, exemplarsPool, fmt.Errorf("cannot read the next field: %w", err)
+			return labelsPool, exemplarLabelsPool, samplesPool, exemplarsPool, fmt.Errorf("cannot read the next field: %w", err)
 		}
 		switch fc.FieldNum {
 		case 1:
 			data, ok := fc.MessageData()
 			if !ok {
-				return labelsPool, samplesPool, exemplarsPool, fmt.Errorf("cannot read label data")
+				return labelsPool, exemplarLabelsPool, samplesPool, exemplarsPool, fmt.Errorf("cannot read label data")
 			}
 			if len(labelsPool) < cap(labelsPool) {
 				labelsPool = labelsPool[:len(labelsPool)+1]
@@ -156,12 +162,12 @@ func (ts *TimeSeries) unmarshalProtobuf(src []byte, labelsPool []Label, samplesP
 			}
 			label := &labelsPool[len(labelsPool)-1]
 			if err := label.unmarshalProtobuf(data); err != nil {
-				return labelsPool, samplesPool, exemplarsPool, fmt.Errorf("cannot unmarshal label: %w", err)
+				return labelsPool, exemplarLabelsPool, samplesPool, exemplarsPool, fmt.Errorf("cannot unmarshal label: %w", err)
 			}
 		case 2:
 			data, ok := fc.MessageData()
 			if !ok {
-				return labelsPool, samplesPool, exemplarsPool, fmt.Errorf("cannot read the sample data")
+				return labelsPool, exemplarLabelsPool, samplesPool, exemplarsPool, fmt.Errorf("cannot read the sample data")
 			}
 			if len(samplesPool) < cap(samplesPool) {
 				samplesPool = samplesPool[:len(samplesPool)+1]
@@ -170,12 +176,12 @@ func (ts *TimeSeries) unmarshalProtobuf(src []byte, labelsPool []Label, samplesP
 			}
 			sample := &samplesPool[len(samplesPool)-1]
 			if err := sample.unmarshalProtobuf(data); err != nil {
-				return labelsPool, samplesPool, exemplarsPool, fmt.Errorf("cannot unmarshal sample: %w", err)
+				return labelsPool, exemplarLabelsPool, samplesPool, exemplarsPool, fmt.Errorf("cannot unmarshal sample: %w", err)
 			}
 		case 3:
 			data, ok := fc.MessageData()
 			if !ok {
-				return labelsPool, samplesPool, exemplarsPool, fmt.Errorf("cannot read the exemplar data")
+				return labelsPool, exemplarLabelsPool, samplesPool, exemplarsPool, fmt.Errorf("cannot read the exemplar data")
 			}
 			if len(exemplarsPool) < cap(exemplarsPool) {
 				exemplarsPool = exemplarsPool[:len(exemplarsPool)+1]
@@ -183,60 +189,64 @@ func (ts *TimeSeries) unmarshalProtobuf(src []byte, labelsPool []Label, samplesP
 				exemplarsPool = append(exemplarsPool, Exemplar{})
 			}
 			exemplar := &exemplarsPool[len(exemplarsPool)-1]
-			if err := exemplar.unmarshalProtobuf(data); err != nil {
-				return labelsPool, samplesPool, exemplarsPool, fmt.Errorf("cannot unmarshal exemplar: %w", err)
+			if exemplarLabelsPool, err = exemplar.unmarshalProtobuf(data, exemplarLabelsPool); err != nil {
+				return labelsPool, exemplarLabelsPool, samplesPool, exemplarsPool, fmt.Errorf("cannot unmarshal exemplar: %w", err)
 			}
-			exemplar.Labels = exemplar.labelsPool
 		}
 	}
 	ts.Labels = labelsPool[labelsPoolLen:]
 	ts.Samples = samplesPool[samplesPoolLen:]
 	ts.Exemplars = exemplarsPool[exemplarsPoolLen:]
-	return labelsPool, samplesPool, exemplarsPool, nil
+	return labelsPool, exemplarLabelsPool, samplesPool, exemplarsPool, nil
 }
 
-func (exemplar *Exemplar) unmarshalProtobuf(src []byte) (err error) {
+func (exemplar *Exemplar) unmarshalProtobuf(src []byte, labelsPool []Label) ([]Label, error) {
 	// message Exemplar {
 	//   repeated Label Labels  = 1;
 	//   float64 Value = 2;
-	//   int64 Timestamp = 2;
+	//   int64 Timestamp = 3;
 	// }
 	var fc easyproto.FieldContext
+
+	labelsPoolLen := len(labelsPool)
+
 	for len(src) > 0 {
+		var err error
 		src, err = fc.NextField(src)
 		if err != nil {
-			return fmt.Errorf("cannot read the next field: %w", err)
+			return labelsPool, fmt.Errorf("cannot read the next field: %w", err)
 		}
 		switch fc.FieldNum {
 		case 1:
 			data, ok := fc.MessageData()
 			if !ok {
-				return fmt.Errorf("cannot read label data")
+				return labelsPool, fmt.Errorf("cannot read label data")
 			}
-			if len(exemplar.labelsPool) < cap(exemplar.labelsPool) {
-				exemplar.labelsPool = exemplar.labelsPool[:len(exemplar.labelsPool)+1]
+			if len(labelsPool) < cap(labelsPool) {
+				labelsPool = labelsPool[:len(labelsPool)+1]
 			} else {
-				exemplar.labelsPool = append(exemplar.labelsPool, Label{})
+				labelsPool = append(labelsPool, Label{})
 			}
-			label := &exemplar.labelsPool[len(exemplar.labelsPool)-1]
+			label := &labelsPool[len(labelsPool)-1]
 			if err := label.unmarshalProtobuf(data); err != nil {
-				return fmt.Errorf("cannot unmarshal label: %w", err)
+				return labelsPool, fmt.Errorf("cannot unmarshal label: %w", err)
 			}
 		case 2:
 			value, ok := fc.Double()
 			if !ok {
-				return fmt.Errorf("cannot read exemplar value")
+				return labelsPool, fmt.Errorf("cannot read exemplar value")
 			}
 			exemplar.Value = value
 		case 3:
 			timestamp, ok := fc.Int64()
 			if !ok {
-				return fmt.Errorf("cannot read exemplar timestamp")
+				return labelsPool, fmt.Errorf("cannot read exemplar timestamp")
 			}
 			exemplar.Timestamp = timestamp
 		}
 	}
-	return nil
+	exemplar.Labels = labelsPool[labelsPoolLen:]
+	return labelsPool, nil
 }
 func (lbl *Label) unmarshalProtobuf(src []byte) (err error) {
 	// message Label {

--- a/lib/prompb/prompb.go
+++ b/lib/prompb/prompb.go
@@ -34,6 +34,11 @@ func (wr *WriteRequest) Reset() {
 		samplesPool[i] = Sample{}
 	}
 	wr.samplesPool = samplesPool[:0]
+	exemplarsPool := wr.exemplarsPool
+	for i := range exemplarsPool {
+		exemplarsPool[i] = Exemplar{}
+	}
+	wr.exemplarsPool = exemplarsPool[:0]
 }
 
 // Exemplar Support

--- a/lib/prompb/prompb.go
+++ b/lib/prompb/prompb.go
@@ -36,15 +36,10 @@ func (wr *WriteRequest) Reset() {
 	wr.samplesPool = samplesPool[:0]
 }
 
-/*
-Exemplar Support
-
-Labels: a list of labels that uniquely identifies exemplar
-
-Value: the value of the exemplar
-
-Timestamp: the time the exemplar was recorded
-*/
+// Exemplar Support
+// Labels: a list of labels that uniquely identifies exemplar
+// Value: the value of the exemplar
+// Timestamp: the time the exemplar was recorded
 type Exemplar struct {
 	// Optional, can be empty.
 	Labels []Label

--- a/lib/prompb/prompb.go
+++ b/lib/prompb/prompb.go
@@ -41,14 +41,13 @@ func (wr *WriteRequest) Reset() {
 	wr.exemplarsPool = exemplarsPool[:0]
 }
 
-// Exemplar Support
-// Labels: a list of labels that uniquely identifies exemplar
-// Value: the value of the exemplar
-// Timestamp: the time the exemplar was recorded
+// Exemplar is an exemplar
 type Exemplar struct {
+	// Labels a list of labels that uniquely identifies exemplar
 	// Optional, can be empty.
 	Labels []Label
-	Value  float64
+	// Value: the value of the exemplar
+	Value float64
 	// timestamp is in ms format, see model/timestamp/timestamp.go for
 	// conversion from time.Time to Prometheus timestamp.
 	Timestamp  int64
@@ -132,7 +131,7 @@ func (ts *TimeSeries) unmarshalProtobuf(src []byte, labelsPool []Label, samplesP
 	// message TimeSeries {
 	//   repeated Label labels   = 1;
 	//   repeated Sample samples = 2;
-	// 	 repeated Exemplar exemplars = 3
+	//   repeated Exemplar exemplars = 3
 	// }
 	labelsPoolLen := len(labelsPool)
 	samplesPoolLen := len(samplesPool)

--- a/lib/prompb/prompb_test.go
+++ b/lib/prompb/prompb_test.go
@@ -36,9 +36,24 @@ func TestWriteRequestUnmarshalProtobuf(t *testing.T) {
 					Timestamp: sample.Timestamp,
 				})
 			}
+			var exemplars []prompbmarshal.Exemplar
+			for _, exemplar := range ts.Exemplars {
+				exemplars = append(exemplars, prompbmarshal.Exemplar{
+					Labels: []prompbmarshal.Label{
+						{
+							Name:  exemplar.Labels[0].Name,
+							Value: exemplar.Labels[0].Value,
+						},
+					},
+					Value:     exemplar.Value,
+					Timestamp: exemplar.Timestamp,
+				},
+				)
+			}
 			wrm.Timeseries = append(wrm.Timeseries, prompbmarshal.TimeSeries{
-				Labels:  labels,
-				Samples: samples,
+				Labels:    labels,
+				Samples:   samples,
+				Exemplars: exemplars,
 			})
 		}
 		dataResult := wrm.MarshalProtobuf(nil)
@@ -97,6 +112,24 @@ func TestWriteRequestUnmarshalProtobuf(t *testing.T) {
 	wrm.Reset()
 	wrm.Timeseries = []prompbmarshal.TimeSeries{
 		{
+			Exemplars: []prompbmarshal.Exemplar{
+				{
+					Labels: []prompbmarshal.Label{
+						{
+							Name:  "trace-id",
+							Value: "123456",
+						},
+					},
+					Value:     12345.6,
+					Timestamp: 456,
+				},
+			},
+		}}
+	data = wrm.MarshalProtobuf(data[:0])
+	f(data)
+	wrm.Reset()
+	wrm.Timeseries = []prompbmarshal.TimeSeries{
+		{
 			Labels: []prompbmarshal.Label{
 				{
 					Name:  "__name__",
@@ -119,6 +152,17 @@ func TestWriteRequestUnmarshalProtobuf(t *testing.T) {
 				{
 					Value:     -123.3434,
 					Timestamp: 18939432423,
+				},
+			},
+			Exemplars: []prompbmarshal.Exemplar{
+				{
+					Labels: []prompbmarshal.Label{
+						{Name: "trace-id",
+							Value: "123456",
+						},
+					},
+					Value:     12345.6,
+					Timestamp: 456,
 				},
 			},
 		},
@@ -153,6 +197,18 @@ func TestWriteRequestUnmarshalProtobuf(t *testing.T) {
 					Timestamp: 18939432423,
 				},
 			},
+			Exemplars: []prompbmarshal.Exemplar{
+				{
+					Labels: []prompbmarshal.Label{
+						{
+							Name:  "trace-id",
+							Value: "123456",
+						},
+					},
+					Value:     12345.6,
+					Timestamp: 456,
+				},
+			},
 		},
 		{
 			Labels: []prompbmarshal.Label{
@@ -164,6 +220,18 @@ func TestWriteRequestUnmarshalProtobuf(t *testing.T) {
 			Samples: []prompbmarshal.Sample{
 				{
 					Value: 9873,
+				},
+			},
+			Exemplars: []prompbmarshal.Exemplar{
+				{
+					Labels: []prompbmarshal.Label{
+						{
+							Name:  "trace-id",
+							Value: "123456",
+						},
+					},
+					Value:     12345.6,
+					Timestamp: 456,
 				},
 			},
 		},

--- a/lib/prompb/prompb_test.go
+++ b/lib/prompb/prompb_test.go
@@ -145,7 +145,7 @@ func TestWriteRequestUnmarshalProtobuf(t *testing.T) {
 							Value: "123456",
 						},
 						{Name: "log_id",
-							Value: "987654"},
+							Value: "987664"},
 					},
 					Value:     12345.6,
 					Timestamp: 456,
@@ -214,6 +214,10 @@ func TestWriteRequestUnmarshalProtobuf(t *testing.T) {
 						{
 							Name:  "trace-id",
 							Value: "123456",
+						},
+						{
+							Name:  "log_id",
+							Value: "987654",
 						},
 					},
 					Value:     12345.6,

--- a/lib/prompb/prompb_test.go
+++ b/lib/prompb/prompb_test.go
@@ -38,13 +38,15 @@ func TestWriteRequestUnmarshalProtobuf(t *testing.T) {
 			}
 			var exemplars []prompbmarshal.Exemplar
 			for _, exemplar := range ts.Exemplars {
+				exemplarLabels := make([]prompbmarshal.Label, len(exemplar.Labels))
+				for i, label := range exemplar.Labels {
+					exemplarLabels[i] = prompbmarshal.Label{
+						Name:  label.Name,
+						Value: label.Value,
+					}
+				}
 				exemplars = append(exemplars, prompbmarshal.Exemplar{
-					Labels: []prompbmarshal.Label{
-						{
-							Name:  exemplar.Labels[0].Name,
-							Value: exemplar.Labels[0].Value,
-						},
-					},
+					Labels:    exemplarLabels,
 					Value:     exemplar.Value,
 					Timestamp: exemplar.Timestamp,
 				},
@@ -112,24 +114,6 @@ func TestWriteRequestUnmarshalProtobuf(t *testing.T) {
 	wrm.Reset()
 	wrm.Timeseries = []prompbmarshal.TimeSeries{
 		{
-			Exemplars: []prompbmarshal.Exemplar{
-				{
-					Labels: []prompbmarshal.Label{
-						{
-							Name:  "trace-id",
-							Value: "123456",
-						},
-					},
-					Value:     12345.6,
-					Timestamp: 456,
-				},
-			},
-		}}
-	data = wrm.MarshalProtobuf(data[:0])
-	f(data)
-	wrm.Reset()
-	wrm.Timeseries = []prompbmarshal.TimeSeries{
-		{
 			Labels: []prompbmarshal.Label{
 				{
 					Name:  "__name__",
@@ -160,6 +144,8 @@ func TestWriteRequestUnmarshalProtobuf(t *testing.T) {
 						{Name: "trace-id",
 							Value: "123456",
 						},
+						{Name: "log_id",
+							Value: "987654"},
 					},
 					Value:     12345.6,
 					Timestamp: 456,

--- a/lib/prompb/prompb_test.go
+++ b/lib/prompb/prompb_test.go
@@ -49,8 +49,7 @@ func TestWriteRequestUnmarshalProtobuf(t *testing.T) {
 					Labels:    exemplarLabels,
 					Value:     exemplar.Value,
 					Timestamp: exemplar.Timestamp,
-				},
-				)
+				})
 			}
 			wrm.Timeseries = append(wrm.Timeseries, prompbmarshal.TimeSeries{
 				Labels:    labels,

--- a/lib/prompbmarshal/prompbmarshal_test.go
+++ b/lib/prompbmarshal/prompbmarshal_test.go
@@ -2,7 +2,6 @@ package prompbmarshal_test
 
 import (
 	"bytes"
-	"fmt"
 	"testing"
 
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/prompb"
@@ -44,6 +43,10 @@ func TestWriteRequestMarshalProtobuf(t *testing.T) {
 								Name:  "trace-id",
 								Value: "123456",
 							},
+							{
+								Name:  "log_id",
+								Value: "987654",
+							},
 						},
 						Value:     12345.6,
 						Timestamp: 456,
@@ -59,7 +62,6 @@ func TestWriteRequestMarshalProtobuf(t *testing.T) {
 	if err := wr.UnmarshalProtobuf(data); err != nil {
 		t.Fatalf("cannot unmarshal protobuf: %s", err)
 	}
-	fmt.Println(wr.Timeseries)
 
 	// Compare the unmarshaled wr with the original wrm.
 	wrm.Reset()
@@ -80,13 +82,15 @@ func TestWriteRequestMarshalProtobuf(t *testing.T) {
 		}
 		var exemplars []prompbmarshal.Exemplar
 		for _, exemplar := range ts.Exemplars {
+			exemplarLabels := make([]prompbmarshal.Label, len(exemplar.Labels))
+			for i, label := range exemplar.Labels {
+				exemplarLabels[i] = prompbmarshal.Label{
+					Name:  label.Name,
+					Value: label.Value,
+				}
+			}
 			exemplars = append(exemplars, prompbmarshal.Exemplar{
-				Labels: []prompbmarshal.Label{
-					{
-						Name:  exemplar.Labels[0].Name,
-						Value: exemplar.Labels[0].Value,
-					},
-				},
+				Labels:    exemplarLabels,
 				Value:     exemplar.Value,
 				Timestamp: exemplar.Timestamp,
 			})

--- a/lib/prompbmarshal/types.pb.go
+++ b/lib/prompbmarshal/types.pb.go
@@ -13,10 +13,73 @@ type Sample struct {
 	Timestamp int64
 }
 
+type Exemplar struct {
+	// Optional, can be empty.
+	Labels []Label
+	Value  float64
+	// timestamp is in ms format, see model/timestamp/timestamp.go for
+	// conversion from time.Time to Prometheus timestamp.
+	Timestamp int64
+}
+
+func (m *Exemplar) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.Timestamp != 0 {
+		i = encodeVarint(dAtA, i, uint64(m.Timestamp))
+		i--
+		dAtA[i] = 0x18
+	}
+	if m.Value != 0 {
+		i -= 8
+		binary.LittleEndian.PutUint64(dAtA[i:], uint64(math.Float64bits(float64(m.Value))))
+		i--
+		dAtA[i] = 0x11
+	}
+	if len(m.Labels) > 0 {
+		for iNdEx := len(m.Labels) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.Labels[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarint(dAtA, i, uint64(size))
+			}
+			i--
+			dAtA[i] = 0xa
+		}
+	}
+	return len(dAtA) - i, nil
+}
+func (m *Exemplar) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if len(m.Labels) > 0 {
+		for _, e := range m.Labels {
+			l = e.Size()
+			n += 1 + l + sov(uint64(l))
+		}
+	}
+	if m.Value != 0 {
+		n += 9
+	}
+	if m.Timestamp != 0 {
+		n += 1 + sov(uint64(m.Timestamp))
+	}
+	return n
+}
+
 // TimeSeries represents samples and labels for a single time series.
 type TimeSeries struct {
-	Labels  []Label
-	Samples []Sample
+	Labels    []Label
+	Samples   []Sample
+	Exemplars []Exemplar
 }
 
 type Label struct {
@@ -42,6 +105,16 @@ func (m *Sample) MarshalToSizedBuffer(dst []byte) (int, error) {
 
 func (m *TimeSeries) MarshalToSizedBuffer(dst []byte) (int, error) {
 	i := len(dst)
+	for j := len(m.Exemplars) - 1; j >= 0; j-- {
+		size, err := m.Exemplars[j].MarshalToSizedBuffer(dst[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = encodeVarint(dst, i, uint64(size))
+		i--
+		dst[i] = 0x1a
+	}
 	for j := len(m.Samples) - 1; j >= 0; j-- {
 		size, err := m.Samples[j].MarshalToSizedBuffer(dst[:i])
 		if err != nil {
@@ -106,6 +179,10 @@ func (m *TimeSeries) Size() (n int) {
 		n += 1 + l + sov(uint64(l))
 	}
 	for _, e := range m.Samples {
+		l := e.Size()
+		n += 1 + l + sov(uint64(l))
+	}
+	for _, e := range m.Exemplars {
 		l := e.Size()
 		n += 1 + l + sov(uint64(l))
 	}

--- a/lib/prompbmarshal/types.pb.go
+++ b/lib/prompbmarshal/types.pb.go
@@ -24,9 +24,6 @@ type Exemplar struct {
 
 func (m *Exemplar) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	i := len(dAtA)
-	_ = i
-	var l int
-	_ = l
 	if m.Timestamp != 0 {
 		i = encodeVarint(dAtA, i, uint64(m.Timestamp))
 		i--

--- a/lib/promscrape/client.go
+++ b/lib/promscrape/client.go
@@ -120,6 +120,9 @@ func (c *client) ReadData(dst *bytesutil.ByteBuffer) error {
 	// See https://github.com/VictoriaMetrics/VictoriaMetrics/issues/608 for details.
 	// Do not bloat the `Accept` header with OpenMetrics shit, since it looks like dead standard now.
 	req.Header.Set("Accept", "text/plain;version=0.0.4;q=1,*/*;q=0.1")
+	// We set this order support exemplars to be compatible with Prometheus Exposition format which uses
+	// Open Metrics Specification
+	// See https://github.com/prometheus/docs/blob/main/content/docs/instrumenting/exposition_formats.md#openmetrics-text-format
 	req.Header.Set("Accept", "application/openmetrics-text")
 	// Set X-Prometheus-Scrape-Timeout-Seconds like Prometheus does, since it is used by some exporters such as PushProx.
 	// See https://github.com/VictoriaMetrics/VictoriaMetrics/issues/1179#issuecomment-813117162

--- a/lib/promscrape/client.go
+++ b/lib/promscrape/client.go
@@ -120,7 +120,7 @@ func (c *client) ReadData(dst *bytesutil.ByteBuffer) error {
 	// See https://github.com/VictoriaMetrics/VictoriaMetrics/issues/608 for details.
 	// Do not bloat the `Accept` header with OpenMetrics shit, since it looks like dead standard now.
 	req.Header.Set("Accept", "text/plain;version=0.0.4;q=1,*/*;q=0.1")
-	// We set this order support exemplars to be compatible with Prometheus Exposition format which uses
+	// We set to support exemplars to be compatible with Prometheus Exposition format which uses
 	// Open Metrics Specification
 	// See https://github.com/prometheus/docs/blob/main/content/docs/instrumenting/exposition_formats.md#openmetrics-text-format
 	req.Header.Set("Accept", "application/openmetrics-text")

--- a/lib/promscrape/client.go
+++ b/lib/promscrape/client.go
@@ -120,6 +120,7 @@ func (c *client) ReadData(dst *bytesutil.ByteBuffer) error {
 	// See https://github.com/VictoriaMetrics/VictoriaMetrics/issues/608 for details.
 	// Do not bloat the `Accept` header with OpenMetrics shit, since it looks like dead standard now.
 	req.Header.Set("Accept", "text/plain;version=0.0.4;q=1,*/*;q=0.1")
+	req.Header.Set("Accept", "application/openmetrics-text")
 	// Set X-Prometheus-Scrape-Timeout-Seconds like Prometheus does, since it is used by some exporters such as PushProx.
 	// See https://github.com/VictoriaMetrics/VictoriaMetrics/issues/1179#issuecomment-813117162
 	req.Header.Set("X-Prometheus-Scrape-Timeout-Seconds", c.scrapeTimeoutSecondsStr)

--- a/lib/promscrape/client.go
+++ b/lib/promscrape/client.go
@@ -30,6 +30,7 @@ var (
 	streamParse = flag.Bool("promscrape.streamParse", false, "Whether to enable stream parsing for metrics obtained from scrape targets. This may be useful "+
 		"for reducing memory usage when millions of metrics are exposed per each scrape target. "+
 		"It is possible to set 'stream_parse: true' individually per each 'scrape_config' section in '-promscrape.config' for fine-grained control")
+	scrapeExemplars = flag.Bool("promscrape.scrapeExemplars", false, "Whether to enable scraping of exemplars from scrape targets.")
 )
 
 type client struct {
@@ -123,7 +124,9 @@ func (c *client) ReadData(dst *bytesutil.ByteBuffer) error {
 	// We set to support exemplars to be compatible with Prometheus Exposition format which uses
 	// Open Metrics Specification
 	// See https://github.com/prometheus/docs/blob/main/content/docs/instrumenting/exposition_formats.md#openmetrics-text-format
-	req.Header.Set("Accept", "application/openmetrics-text")
+	if *scrapeExemplars {
+		req.Header.Set("Accept", "application/openmetrics-text")
+	}
 	// Set X-Prometheus-Scrape-Timeout-Seconds like Prometheus does, since it is used by some exporters such as PushProx.
 	// See https://github.com/VictoriaMetrics/VictoriaMetrics/issues/1179#issuecomment-813117162
 	req.Header.Set("X-Prometheus-Scrape-Timeout-Seconds", c.scrapeTimeoutSecondsStr)

--- a/lib/promscrape/scrapework.go
+++ b/lib/promscrape/scrapework.go
@@ -909,13 +909,12 @@ func (sw *scrapeWork) addRowToTimeseries(wc *writeRequestCtx, r *parser.Row, tim
 	})
 	// Add Exemplars to Timeseries
 	exemplarsLen := len(wc.exemplars)
-	if len(r.Exemplar.Tags) > 0 {
-		exemplarLabels := make([]prompbmarshal.Label, len(r.Exemplar.Tags))
+	exemplarTagsLen := len(r.Exemplar.Tags)
+	if exemplarTagsLen > 0 {
+		exemplarLabels := make([]prompbmarshal.Label, exemplarTagsLen)
 		for i, label := range r.Exemplar.Tags {
-			exemplarLabels[i] = prompbmarshal.Label{
-				Name:  label.Key,
-				Value: label.Value,
-			}
+			exemplarLabels[i].Name = label.Key
+			exemplarLabels[i].Value = label.Value
 		}
 		wc.exemplars = append(wc.exemplars, prompbmarshal.Exemplar{
 			Labels:    exemplarLabels,

--- a/lib/promscrape/scrapework.go
+++ b/lib/promscrape/scrapework.go
@@ -910,12 +910,12 @@ func (sw *scrapeWork) addRowToTimeseries(wc *writeRequestCtx, r *parser.Row, tim
 	// Add Exemplars to Timeseries
 	exemplarsLen := len(wc.exemplars)
 	if len(r.Exemplar.Tags) > 0 {
-		exemplarLabels := []prompbmarshal.Label{}
-		for _, label := range r.Exemplar.Tags {
-			exemplarLabels = append(exemplarLabels, prompbmarshal.Label{
+		exemplarLabels := make([]prompbmarshal.Label, len(r.Exemplar.Tags))
+		for i, label := range r.Exemplar.Tags {
+			exemplarLabels[i] = prompbmarshal.Label{
 				Name:  label.Key,
 				Value: label.Value,
-			})
+			}
 		}
 		wc.exemplars = append(wc.exemplars, prompbmarshal.Exemplar{
 			Labels:    exemplarLabels,

--- a/lib/promscrape/scrapework_test.go
+++ b/lib/promscrape/scrapework_test.go
@@ -786,17 +786,19 @@ func parseData(data string) []prompbmarshal.TimeSeries {
 			})
 		}
 		exemplarLabels := []prompbmarshal.Label{}
-		for _, tag := range r.Exemplar.Tags {
-			exemplarLabels = append(exemplarLabels, prompbmarshal.Label{
-				Name:  tag.Key,
-				Value: tag.Value,
+		if len(r.Exemplar.Tags) > 0 {
+			for _, tag := range r.Exemplar.Tags {
+				exemplarLabels = append(exemplarLabels, prompbmarshal.Label{
+					Name:  tag.Key,
+					Value: tag.Value,
+				})
+			}
+			exemplars = append(exemplars, prompbmarshal.Exemplar{
+				Labels:    exemplarLabels,
+				Value:     r.Exemplar.Value,
+				Timestamp: r.Exemplar.Timestamp,
 			})
 		}
-		exemplars = append(exemplars, prompbmarshal.Exemplar{
-			Labels:    exemplarLabels,
-			Value:     r.Exemplar.Value,
-			Timestamp: r.Exemplar.Timestamp,
-		})
 
 		var ts prompbmarshal.TimeSeries
 		ts.Labels = labels

--- a/lib/promscrape/scrapework_test.go
+++ b/lib/promscrape/scrapework_test.go
@@ -708,6 +708,11 @@ func TestAddRowToTimeseriesNoRelabeling(t *testing.T) {
 			HonorLabels: true,
 		},
 		`metric{a="e",foo="bar"} 0 123`)
+	f(`metric{foo="bar"} 0 123 # {trace_id="12345"} 52 456`,
+		&ScrapeWork{
+			HonorLabels: true,
+		},
+		`metric{foo="bar"} 0 123 # {trace_id="12345"} 52 456`)
 }
 
 func TestSendStaleSeries(t *testing.T) {
@@ -765,6 +770,8 @@ func parseData(data string) []prompbmarshal.TimeSeries {
 	}
 	rows.UnmarshalWithErrLogger(data, errLogger)
 	var tss []prompbmarshal.TimeSeries
+	var exemplars []prompbmarshal.Exemplar
+
 	for _, r := range rows.Rows {
 		labels := []prompbmarshal.Label{
 			{
@@ -778,6 +785,19 @@ func parseData(data string) []prompbmarshal.TimeSeries {
 				Value: tag.Value,
 			})
 		}
+		exemplarLabels := []prompbmarshal.Label{}
+		for _, tag := range r.Exemplar.Tags {
+			exemplarLabels = append(exemplarLabels, prompbmarshal.Label{
+				Name:  tag.Key,
+				Value: tag.Value,
+			})
+		}
+		exemplars = append(exemplars, prompbmarshal.Exemplar{
+			Labels:    exemplarLabels,
+			Value:     r.Exemplar.Value,
+			Timestamp: r.Exemplar.Timestamp,
+		})
+
 		var ts prompbmarshal.TimeSeries
 		ts.Labels = labels
 		ts.Samples = []prompbmarshal.Sample{
@@ -786,6 +806,7 @@ func parseData(data string) []prompbmarshal.TimeSeries {
 				Timestamp: r.Timestamp,
 			},
 		}
+		ts.Exemplars = exemplars
 		tss = append(tss, ts)
 	}
 	return tss
@@ -850,6 +871,19 @@ func timeseriesToString(ts *prompbmarshal.TimeSeries) string {
 	}
 	s := ts.Samples[0]
 	fmt.Fprintf(&sb, "%g %d", s.Value, s.Timestamp)
+	// Add Exemplars to the end of string
+	for j, exemplar := range ts.Exemplars {
+		for i, label := range exemplar.Labels {
+			fmt.Fprintf(&sb, "%s=%q", label.Name, label.Value)
+			if i+1 < len(ts.Labels) {
+				fmt.Fprintf(&sb, ",")
+			}
+		}
+		fmt.Fprintf(&sb, "%g %d", exemplar.Value, exemplar.Timestamp)
+		if j+1 < len(ts.Exemplars) {
+			fmt.Fprintf(&sb, ",")
+		}
+	}
 	return sb.String()
 }
 

--- a/lib/protoparser/prometheus/parser.go
+++ b/lib/protoparser/prometheus/parser.go
@@ -250,7 +250,7 @@ func (tvt *tagsValueTimestamp) parse(s string, tagsPool []Tag, noEscapes bool) (
 		}
 	}
 	s = skipLeadingWhitespace(s)
-	// log and remove the comments
+	// save and remove the comments
 	n = strings.IndexByte(s, '#')
 	if n >= 0 {
 		tvt.Comments = s[n:]

--- a/lib/protoparser/prometheus/parser.go
+++ b/lib/protoparser/prometheus/parser.go
@@ -66,7 +66,7 @@ type Exemplar struct {
 	Tags []Tag
 	// Value: the value of the exemplar
 	Value float64
-	// Timestamp: the time the exemplar was recorded
+	// Timestamp: the time when exemplar was recorded
 	Timestamp int64
 }
 

--- a/lib/protoparser/prometheus/parser.go
+++ b/lib/protoparser/prometheus/parser.go
@@ -60,13 +60,13 @@ func (rs *Rows) UnmarshalWithErrLogger(s string, errLogger func(s string)) {
 const tagsPrefix = '{'
 const exemplarPreifx = '{'
 
-// Exemplar Support
-// Tags: a list of labels that uniquely identifies exemplar
-// Value: the value of the exemplar
-// Timestamp: the time the exemplar was recorded
+// Exemplar Item
 type Exemplar struct {
-	Tags      []Tag
-	Value     float64
+	// Tags: a list of labels that uniquely identifies exemplar
+	Tags []Tag
+	// Value: the value of the exemplar
+	Value float64
+	// Timestamp: the time the exemplar was recorded
 	Timestamp int64
 }
 

--- a/lib/protoparser/prometheus/parser.go
+++ b/lib/protoparser/prometheus/parser.go
@@ -60,15 +60,10 @@ func (rs *Rows) UnmarshalWithErrLogger(s string, errLogger func(s string)) {
 const tagsPrefix = '{'
 const exemplarPreifx = '{'
 
-/*
-Exemplar Support
-
-Tags: a list of labels that uniquely identifies exemplar
-
-Value: the value of the exemplar
-
-Timestamp: the time the exemplar was recorded
-*/
+// Exemplar Support
+// Tags: a list of labels that uniquely identifies exemplar
+// Value: the value of the exemplar
+// Timestamp: the time the exemplar was recorded
 type Exemplar struct {
 	Tags      []Tag
 	Value     float64

--- a/lib/protoparser/prometheus/parser.go
+++ b/lib/protoparser/prometheus/parser.go
@@ -210,7 +210,6 @@ func (tvt *tagsValueTimestamp) reset() {
 }
 func (tvt *tagsValueTimestamp) parse(s string, tagsPool []Tag, noEscapes bool) ([]Tag, error) {
 	n := 0
-	s = skipLeadingWhitespace(s)
 	// Prefix is everything up to a tag start or a space
 	t := strings.IndexByte(s, tagsPrefix)
 	// If there is no tag start process rest of string
@@ -252,6 +251,7 @@ func (tvt *tagsValueTimestamp) parse(s string, tagsPool []Tag, noEscapes bool) (
 			s = s[n:]
 		} else {
 			tvt.Prefix = s
+			return tagsPool, fmt.Errorf("missing value")
 		}
 	}
 	s = skipLeadingWhitespace(s)

--- a/lib/protoparser/prometheus/parser.go
+++ b/lib/protoparser/prometheus/parser.go
@@ -73,7 +73,7 @@ type Exemplar struct {
 // Reset - resets the Exemplar object to defaults
 func (e *Exemplar) Reset() {
 	e.Tags = nil
-	e.Value = 0.
+	e.Value = 0
 	e.Timestamp = 0
 }
 

--- a/lib/protoparser/prometheus/parser_test.go
+++ b/lib/protoparser/prometheus/parser_test.go
@@ -404,7 +404,7 @@ cassandra_token_ownership_ratio 78.9`, &Rows{
 	})
 	f(`foo_bucket{le="10",a="#b"} 17 # {test_id="oHg5SJ#YRHA0"} 9.8 1520879607.789
 		   abc 123 456 # foobar
-		   foo   344#bar`, &Rows{
+		   foo   344# {test_id="oHg5SJ#YRHA0"} 9.8 1520879607.789`, &Rows{
 		Rows: []Row{
 			{
 				Metric: "foo_bucket",
@@ -438,6 +438,16 @@ cassandra_token_ownership_ratio 78.9`, &Rows{
 			{
 				Metric: "foo",
 				Value:  344,
+				Exemplar: Exemplar{
+					Tags: []Tag{
+						{
+							Key:   "test_id",
+							Value: "oHg5SJ#YRHA0",
+						},
+					},
+					Value:     9.8,
+					Timestamp: 1520879607789,
+				},
 			},
 		},
 	})

--- a/lib/protoparser/prometheus/parser_test.go
+++ b/lib/protoparser/prometheus/parser_test.go
@@ -364,8 +364,8 @@ cassandra_token_ownership_ratio 78.9`, &Rows{
 	})
 	// Exemplars - see https://github.com/OpenObservability/OpenMetrics/blob/master/OpenMetrics.md#exemplars-1
 	f(`foo_bucket{le="10",a="#b"} 17 # {trace_id="oHg5SJ#YRHA0"} 9.8 1520879607.789
-	   abc 123 456 # foobar
-	   foo   344#bar`, &Rows{
+	  abc 123 456 # foobar
+	  foo   344#bar`, &Rows{
 		Rows: []Row{
 			{
 				Metric: "foo_bucket",
@@ -387,6 +387,8 @@ cassandra_token_ownership_ratio 78.9`, &Rows{
 							Value: "oHg5SJ#YRHA0",
 						},
 					},
+					Value:     9.8,
+					Timestamp: 1520879607789,
 				},
 			},
 			{
@@ -401,8 +403,8 @@ cassandra_token_ownership_ratio 78.9`, &Rows{
 		},
 	})
 	f(`foo_bucket{le="10",a="#b"} 17 # {test_id="oHg5SJ#YRHA0"} 9.8 1520879607.789
-	   abc 123 456 # foobar
-	   foo   344#bar`, &Rows{
+		   abc 123 456 # foobar
+		   foo   344#bar`, &Rows{
 		Rows: []Row{
 			{
 				Metric: "foo_bucket",
@@ -424,6 +426,8 @@ cassandra_token_ownership_ratio 78.9`, &Rows{
 							Value: "oHg5SJ#YRHA0",
 						},
 					},
+					Value:     9.8,
+					Timestamp: 1520879607789,
 				},
 			},
 			{

--- a/lib/protoparser/prometheus/parser_test.go
+++ b/lib/protoparser/prometheus/parser_test.go
@@ -362,7 +362,6 @@ cassandra_token_ownership_ratio 78.9`, &Rows{
 			Value: 56,
 		}},
 	})
-
 	// Exemplars - see https://github.com/OpenObservability/OpenMetrics/blob/master/OpenMetrics.md#exemplars-1
 	f(`foo_bucket{le="10",a="#b"} 17 # {trace_id="oHg5SJ#YRHA0"} 9.8 1520879607.789
 	   abc 123 456 # foobar
@@ -381,6 +380,51 @@ cassandra_token_ownership_ratio 78.9`, &Rows{
 					},
 				},
 				Value: 17,
+				Exemplar: Exemplar{
+					Tags: []Tag{
+						{
+							Key:   "trace_id",
+							Value: "oHg5SJ#YRHA0",
+						},
+					},
+				},
+			},
+			{
+				Metric:    "abc",
+				Value:     123,
+				Timestamp: 456000,
+			},
+			{
+				Metric: "foo",
+				Value:  344,
+			},
+		},
+	})
+	f(`foo_bucket{le="10",a="#b"} 17 # {test_id="oHg5SJ#YRHA0"} 9.8 1520879607.789
+	   abc 123 456 # foobar
+	   foo   344#bar`, &Rows{
+		Rows: []Row{
+			{
+				Metric: "foo_bucket",
+				Tags: []Tag{
+					{
+						Key:   "le",
+						Value: "10",
+					},
+					{
+						Key:   "a",
+						Value: "#b",
+					},
+				},
+				Value: 17,
+				Exemplar: Exemplar{
+					Tags: []Tag{
+						{
+							Key:   "test_id",
+							Value: "oHg5SJ#YRHA0",
+						},
+					},
+				},
 			},
 			{
 				Metric:    "abc",

--- a/lib/protoparser/prometheus/parser_test.go
+++ b/lib/protoparser/prometheus/parser_test.go
@@ -362,50 +362,59 @@ cassandra_token_ownership_ratio 78.9`, &Rows{
 			Value: 56,
 		}},
 	})
-	// Exemplars - see https://github.com/OpenObservability/OpenMetrics/blob/master/OpenMetrics.md#exemplars-1
-	f(`foo_bucket{le="10",a="#b"} 17 # {trace_id="oHg5SJ#YRHA0"} 9.8 1520879607.789
-	  abc 123 456 # foobar
-	  foo   344#bar`, &Rows{
+	// Support for Exemplars Open Metric Specification
+	// see: https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#exemplars-1
+	f(`foo_bucket{le="0.01"} 0
+			foo_bucket{le="0.1"} 8 # {} 0.054
+			foo_bucket{le="1"} 11 # {trace_id="KOO5S4vxi0o"} 0.67
+			foo_bucket{le="10"} 17 # {trace_id="oHg5SJYRHA0"} 9.8 1520879607.789
+			foo_bucket{nospace="exemplar"} 17 #{trace_id="oHg5SJYRHA0"} 9.8 1520879607.789
+			foo_bucket{le="+Inf"} 17
+			foo_count 17
+			foo_sum 324789.3
+			foo_created  1520430000.123`, &Rows{
 		Rows: []Row{
 			{
 				Metric: "foo_bucket",
 				Tags: []Tag{
 					{
 						Key:   "le",
-						Value: "10",
-					},
-					{
-						Key:   "a",
-						Value: "#b",
+						Value: "0.01",
 					},
 				},
-				Value: 17,
+			},
+			{
+				Metric: "foo_bucket",
+				Tags: []Tag{
+					{
+						Key:   "le",
+						Value: "0.1",
+					},
+				},
+				Value: 8,
 				Exemplar: Exemplar{
+					Value: 0.054,
+				},
+			},
+			{
+				Metric: "foo_bucket",
+				Tags: []Tag{
+					{
+						Key:   "le",
+						Value: "1",
+					},
+				},
+				Value: 11,
+				Exemplar: Exemplar{
+					Value: 0.67,
 					Tags: []Tag{
 						{
 							Key:   "trace_id",
-							Value: "oHg5SJ#YRHA0",
+							Value: "KOO5S4vxi0o",
 						},
 					},
-					Value:     9.8,
-					Timestamp: 1520879607789,
 				},
 			},
-			{
-				Metric:    "abc",
-				Value:     123,
-				Timestamp: 456000,
-			},
-			{
-				Metric: "foo",
-				Value:  344,
-			},
-		},
-	})
-	f(`foo_bucket{le="10",a="#b"} 17 # {test_id="oHg5SJ#YRHA0"} 9.8 1520879607.789
-		   abc 123 456 # foobar
-		   foo   344# {test_id="oHg5SJ#YRHA0"} 9.8 1520879607.789`, &Rows{
-		Rows: []Row{
 			{
 				Metric: "foo_bucket",
 				Tags: []Tag{
@@ -413,41 +422,60 @@ cassandra_token_ownership_ratio 78.9`, &Rows{
 						Key:   "le",
 						Value: "10",
 					},
+				},
+				Value: 17,
+				Exemplar: Exemplar{
+					Value: 9.8,
+					Tags: []Tag{
+						{
+							Key:   "trace_id",
+							Value: "oHg5SJYRHA0",
+						},
+					},
+					Timestamp: 1520879607789,
+				},
+			},
+			{
+				Metric: "foo_bucket",
+				Tags: []Tag{
 					{
-						Key:   "a",
-						Value: "#b",
+						Key:   "nospace",
+						Value: "exemplar",
 					},
 				},
 				Value: 17,
 				Exemplar: Exemplar{
+					Value: 9.8,
 					Tags: []Tag{
 						{
-							Key:   "test_id",
-							Value: "oHg5SJ#YRHA0",
+							Key:   "trace_id",
+							Value: "oHg5SJYRHA0",
 						},
 					},
-					Value:     9.8,
 					Timestamp: 1520879607789,
 				},
 			},
 			{
-				Metric:    "abc",
-				Value:     123,
-				Timestamp: 456000,
+				Metric: "foo_bucket",
+				Tags: []Tag{
+					{
+						Key:   "le",
+						Value: "+Inf",
+					},
+				},
+				Value: 17,
 			},
 			{
-				Metric: "foo",
-				Value:  344,
-				Exemplar: Exemplar{
-					Tags: []Tag{
-						{
-							Key:   "test_id",
-							Value: "oHg5SJ#YRHA0",
-						},
-					},
-					Value:     9.8,
-					Timestamp: 1520879607789,
-				},
+				Metric: "foo_count",
+				Value:  17,
+			},
+			{
+				Metric: "foo_sum",
+				Value:  324789.3,
+			},
+			{
+				Metric: "foo_created",
+				Value:  1520430000.123,
 			},
 		},
 	})

--- a/lib/protoparser/prometheus/parser_test.go
+++ b/lib/protoparser/prometheus/parser_test.go
@@ -364,15 +364,43 @@ cassandra_token_ownership_ratio 78.9`, &Rows{
 	})
 	// Support for Exemplars Open Metric Specification
 	// see: https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#exemplars-1
+	f(`foo_bucket{le="25"} 17 # {trace_id="oHg5SJYRHA0", log_id="test_id"} 9.8 1520879607.789`, &Rows{
+		Rows: []Row{
+			{
+				Metric: "foo_bucket",
+				Tags: []Tag{
+					{
+						Key:   "le",
+						Value: "25",
+					},
+				},
+				Value: 17,
+				Exemplar: Exemplar{
+					Value: 9.8,
+					Tags: []Tag{
+						{
+							Key:   "trace_id",
+							Value: "oHg5SJYRHA0",
+						},
+						{
+							Key:   "log_id",
+							Value: "test_id",
+						},
+					},
+					Timestamp: 1520879607789,
+				},
+			},
+		}})
 	f(`foo_bucket{le="0.01"} 0
-			foo_bucket{le="0.1"} 8 # {} 0.054
-			foo_bucket{le="1"} 11 # {trace_id="KOO5S4vxi0o"} 0.67
-			foo_bucket{le="10"} 17 # {trace_id="oHg5SJYRHA0"} 9.8 1520879607.789
-			foo_bucket{nospace="exemplar"} 17 #{trace_id="oHg5SJYRHA0"} 9.8 1520879607.789
-			foo_bucket{le="+Inf"} 17
-			foo_count 17
-			foo_sum 324789.3
-			foo_created  1520430000.123`, &Rows{
+foo_bucket{le="0.1"} 8 # {} 0.054
+foo_bucket{le="1"} 11 # {trace_id="KOO5S4vxi0o"} 0.67
+foo_bucket{le="10"} 17 # {trace_id="oHg5SJYRHA0"} 9.8 1520879607.789
+foo_bucket{le="25"} 17 # {trace_id="oHg5SJYRHA0", log_id="test_id"} 9.8 1520879607.789
+foo_bucket{nospace="exemplar"} 17 #{trace_id="oHg5SJYRHA0"} 9.8 1520879607.789
+foo_bucket{le="+Inf"} 17
+foo_count 17
+foo_sum 324789.3
+foo_created  1520430000.123`, &Rows{
 		Rows: []Row{
 			{
 				Metric: "foo_bucket",
@@ -430,6 +458,30 @@ cassandra_token_ownership_ratio 78.9`, &Rows{
 						{
 							Key:   "trace_id",
 							Value: "oHg5SJYRHA0",
+						},
+					},
+					Timestamp: 1520879607789,
+				},
+			},
+			{
+				Metric: "foo_bucket",
+				Tags: []Tag{
+					{
+						Key:   "le",
+						Value: "25",
+					},
+				},
+				Value: 17,
+				Exemplar: Exemplar{
+					Value: 9.8,
+					Tags: []Tag{
+						{
+							Key:   "trace_id",
+							Value: "oHg5SJYRHA0",
+						},
+						{
+							Key:   "log_id",
+							Value: "test_id",
 						},
 					},
 					Timestamp: 1520879607789,

--- a/lib/protoparser/prometheus/parser_timing_test.go
+++ b/lib/protoparser/prometheus/parser_timing_test.go
@@ -146,10 +146,11 @@ container_ulimits_soft{container="kube-scheduler",id="/kubelet/kubepods/burstabl
 }
 
 func BenchmarkRowsUnmarshal(b *testing.B) {
-	s := `cpu_usage{mode="user"} 1.23
-cpu_usage{mode="system"} 23.344
-cpu_usage{mode="iowait"} 3.3443
-cpu_usage{mode="irq"} 0.34432
+	s := ` cpu_usage{mode="user"} 1.23 # {trace_id="2"} 2 
+cpu_usage{mode="system"} 23.344 # {trace_id="3"} 3
+cpu_usage{mode="iowait"} 3.3443 # {trace_id="4"} 4
+cpu_usage{mode="irq"} 0.34432 # {trace_id="1"} 5
+cpu_usage{mode2="irq"} 0.34432 # {trace_id="1"} 5 1
 `
 	b.SetBytes(int64(len(s)))
 	b.ReportAllocs()
@@ -157,7 +158,7 @@ cpu_usage{mode="irq"} 0.34432
 		var rows Rows
 		for pb.Next() {
 			rows.Unmarshal(s)
-			if len(rows.Rows) != 4 {
+			if len(rows.Rows) != 5 {
 				panic(fmt.Errorf("unexpected number of rows unmarshaled: got %d; want 4", len(rows.Rows)))
 			}
 		}

--- a/lib/protoparser/prometheus/parser_timing_test.go
+++ b/lib/protoparser/prometheus/parser_timing_test.go
@@ -146,11 +146,10 @@ container_ulimits_soft{container="kube-scheduler",id="/kubelet/kubepods/burstabl
 }
 
 func BenchmarkRowsUnmarshal(b *testing.B) {
-	s := ` cpu_usage{mode="user"} 1.23 # {trace_id="2"} 2 
-cpu_usage{mode="system"} 23.344 # {trace_id="3"} 3
-cpu_usage{mode="iowait"} 3.3443 # {trace_id="4"} 4
-cpu_usage{mode="irq"} 0.34432 # {trace_id="1"} 5
-cpu_usage{mode2="irq"} 0.34432 # {trace_id="1"} 5 1
+	s := `foo_bucket{le="0.01"} 0
+			foo_bucket{le="1"} 11 # {trace_id="KOO5S4vxi0o"} 0.67
+			foo_bucket{le="10"} 17 # {trace_id="oHg5SJYRHA0"} 9.8 1520879607.789
+			foo_bucket{nospace="exemplar"} 17 #{trace_id="oHg5SJYRHA0"} 9.8 1520879607.789 
 `
 	b.SetBytes(int64(len(s)))
 	b.ReportAllocs()
@@ -158,7 +157,7 @@ cpu_usage{mode2="irq"} 0.34432 # {trace_id="1"} 5 1
 		var rows Rows
 		for pb.Next() {
 			rows.Unmarshal(s)
-			if len(rows.Rows) != 5 {
+			if len(rows.Rows) != 4 {
 				panic(fmt.Errorf("unexpected number of rows unmarshaled: got %d; want 4", len(rows.Rows)))
 			}
 		}


### PR DESCRIPTION
This code adds Exemplars to VMagent and the promscrape parser adhering to OpenMetrics Specifications.  This will allow forwarding of exemplars to Prometheus and other third party apps that support OpenMetrics specs.