### PR TITLE
vmui/logs: change time range to `start` and `end` query args

### DIFF
--- a/app/vmui/packages/vmui/src/pages/ExploreLogs/hooks/useFetchLogs.ts
+++ b/app/vmui/packages/vmui/src/pages/ExploreLogs/hooks/useFetchLogs.ts
@@ -13,27 +13,18 @@ export const useFetchLogs = (server: string, query: string, limit: number) => {
 
   const url = useMemo(() => getLogsUrl(server), [server]);
 
-  // include time range in query if not already present
-  const queryWithTime = useMemo(() => {
-    if (!/_time/.test(query)) {
-      const start = dayjs(period.start * 1000).tz().toISOString();
-      const end = dayjs(period.end * 1000).tz().toISOString();
-      const timerange = `_time:[${start}, ${end}]`;
-      return `${timerange} AND (${query})`;
-    }
-    return query;
-  }, [query, period]);
-
   const options = useMemo(() => ({
     method: "POST",
     headers: {
       "Accept": "application/stream+json",
     },
     body: new URLSearchParams({
-      query: queryWithTime.trim(),
-      limit: `${limit}`
+      query: query.trim(),
+      limit: `${limit}`,
+      start: dayjs(period.start * 1000).tz().toISOString(),
+      end: dayjs(period.end * 1000).tz().toISOString()
     })
-  }), [queryWithTime, limit]);
+  }), [query, limit, period]);
 
   const parseLineToJSON = (line: string): Logs | null => {
     try {

--- a/docs/VictoriaLogs/CHANGELOG.md
+++ b/docs/VictoriaLogs/CHANGELOG.md
@@ -19,6 +19,8 @@ according to [these docs](https://docs.victoriametrics.com/VictoriaLogs/QuickSta
 
 ## tip
 
+* FEATURE: [web UI](https://docs.victoriametrics.com/VictoriaLogs/querying/#web-ui): change time range limitation from `_time` in the expression to `start` and `end` query args.
+
 ## [v0.8.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v0.8.0-victorialogs)
 
 Released at 2024-05-20


### PR DESCRIPTION
### Describe Your Changes

change time range limitation from `_time` in the expression to `start` and `end` query args.

### Checklist

The following checks are **mandatory**:

- [ ] My change adheres [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/contributing/).
