### PR TITLE
docs: fix typo in the curl command

### DIFF
--- a/docs/managed-victoriametrics/alertmanager-setup-for-deployment.md
+++ b/docs/managed-victoriametrics/alertmanager-setup-for-deployment.md
@@ -137,7 +137,7 @@ groups:
 Upload rules to the Managed VictoriaMetrics using the following command:
 
 ```sh
-curl https://https://cloud.victoriametrics.com/api/v1/deployments/DEPLOYMENT_ID/rule-sets/files/testing-rules -v -H 'X-VM-Cloud-Access: CLOUD_API_TOKEN' -XPOST --data-binary '@testing-rules.yaml'
+curl https://cloud.victoriametrics.com/api/v1/deployments/DEPLOYMENT_ID/rule-sets/files/testing-rules -v -H 'X-VM-Cloud-Access: CLOUD_API_TOKEN' -XPOST --data-binary '@testing-rules.yaml'
 ```
 
 ## Troubleshooting


### PR DESCRIPTION
There was a typo in the `curl` usage