### PR TITLE
Publish Alertmanager configuration docs for Managed VictoriaMetrics

### DIFF
--- a/docs/managed-victoriametrics/README.md
+++ b/docs/managed-victoriametrics/README.md
@@ -7,14 +7,15 @@ disableToc: true
 
 # Managed VictoriaMetrics
 
-* [Overview of Managed VictoriaMetrics](/managed-victoriametrics/overview.html)
-* [Quick Start](/managed-victoriametrics/quickstart.html)
+* [Overview of Managed VictoriaMetrics](/managed-victoriametrics/overview/)
+* [Quick Start](/managed-victoriametrics/quickstart/)
 
 ## Guides
-* [User Management](/managed-victoriametrics/user-managment.html)
-* [Kubernetes Monitoring with Managed VictoriaMetrics](/managed-victoriametrics/how-to-monitor-k8s.html)
-* [Understand Your Setup Size](/guides/understand-your-setup-size.html)
-* [Setup Notifications](/managed-victoriametrics/setup-notifications.html)
+* [Understand Your Setup Size](/guides/understand-your-setup-size/)
+* [Alerting & recording rules with Alertmanager configuration for Managed VictoriaMetrics deployment](/managed-victoriametrics/alertmanager-setup-for-deployment/)
+* [Kubernetes Monitoring with Managed VictoriaMetrics](/managed-victoriametrics/how-to-monitor-k8s/)
+* [Setup Notifications](/managed-victoriametrics/setup-notifications/)
+* [User Management](/managed-victoriametrics/user-managment/)
 
 Learn more about Managed VictoriaMetrics:
 * [Managed VictoriaMetrics announcement](https://victoriametrics.com/blog/managed-victoriametrics-announcement)

--- a/docs/managed-victoriametrics/alerting-vmalert-managed-victoria-metrics.md
+++ b/docs/managed-victoriametrics/alerting-vmalert-managed-victoria-metrics.md
@@ -1,11 +1,11 @@
 ---
-sort: 4
-weight: 4
+sort: 5
+weight: 5
 title: Alerting with vmalert and Managed VictoriaMetrics
 menu:
   docs:
     parent: "managed"
-    weight: 4
+    weight: 5
 aliases:
 - /managed-victoriametrics/alerting-vmalert-managed-victoria-metrics.html
 ---

--- a/docs/managed-victoriametrics/alertmanager-setup-for-deployment.md
+++ b/docs/managed-victoriametrics/alertmanager-setup-for-deployment.md
@@ -1,19 +1,27 @@
 ---
-title: Alertmanager and VMAlert configuration for Deployment
+sort: 4
+weight: 4
+title: Alertmanager and VMAlert configuration for Managed VictoriaMetrics deployment
+menu:
+  docs:
+    parent: "managed"
+    weight: 4
+aliases:
+  - /managed-victoriametrics/alertmanager-setup-for-deployment.html
 ---
 
 ## Alerting stack configuration and Managed VictoriaMetrics
 
-Managed VictoriaMetrics supports configuring alerting rules and notifications through Alertmanager and internal vmalert.
+Managed VictoriaMetrics supports configuring alerting rules, powered by vmalert, and sending notifications with hosted Alertmanager.
 
 ## Configure Alertmanager
 
- Managed VictoriaMetrics supports Alertmanager with standard [configuration](https://prometheus.io/docs/alerting/latest/configuration/).
-Configuration menu located at `deployment` page under `Alertmanager` section.
+Managed VictoriaMetrics supports Alertmanager with standard [configuration](https://prometheus.io/docs/alerting/latest/configuration/).
+Configuration menu is located under `Alertmanager` section of your deployment.
 
 <img src="alertmanager-setup-for-deployment_location.webp">
 
- Please check the configuration options and limitations:
+Please check the configuration options and limitations:
 
 ### Allowed receivers
 
@@ -31,7 +39,7 @@ Configuration menu located at `deployment` page under `Alertmanager` section.
 
 ### Limitation
 
- All configuration params with `_file` suffix are not allowed for security reasons.
+All configuration params with `_file` suffix are not allowed for security reasons.
 
 ### Configuration example
 
@@ -97,18 +105,18 @@ receivers:
 
 ## Configure alerting rules
 
- Alerting and recording rules could be configured via API calls.
+Alerting and recording rules could be configured via API calls.
 
 ### Managed VictoriaMetrics rules API
 
-Managed VictoriaMetrics has following APIs for rules:
+Managed VictoriaMetrics has the following APIs for rules:
 
 * POST: `/api/v1/deployments/{deploymentId}/rule-sets/files/{fileName}`
 * DELETE `/api/v1/deployments/{deploymentId}/rule-sets/files/{fileName}`
 
- OpenAPI [link](https://cloud.victoriametrics.com/api-docs)
+For more details, please check [OpenAPI Reference](https://cloud.victoriametrics.com/api-docs)
 
-### rules creation with API
+### Rules creation with API
 
 Let's create two example rules for deployment in `testing-rules.yaml`
 
@@ -137,24 +145,24 @@ groups:
 Upload rules to the Managed VictoriaMetrics using the following command:
 
 ```sh
-curl https://cloud.victoriametrics.com/api/v1/deployments/DEPLOYMENT_ID/rule-sets/files/testing-rules -v -H 'X-VM-Cloud-Access: CLOUD_API_TOKEN' -XPOST --data-binary '@testing-rules.yaml'
+curl https://cloud.victoriametrics.com/api/v1/deployments/<DEPLOYMENT_ID>/rule-sets/files/testing-rules -v -H 'X-VM-Cloud-Access: <CLOUD_API_TOKEN>' -XPOST --data-binary '@testing-rules.yaml'
 ```
 
 ## Troubleshooting
 
-### rules execution state
+### Rules execution state
 
-The state of created rules is located in the rules section for Deployment:
+The state of created rules is located in the `Rules` section of your deployment:
 
 <img src="alertmanager-setup-for-deployment_rules_state.webp">
 
-### debug
+### Debug
 
-It's possible to debug the alerting stack with logs for vmalert and alertmanager, which are accessible in the Logs section of the deployment.
+It's possible to debug the alerting stack with logs for vmalert and Alertmanager, which are accessible in the `Logs` section of the deployment.
 
 <img src="alertmanager-setup-for-deployment_troubleshoot_logs.webp">
 
-### cloud monitoring
+### Monitoring
 
- Alertmanager and vmalert errors are tracked by internal cloud monitoring system. 
-Deployment `Alerts` section has information for active incidents and incident history log.
+Alertmanager and vmalert errors are tracked by a built-in monitoring system. 
+Deployment's `Alerts` section has information about active incidents and incident history log.

--- a/docs/managed-victoriametrics/overview.md
+++ b/docs/managed-victoriametrics/overview.md
@@ -26,14 +26,16 @@ Managed VictoriaMetrics allows users to run Enterprise version of VictoriaMetric
 DevOps tasks such as proper configuration, monitoring, logs collection, access protection, software updates, 
 backups, etc. [Try it right now](https://cloud.victoriametrics.com/signUp?utm_source=website&utm_campaign=docs_overview)
 
-We run Managed VictoriaMetrics instances in our environment on AWS and provide easy-to-use endpoints 
+We run Managed VictoriaMetrics deployments in our environment on AWS and provide easy-to-use endpoints 
 for data ingestion and querying. The VictoriaMetrics team takes care of optimal configuration and software 
 maintenance.
 
 Managed VictoriaMetrics comes with the following features:
 
 * It can be used as a Managed Prometheus - just configure Prometheus or vmagent to write data to Managed VictoriaMetrics and then use the provided endpoint as a Prometheus datasource in Grafana;
-* Every Managed VictoriaMetrics instance runs in an isolated environment, so instances cannot interfere with each other;
-* Managed VictoriaMetrics instance can be scaled up or scaled down in a few clicks;
+* Built-in [Alerting & Recording](https://docs.victoriametrics.com/managed-victoriametrics/alertmanager-setup-for-deployment/#configure-alerting-rules) rules execution;
+* Hosted [Alertmanager](https://docs.victoriametrics.com/managed-victoriametrics/alertmanager-setup-for-deployment/) for sending notifications;
+* Every Managed VictoriaMetrics deployment runs in an isolated environment, so deployments cannot interfere with each other;
+* Managed VictoriaMetrics deployment can be scaled up or scaled down in a few clicks;
 * Automated backups;
 * Pay only for the actually used resources - compute, storage, traffic.

--- a/docs/managed-victoriametrics/quickstart.md
+++ b/docs/managed-victoriametrics/quickstart.md
@@ -11,7 +11,7 @@ aliases:
 ---
 # Quick Start
 
-Managed VictoriaMetrics – is a database-as-a-service platform, where users can run the VictoriaMetrics 
+Managed VictoriaMetrics is a hosted monitoring platform, where users can run the VictoriaMetrics 
 that they know and love on AWS without the need to perform typical DevOps tasks such as proper configuration, 
 monitoring, logs collection, access protection, software updates, backups, etc.
 

--- a/docs/managed-victoriametrics/setup-notifications.md
+++ b/docs/managed-victoriametrics/setup-notifications.md
@@ -1,11 +1,11 @@
 ---
-sort: 6
-weight: 6
+sort: 7
+weight: 7
 title: Notifications in Managed VictoriaMetrics
 menu:
   docs:
     parent: "managed"
-    weight: 6
+    weight: 7
 aliases:
 - /managed-victoriametrics/setup-notifications.html
 ---

--- a/docs/managed-victoriametrics/user-managment.md
+++ b/docs/managed-victoriametrics/user-managment.md
@@ -1,11 +1,11 @@
 ---
-sort: 5
-weight: 5
+sort: 6
+weight: 6
 title: User Management in Managed VictoriaMetrics
 menu:
   docs:
     parent: "managed"
-    weight: 5
+    weight: 6
 aliases:
 - /managed-victoriametrics/user-management.html
 ---


### PR DESCRIPTION
### Describe Your Changes

With the recent release of Managed VictoriaMetrics users are able to create and execute Alerting & Recording rules and send notifications via hosted Alertmanager.

So, we're publishing Alertmanager configuration docs for Managed VictoriaMetrics.

### Checklist

The following checks are **mandatory**:

- [x] My change adheres [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/contributing/).
