### PR TITLE
docs/vmctl: improve source URL example for `vm-native` method

### DIFF
--- a/docs/vmctl.md
+++ b/docs/vmctl.md
@@ -805,14 +805,14 @@ Migration in `vm-native` mode takes two steps:
 
 ```sh
 ./vmctl vm-native \
-    --vm-native-src-addr=http://127.0.0.1:8481/select/0/prometheus \ # migrate from
-    --vm-native-dst-addr=http://localhost:8428 \                     # migrate to
-    --vm-native-filter-time-start='2022-11-20T00:00:00Z' \           # starting from
-    --vm-native-filter-match='{__name__!~"vm_.*"}'                   # filter out metrics matching the selector
+    --vm-native-src-addr=http://127.0.0.1:8481 \            # migrate from
+    --vm-native-dst-addr=http://localhost:8428 \            # migrate to
+    --vm-native-filter-time-start='2022-11-20T00:00:00Z' \  # starting from
+    --vm-native-filter-match='{__name__!~"vm_.*"}'          # filter out metrics matching the selector
 VictoriaMetrics Native import mode
 
-2023/03/02 09:22:02 Initing import process from "http://127.0.0.1:8481/select/0/prometheus/api/v1/export/native" 
-                    to "http://localhost:8428/api/v1/import/native" with filter 
+2023/03/02 09:22:02 Initing import process from "http://127.0.0.1:8481/api/v1/export/native"
+                    to "http://localhost:8428/api/v1/import/native" with filter
         filter: match[]={__name__!~"vm_.*"}
         start: 2022-11-20T00:00:00Z
 2023/03/02 09:22:02 Exploring metrics...


### PR DESCRIPTION
The `/select/0/prometheus` path is not not supported by modern versions of VictoriaMetrics.