### PR TITLE
docs: removed code-style highlighting for commanad-line flags of VM components

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2694,7 +2694,7 @@ Files included in each folder:
 
 Pass `-help` to VictoriaMetrics in order to see the list of supported command-line flags with their description:
 
-```sh
+```
   -bigMergeConcurrency int
      Deprecated: this flag does nothing
   -blockcache.missesBeforeCaching int

--- a/docs/Single-server-VictoriaMetrics.md
+++ b/docs/Single-server-VictoriaMetrics.md
@@ -2702,7 +2702,7 @@ Files included in each folder:
 
 Pass `-help` to VictoriaMetrics in order to see the list of supported command-line flags with their description:
 
-```sh
+```
   -bigMergeConcurrency int
      Deprecated: this flag does nothing
   -blockcache.missesBeforeCaching int

--- a/docs/vmagent.md
+++ b/docs/vmagent.md
@@ -1617,7 +1617,7 @@ It is safe sharing the collected profiles from security point of view, since the
 
 `vmagent` can be fine-tuned with various command-line flags. Run `./vmagent -help` in order to see the full list of these flags with their descriptions and default values:
 
-```sh
+```
 ./vmagent -help
 
 vmagent collects metrics data via popular data ingestion protocols and routes them to VictoriaMetrics.

--- a/docs/vmalert.md
+++ b/docs/vmalert.md
@@ -965,7 +965,7 @@ command-line flags with their descriptions.
 
 The shortlist of configuration flags is the following:
 
-```sh
+```
   -clusterMode
      If clusterMode is enabled, then vmalert automatically adds the tenant specified in config groups to -datasource.url, -remoteWrite.url and -remoteRead.url. See https://docs.victoriametrics.com/vmalert/#multitenancy . This flag is available only in Enterprise binaries. See https://docs.victoriametrics.com/enterprise/
   -configCheckInterval duration

--- a/docs/vmauth.md
+++ b/docs/vmauth.md
@@ -1121,7 +1121,7 @@ It is safe sharing the collected profiles from security point of view, since the
 
 Pass `-help` command-line arg to `vmauth` in order to see all the configuration options:
 
-```sh
+```
 ./vmauth -help
 
 vmauth authenticates and authorizes incoming requests and proxies them to VictoriaMetrics.

--- a/docs/vmbackup.md
+++ b/docs/vmbackup.md
@@ -304,7 +304,7 @@ Refer to the respective documentation for your object storage provider for more 
 
 Run `vmbackup -help` in order to see all the available options:
 
-```sh
+```
   -concurrency int
      The number of concurrent workers. Higher concurrency may reduce backup duration (default 10)
   -configFilePath string

--- a/docs/vmbackupmanager.md
+++ b/docs/vmbackupmanager.md
@@ -415,7 +415,7 @@ command-line flags with their descriptions.
 
 The shortlist of configuration flags is the following:
 
-```text
+```
 vmbackupmanager performs regular backups according to the provided configs.
 
 subcommands:

--- a/docs/vmgateway.md
+++ b/docs/vmgateway.md
@@ -273,7 +273,7 @@ Example usage for tokens issued by Google:
 
 Below is the list of configuration flags (it can be viewed by running `./vmgateway -help`):
 
-```sh
+```
   -auth.httpHeader string
      HTTP header name to look for JWT authorization token (default "Authorization")
   -auth.jwksEndpoints array

--- a/docs/vmrestore.md
+++ b/docs/vmrestore.md
@@ -91,7 +91,7 @@ i.e. the end result would be similar to [rsync --delete](https://askubuntu.com/q
 
 * Run `vmrestore -help` in order to see all the available options:
 
-```sh
+```
   -concurrency int
      The number of concurrent workers. Higher concurrency may reduce restore duration (default 10)
   -configFilePath string


### PR DESCRIPTION
It should render a description of the cmd-flags with wrapping as on the VictoriaLogs page https://docs.victoriametrics.com/victorialogs/#list-of-command-line-flags