### PR TITLE
lib/flagutil: use month limit for duration flag for parsed duration assessment

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -45,6 +45,7 @@ See also [LTS releases](https://docs.victoriametrics.com/lts-releases/).
 * BUGFIX: [vmbackup](https://docs.victoriametrics.com/vmbackup/): properly configure authentication with S3 when `-configFilePath` cmd-line flag is specified.
 * BUGFIX: [vmalert](https://docs.victoriametrics.com/vmalert/) enterprise: properly configure authentication with S3 when `-s3.configFilePath` cmd-line flag is specified for reading rule configs.
 * BUGFIX: [vmalert](https://docs.victoriametrics.com/vmalert/): properly specify oauth2 `ClientSecret` when configuring authentication for `notifier.url`. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/6471) for details. Thanks to @yincongcyincong for the [pull request](https://github.com/VictoriaMetrics/VictoriaMetrics/pull/6478).
+* BUGFIX: [Single-node VictoriaMetrics](https://docs.victoriametrics.com/) and `vmstorage` in [VictoriaMetrics cluster](https://docs.victoriametrics.com/cluster-victoriametrics/): limit duration flag max value returned from metricsql's parse duration function.
 
 ## [v1.102.0-rc1](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.102.0-rc1)
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -45,7 +45,7 @@ See also [LTS releases](https://docs.victoriametrics.com/lts-releases/).
 * BUGFIX: [vmbackup](https://docs.victoriametrics.com/vmbackup/): properly configure authentication with S3 when `-configFilePath` cmd-line flag is specified.
 * BUGFIX: [vmalert](https://docs.victoriametrics.com/vmalert/) enterprise: properly configure authentication with S3 when `-s3.configFilePath` cmd-line flag is specified for reading rule configs.
 * BUGFIX: [vmalert](https://docs.victoriametrics.com/vmalert/): properly specify oauth2 `ClientSecret` when configuring authentication for `notifier.url`. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/6471) for details. Thanks to @yincongcyincong for the [pull request](https://github.com/VictoriaMetrics/VictoriaMetrics/pull/6478).
-* BUGFIX: [Single-node VictoriaMetrics](https://docs.victoriametrics.com/) and `vmstorage` in [VictoriaMetrics cluster](https://docs.victoriametrics.com/cluster-victoriametrics/): limit duration flag max value returned from metricsql's parse duration function.
+* BUGFIX: [Single-node VictoriaMetrics](https://docs.victoriametrics.com/) and `vmstorage` in [VictoriaMetrics cluster](https://docs.victoriametrics.com/cluster-victoriametrics/): add validation for the max value specified for `-retentionPeriod`. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/6330) for details.
 
 ## [v1.102.0-rc1](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.102.0-rc1)
 

--- a/lib/flagutil/duration.go
+++ b/lib/flagutil/duration.go
@@ -76,11 +76,13 @@ func (d *Duration) Set(value string) error {
 	if err != nil {
 		return err
 	}
+	if msecs/msecsPer31Days > maxMonths {
+		return fmt.Errorf("duration must be smaller than %d months; got approx %d months", maxMonths, msecs/msecsPer31Days)
+	}
 	d.msecs = msecs
 	d.valueString = value
 	return nil
 }
 
 const maxMonths = 12 * 100
-
 const msecsPer31Days = 31 * 24 * 3600 * 1000

--- a/lib/flagutil/duration_test.go
+++ b/lib/flagutil/duration_test.go
@@ -32,6 +32,7 @@ func TestDurationSetFailure(t *testing.T) {
 
 	// Duration in minutes is confused with duration in months
 	f("1m")
+	f("999y")
 }
 
 func TestDurationSetSuccess(t *testing.T) {

--- a/lib/flagutil/duration_test.go
+++ b/lib/flagutil/duration_test.go
@@ -24,6 +24,7 @@ func TestDurationSetFailure(t *testing.T) {
 	f("12345")
 
 	// Too big duration
+	f("999y")
 	f("100000000000y")
 
 	// Negative duration
@@ -32,7 +33,6 @@ func TestDurationSetFailure(t *testing.T) {
 
 	// Duration in minutes is confused with duration in months
 	f("1m")
-	f("999y")
 }
 
 func TestDurationSetSuccess(t *testing.T) {
@@ -60,6 +60,7 @@ func TestDurationSetSuccess(t *testing.T) {
 	f("2.3W", 2.3*7*24*3600*1000)
 	f("1w", 7*24*3600*1000)
 	f("0.25y", 0.25*365*24*3600*1000)
+	f("100y", 100*365*24*3600*1000)
 }
 
 func TestDurationDuration(t *testing.T) {


### PR DESCRIPTION
### Describe Your Changes

use maxMonths limit for parsed duration flag value
fixes #6330 

### Checklist

The following checks are **mandatory**:

- [ ] My change adheres [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/contributing/).
