### PR TITLE
Use GetDeadlineForLabelsAPI for LabelAPI requests

### DIFF
--- a/app/vmselect/prometheus/prometheus.go
+++ b/app/vmselect/prometheus/prometheus.go
@@ -1138,7 +1138,7 @@ func getCommonParamsForLabelsAPI(r *http.Request, startTime time.Time, requireNo
 	if cp.start == 0 {
 		cp.start = cp.end - defaultStep
 	}
-	cp.deadline = searchutils.GetDeadlineForExport(r, startTime)
+	cp.deadline = searchutils.GetDeadlineForLabelsAPI(r, startTime)
 	return cp, nil
 }
 


### PR DESCRIPTION
`GetDeadlineForLabelsAPI` exists but is unused. It seems like it was intended to be used here and just got over looked. My LabelAPI requests were running for multiple minutes on end which led me here.