### PR TITLE
app/vlselect: follow-up for 0514091948cf8e00e42f44318c0e5e5b63b6388f

### DIFF
--- a/app/vlselect/logsql/sort_writer.go
+++ b/app/vlselect/logsql/sort_writer.go
@@ -123,7 +123,6 @@ func (sw *sortWriter) writeToUnderlyingWriterLocked(p []byte) bool {
 		}
 		var linesLeft int
 		p, linesLeft = trimLines(p, sw.maxLines-sw.linesWritten)
-		println("DEBUG: end trimLines", string(p), linesLeft)
 		sw.linesWritten += linesLeft
 	}
 	if _, err := sw.w.Write(p); err != nil {
@@ -133,7 +132,6 @@ func (sw *sortWriter) writeToUnderlyingWriterLocked(p []byte) bool {
 }
 
 func trimLines(p []byte, maxLines int) ([]byte, int) {
-	println("DEBUG: start trimLines", string(p), maxLines)
 	if maxLines <= 0 {
 		return nil, 0
 	}

--- a/docs/VictoriaLogs/CHANGELOG.md
+++ b/docs/VictoriaLogs/CHANGELOG.md
@@ -19,6 +19,7 @@ according to [these docs](https://docs.victoriametrics.com/VictoriaLogs/QuickSta
 
 ## tip
 
+* BUGFIX: removes `println` lines after 0514091948cf8e00e42f44318c0e5e5b63b6388f.
 ## [v0.5.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v0.5.0-victorialogs)
 
 Released at 2024-03-01


### PR DESCRIPTION
removes println lines