### PR TITLE
app/vmalert: make `TestGroupStart` more reliable

### DIFF
--- a/app/vmalert/rule/group_test.go
+++ b/app/vmalert/rule/group_test.go
@@ -264,19 +264,14 @@ func TestGroupStart(t *testing.T) {
 	waitForIterations := func(n int, interval time.Duration) {
 		t.Helper()
 
-		var iterationsMade int
 		var cur uint64
 		prev := g.metrics.iterationTotal.Get()
 		for i := 0; ; i++ {
-			if i > 20 {
-				t.Fatalf("group wasn't able to perfrom %d evaluations during %d eval intervals", n, i)
+			if i > 40 {
+				t.Fatalf("group wasn't able to perform %d evaluations during %d eval intervals", n, i)
 			}
 			cur = g.metrics.iterationTotal.Get()
-			if cur > prev {
-				iterationsMade += int(cur - prev)
-				prev = cur
-			}
-			if iterationsMade >= n {
+			if int(cur-prev) >= n {
 				return
 			}
 			time.Sleep(interval)

--- a/app/vmalert/rule/group_test.go
+++ b/app/vmalert/rule/group_test.go
@@ -263,9 +263,10 @@ func TestGroupStart(t *testing.T) {
 
 	waitForIterations := func(n int, interval time.Duration) {
 		t.Helper()
-		prev := g.metrics.iterationTotal.Get()
-		cur := prev
+
 		var iterationsMade int
+		var cur uint64
+		prev := g.metrics.iterationTotal.Get()
 		for i := 0; ; i++ {
 			if i > 20 {
 				t.Fatalf("group wasn't able to perfrom %d evaluations during %d eval intervals", n, i)


### PR DESCRIPTION
There was a sleep statement in the test, waiting for Group to perform a couple of evaluation. But looks like
it worked unreliable for some CI tests like the one below https://github.com/VictoriaMetrics/VictoriaMetrics/actions/runs/8718213844/job/23915007958?pr=6115

This commit changes the sleep statement on a function that waits for a specific number of evaluations. It should make this test faster in general case, and more reliable for slow environemnts.