### PR TITLE
vmui: fix issue preventing first query trace expansion

### DIFF
--- a/app/vmui/packages/vmui/src/hooks/useElementSize.ts
+++ b/app/vmui/packages/vmui/src/hooks/useElementSize.ts
@@ -1,5 +1,4 @@
-import { useCallback, useState } from "react";
-import useIsomorphicLayoutEffect from "./useIsomorphicLayoutEffect";
+import { useCallback, useEffect, useState } from "react";
 import useEventListener from "./useEventListener";
 
 export interface ElementSize {
@@ -28,7 +27,7 @@ const useElementSize = <T extends HTMLElement = HTMLDivElement>(): [(node: T | n
 
   useEventListener("resize", handleSize);
 
-  useIsomorphicLayoutEffect(handleSize, [ref?.offsetHeight, ref?.offsetWidth]);
+  useEffect(handleSize, [ref?.offsetHeight, ref?.offsetWidth]);
 
   return [setRef, size];
 };

--- a/app/vmui/packages/vmui/src/hooks/useEventListener.ts
+++ b/app/vmui/packages/vmui/src/hooks/useEventListener.ts
@@ -1,5 +1,4 @@
 import { RefObject, useEffect, useRef } from "react";
-import useIsomorphicLayoutEffect from "./useIsomorphicLayoutEffect";
 
 // MediaQueryList Event based useEventListener interface
 function useEventListener<K extends keyof MediaQueryListEventMap>(
@@ -56,7 +55,7 @@ function useEventListener<
   // Create a ref that stores handler
   const savedHandler = useRef(handler);
 
-  useIsomorphicLayoutEffect(() => {
+  useEffect(() => {
     savedHandler.current = handler;
   }, [handler]);
 

--- a/app/vmui/packages/vmui/src/hooks/useIsomorphicLayoutEffect.ts
+++ b/app/vmui/packages/vmui/src/hooks/useIsomorphicLayoutEffect.ts
@@ -1,5 +1,0 @@
-import { useEffect, useLayoutEffect } from "react";
-
-const useIsomorphicLayoutEffect = typeof window !== "undefined" ? useLayoutEffect : useEffect;
-
-export default useIsomorphicLayoutEffect;

--- a/app/vmui/packages/vmui/src/hooks/useWindowSize.ts
+++ b/app/vmui/packages/vmui/src/hooks/useWindowSize.ts
@@ -1,6 +1,6 @@
 import { useState } from "react";
-import useIsomorphicLayoutEffect from "./useIsomorphicLayoutEffect";
 import useEventListener from "./useEventListener";
+import { useEffect } from "preact/compat";
 
 interface WindowSize {
     width: number
@@ -23,7 +23,7 @@ const useWindowSize = (): WindowSize => {
   useEventListener("resize", handleSize);
 
   // Set size at the first client-side load
-  useIsomorphicLayoutEffect(handleSize, []);
+  useEffect(handleSize, []);
 
   return windowSize;
 };

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -30,6 +30,8 @@ See also [LTS releases](https://docs.victoriametrics.com/lts-releases/).
 
 ## tip
 
+* BUGFIX: [vmui](https://docs.victoriametrics.com/#vmui): corrects an issue that prevents the first query trace from expanding on click. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/6186).
+
 ## [v1.101.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.101.0)
 
 Released at 2024-04-26


### PR DESCRIPTION
### Describe Your Changes

Resolves an issue where the first query trace in VMUI failed to expand due to incorrect handling within `useLayoutEffect`. 
This fix involves replacing `useLayoutEffect` with `useEffect` in the `useElementSize` and `useWindowSize` hooks to ensure proper initialization and state updates.

#6186

### Checklist

The following checks are **mandatory**:

- [ ] My change adheres [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/contributing/).
