### PR TITLE
lib/protoparser/opentelemetry/firehose: escape requestID before returning it to user

### DIFF
--- a/lib/protoparser/opentelemetry/firehose/http.go
+++ b/lib/protoparser/opentelemetry/firehose/http.go
@@ -2,6 +2,7 @@ package firehose
 
 import (
 	"fmt"
+	"html"
 	"net/http"
 	"time"
 )
@@ -12,11 +13,12 @@ import (
 func WriteSuccessResponse(w http.ResponseWriter, r *http.Request) {
 	requestID := r.Header.Get("X-Amz-Firehose-Request-Id")
 	if requestID == "" {
-		// This isn't a AWS firehose request - just return an empty response in this case.
+		// This isn't an AWS firehose request - just return an empty response in this case.
 		w.WriteHeader(http.StatusOK)
 		return
 	}
 
+	requestID = html.EscapeString(requestID)
 	body := fmt.Sprintf(`{"requestId":%q,"timestamp":%d}`, requestID, time.Now().UnixMilli())
 
 	h := w.Header()


### PR DESCRIPTION
All user input should be sanitized before rendering. This should prevent possible attacks. See https://github.com/VictoriaMetrics/VictoriaMetrics/security/code-scanning/203

### Describe Your Changes

Please provide a brief description of the changes you made. Be as specific as possible to help others understand the purpose and impact of your modifications.

