### PR TITLE
vmui/logs: add support for head|limit in expressions

### DIFF
--- a/app/vmui/packages/vmui/src/pages/ExploreLogs/hooks/useFetchLogs.ts
+++ b/app/vmui/packages/vmui/src/pages/ExploreLogs/hooks/useFetchLogs.ts
@@ -13,13 +13,21 @@ export const useFetchLogs = (server: string, query: string, limit: number) => {
 
   const url = useMemo(() => getLogsUrl(server), [server]);
 
+  const prepareQuery = (query: string) => {
+    const limitRegex = /\|\s*(limit|head)\s*:?[\s-]*\d+/gm;
+    const matchHeadLimit = query.match(limitRegex);
+    if (!matchHeadLimit) return `(${query})`;
+    const cleanedQuery = query.replace(limitRegex, "").trim();
+    return `(${cleanedQuery}) ${matchHeadLimit.join(" ")}`;
+  };
+
   // include time range in query if not already present
   const queryWithTime = useMemo(() => {
     if (!/_time/.test(query)) {
       const start = dayjs(period.start * 1000).tz().toISOString();
       const end = dayjs(period.end * 1000).tz().toISOString();
       const timerange = `_time:[${start}, ${end}]`;
-      return `${timerange} AND (${query})`;
+      return `${timerange} AND ${prepareQuery(query)}`;
     }
     return query;
   }, [query, period]);

--- a/docs/VictoriaLogs/CHANGELOG.md
+++ b/docs/VictoriaLogs/CHANGELOG.md
@@ -19,6 +19,8 @@ according to [these docs](https://docs.victoriametrics.com/VictoriaLogs/QuickSta
 
 ## tip
 
+* FEATURE: [web UI](https://docs.victoriametrics.com/VictoriaLogs/querying/#web-ui): add support for head|limit in expressions. See [this pull request](https://github.com/VictoriaMetrics/VictoriaMetrics/pull/6154).
+
 ## [v0.5.2](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v0.5.2-victorialogs)
 
 Released at 2024-04-11


### PR DESCRIPTION
Adds correct handling of `head|limit` in expressions. 
For example, the query `* | limit 10` will be transformed into `_time:[some_interval] AND (*) | limit 10`.

Related pull request: [https://github.com/VictoriaMetrics/VictoriaMetrics/pull/6154](https://github.com/VictoriaMetrics/VictoriaMetrics/pull/6154).