### PR TITLE
feat: [zabbix connector] added push data with zabbix connector from vmagent

### DIFF
--- a/app/vmagent/main.go
+++ b/app/vmagent/main.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -25,6 +26,7 @@ import (
 	"github.com/VictoriaMetrics/VictoriaMetrics/app/vmagent/promremotewrite"
 	"github.com/VictoriaMetrics/VictoriaMetrics/app/vmagent/remotewrite"
 	"github.com/VictoriaMetrics/VictoriaMetrics/app/vmagent/vmimport"
+	"github.com/VictoriaMetrics/VictoriaMetrics/app/vmagent/zabbixconnector"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/auth"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/buildinfo"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/bytesutil"
@@ -325,6 +327,17 @@ func requestHandler(w http.ResponseWriter, r *http.Request) bool {
 		}
 		firehose.WriteSuccessResponse(w, r)
 		return true
+	case "/zabbixconnector/api/v1/history":
+		zabbixconnectorHistoryRequests.Inc()
+		if err := zabbixconnector.InsertHandlerForHTTP(nil, r); err != nil {
+			zabbixconnectorHistoryErrors.Inc()
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusBadRequest)
+			fmt.Fprintf(w, `{"error":%s}`, strconv.Quote(err.Error()))
+			return true
+		}
+		w.WriteHeader(http.StatusOK)
+		return true
 	case "/newrelic":
 		newrelicCheckRequest.Inc()
 		w.Header().Set("Content-Type", "application/json")
@@ -571,6 +584,17 @@ func processMultitenantRequest(w http.ResponseWriter, r *http.Request, path stri
 		}
 		firehose.WriteSuccessResponse(w, r)
 		return true
+	case "zabbixconnector/api/v1/history":
+		zabbixconnectorHistoryRequests.Inc()
+		if err := zabbixconnector.InsertHandlerForHTTP(at, r); err != nil {
+			zabbixconnectorHistoryErrors.Inc()
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusBadRequest)
+			fmt.Fprintf(w, `{"error":%s}`, strconv.Quote(err.Error()))
+			return true
+		}
+		w.WriteHeader(http.StatusOK)
+		return true
 	case "newrelic":
 		newrelicCheckRequest.Inc()
 		w.Header().Set("Content-Type", "application/json")
@@ -690,6 +714,9 @@ var (
 
 	opentelemetryPushRequests = metrics.NewCounter(`vmagent_http_requests_total{path="/opentelemetry/v1/metrics", protocol="opentelemetry"}`)
 	opentelemetryPushErrors   = metrics.NewCounter(`vmagent_http_request_errors_total{path="/opentelemetry/v1/metrics", protocol="opentelemetry"}`)
+
+	zabbixconnectorHistoryRequests = metrics.NewCounter(`vmagent_http_requests_total{path="/zabbixconnector/api/v1/history", protocol="zabbixconnector"}`)
+	zabbixconnectorHistoryErrors   = metrics.NewCounter(`vmagent_http_request_errors_total{path="/zabbixconnector/api/v1/history", protocol="zabbixconnector"}`)
 
 	newrelicWriteRequests = metrics.NewCounter(`vm_http_requests_total{path="/newrelic/infra/v2/metrics/events/bulk", protocol="newrelic"}`)
 	newrelicWriteErrors   = metrics.NewCounter(`vm_http_request_errors_total{path="/newrelic/infra/v2/metrics/events/bulk", protocol="newrelic"}`)

--- a/app/vmagent/zabbixconnector/request_handler.go
+++ b/app/vmagent/zabbixconnector/request_handler.go
@@ -1,0 +1,80 @@
+package zabbixconnector
+
+import (
+	"net/http"
+
+	"github.com/VictoriaMetrics/VictoriaMetrics/app/vmagent/common"
+	"github.com/VictoriaMetrics/VictoriaMetrics/app/vmagent/remotewrite"
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/auth"
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/bytesutil"
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/prompbmarshal"
+	parserCommon "github.com/VictoriaMetrics/VictoriaMetrics/lib/protoparser/common"
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/protoparser/zabbixconnector"
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/protoparser/zabbixconnector/stream"
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/tenantmetrics"
+	"github.com/VictoriaMetrics/metrics"
+)
+
+var (
+	rowsInserted       = metrics.NewCounter(`vmagent_rows_inserted_total{type="zabbixconnector"}`)
+	rowsTenantInserted = tenantmetrics.NewCounterMap(`vmagent_tenant_inserted_rows_total{type="zabbixconnector"}`)
+	rowsPerInsert      = metrics.NewHistogram(`vmagent_rows_per_insert{type="zabbixconnector"}`)
+)
+
+// InsertHandlerForHTTP processes remote write for ZabbixConnector POST /zabbixconnector/v1/history request.
+func InsertHandlerForHTTP(at *auth.Token, req *http.Request) error {
+	extraLabels, err := parserCommon.GetExtraLabels(req)
+	if err != nil {
+		return err
+	}
+	isGzipped := req.Header.Get("Content-Encoding") == "gzip"
+	return stream.Parse(req.Body, isGzipped, func(rows []zabbixconnector.Row) error {
+		return insertRows(at, rows, extraLabels)
+	})
+}
+
+func insertRows(at *auth.Token, rows []zabbixconnector.Row, extraLabels []prompbmarshal.Label) error {
+	ctx := common.GetPushCtx()
+	defer common.PutPushCtx(ctx)
+
+	rowsTotal := len(rows)
+	tssDst := ctx.WriteRequest.Timeseries[:0]
+	labels := ctx.Labels[:0]
+	samples := ctx.Samples[:0]
+	for i := range rows {
+		r := &rows[i]
+
+		labelsLen := len(labels)
+		for j := range r.Tags {
+			tag := &r.Tags[j]
+			labels = append(labels, prompbmarshal.Label{
+				Name:  bytesutil.ToUnsafeString(tag.Key),
+				Value: bytesutil.ToUnsafeString(tag.Value),
+			})
+		}
+		labels = append(labels, extraLabels...)
+
+		samplesLen := len(samples)
+		samples = append(samples, prompbmarshal.Sample{
+			Value:     r.Value,
+			Timestamp: r.Timestamp,
+		})
+
+		tssDst = append(tssDst, prompbmarshal.TimeSeries{
+			Labels:  labels[labelsLen:],
+			Samples: samples[samplesLen:],
+		})
+	}
+	ctx.WriteRequest.Timeseries = tssDst
+	ctx.Labels = labels
+	ctx.Samples = samples
+	if !remotewrite.TryPush(at, &ctx.WriteRequest) {
+		return remotewrite.ErrQueueFullHTTPRetry
+	}
+	rowsInserted.Add(rowsTotal)
+	if at != nil {
+		rowsTenantInserted.Get(at).Add(rowsTotal)
+	}
+	rowsPerInsert.Update(float64(rowsTotal))
+	return nil
+}

--- a/lib/protoparser/zabbixconnector/parser.go
+++ b/lib/protoparser/zabbixconnector/parser.go
@@ -1,0 +1,267 @@
+package zabbixconnector
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/logger"
+	"github.com/VictoriaMetrics/metrics"
+	"github.com/valyala/fastjson"
+)
+
+const (
+	ADDGROUPS    byte = 0b00000001
+	ADDEMPTYTAGS byte = 0b00000010
+	EMPTYVALUE   byte = 49 // "1"
+)
+
+type Rows struct {
+	Rows []Row
+}
+
+func (rs *Rows) Reset() {
+	for i := range rs.Rows {
+		rs.Rows[i].reset()
+	}
+	rs.Rows = rs.Rows[:0]
+}
+
+func (rs *Rows) Unmarshal(s string, par byte) {
+	rs.Rows = unmarshalRows(rs.Rows[:0], s, par)
+}
+
+// Row is a single Zabbix Connector row
+type Row struct {
+	Tags      []Tag
+	Value     float64
+	Timestamp int64
+}
+
+func (r *Row) reset() {
+	tags := r.Tags
+	for i := range tags {
+		tags[i].reset()
+	}
+	r.Tags = tags[:0]
+
+	r.Value = 0
+	r.Timestamp = 0
+}
+
+func (r *Row) addTag() *Tag {
+	dst := r.Tags
+	if cap(dst) > len(dst) {
+		dst = dst[:len(dst)+1]
+	} else {
+		dst = append(dst, Tag{})
+	}
+	tag := &dst[len(dst)-1]
+	r.Tags = dst
+	return tag
+}
+
+func (r *Row) unmarshal(o *fastjson.Value, par byte) error {
+	r.reset()
+
+	host := o.GetObject("host")
+	if host == nil {
+		return fmt.Errorf("missing `host` object")
+	}
+
+	v := host.Get("host").GetStringBytes()
+	if len(v) == 0 {
+		return fmt.Errorf("missing `host` element in `host` object")
+	}
+	tag := r.addTag()
+	tag.Key = append(tag.Key[:0], []byte("host")...)
+	tag.Value = append(tag.Value[:0], v...)
+
+	v = host.Get("name").GetStringBytes()
+	if len(v) == 0 {
+		return fmt.Errorf("missing `name` element in `host` object")
+	}
+	tag = r.addTag()
+	tag.Key = append(tag.Key[:0], []byte("hostname")...)
+	tag.Value = append(tag.Value[:0], v...)
+
+	v = o.GetStringBytes("name")
+	if len(v) == 0 {
+		return fmt.Errorf("missing `name` element")
+	}
+	tag = r.addTag()
+	tag.Key = append(tag.Key[:0], []byte("__name__")...)
+	tag.Value = append(tag.Value[:0], v...)
+
+	n, err := getFloat64(o, "value")
+	if err != nil {
+		return fmt.Errorf("missing `value` element, %s", err)
+	}
+	r.Value = n
+
+	cl, err := getInt64(o, "clock")
+	if err != nil {
+		return fmt.Errorf("missing `clock` element, %s", err)
+	}
+	ns, err := getInt64(o, "ns")
+	if err != nil {
+		return fmt.Errorf("missing `ns` element, %s", err)
+	}
+	// clock - Number of seconds since Epoch to the moment when value was collected (integer part).
+	// ns - Number of nanoseconds to be added to clock to get a precise value collection time.
+	//
+	// See https://www.zabbix.com/documentation/current/en/manual/appendix/protocols/real_time_export#item-values
+	r.Timestamp = cl*1e3 + ns/1e6
+
+	if (par & ADDGROUPS) != 0 {
+		groups, err := getArray(o, "groups")
+		if err != nil {
+			return fmt.Errorf("missing `groups` element, %s", err)
+		}
+		for _, g := range groups {
+			k := g.GetStringBytes()
+			if len(k) == 0 {
+				continue
+			}
+
+			tag = r.addTag()
+			tag.Key = append(tag.Key[:0], k...)
+			tag.Value = append(tag.Value[:0], EMPTYVALUE)
+		}
+	}
+
+	skipEmptyTags := (par & ADDEMPTYTAGS) == 0
+	item_tags, err := getArray(o, "item_tags")
+	if err != nil {
+		return fmt.Errorf("missing `item_tags` element, %s", err)
+	}
+	for _, t := range item_tags {
+		k := t.GetStringBytes("tag")
+		if len(k) == 0 {
+			continue
+		}
+
+		v := t.GetStringBytes("value")
+		if len(v) == 0 && skipEmptyTags {
+			continue
+		}
+		tag = r.addTag()
+		tag.Key = append(tag.Key[:0], k...)
+		if len(v) == 0 {
+			tag.Value = append(tag.Value[:0], EMPTYVALUE)
+		} else {
+			tag.Value = append(tag.Value[:0], v...)
+		}
+	}
+
+	return nil
+}
+
+func getFloat64(o *fastjson.Value, k string) (float64, error) {
+	v := o.Get(k)
+	if v == nil {
+		return 0, fmt.Errorf("value is not exist")
+	}
+	switch v.Type() {
+	case fastjson.TypeNumber:
+		return v.Float64()
+	default:
+		return 0, fmt.Errorf("value doesn't contain float64; it contains %s", v.Type())
+	}
+}
+
+func getInt64(o *fastjson.Value, k string) (int64, error) {
+	v := o.Get(k)
+	if v == nil {
+		return 0, fmt.Errorf("value is not exist")
+	}
+	switch v.Type() {
+	case fastjson.TypeNumber:
+		return v.Int64()
+	default:
+		return 0, fmt.Errorf("value doesn't contain int64; it contains %s", v.Type())
+	}
+}
+
+func getArray(o *fastjson.Value, k string) ([]*fastjson.Value, error) {
+	v := o.Get(k)
+	if v == nil {
+		return nil, fmt.Errorf("value is not exist")
+	}
+	switch v.Type() {
+	case fastjson.TypeArray:
+		return v.Array()
+	default:
+		return nil, fmt.Errorf("value doesn't contain array; it contains %s", v.Type())
+	}
+}
+
+type Tag struct {
+	Key   []byte
+	Value []byte
+}
+
+func (t *Tag) reset() {
+	t.Key = t.Key[:0]
+	t.Value = t.Value[:0]
+}
+
+func unmarshalRows(dst []Row, s string, par byte) []Row {
+	for len(s) > 0 {
+		n := strings.IndexByte(s, '\n')
+		if n < 0 {
+			// The last line.
+			return unmarshalRow(dst, s, par)
+		}
+		dst = unmarshalRow(dst, s[:n], par)
+		s = s[n+1:]
+	}
+	return dst
+}
+
+var jsonParserPool fastjson.ParserPool
+
+func unmarshalRow(dst []Row, s string, par byte) []Row {
+	p := jsonParserPool.Get()
+	defer jsonParserPool.Put(p)
+
+	if len(s) > 0 && s[len(s)-1] == '\r' {
+		s = s[:len(s)-1]
+	}
+	if len(s) == 0 {
+		return dst
+	}
+
+	v, err := p.Parse(s)
+	if err != nil {
+		logger.Errorf("skipping json line %q because of error: %s", s, err)
+		invalidLines.Inc()
+		return dst
+	}
+
+	// Skip non numeric metrics
+	zt, err := getInt64(v, "type")
+	if err != nil {
+		logger.Errorf("skipping json line %q because of error: missing `type` element, %s", s, err)
+		invalidLines.Inc()
+		return dst
+	}
+	if zt != 0 && zt != 3 {
+		invalidLines.Inc()
+		return dst
+	}
+
+	if cap(dst) > len(dst) {
+		dst = dst[:len(dst)+1]
+	} else {
+		dst = append(dst, Row{})
+	}
+	r := &dst[len(dst)-1]
+	if err := r.unmarshal(v, par); err != nil {
+		dst = dst[:len(dst)-1]
+		logger.Errorf("skipping json line %q because of error: %s", s, err)
+		invalidLines.Inc()
+	}
+	return dst
+}
+
+var invalidLines = metrics.NewCounter(`vm_rows_invalid_total{type="zabbixconnector"}`)

--- a/lib/protoparser/zabbixconnector/parser_test.go
+++ b/lib/protoparser/zabbixconnector/parser_test.go
@@ -1,0 +1,621 @@
+package zabbixconnector
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+func TestRowsUnmarshalFailure(t *testing.T) {
+	f := func(s string, par byte) {
+		t.Helper()
+		var rows Rows
+		rows.Unmarshal(s, par)
+		if len(rows.Rows) != 0 {
+			t.Fatalf("expecting zero rows; got %d rows", len(rows.Rows))
+		}
+
+		// Try again
+		rows.Unmarshal(s, par)
+		if len(rows.Rows) != 0 {
+			t.Fatalf("expecting zero rows; got %d rows", len(rows.Rows))
+		}
+	}
+
+	par := byte(0b00000011)
+	// Invalid json line
+	f("", par)
+	f("\n", par)
+	f("foo\n", par)
+	f("123", par)
+	f("[1,3]", par)
+	f("{}", par)
+	f("[]", par)
+	f(`{"foo":"bar"}`, par)
+
+	// Invalid type
+	f(`{"host":{"host":"h1","name":"n1"},"groups":["g1"],"item_tags":[{"tag":"tn1","value":"tv1"}],"itemid":1,"name":"in1","clock":1712417868,"ns":425677241,"value":1}`, par)
+	f(`{"host":{"host":"h1","name":"n1"},"groups":["g1"],"item_tags":[{"tag":"tn1","value":"tv1"}],"itemid":1,"name":"in1","clock":1712417868,"ns":425677241,"value":1,"type":"0"}`, par)
+	f(`{"host":{"host":"h1","name":"n1"},"groups":["g1"],"item_tags":[{"tag":"tn1","value":"tv1"}],"itemid":1,"name":"in1","clock":1712417868,"ns":425677241,"value":1,"type":[]}`, par)
+	f(`{"host":{"host":"h1","name":"n1"},"groups":["g1"],"item_tags":[{"tag":"tn1","value":"tv1"}],"itemid":1,"name":"in1","clock":1712417868,"ns":425677241,"value":1,"type":2}`, par)
+	f(`{"host":{"host":"h1","name":"n1"},"groups":["g1"],"item_tags":[{"tag":"tn1","value":"tv1"}],"itemid":1,"name":"in1","clock":1712417868,"ns":425677241,"value":1,"type":10}`, par)
+
+	// Invalid host object
+	f(`{"groups":["g1"],"item_tags":[{"tag":"tn1","value":"tv1"}],"itemid":1,"name":"in1","clock":1712417868,"ns":425677241,"value":1,"type":0}`, par)
+	f(`{"host":{"name":"n1"},"groups":["g1"],"item_tags":[{"tag":"tn1","value":"tv1"}],"itemid":1,"name":"in1","clock":1712417868,"ns":425677241,"value":1,"type":0}`, par)
+	f(`{"host":{"host":"h1"},"groups":["g1"],"item_tags":[{"tag":"tn1","value":"tv1"}],"itemid":1,"name":"in1","clock":1712417868,"ns":425677241,"value":1,"type":0}`, par)
+	f(`{"host":{"host":"h1","name":1},"groups":["g1"],"item_tags":[{"tag":"tn1","value":"tv1"}],"itemid":1,"name":"in1","clock":1712417868,"ns":425677241,"value":1,"type":0}`, par)
+	f(`{"host":{"host":"h1","name":[]},"groups":["g1"],"item_tags":[{"tag":"tn1","value":"tv1"}],"itemid":1,"name":"in1","clock":1712417868,"ns":425677241,"value":1,"type":0}`, par)
+	f(`{"host":{"host":1,"name":"n1"},"groups":["g1"],"item_tags":[{"tag":"tn1","value":"tv1"}],"itemid":1,"name":"in1","clock":1712417868,"ns":425677241,"value":1,"type":0}`, par)
+	f(`{"host":{"host":{},"name":"n1"},"groups":["g1"],"item_tags":[{"tag":"tn1","value":"tv1"}],"itemid":1,"name":"in1","clock":1712417868,"ns":425677241,"value":1,"type":0}`, par)
+	f(`{"host":"1","groups":["g1"],"item_tags":[{"tag":"tn1","value":"tv1"}],"itemid":1,"name":"in1","clock":1712417868,"ns":425677241,"value":1,"type":0}`, par)
+	f(`{"host":[],"groups":["g1"],"item_tags":[{"tag":"tn1","value":"tv1"}],"itemid":1,"name":"in1","clock":1712417868,"ns":425677241,"value":1,"type":0}`, par)
+
+	// Invalid item name
+	f(`{"host":{"host":"h1","name":"n1"},"groups":["g1"],"item_tags":[{"tag":"tn1","value":"tv1"}],"itemid":1,"clock":1712417868,"ns":425677241,"value":1,"type":0}`, par)
+	f(`{"host":{"host":"h1","name":"n1"},"groups":["g1"],"item_tags":[{"tag":"tn1","value":"tv1"}],"itemid":1,"name":"","clock":1712417868,"ns":425677241,"value":1,"type":0}`, par)
+	f(`{"host":{"host":"h1","name":"n1"},"groups":["g1"],"item_tags":[{"tag":"tn1","value":"tv1"}],"itemid":1,"name":1,"clock":1712417868,"ns":425677241,"value":1,"type":0}`, par)
+	f(`{"host":{"host":"h1","name":"n1"},"groups":["g1"],"item_tags":[{"tag":"tn1","value":"tv1"}],"itemid":1,"name":{},"clock":1712417868,"ns":425677241,"value":1,"type":0}`, par)
+
+	// Invalid item value
+	f(`{"host":{"host":"h1","name":"n1"},"groups":["g1"],"item_tags":[{"tag":"tn1","value":"tv1"}],"itemid":1,"name":"in1","clock":1712417868,"ns":425677241,"type":0}`, par)
+	f(`{"host":{"host":"h1","name":"n1"},"groups":["g1"],"item_tags":[{"tag":"tn1","value":"tv1"}],"itemid":1,"name":"in1","clock":1712417868,"ns":425677241,"value":"1","type":0}`, par)
+	f(`{"host":{"host":"h1","name":"n1"},"groups":["g1"],"item_tags":[{"tag":"tn1","value":"tv1"}],"itemid":1,"name":"in1","clock":1712417868,"ns":425677241,"value":[],"type":0}`, par)
+
+	// Invalid clock
+	f(`{"host":{"host":"h1","name":"n1"},"groups":["g1"],"item_tags":[{"tag":"tn1","value":"tv1"}],"itemid":1,"name":"in1","ns":425677241,"value":1,"type":0}`, par)
+	f(`{"host":{"host":"h1","name":"n1"},"groups":["g1"],"item_tags":[{"tag":"tn1","value":"tv1"}],"itemid":1,"name":"in1","clock":"1712417868","ns":425677241,"value":1,"type":0}`, par)
+	f(`{"host":{"host":"h1","name":"n1"},"groups":["g1"],"item_tags":[{"tag":"tn1","value":"tv1"}],"itemid":1,"name":"in1","clock":[],"ns":425677241,"value":1,"type":0}`, par)
+	f(`{"host":{"host":"h1","name":"n1"},"groups":["g1"],"item_tags":[{"tag":"tn1","value":"tv1"}],"itemid":1,"name":"in1","clock":1.1,"ns":425677241,"value":1,"type":0}`, par)
+
+	// Invalid ns
+	f(`{"host":{"host":"h1","name":"n1"},"groups":["g1"],"item_tags":[{"tag":"tn1","value":"tv1"}],"itemid":1,"name":"in1","clock":1712417868,"value":1,"type":0}`, par)
+	f(`{"host":{"host":"h1","name":"n1"},"groups":["g1"],"item_tags":[{"tag":"tn1","value":"tv1"}],"itemid":1,"name":"in1","clock":1712417868,"ns":"425677241","value":1,"type":0}`, par)
+	f(`{"host":{"host":"h1","name":"n1"},"groups":["g1"],"item_tags":[{"tag":"tn1","value":"tv1"}],"itemid":1,"name":"in1","clock":1712417868,"ns":{},"value":1,"type":0}`, par)
+	f(`{"host":{"host":"h1","name":"n1"},"groups":["g1"],"item_tags":[{"tag":"tn1","value":"tv1"}],"itemid":1,"name":"in1","clock":1712417868,"ns":1.2,"value":1,"type":0}`, par)
+
+	// Invalit groups
+	f(`{"host":{"host":"h1","name":"n1"},"item_tags":[{"tag":"tn1","value":"tv1"}],"itemid":1,"name":"in1","clock":1712417868,"ns":425677241,"value":1,"type":0}`, par)
+	f(`{"host":{"host":"h1","name":"n1"},"groups":1,"item_tags":[{"tag":"tn1","value":"tv1"}],"itemid":1,"name":"in1","clock":1712417868,"ns":425677241,"value":1,"type":0}`, par)
+	f(`{"host":{"host":"h1","name":"n1"},"groups":{},"item_tags":[{"tag":"tn1","value":"tv1"}],"itemid":1,"name":"in1","clock":1712417868,"ns":425677241,"value":1,"type":0}`, par)
+
+	// Invalid item_tags
+	f(`{"host":{"host":"h1","name":"n1"},"groups":["g1"],"itemid":1,"name":"in1","clock":1712417868,"ns":425677241,"value":1,"type":0}`, par)
+	f(`{"host":{"host":"h1","name":"n1"},"groups":["g1"],"item_tags":1,"itemid":1,"name":"in1","clock":1712417868,"ns":425677241,"value":1,"type":0}`, par)
+	f(`{"host":{"host":"h1","name":"n1"},"groups":["g1"],"item_tags":{},"itemid":1,"name":"in1","clock":1712417868,"ns":425677241,"value":1,"type":0}`, par)
+
+	//f(`{"host":{"host":"h1","name":"n1"},"groups":["g1"],"item_tags":[{"tag":"tn1","value":"tv1"}],"itemid":1,"name":"in1","clock":1712417868,"ns":425677241,"value":1,"type":0}`, par)
+}
+
+func TestRowsUnmarshalSuccess(t *testing.T) {
+	f := func(s string, par byte, rowsExpected *Rows) {
+		t.Helper()
+		var rows Rows
+		rows.Unmarshal(s, par)
+
+		if err := compareRows(&rows, rowsExpected); err != nil {
+			t.Fatalf("unexpected rows: %s;\ngot\n%+v;\nwant\n%+v", err, rows.Rows, rowsExpected.Rows)
+		}
+
+		// Try unmarshaling again
+		rows.Unmarshal(s, par)
+		if err := compareRows(&rows, rowsExpected); err != nil {
+			t.Fatalf("unexpected rows at second unmarshal: %s;\ngot\n%+v;\nwant\n%+v", err, rows.Rows, rowsExpected.Rows)
+		}
+
+		rows.Reset()
+		if len(rows.Rows) != 0 {
+			t.Fatalf("non-empty rows after reset: %+v", rows.Rows)
+		}
+	}
+
+	// Add groups and empty tags
+	par := byte(0b00000011)
+	// Empty line
+	f("", par, &Rows{})
+	f("\n\n", par, &Rows{})
+	f("\n\r\n", par, &Rows{})
+
+	// Single line with groups and empty tags
+	f(`{"host":{"host":"h1","name":"n1"},"groups":["g1"],"item_tags":[{"tag":"tn1","value":"tv1"},{"tag":"tn2","value":""}],"itemid":1,"name":"in1","clock":1712417868,"ns":425677241,"value":1,"type":0}`, par,
+		&Rows{
+			Rows: []Row{
+				{
+					Tags: []Tag{
+						{
+							Key:   []byte("host"),
+							Value: []byte("h1"),
+						},
+						{
+							Key:   []byte("hostname"),
+							Value: []byte("n1"),
+						},
+						{
+							Key:   []byte("__name__"),
+							Value: []byte("in1"),
+						},
+						{
+							Key:   []byte("g1"),
+							Value: []byte("1"),
+						},
+						{
+							Key:   []byte("tn1"),
+							Value: []byte("tv1"),
+						},
+						{
+							Key:   []byte("tn2"),
+							Value: []byte("1"),
+						},
+					},
+					Value:     1,
+					Timestamp: 1712417868425,
+				},
+			},
+		})
+
+	// Single line with groups and damage tags
+	f(`{"host":{"host":"h1","name":"n1"},"groups":["g1"],"item_tags":[{"tag":"tn1","value":{}},{"tag":"tn2","value":""}],"itemid":1,"name":"in1","clock":1712417868,"ns":425677241,"value":1,"type":0}`, par,
+		&Rows{
+			Rows: []Row{
+				{
+					Tags: []Tag{
+						{
+							Key:   []byte("host"),
+							Value: []byte("h1"),
+						},
+						{
+							Key:   []byte("hostname"),
+							Value: []byte("n1"),
+						},
+						{
+							Key:   []byte("__name__"),
+							Value: []byte("in1"),
+						},
+						{
+							Key:   []byte("g1"),
+							Value: []byte("1"),
+						},
+						{
+							Key:   []byte("tn1"),
+							Value: []byte("1"),
+						},
+						{
+							Key:   []byte("tn2"),
+							Value: []byte("1"),
+						},
+					},
+					Value:     1,
+					Timestamp: 1712417868425,
+				},
+			},
+		})
+
+	// Single line with empty groups and empty tags
+	f(`{"host":{"host":"h1","name":"n1"},"groups":[],"item_tags":[],"itemid":1,"name":"in1","clock":1712417868,"ns":425677241,"value":1,"type":0}`, par,
+		&Rows{
+			Rows: []Row{
+				{
+					Tags: []Tag{
+						{
+							Key:   []byte("host"),
+							Value: []byte("h1"),
+						},
+						{
+							Key:   []byte("hostname"),
+							Value: []byte("n1"),
+						},
+						{
+							Key:   []byte("__name__"),
+							Value: []byte("in1"),
+						},
+					},
+					Value:     1,
+					Timestamp: 1712417868425,
+				},
+			},
+		})
+
+	// Multiple lines
+	f(`{"host":{"host":"h1","name":"n1"},"groups":["g1"],"item_tags":[{"tag":"tn1","value":"tv1"},{"tag":"tn2","value":""}],"itemid":1,"name":"in1","clock":1712417868,"ns":425677241,"value":1,"type":0}
+{"host":{"host":"h2","name":"n2"},"groups":["g2"],"item_tags":[{"tag":"tn1","value":"tv1"}],"itemid":2,"name":"in2","clock":1712417868,"ns":425677241,"value":1.5,"type":3}
+`, par,
+		&Rows{
+			Rows: []Row{
+				{
+					Tags: []Tag{
+						{
+							Key:   []byte("host"),
+							Value: []byte("h1"),
+						},
+						{
+							Key:   []byte("hostname"),
+							Value: []byte("n1"),
+						},
+						{
+							Key:   []byte("__name__"),
+							Value: []byte("in1"),
+						},
+						{
+							Key:   []byte("g1"),
+							Value: []byte("1"),
+						},
+						{
+							Key:   []byte("tn1"),
+							Value: []byte("tv1"),
+						},
+						{
+							Key:   []byte("tn2"),
+							Value: []byte("1"),
+						},
+					},
+					Value:     1,
+					Timestamp: 1712417868425,
+				},
+				{
+					Tags: []Tag{
+						{
+							Key:   []byte("host"),
+							Value: []byte("h2"),
+						},
+						{
+							Key:   []byte("hostname"),
+							Value: []byte("n2"),
+						},
+						{
+							Key:   []byte("__name__"),
+							Value: []byte("in2"),
+						},
+						{
+							Key:   []byte("g2"),
+							Value: []byte("1"),
+						},
+						{
+							Key:   []byte("tn1"),
+							Value: []byte("tv1"),
+						},
+					},
+					Value:     1.5,
+					Timestamp: 1712417868425,
+				},
+			},
+		})
+
+	// Multiple lines with invalid lines in the middle.
+	f(`{"host":{"host":"h1","name":"n1"},"groups":["g1"],"item_tags":[{"tag":"tn1","value":"tv1"},{"tag":"tn2","value":""}],"itemid":1,"name":"in1","clock":1712417868,"ns":425677241,"value":1,"type":0}
+failed line
+
+{"host":{"host":"h2","name":"n2"},"groups":["g2"],"item_tags":[{"tag":"tn1","value":"tv1"}],"itemid":2,"name":"in2","clock":1712417868,"ns":425677241,"value":1.5,"type":3}`, par,
+		&Rows{
+			Rows: []Row{
+				{
+					Tags: []Tag{
+						{
+							Key:   []byte("host"),
+							Value: []byte("h1"),
+						},
+						{
+							Key:   []byte("hostname"),
+							Value: []byte("n1"),
+						},
+						{
+							Key:   []byte("__name__"),
+							Value: []byte("in1"),
+						},
+						{
+							Key:   []byte("g1"),
+							Value: []byte("1"),
+						},
+						{
+							Key:   []byte("tn1"),
+							Value: []byte("tv1"),
+						},
+						{
+							Key:   []byte("tn2"),
+							Value: []byte("1"),
+						},
+					},
+					Value:     1,
+					Timestamp: 1712417868425,
+				},
+				{
+					Tags: []Tag{
+						{
+							Key:   []byte("host"),
+							Value: []byte("h2"),
+						},
+						{
+							Key:   []byte("hostname"),
+							Value: []byte("n2"),
+						},
+						{
+							Key:   []byte("__name__"),
+							Value: []byte("in2"),
+						},
+						{
+							Key:   []byte("g2"),
+							Value: []byte("1"),
+						},
+						{
+							Key:   []byte("tn1"),
+							Value: []byte("tv1"),
+						},
+					},
+					Value:     1.5,
+					Timestamp: 1712417868425,
+				},
+			},
+		})
+
+	// No newline after the second line.
+	f(`{"host":{"host":"h1","name":"n1"},"groups":["g1"],"item_tags":[{"tag":"tn1","value":"tv1"},{"tag":"tn2","value":""}],"itemid":1,"name":"in1","clock":1712417868,"ns":425677241,"value":1,"type":0}
+{"host":{"host":"h2","name":"n2"},"groups":["g2"],"item_tags":[{"tag":"tn1","value":"tv1"}],"itemid":2,"name":"in2","clock":1712417868,"ns":425677241,"value":1.5,"type":3}`, par,
+		&Rows{
+			Rows: []Row{
+				{
+					Tags: []Tag{
+						{
+							Key:   []byte("host"),
+							Value: []byte("h1"),
+						},
+						{
+							Key:   []byte("hostname"),
+							Value: []byte("n1"),
+						},
+						{
+							Key:   []byte("__name__"),
+							Value: []byte("in1"),
+						},
+						{
+							Key:   []byte("g1"),
+							Value: []byte("1"),
+						},
+						{
+							Key:   []byte("tn1"),
+							Value: []byte("tv1"),
+						},
+						{
+							Key:   []byte("tn2"),
+							Value: []byte("1"),
+						},
+					},
+					Value:     1,
+					Timestamp: 1712417868425,
+				},
+				{
+					Tags: []Tag{
+						{
+							Key:   []byte("host"),
+							Value: []byte("h2"),
+						},
+						{
+							Key:   []byte("hostname"),
+							Value: []byte("n2"),
+						},
+						{
+							Key:   []byte("__name__"),
+							Value: []byte("in2"),
+						},
+						{
+							Key:   []byte("g2"),
+							Value: []byte("1"),
+						},
+						{
+							Key:   []byte("tn1"),
+							Value: []byte("tv1"),
+						},
+					},
+					Value:     1.5,
+					Timestamp: 1712417868425,
+				},
+			},
+		})
+
+	// Add empty tags and skip groups
+	par = byte(0b00000010)
+
+	// Multiple lines with invalid lines in the middle.
+	f(`{"host":{"host":"h1","name":"n1"},"groups":["g1"],"item_tags":[{"tag":"tn1","value":"tv1"},{"tag":"tn2","value":""}],"itemid":1,"name":"in1","clock":1712417868,"ns":425677241,"value":1,"type":0}
+failed line
+
+{"host":{"host":"h2","name":"n2"},"groups":["g2"],"item_tags":[{"tag":"tn1","value":"tv1"}],"itemid":2,"name":"in2","clock":1712417868,"ns":425677241,"value":1.5,"type":3}`, par,
+		&Rows{
+			Rows: []Row{
+				{
+					Tags: []Tag{
+						{
+							Key:   []byte("host"),
+							Value: []byte("h1"),
+						},
+						{
+							Key:   []byte("hostname"),
+							Value: []byte("n1"),
+						},
+						{
+							Key:   []byte("__name__"),
+							Value: []byte("in1"),
+						},
+						{
+							Key:   []byte("tn1"),
+							Value: []byte("tv1"),
+						},
+						{
+							Key:   []byte("tn2"),
+							Value: []byte("1"),
+						},
+					},
+					Value:     1,
+					Timestamp: 1712417868425,
+				},
+				{
+					Tags: []Tag{
+						{
+							Key:   []byte("host"),
+							Value: []byte("h2"),
+						},
+						{
+							Key:   []byte("hostname"),
+							Value: []byte("n2"),
+						},
+						{
+							Key:   []byte("__name__"),
+							Value: []byte("in2"),
+						},
+						{
+							Key:   []byte("tn1"),
+							Value: []byte("tv1"),
+						},
+					},
+					Value:     1.5,
+					Timestamp: 1712417868425,
+				},
+			},
+		})
+
+	// Add groups and skip empty tags
+	par = byte(0b00000001)
+
+	// Multiple lines with invalid lines in the middle.
+	f(`{"host":{"host":"h1","name":"n1"},"groups":["g1"],"item_tags":[{"tag":"tn1","value":"tv1"},{"tag":"tn2","value":""}],"itemid":1,"name":"in1","clock":1712417868,"ns":425677241,"value":1,"type":0}
+failed line
+
+{"host":{"host":"h2","name":"n2"},"groups":["g2"],"item_tags":[{"tag":"tn1","value":"tv1"}],"itemid":2,"name":"in2","clock":1712417868,"ns":425677241,"value":1.5,"type":3}`, par,
+		&Rows{
+			Rows: []Row{
+				{
+					Tags: []Tag{
+						{
+							Key:   []byte("host"),
+							Value: []byte("h1"),
+						},
+						{
+							Key:   []byte("hostname"),
+							Value: []byte("n1"),
+						},
+						{
+							Key:   []byte("__name__"),
+							Value: []byte("in1"),
+						},
+						{
+							Key:   []byte("g1"),
+							Value: []byte("1"),
+						},
+						{
+							Key:   []byte("tn1"),
+							Value: []byte("tv1"),
+						},
+					},
+					Value:     1,
+					Timestamp: 1712417868425,
+				},
+				{
+					Tags: []Tag{
+						{
+							Key:   []byte("host"),
+							Value: []byte("h2"),
+						},
+						{
+							Key:   []byte("hostname"),
+							Value: []byte("n2"),
+						},
+						{
+							Key:   []byte("__name__"),
+							Value: []byte("in2"),
+						},
+						{
+							Key:   []byte("g2"),
+							Value: []byte("1"),
+						},
+						{
+							Key:   []byte("tn1"),
+							Value: []byte("tv1"),
+						},
+					},
+					Value:     1.5,
+					Timestamp: 1712417868425,
+				},
+			},
+		})
+
+	// skip groups and empty tags
+	par = byte(0b00000000)
+
+	// Multiple lines with invalid lines in the middle.
+	f(`{"host":{"host":"h1","name":"n1"},"groups":["g1"],"item_tags":[{"tag":"tn1","value":"tv1"},{"tag":"tn2","value":""}],"itemid":1,"name":"in1","clock":1712417868,"ns":425677241,"value":1,"type":0}
+failed line
+
+{"host":{"host":"h2","name":"n2"},"groups":["g2"],"item_tags":[{"tag":"tn1","value":"tv1"}],"itemid":2,"name":"in2","clock":1712417868,"ns":425677241,"value":1.5,"type":3}`, par,
+		&Rows{
+			Rows: []Row{
+				{
+					Tags: []Tag{
+						{
+							Key:   []byte("host"),
+							Value: []byte("h1"),
+						},
+						{
+							Key:   []byte("hostname"),
+							Value: []byte("n1"),
+						},
+						{
+							Key:   []byte("__name__"),
+							Value: []byte("in1"),
+						},
+						{
+							Key:   []byte("tn1"),
+							Value: []byte("tv1"),
+						},
+					},
+					Value:     1,
+					Timestamp: 1712417868425,
+				},
+				{
+					Tags: []Tag{
+						{
+							Key:   []byte("host"),
+							Value: []byte("h2"),
+						},
+						{
+							Key:   []byte("hostname"),
+							Value: []byte("n2"),
+						},
+						{
+							Key:   []byte("__name__"),
+							Value: []byte("in2"),
+						},
+						{
+							Key:   []byte("tn1"),
+							Value: []byte("tv1"),
+						},
+					},
+					Value:     1.5,
+					Timestamp: 1712417868425,
+				},
+			},
+		})
+}
+
+func compareRows(rows, rowsExpected *Rows) error {
+	if len(rows.Rows) != len(rowsExpected.Rows) {
+		return fmt.Errorf("unexpected number of rows; got %d; want %d", len(rows.Rows), len(rowsExpected.Rows))
+	}
+	for i, row := range rows.Rows {
+		rowExpected := rowsExpected.Rows[i]
+		if err := compareSingleRow(&row, &rowExpected); err != nil {
+			return fmt.Errorf("unexpected row at position #%d: %w", i, err)
+		}
+	}
+	return nil
+}
+
+func compareSingleRow(row, rowExpected *Row) error {
+	if !reflect.DeepEqual(row.Tags, rowExpected.Tags) {
+		return fmt.Errorf("unexpected tags; got %q; want %q", row.Tags, rowExpected.Tags)
+	}
+	if row.Value != rowExpected.Value {
+		return fmt.Errorf("unexpected values; got %v; want %v", row.Value, rowExpected.Value)
+	}
+	if row.Timestamp != rowExpected.Timestamp {
+		return fmt.Errorf("unexpected values; got %v; want %v", row.Timestamp, rowExpected.Timestamp)
+	}
+	return nil
+}

--- a/lib/protoparser/zabbixconnector/stream/streamparesr.go
+++ b/lib/protoparser/zabbixconnector/stream/streamparesr.go
@@ -1,0 +1,203 @@
+package stream
+
+import (
+	"bufio"
+	"flag"
+	"fmt"
+	"io"
+	"sync"
+
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/bytesutil"
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/cgroup"
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/flagutil"
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/protoparser/common"
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/protoparser/zabbixconnector"
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/writeconcurrencylimiter"
+	"github.com/VictoriaMetrics/metrics"
+)
+
+var (
+	maxLineLen = flagutil.NewBytes("zabbixconnector.maxLineLen", 32*1024*1024, "The maximum length in bytes of a single line accepted by "+
+		"/zabbixconnector/api/v1/history")
+	addGroups    = flag.Bool("zabbixconnector.addGroups", false, "Enable adding Zabbix host groups to labels (group_name=\"1\").")
+	addEmptyTags = flag.Bool("zabbixconnector.addEmptyTags", false, "Enable adding Zabbix tags without values to labels (tag_name=\"1\").")
+)
+
+// Parse parses Zabbix Connector http lines from req and calls callback for the parsed rows.
+//
+// The callback can be called concurrently multiple times for streamed data from req.
+//
+// callback shouldn't hold rows after returning.
+func Parse(r io.Reader, isGzipped bool, callback func(rows []zabbixconnector.Row) error) error {
+	wcr := writeconcurrencylimiter.GetReader(r)
+	defer writeconcurrencylimiter.PutReader(wcr)
+	r = wcr
+
+	if isGzipped {
+		zr, err := common.GetGzipReader(r)
+		if err != nil {
+			return fmt.Errorf("cannot read gzipped zabbixconnector line protocol data: %w", err)
+		}
+		defer common.PutGzipReader(zr)
+		r = zr
+	}
+	ctx := getStreamContext(r)
+	defer putStreamContext(ctx)
+	for ctx.Read() {
+		uw := getUnmarshalWork()
+		uw.ctx = ctx
+		uw.callback = callback
+		if *addGroups {
+			uw.extparams |= zabbixconnector.ADDGROUPS
+		}
+		if *addEmptyTags {
+			uw.extparams |= zabbixconnector.ADDEMPTYTAGS
+		}
+		uw.reqBuf, ctx.reqBuf = ctx.reqBuf, uw.reqBuf
+		ctx.wg.Add(1)
+		common.ScheduleUnmarshalWork(uw)
+		wcr.DecConcurrency()
+	}
+	ctx.wg.Wait()
+	if err := ctx.Error(); err != nil {
+		return err
+	}
+	return ctx.callbackErr
+}
+
+func (ctx *streamContext) Read() bool {
+	readCalls.Inc()
+	if ctx.err != nil || ctx.hasCallbackError() {
+		return false
+	}
+	ctx.reqBuf, ctx.tailBuf, ctx.err = common.ReadLinesBlockExt(ctx.br, ctx.reqBuf, ctx.tailBuf, maxLineLen.IntN())
+	if ctx.err != nil {
+		if ctx.err != io.EOF {
+			readErrors.Inc()
+			ctx.err = fmt.Errorf("cannot read zabbixconnector data: %w", ctx.err)
+		}
+		return false
+	}
+	return true
+}
+
+var (
+	readCalls  = metrics.NewCounter(`vm_protoparser_read_calls_total{type="zabbixconnector"}`)
+	readErrors = metrics.NewCounter(`vm_protoparser_read_errors_total{type="zabbixconnector"}`)
+	rowsRead   = metrics.NewCounter(`vm_protoparser_rows_read_total{type="zabbixconnector"}`)
+)
+
+type streamContext struct {
+	br      *bufio.Reader
+	reqBuf  []byte
+	tailBuf []byte
+	err     error
+
+	wg              sync.WaitGroup
+	callbackErrLock sync.Mutex
+	callbackErr     error
+}
+
+func (ctx *streamContext) Error() error {
+	if ctx.err == io.EOF {
+		return nil
+	}
+	return ctx.err
+}
+
+func (ctx *streamContext) hasCallbackError() bool {
+	ctx.callbackErrLock.Lock()
+	ok := ctx.callbackErr != nil
+	ctx.callbackErrLock.Unlock()
+	return ok
+}
+
+func (ctx *streamContext) reset() {
+	ctx.br.Reset(nil)
+	ctx.reqBuf = ctx.reqBuf[:0]
+	ctx.tailBuf = ctx.tailBuf[:0]
+	ctx.err = nil
+	ctx.callbackErr = nil
+}
+
+func getStreamContext(r io.Reader) *streamContext {
+	select {
+	case ctx := <-streamContextPoolCh:
+		ctx.br.Reset(r)
+		return ctx
+	default:
+		if v := streamContextPool.Get(); v != nil {
+			ctx := v.(*streamContext)
+			ctx.br.Reset(r)
+			return ctx
+		}
+		return &streamContext{
+			br: bufio.NewReaderSize(r, 64*1024),
+		}
+	}
+}
+
+func putStreamContext(ctx *streamContext) {
+	ctx.reset()
+	select {
+	case streamContextPoolCh <- ctx:
+	default:
+		streamContextPool.Put(ctx)
+	}
+}
+
+var streamContextPool sync.Pool
+var streamContextPoolCh = make(chan *streamContext, cgroup.AvailableCPUs())
+
+type unmarshalWork struct {
+	rows      zabbixconnector.Rows
+	ctx       *streamContext
+	callback  func(rows []zabbixconnector.Row) error
+	extparams byte
+	reqBuf    []byte
+}
+
+func (uw *unmarshalWork) reset() {
+	uw.rows.Reset()
+	uw.ctx = nil
+	uw.callback = nil
+	uw.extparams = 0
+	uw.reqBuf = uw.reqBuf[:0]
+}
+
+func (uw *unmarshalWork) runCallback(rows []zabbixconnector.Row) {
+	ctx := uw.ctx
+	if err := uw.callback(rows); err != nil {
+		ctx.callbackErrLock.Lock()
+		if ctx.callbackErr == nil {
+			ctx.callbackErr = fmt.Errorf("error when processing imported data: %w", err)
+		}
+		ctx.callbackErrLock.Unlock()
+	}
+	ctx.wg.Done()
+}
+
+// Unmarshal implements common.UnmarshalWork
+func (uw *unmarshalWork) Unmarshal() {
+	uw.rows.Unmarshal(bytesutil.ToUnsafeString(uw.reqBuf), uw.extparams)
+	rows := uw.rows.Rows
+	rowsRead.Add(len(rows))
+
+	uw.runCallback(rows)
+	putUnmarshalWork(uw)
+}
+
+func getUnmarshalWork() *unmarshalWork {
+	v := unmarshalWorkPool.Get()
+	if v == nil {
+		return &unmarshalWork{}
+	}
+	return v.(*unmarshalWork)
+}
+
+func putUnmarshalWork(uw *unmarshalWork) {
+	uw.reset()
+	unmarshalWorkPool.Put(uw)
+}
+
+var unmarshalWorkPool sync.Pool


### PR DESCRIPTION
### Description
Support receiving data from the Zabbix connector. (vmagent)

#### Added
- New path `/zabbixconnector/api/v1/history`
- New command-line flag:
    - `-zabbixconnector.maxLineLen` (similar to the `-import.maxLineLen` flag)
    - `-zabbixconnector.addGroups` (Enable adding Zabbix host groups to labels (group_name="1"))
    - `-zabbixconnector.addEmptyTags` (Enable adding Zabbix tags without values to labels (tag_name="1"))

#### Note
- Labels:
    - The metric name is added to the `__name__` label.
    - Host name to `host` label.
    - Visible name  to `hostname` label.
- The returned response complies with the requirements of the Zabbix Connector [protocol](https://www.zabbix.com/documentation/current/en/manual/config/export/streaming).
- Support sending item numeric values only.

Otherwise, I tried to adhere to the functionality of /api/v1/import

Useful links:
- Zabbix Streaming to external systems (https://www.zabbix.com/documentation/current/en/manual/config/export/streaming)
- Zabbix Newline-delimited JSON expor (https://www.zabbix.com/documentation/current/en/manual/appendix/protocols/real_time_export)