### PR TITLE
Vm buckets promql transform

### DIFF
--- a/app/vmagent/prometheusimport/request_handler.go
+++ b/app/vmagent/prometheusimport/request_handler.go
@@ -15,13 +15,15 @@ import (
 	"github.com/VictoriaMetrics/metrics"
 	"strconv"
 	"flag"
+	"strings"
 )
 
 var (
 	rowsInserted       = metrics.NewCounter(`vmagent_rows_inserted_total{type="prometheus"}`)
 	rowsTenantInserted = tenantmetrics.NewCounterMap(`vmagent_tenant_inserted_rows_total{type="prometheus"}`)
 	rowsPerInsert      = metrics.NewHistogram(`vmagent_rows_per_insert{type="prometheus"}`)
-	prom_bucket_metric_name = flag.String("prom_bucket_metric_name", "", "Metric name for prometheus convertion bucket type.")
+	prom_bucket_metric_name = flag.String("prom_bucket_metric_name", "", "Metric name for prometheus convertion bucket type. Example: prom_bucket_metric_name=nginx_latency_target")
+	prom_bucket_metric_samples = flag.String("prom_bucket_metric_samples", "0.1, 0.2, 0.3, 0.5, 0.8, 1, 2, 3, 5", "Metric bucket samples for split latency. Example: prom_bucket_metric_samples=\"0.1, 0.5, 1,7\".")
 )
 
 // InsertHandler processes `/api/v1/import/prometheus` request.
@@ -56,18 +58,6 @@ func insertRows(at *auth.Token, rows []parser.Row, extraLabels []prompbmarshal.L
 			Name:  "__name__",
 			Value: r.Metric,
 		})
-		if *prom_bucket_metric_name != "" && r.Metric == *prom_bucket_metric_name {
-			PromValue := strconv.FormatFloat(r.Value, 'f', -1, 32)
-			labels = append(labels, prompbmarshal.Label{
-				Name:  "le",
-				Value: PromValue,
-			})
-			NewValue, err := strconv.ParseFloat("1", 64)
-			if err != nil {
-				return err
-			}
-			r.Value = NewValue
-		}
 		for j := range r.Tags {
 			tag := &r.Tags[j]
 			labels = append(labels, prompbmarshal.Label{
@@ -75,15 +65,64 @@ func insertRows(at *auth.Token, rows []parser.Row, extraLabels []prompbmarshal.L
 				Value: tag.Value,
 			})
 		}
-		labels = append(labels, extraLabels...)
-		samples = append(samples, prompbmarshal.Sample{
-			Value:     r.Value,
-			Timestamp: r.Timestamp,
-		})
-		tssDst = append(tssDst, prompbmarshal.TimeSeries{
-			Labels:  labels[labelsLen:],
-			Samples: samples[len(samples)-1:],
-		})
+	        if *prom_bucket_metric_name != "" && r.Metric == *prom_bucket_metric_name {
+	                buckets_samples := strings.Replace(*prom_bucket_metric_samples, " ", "", -1)
+	                buckets_samples_fmt := strings.Split(buckets_samples, ",")
+	                for _, bucket := range buckets_samples_fmt {
+	                        bucket_fmt, err := strconv.ParseFloat(bucket, 64)
+	                        if err != nil {
+	                                return err
+	                        }
+	                        if r.Value <= bucket_fmt {
+	                                labels = append(labels, prompbmarshal.Label{
+	                                        Name:  "le",
+	                                        Value: bucket,
+	                                })
+	                                NewValue, err := strconv.ParseFloat("1", 64)
+	                                if err != nil {
+	                                        return err
+	                                }
+	                                r.Value = NewValue
+	                                labels = append(labels, extraLabels...)
+	                                samples = append(samples, prompbmarshal.Sample{
+	                                        Value:     r.Value,
+	                                        Timestamp: r.Timestamp,
+	                                })
+	                                tssDst = append(tssDst, prompbmarshal.TimeSeries{
+	                                        Labels:  labels[labelsLen:],
+	                                        Samples: samples[len(samples)-1:],
+	                                })
+	                        }
+	                }
+	                labels = append(labels, prompbmarshal.Label{
+	                        Name:  "le",
+	                        Value: "+Inf",
+	                })
+	                NewValue, err := strconv.ParseFloat("1", 64)
+	                if err != nil {
+	                        return err
+	                }
+	                r.Value = NewValue
+	                labels = append(labels, extraLabels...)
+	                samples = append(samples, prompbmarshal.Sample{
+	                        Value:     r.Value,
+	                        Timestamp: r.Timestamp,
+	                })
+	                tssDst = append(tssDst, prompbmarshal.TimeSeries{
+	                        Labels:  labels[labelsLen:],
+	                        Samples: samples[len(samples)-1:],
+	                })
+	        } else {
+	                labels = append(labels, extraLabels...)
+	                samples = append(samples, prompbmarshal.Sample{
+	                        Value:     r.Value,
+	                        Timestamp: r.Timestamp,
+	                })
+	                tssDst = append(tssDst, prompbmarshal.TimeSeries{
+	                        Labels:  labels[labelsLen:],
+	                        Samples: samples[len(samples)-1:],
+	                })
+	        }
 	}
 	ctx.WriteRequest.Timeseries = tssDst
 	ctx.Labels = labels


### PR DESCRIPTION
### Describe Your Changes

This is a strategy to transform latency buckets provided by native or legacy loadbalancers which the latency is used as metric value.

Basically transforms the value received in the metric to label named "le" for prometheus compatibility and SLIs and SLOs calculation.

There is two variables to be used:

- prom_bucket_metric_name (default: None)
  - To disable, not set this variable
- prom_bucket_metric_samples (default buckets: "0.1, 0.2, 0.3, 0.5, 0.8, 1, 2, 3, 5")
