### PR TITLE
lib/mergeset: improve test coverage

### DIFF
--- a/lib/mergeset/table.go
+++ b/lib/mergeset/table.go
@@ -167,7 +167,7 @@ var rawItemsShardsPerTable = func() int {
 	return cpus * multiplier
 }()
 
-const maxBlocksPerShard = 256
+var maxBlocksPerShard = 256
 
 func (riss *rawItemsShards) init() {
 	riss.shards = make([]rawItemsShard, rawItemsShardsPerTable)


### PR DESCRIPTION
Add test to cover the code path with overflowing shards buffers and triggering merge to partition.

This test covers the code path which leaded to https://github.com/VictoriaMetrics/VictoriaMetrics/issues/5959