### PR TITLE
lib/streamaggr: allow setting keep_input for each aggregator separately

### DIFF
--- a/app/vmagent/remotewrite/remotewrite_test.go
+++ b/app/vmagent/remotewrite/remotewrite_test.go
@@ -70,8 +70,6 @@ func TestRemoteWriteContext_TryPush_ImmutableTimeseries(t *testing.T) {
 		pss[0] = newPendingSeries(nil, true, 0, 100)
 		rwctx := &remoteWriteCtx{
 			idx:                    0,
-			streamAggrKeepInput:    keepInput,
-			streamAggrDropInput:    dropInput,
 			pss:                    pss,
 			rowsPushedAfterRelabel: metrics.GetOrCreateCounter(`foo`),
 			rowsDroppedByRelabel:   metrics.GetOrCreateCounter(`bar`),

--- a/app/vmagent/remotewrite/streamaggr.go
+++ b/app/vmagent/remotewrite/streamaggr.go
@@ -50,8 +50,7 @@ var (
 	streamAggrIgnoreOldSamples = flagutil.NewArrayBool("remoteWrite.streamAggr.ignoreOldSamples", "Whether to ignore input samples with old timestamps outside the current "+
 		"aggregation interval for the corresponding -remoteWrite.streamAggr.config at the corresponding -remoteWrite.url. "+
 		"See https://docs.victoriametrics.com/stream-aggregation/#ignoring-old-samples")
-	streamAggrIgnoreFirstIntervals = flag.Int("remoteWrite.streamAggr.ignoreFirstIntervals", 0, "Number of aggregation intervals to skip after the start "+
-		"for the corresponding -remoteWrite.streamAggr.config at the corresponding -remoteWrite.url. Increase this value if "+
+	streamAggrIgnoreFirstIntervals = flagutil.NewArrayInt("remoteWrite.streamAggr.ignoreFirstIntervals", 0, "Number of aggregation intervals to skip after the start "+"for the corresponding -remoteWrite.streamAggr.config at the corresponding -remoteWrite.url. Increase this value if "+
 		"you observe incorrect aggregation results after vmagent restarts. It could be caused by receiving bufferred delayed data from clients pushing data into the vmagent. "+
 		"See https://docs.victoriametrics.com/stream-aggregation/#ignore-aggregation-intervals-on-start")
 	streamAggrDropInputLabels = flagutil.NewArrayString("remoteWrite.streamAggr.dropInputLabels", "An optional list of labels to drop from samples "+
@@ -148,8 +147,6 @@ func (rwctx *remoteWriteCtx) initStreamAggrConfig() {
 	if sas != nil {
 		filePath := sas.FilePath()
 		rwctx.sas.Store(sas)
-		rwctx.streamAggrKeepInput = streamAggrKeepInput.GetOptionalArg(idx)
-		rwctx.streamAggrDropInput = streamAggrDropInput.GetOptionalArg(idx)
 		metrics.GetOrCreateCounter(fmt.Sprintf(`vmagent_streamaggr_config_reload_successful{path=%q}`, filePath)).Set(1)
 		metrics.GetOrCreateCounter(fmt.Sprintf(`vmagent_streamaggr_config_reload_success_timestamp_seconds{path=%q}`, filePath)).Set(fasttime.UnixTimestamp())
 	} else {
@@ -202,6 +199,8 @@ func newStreamAggrConfigGlobal() (*streamaggr.Aggregators, error) {
 		DropInputLabels:      *streamAggrGlobalDropInputLabels,
 		IgnoreOldSamples:     *streamAggrGlobalIgnoreOldSamples,
 		IgnoreFirstIntervals: *streamAggrGlobalIgnoreFirstIntervals,
+		KeepInput:            *streamAggrGlobalKeepInput,
+		DropInput:            *streamAggrGlobalDropInput,
 	}
 
 	sas, err := streamaggr.LoadFromFile(path, pushToRemoteStoragesTrackDropped, opts, "global")
@@ -229,7 +228,9 @@ func newStreamAggrConfigPerURL(idx int, pushFunc streamaggr.PushFunc) (*streamag
 		DedupInterval:        streamAggrDedupInterval.GetOptionalArg(idx),
 		DropInputLabels:      *streamAggrDropInputLabels,
 		IgnoreOldSamples:     streamAggrIgnoreOldSamples.GetOptionalArg(idx),
-		IgnoreFirstIntervals: *streamAggrIgnoreFirstIntervals,
+		IgnoreFirstIntervals: streamAggrIgnoreFirstIntervals.GetOptionalArg(idx),
+		KeepInput:            streamAggrKeepInput.GetOptionalArg(idx),
+		DropInput:            streamAggrDropInput.GetOptionalArg(idx),
 	}
 
 	sas, err := streamaggr.LoadFromFile(path, pushFunc, opts, alias)

--- a/app/vminsert/common/streamaggr.go
+++ b/app/vminsert/common/streamaggr.go
@@ -62,6 +62,8 @@ func CheckStreamAggrConfig() error {
 		DropInputLabels:      *streamAggrDropInputLabels,
 		IgnoreOldSamples:     *streamAggrIgnoreOldSamples,
 		IgnoreFirstIntervals: *streamAggrIgnoreFirstIntervals,
+		KeepInput:            *streamAggrKeepInput,
+		DropInput:            *streamAggrDropInput,
 	}
 	sas, err := streamaggr.LoadFromFile(*streamAggrConfig, pushNoop, opts, "global")
 	if err != nil {
@@ -90,6 +92,8 @@ func InitStreamAggr() {
 		DropInputLabels:      *streamAggrDropInputLabels,
 		IgnoreOldSamples:     *streamAggrIgnoreOldSamples,
 		IgnoreFirstIntervals: *streamAggrIgnoreFirstIntervals,
+		KeepInput:            *streamAggrKeepInput,
+		DropInput:            *streamAggrDropInput,
 	}
 	sas, err := streamaggr.LoadFromFile(*streamAggrConfig, pushAggregateSeries, opts, "global")
 	if err != nil {
@@ -124,6 +128,8 @@ func reloadStreamAggrConfig() {
 		DropInputLabels:      *streamAggrDropInputLabels,
 		IgnoreOldSamples:     *streamAggrIgnoreOldSamples,
 		IgnoreFirstIntervals: *streamAggrIgnoreFirstIntervals,
+		KeepInput:            *streamAggrKeepInput,
+		DropInput:            *streamAggrDropInput,
 	}
 	sasNew, err := streamaggr.LoadFromFile(*streamAggrConfig, pushAggregateSeries, opts, "global")
 	if err != nil {
@@ -180,12 +186,13 @@ func (ctx *streamAggrCtx) Reset() {
 	ctx.buf = ctx.buf[:0]
 }
 
-func (ctx *streamAggrCtx) push(mrs []storage.MetricRow, matchIdxs []byte) []byte {
+func (ctx *streamAggrCtx) push(insertCtx *InsertCtx) {
 	mn := &ctx.mn
 	tss := ctx.tss
 	labels := ctx.labels
 	samples := ctx.samples
 	buf := ctx.buf
+	mrs := insertCtx.mrs
 
 	tssLen := len(tss)
 	for _, mr := range mrs {
@@ -237,18 +244,16 @@ func (ctx *streamAggrCtx) push(mrs []storage.MetricRow, matchIdxs []byte) []byte
 
 	sas := sasGlobal.Load()
 	if sas.IsEnabled() {
-		matchIdxs = sas.Push(tss, matchIdxs)
+		_ = sas.PushWithCallback(tss, func(matchIdxs []byte) {
+			insertCtx.dropAggregatedRows(matchIdxs)
+		})
 	} else if deduplicator != nil {
-		matchIdxs = bytesutil.ResizeNoCopyMayOverallocate(matchIdxs, len(tss))
-		for i := range matchIdxs {
-			matchIdxs[i] = 1
-		}
 		deduplicator.Push(tss)
+		mrs = mrs[:0]
 	}
 
 	ctx.Reset()
-
-	return matchIdxs
+	insertCtx.mrs = mrs
 }
 
 func pushAggregateSeries(tss []prompbmarshal.TimeSeries) {

--- a/docs/stream-aggregation.md
+++ b/docs/stream-aggregation.md
@@ -44,7 +44,8 @@ This behaviour can be changed via the following command-line flags:
 
 - `-streamAggr.keepInput` at [single-node VictoriaMetrics](https://docs.victoriametrics.com/single-server-victoriametrics/) 
   and [vmagent](https://docs.victoriametrics.com/vmagent/). At [vmagent](https://docs.victoriametrics.com/vmagent/)
-  `-remoteWrite.streamAggr.keepInput` flag can be specified individually per each `-remoteWrite.url`.
+  `-remoteWrite.streamAggr.keepInput` flag can be specified individually per each `-remoteWrite.url` and `keep_input` parameter can be defined
+  for each aggregator separately.
   If one of these flags is set, then all the input samples are written to the storage alongside the aggregated samples.
 - `-streamAggr.dropInput` at [single-node VictoriaMetrics](https://docs.victoriametrics.com/single-server-victoriametrics/) 
   and [vmagent](https://docs.victoriametrics.com/vmagent/). At [vmagent](https://docs.victoriametrics.com/vmagent/)

--- a/lib/streamaggr/streamaggr.go
+++ b/lib/streamaggr/streamaggr.go
@@ -135,6 +135,14 @@ type Options struct {
 	//
 	// This option can be overridden individually per each aggregation via ignore_first_intervals option.
 	IgnoreFirstIntervals int
+
+	// KeepInput defines whether to keep all the input samples after the aggregation.
+	// By default, only aggregates samples are dropped, while the remaining samples are written to remote storages write.
+	KeepInput bool
+
+	// DropInput defines whether to drop all the input samples after the aggregation.
+	// By default, only aggregates samples are dropped, while the remaining samples are written to remote storages write.
+	DropInput bool
 }
 
 // Config is a configuration for a single stream aggregation.
@@ -237,6 +245,10 @@ type Config struct {
 	// OutputRelabelConfigs is an optional relabeling rules, which are applied
 	// on the aggregated output before being sent to remote storage.
 	OutputRelabelConfigs []promrelabel.RelabelConfig `yaml:"output_relabel_configs,omitempty"`
+
+	// KeepInput defines whether to keep all the input samples after the aggregation.
+	// By default, only aggregates samples are dropped, while the remaining samples are written to remote storages write.
+	KeepInput *bool `yaml:"keep_input,omitempty"`
 }
 
 // Aggregators aggregates metrics passed to Push and calls pushFunc for aggregated data.
@@ -252,6 +264,8 @@ type Aggregators struct {
 
 	// ms contains metrics associated with the Aggregators.
 	ms *metrics.Set
+
+	dropInput bool
 }
 
 // FilePath returns path to file with the configuration used for creating the given Aggregators.
@@ -291,12 +305,16 @@ func loadFromData(data []byte, filePath string, pushFunc PushFunc, opts *Options
 	}
 
 	metrics.RegisterSet(ms)
-	return &Aggregators{
+	a := &Aggregators{
 		as:         as,
 		configData: configData,
 		filePath:   filePath,
 		ms:         ms,
-	}, nil
+	}
+	if opts != nil {
+		a.dropInput = opts.DropInput
+	}
+	return a, nil
 }
 
 // IsEnabled returns true if Aggregators has at least one configured aggregator
@@ -325,6 +343,19 @@ func (a *Aggregators) MustStop() {
 	a.as = nil
 }
 
+// ExpectModifications returns true if Push modifies original timeseries
+func (a *Aggregators) ExpectModifications() bool {
+	if a == nil {
+		return false
+	}
+	for _, aggr := range a.as {
+		if aggr.keepInput {
+			return true
+		}
+	}
+	return false
+}
+
 // Equal returns true if a and b are initialized from identical configs.
 func (a *Aggregators) Equal(b *Aggregators) bool {
 	if a == nil || b == nil {
@@ -333,28 +364,39 @@ func (a *Aggregators) Equal(b *Aggregators) bool {
 	return string(a.configData) == string(b.configData)
 }
 
-// Push pushes tss to a.
+// Push calls PushWithCallback with an empty default callback
+func (a *Aggregators) Push(tss []prompbmarshal.TimeSeries) []prompbmarshal.TimeSeries {
+	defaultCallback := func(_ []byte) {}
+	return a.PushWithCallback(tss, defaultCallback)
+}
+
+// PushWithCallback pushes tss to a.
 //
-// Push sets matchIdxs[idx] to 1 if the corresponding tss[idx] was used in aggregations.
+// PushWithCallback calls callback with matchIdxs, where matchIdx[idx] is set to 1 if the corresponding tss[idx] was used in aggregations.
 // Otherwise matchIdxs[idx] is set to 0.
 //
-// Push returns matchIdxs with len equal to len(tss).
-// It re-uses the matchIdxs if it has enough capacity to hold len(tss) items.
-// Otherwise it allocates new matchIdxs.
-func (a *Aggregators) Push(tss []prompbmarshal.TimeSeries, matchIdxs []byte) []byte {
-	matchIdxs = bytesutil.ResizeNoCopyMayOverallocate(matchIdxs, len(tss))
-	for i := range matchIdxs {
-		matchIdxs[i] = 0
-	}
+// Push returns modified timeseries.
+func (a *Aggregators) PushWithCallback(tss []prompbmarshal.TimeSeries, callback func([]byte)) []prompbmarshal.TimeSeries {
 	if a == nil {
-		return matchIdxs
+		return tss
 	}
-
+	matchIdxs := matchIdxsPool.Get()
+	defer matchIdxsPool.Put(matchIdxs)
 	for _, aggr := range a.as {
-		aggr.Push(tss, matchIdxs)
+		matchIdxs.B = bytesutil.ResizeNoCopyMayOverallocate(matchIdxs.B, len(tss))
+		for i := range matchIdxs.B {
+			matchIdxs.B[i] = 0
+		}
+		aggr.Push(tss, matchIdxs.B)
+		if !aggr.keepInput {
+			callback(matchIdxs.B)
+			tss = dropAggregatedSeries(tss, matchIdxs.B)
+		}
 	}
-
-	return matchIdxs
+	if a.dropInput {
+		tss = tss[:0]
+	}
+	return tss
 }
 
 // aggregator aggregates input series according to the config passed to NewAggregator
@@ -368,6 +410,7 @@ type aggregator struct {
 
 	keepMetricNames  bool
 	ignoreOldSamples bool
+	keepInput        bool
 
 	by                  []string
 	without             []string
@@ -546,6 +589,12 @@ func newAggregator(cfg *Config, path string, pushFunc PushFunc, ms *metrics.Set,
 	}
 	metricLabels := fmt.Sprintf(`name=%q,path=%q,url=%q,position="%d"`, name, path, alias, aggrID)
 
+	// check cfg.KeepInput
+	keepInput := opts.KeepInput
+	if v := cfg.KeepInput; v != nil {
+		keepInput = *v
+	}
+
 	// initialize aggrOutputs
 	if len(cfg.Outputs) == 0 {
 		return nil, fmt.Errorf("`outputs` list must contain at least a single entry from the list %s; "+
@@ -585,6 +634,7 @@ func newAggregator(cfg *Config, path string, pushFunc PushFunc, ms *metrics.Set,
 
 		keepMetricNames:  keepMetricNames,
 		ignoreOldSamples: ignoreOldSamples,
+		keepInput:        keepInput,
 
 		by:                  by,
 		without:             without,
@@ -884,7 +934,7 @@ func (a *aggregator) MustStop() {
 	a.wg.Wait()
 }
 
-// Push pushes tss to a.
+// push pushes tss to a.
 func (a *aggregator) Push(tss []prompbmarshal.TimeSeries, matchIdxs []byte) {
 	ctx := getPushCtx()
 	defer putPushCtx(ctx)
@@ -1049,6 +1099,8 @@ func putPushCtx(ctx *pushCtx) {
 	ctx.reset()
 	pushCtxPool.Put(ctx)
 }
+
+var matchIdxsPool bytesutil.ByteBufferPool
 
 var pushCtxPool sync.Pool
 
@@ -1270,6 +1322,19 @@ func sortAndRemoveDuplicates(a []string) []string {
 			dst = append(dst, v)
 		}
 	}
+	return dst
+}
+
+func dropAggregatedSeries(src []prompbmarshal.TimeSeries, matchIdxs []byte) []prompbmarshal.TimeSeries {
+	dst := src[:0]
+	for i, match := range matchIdxs {
+		if match == 1 {
+			continue
+		}
+		dst = append(dst, src[i])
+	}
+	tail := src[len(dst):]
+	clear(tail)
 	return dst
 }
 

--- a/lib/streamaggr/streamaggr_timing_test.go
+++ b/lib/streamaggr/streamaggr_timing_test.go
@@ -43,7 +43,7 @@ func BenchmarkAggregatorsFlushInternalSerial(b *testing.B) {
 	pushFunc := func(_ []prompbmarshal.TimeSeries) {}
 	a := newBenchAggregators(benchOutputs, pushFunc)
 	defer a.MustStop()
-	_ = a.Push(benchSeries, nil)
+	benchSeries = a.Push(benchSeries)
 
 	b.ResetTimer()
 	b.ReportAllocs()
@@ -66,10 +66,9 @@ func benchmarkAggregatorsPush(b *testing.B, output string) {
 	b.ReportAllocs()
 	b.SetBytes(int64(len(benchSeries) * loops))
 	b.RunParallel(func(pb *testing.PB) {
-		var matchIdxs []byte
 		for pb.Next() {
 			for i := 0; i < loops; i++ {
-				matchIdxs = a.Push(benchSeries, matchIdxs)
+				benchSeries = a.Push(benchSeries)
 			}
 		}
 	})


### PR DESCRIPTION
### Describe Your Changes

Allow setting keep_input on aggregation level
Fixes #4383

### Checklist

The following checks are **mandatory**:

- [ ] My change adheres [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/contributing/).
