### PR TITLE
vmui: preserve select value on blur if it matches list

### DIFF
--- a/app/vmui/packages/vmui/src/components/Main/Select/Select.tsx
+++ b/app/vmui/packages/vmui/src/components/Main/Select/Select.tsx
@@ -72,6 +72,10 @@ const Select: FC<SelectProps> = ({
     setOpenList(true);
   };
 
+  const handleBlur = () => {
+    list.includes(search) && onChange(search);
+  };
+
   const handleToggleList = (e: MouseEvent<HTMLDivElement>) => {
     if (e.target instanceof HTMLInputElement || disabled) return;
     setOpenList(prev => !prev);
@@ -142,6 +146,7 @@ const Select: FC<SelectProps> = ({
               placeholder={placeholder}
               onInput={handleChange}
               onFocus={handleFocus}
+              onBlur={handleBlur}
               ref={inputRef}
               readOnly={isMobile || !searchable}
             />

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -30,6 +30,7 @@ See also [LTS releases](https://docs.victoriametrics.com/lts-releases/).
 
 ## tip
 
+* FEATURE: [vmui](https://docs.victoriametrics.com/#vmui): in the Select component, user-entered values are now preserved on blur if they match options in the list.
 * FEATURE: [vmauth](https://docs.victoriametrics.com/vmauth/): support regex matching when routing incoming requests based on HTTP [query args](https://en.wikipedia.org/wiki/Query_string) via `src_query_args` option at `url_map`. See [these docs](https://docs.victoriametrics.com/vmauth/#generic-http-proxy-for-different-backends) and [this feature request](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/6070).
 
 * BUGFIX: [vmalert](https://docs.victoriametrics.com/vmalert.html): supported any status codes from the range 200-299 from alertmanager. Previously, only 200 status code considered a successful action. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/6110).


### PR DESCRIPTION
**Problem:**
In `Select` component, user-entered values disappear if the user tabs out without selecting from the dropdown list.

**Solution:**
Implemented retention of the user-entered value in the `Select` component if it matches an option from the list upon blur.