### PR TITLE
app/vmagent: fixed streamaggr args

### DIFF
--- a/app/vmagent/remotewrite/streamaggr.go
+++ b/app/vmagent/remotewrite/streamaggr.go
@@ -143,7 +143,7 @@ func getStreamAggrOpts(idx int) (string, *streamaggr.Options) {
 	if len(*streamAggrConfig) == 0 {
 		return "", &opts
 	}
-	return (*streamAggrConfig)[idx], &opts
+	return streamAggrConfig.GetOptionalArg(idx), &opts
 }
 
 func newStreamAggrConfigWithOpts(pushFunc streamaggr.PushFunc, path string, opts *streamaggr.Options) (*streamaggr.Aggregators, error) {


### PR DESCRIPTION
### Describe Your Changes

use GetOptionalArg instead of index to fallback to a first argument if index is absent for remotewrite.streamaggr.config

### Checklist

The following checks are **mandatory**:

- [ ] My change adheres [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/contributing/).
