### PR TITLE
streamaggr: implement delay in total aggr

### DIFF
--- a/lib/streamaggr/dedup_timing_test.go
+++ b/lib/streamaggr/dedup_timing_test.go
@@ -2,6 +2,8 @@ package streamaggr
 
 import (
 	"fmt"
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/fasttime"
+	"github.com/VictoriaMetrics/metrics"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -19,7 +21,7 @@ func BenchmarkDedupAggr(b *testing.B) {
 }
 
 func BenchmarkDedupAggrFlushSerial(b *testing.B) {
-	as := newTotalAggrState(time.Hour, true, true)
+	as := newTotalAggrState(time.Hour, time.Hour, 0, true, true, fasttime.UnixTimestamp, metrics.NewSet())
 	benchSamples := newBenchSamples(100_000)
 	da := newDedupAggr()
 	da.pushSamples(benchSamples)

--- a/lib/streamaggr/deduplicator_test.go
+++ b/lib/streamaggr/deduplicator_test.go
@@ -36,7 +36,7 @@ baz_aaa_aaa_fdd{instance="x",job="aaa",pod="sdfd-dfdfdfs",node="aosijjewrerfd",n
 	d.flush(pushFunc, time.Hour)
 	d.MustStop()
 
-	result := timeSeriessToString(tssResult)
+	result := timeSeriessToString(tssResult, false)
 	resultExpected := `asfjkldsf{container="ohohffd",job="aaa",namespace="asdff",pod="sdfd-dfdfdfs"} 12322
 bar{container="ohohffd",job="aaa",namespace="asdff",pod="sdfd-dfdfdfs"} 34.54
 baz_aaa_aaa_fdd{container="ohohffd",job="aaa",namespace="asdff",pod="sdfd-dfdfdfs"} -2.3

--- a/lib/streamaggr/streamaggr.go
+++ b/lib/streamaggr/streamaggr.go
@@ -16,6 +16,7 @@ import (
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/cgroup"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/encoding"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/envtemplate"
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/fasttime"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/fs/fscore"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/logger"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/prompbmarshal"
@@ -111,6 +112,9 @@ type Options struct {
 	//
 	// This option can be overridden individually per each aggregation via ignore_old_samples option.
 	IgnoreOldSamples bool
+
+	// Use a custom function for getting timestamps. Just used for testing.
+	Now func() uint64
 }
 
 // Config is a configuration for a single stream aggregation.
@@ -139,6 +143,12 @@ type Config struct {
 	// Staleness interval is interval after which the series state will be reset if no samples have been sent during it.
 	// The parameter is only relevant for outputs: total, total_prometheus, increase, increase_prometheus and histogram_bucket.
 	StalenessInterval string `yaml:"staleness_interval,omitempty"`
+
+	// If greater than zero, the number of seconds (inclusive) a sample can be delayed.
+	// In this mode, sample timestamps are taken into account and aggregated within intervals (defined by intervalSecs).
+	// Aggregated samples have timestamps aligned with the interval.
+	// Default: 0
+	Delay string `yaml:"delay,omitempty"`
 
 	// Outputs is a list of output aggregate functions to produce.
 	//
@@ -432,6 +442,15 @@ func newAggregator(cfg *Config, pushFunc PushFunc, ms *metrics.Set, opts *Option
 		}
 	}
 
+	// check cfg.Delay
+	var delay time.Duration = 0
+	if cfg.Delay != "" {
+		delay, err = time.ParseDuration(cfg.Delay)
+		if err != nil {
+			return nil, fmt.Errorf("cannot parse `delay: %q`: %w", cfg.Delay, err)
+		}
+	}
+
 	// Check cfg.DropInputLabels
 	dropInputLabels := opts.DropInputLabels
 	if v := cfg.DropInputLabels; v != nil {
@@ -479,6 +498,11 @@ func newAggregator(cfg *Config, pushFunc PushFunc, ms *metrics.Set, opts *Option
 		ignoreOldSamples = *v
 	}
 
+	nowFunc := opts.Now
+	if nowFunc == nil {
+		nowFunc = fasttime.UnixTimestamp
+	}
+
 	// initialize outputs list
 	if len(cfg.Outputs) == 0 {
 		return nil, fmt.Errorf("`outputs` list must contain at least a single entry from the list %s; "+
@@ -512,13 +536,13 @@ func newAggregator(cfg *Config, pushFunc PushFunc, ms *metrics.Set, opts *Option
 		}
 		switch output {
 		case "total":
-			aggrStates[i] = newTotalAggrState(stalenessInterval, false, true)
+			aggrStates[i] = newTotalAggrState(interval, stalenessInterval, delay, false, true, nowFunc, ms)
 		case "total_prometheus":
-			aggrStates[i] = newTotalAggrState(stalenessInterval, false, false)
+			aggrStates[i] = newTotalAggrState(interval, stalenessInterval, delay, false, false, nowFunc, ms)
 		case "increase":
-			aggrStates[i] = newTotalAggrState(stalenessInterval, true, true)
+			aggrStates[i] = newTotalAggrState(interval, stalenessInterval, delay, true, true, nowFunc, ms)
 		case "increase_prometheus":
-			aggrStates[i] = newTotalAggrState(stalenessInterval, true, false)
+			aggrStates[i] = newTotalAggrState(interval, stalenessInterval, delay, true, false, nowFunc, ms)
 		case "count_series":
 			aggrStates[i] = newCountSeriesAggrState()
 		case "count_samples":


### PR DESCRIPTION
**Problem**

Sample timestamps are (mostly) ignored and flushed metrics base their timestamps on the wall clock. This is fine for most counters, but problematic for histograms which need to have bucket timestamps aligned. If a flush occurs before all histogram buckets are incremented, the buckets will be flushed across different timestamps and mess up `histogram_quantile` calculations which expect cumulative bucket values (e.g. `histogram{le=30}` should be >= `histogram{le=20}`).

**Solution**

Implement a "delay" mechanism to align input timestamps to outputs. This ensures the following property: all samples with timestamp T will be aggregated and flushed together in the same interval. This solves the histogram use-case since all buckets for a given timestamp T will be aggregated and flushed together.