### PR TITLE
app/vminsert: excluded vmrange and le labels from sharding

### DIFF
--- a/app/vminsert/netstorage/insert_ctx.go
+++ b/app/vminsert/netstorage/insert_ctx.go
@@ -175,8 +175,12 @@ func (ctx *InsertCtx) GetStorageNodeIdx(at *auth.Token, labels []prompb.Label) i
 	buf = encoding.MarshalUint32(buf, at.ProjectID)
 	for i := range labels {
 		label := &labels[i]
-		buf = marshalStringFast(buf, label.Name)
-		buf = marshalStringFast(buf, label.Value)
+		// excluding le and vmrange labels from node idx calculation to put all histogram metrics to the same node
+		// see https://github.com/VictoriaMetrics/VictoriaMetrics/issues/6424
+		if label.Name != "le" && label.Name != "vmrange" {
+			buf = marshalStringFast(buf, label.Name)
+			buf = marshalStringFast(buf, label.Value)
+		}
 	}
 	h := xxhash.Sum64(buf)
 	ctx.labelsBuf = buf

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -39,6 +39,7 @@ See also [LTS releases](https://docs.victoriametrics.com/lts-releases/).
 
 * BUGFIX: all VictoriaMetrics components: prioritize `-configAuthKey` and `-reloadAuthKey` over `-httpAuth.*` settings. This change aligns behavior of mentioned flags with other auth flags like `-metricsAuthKey`, `-flagsAuthKey`, `-pprofAuthKey`. Check [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/6329).
 * BUGFIX: [vmctl](https://docs.victoriametrics.com/vmctl/): add `--disable-progress-bar` global command-line flag. It can be used for disabling dynamic progress bar for all migration modes. `--vm-disable-progress-bar`  command-line flag is deprecated and will be removed in the future releases. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/6367).
+* BUGFIX: `vminsert` in [VictoriaMetrics cluster](https://docs.victoriametrics.com/cluster-victoriametrics/): exclude histogram le and vmrange labels from storage idx calculation to put all histogram metrics to the same node. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/6424).
 
 ## [v1.102.0-rc1](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.102.0-rc1)
 


### PR DESCRIPTION
### Describe Your Changes

to get proper results on operations over histograms, excluded le and vmrange labels from shard index calculation
related to https://github.com/VictoriaMetrics/VictoriaMetrics/issues/6424

### Checklist

The following checks are **mandatory**:

- [ ] My change adheres [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/contributing/).
