### PR TITLE
vmui/vmanomaly: fix default server url

### DIFF
--- a/app/vmui/packages/vmui/src/utils/default-server-url.ts
+++ b/app/vmui/packages/vmui/src/utils/default-server-url.ts
@@ -8,7 +8,7 @@ export const getDefaultServer = (tenantId?: string): string => {
   const { serverURL } = getAppModeParams();
   const storageURL = getFromStorage("SERVER_URL") as string;
   const logsURL = window.location.href.replace(/\/(select\/)?(vmui)\/.*/, "");
-  const anomalyURL = window.location.href.replace(/(?:graph|vmui)\/.*/, "");
+  const anomalyURL = `${window.location.origin}${window.location.pathname}`;
   const defaultURL = window.location.href.replace(/\/(?:prometheus\/)?(?:graph|vmui)\/.*/, "/prometheus");
   const url = serverURL || storageURL || defaultURL;
 
@@ -16,7 +16,7 @@ export const getDefaultServer = (tenantId?: string): string => {
     case AppType.logs:
       return logsURL;
     case AppType.anomaly:
-      return serverURL || storageURL || anomalyURL;
+      return storageURL || anomalyURL;
     default:
       return tenantId ? replaceTenantId(url, tenantId) : url;
   }


### PR DESCRIPTION
### Describe Your Changes

This PR for ui vmanomaly eliminates URL parameters to automatically use the default server URL, simplifying URLs like:

From http://localhost:3000/#/?g0.expr=vm_blocks... to http://localhost:3000
From http://localhost:3000/select/0/vmui/#/?g0.expr=vm_blocks... to http://localhost:3000/select/0/vmui/ etc.

### Checklist

The following checks are **mandatory**:

- [ ] My change adheres [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/contributing/).
