### PR TITLE
cluster: persist storage node IDs

### DIFF
--- a/app/vminsert/clusternative/request_handler.go
+++ b/app/vminsert/clusternative/request_handler.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"net"
 
+	"github.com/VictoriaMetrics/metrics"
+
 	"github.com/VictoriaMetrics/VictoriaMetrics/app/vminsert/netstorage"
 	"github.com/VictoriaMetrics/VictoriaMetrics/app/vminsert/relabel"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/auth"
@@ -12,7 +14,6 @@ import (
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/protoparser/clusternative/stream"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/storage"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/tenantmetrics"
-	"github.com/VictoriaMetrics/metrics"
 )
 
 var (
@@ -25,7 +26,7 @@ var (
 func InsertHandler(c net.Conn) error {
 	// There is no need in response compression, since
 	// lower-level vminsert sends only small packets to upper-level vminsert.
-	bc, err := handshake.VMInsertServer(c, 0)
+	bc, err := handshake.VMInsertServer(c, 0, netstorage.GetNodeID())
 	if err != nil {
 		if errors.Is(err, handshake.ErrIgnoreHealthcheck) {
 			return nil

--- a/app/vminsert/netstorage/consistent_hash.go
+++ b/app/vminsert/netstorage/consistent_hash.go
@@ -1,9 +1,5 @@
 package netstorage
 
-import (
-	"github.com/cespare/xxhash/v2"
-)
-
 // See the following docs:
 // - https://www.eecs.umich.edu/techreports/cse/96/CSE-TR-316-96.pdf
 // - https://github.com/dgryski/go-rendezvous
@@ -13,14 +9,10 @@ type consistentHash struct {
 	nodeHashes []uint64
 }
 
-func newConsistentHash(nodes []string, hashSeed uint64) *consistentHash {
-	nodeHashes := make([]uint64, len(nodes))
-	for i, node := range nodes {
-		nodeHashes[i] = xxhash.Sum64([]byte(node))
-	}
+func newConsistentHash(ids []uint64, hashSeed uint64) *consistentHash {
 	return &consistentHash{
 		hashSeed:   hashSeed,
-		nodeHashes: nodeHashes,
+		nodeHashes: ids,
 	}
 }
 

--- a/app/vminsert/netstorage/consistent_hash_test.go
+++ b/app/vminsert/netstorage/consistent_hash_test.go
@@ -4,16 +4,18 @@ import (
 	"math"
 	"math/rand"
 	"testing"
+
+	"github.com/cespare/xxhash/v2"
 )
 
 func TestConsistentHash(t *testing.T) {
 	r := rand.New(rand.NewSource(1))
 
-	nodes := []string{
-		"node1",
-		"node2",
-		"node3",
-		"node4",
+	nodes := []uint64{
+		xxhash.Sum64String("node1"),
+		xxhash.Sum64String("node2"),
+		xxhash.Sum64String("node3"),
+		xxhash.Sum64String("node4"),
 	}
 	rh := newConsistentHash(nodes, 0)
 

--- a/app/vminsert/netstorage/consistent_hash_timing_test.go
+++ b/app/vminsert/netstorage/consistent_hash_timing_test.go
@@ -4,16 +4,19 @@ import (
 	"math/rand"
 	"sync/atomic"
 	"testing"
+
+	"github.com/cespare/xxhash/v2"
 )
 
 func BenchmarkConsistentHash(b *testing.B) {
-	nodes := []string{
-		"node1",
-		"node2",
-		"node3",
-		"node4",
+	nodes := []uint64{
+		xxhash.Sum64String("node1"),
+		xxhash.Sum64String("node2"),
+		xxhash.Sum64String("node3"),
+		xxhash.Sum64String("node4"),
 	}
 	rh := newConsistentHash(nodes, 0)
+
 	b.ReportAllocs()
 	b.SetBytes(int64(len(benchKeys)))
 	b.RunParallel(func(pb *testing.PB) {

--- a/app/vminsert/netstorage/insert_ctx.go
+++ b/app/vminsert/netstorage/insert_ctx.go
@@ -5,6 +5,8 @@ import (
 	"net/http"
 	"strconv"
 
+	"github.com/cespare/xxhash/v2"
+
 	"github.com/VictoriaMetrics/VictoriaMetrics/app/vminsert/relabel"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/auth"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/bytesutil"
@@ -12,7 +14,6 @@ import (
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/httpserver"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/prompb"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/storage"
-	"github.com/cespare/xxhash/v2"
 )
 
 // InsertCtx is a generic context for inserting data.

--- a/app/vminsert/netstorage/netstorage.go
+++ b/app/vminsert/netstorage/netstorage.go
@@ -419,6 +419,14 @@ func (sn *storageNode) getID() uint64 {
 		sn.checkHealth()
 	}
 
+	// If the id is still not populated after checkHealth than storage node is not reachable
+	// build a unique id based on the address
+	if sn.id.Load() == 0 {
+		id := xxhash.Sum64String(sn.dialer.Addr())
+		sn.id.CompareAndSwap(0, id)
+		return id
+	}
+
 	return sn.id.Load()
 }
 

--- a/app/vminsert/netstorage/netstorage.go
+++ b/app/vminsert/netstorage/netstorage.go
@@ -283,7 +283,7 @@ func (sn *storageNode) checkHealth() {
 		}
 		return
 	}
-	logger.Infof("successfully dialed -storageNode=%q", sn.dialer.Addr())
+	logger.Infof("successfully dialed -storageNode=%q (node ID: %d)", sn.dialer.Addr(), sn.id.Load())
 	sn.lastDialErr = nil
 	sn.bc = bc
 	sn.isBroken.Store(false)
@@ -419,7 +419,7 @@ func (sn *storageNode) getID() uint64 {
 		sn.checkHealth()
 	}
 
-	// If the id is still not populated after checkHealth than storage node is not reachable
+	// If the id is still not populated after checkHealth then storage node is not reachable
 	// build a unique id based on the address
 	if sn.id.Load() == 0 {
 		id := xxhash.Sum64String(sn.dialer.Addr())

--- a/app/vminsert/netstorage/netstorage.go
+++ b/app/vminsert/netstorage/netstorage.go
@@ -679,8 +679,8 @@ func initStorageNodes(addrs []string, hashSeed uint64) *storageNodesBucket {
 						sns:    oldSnb.sns,
 					}
 
-					newNodeIds := append(snb.nodesHash.nodeHashes, sn.getID())
-					snbNew.nodesHash = newConsistentHash(newNodeIds, hashSeed)
+					newNodeIDs := append(snb.nodesHash.nodeHashes, sn.getID())
+					snbNew.nodesHash = newConsistentHash(newNodeIDs, hashSeed)
 
 					if !storageNodes.CompareAndSwap(oldSnb, &snbNew) {
 						goto again

--- a/app/vminsert/netstorage/netstorage.go
+++ b/app/vminsert/netstorage/netstorage.go
@@ -645,7 +645,7 @@ func initStorageNodes(addrs []string, hashSeed uint64) *storageNodesBucket {
 		}(sn, idx)
 	}
 
-	// Watch for node become healthy and add it to consistent hash.
+	// Watch for node become healthy and rebuild snb.
 	for _, sn := range brokenNodes {
 		wg.Add(1)
 		go func(sn *storageNode) {

--- a/app/vminsert/netstorage/netstorage.go
+++ b/app/vminsert/netstorage/netstorage.go
@@ -679,7 +679,7 @@ func initStorageNodes(addrs []string, hashSeed uint64) *storageNodesBucket {
 						sns:    oldSnb.sns,
 					}
 
-					newNodeIDs := append(snb.nodesHash.nodeHashes, sn.getID())
+					newNodeIDs := append(oldSnb.nodesHash.nodeHashes, sn.getID())
 					snbNew.nodesHash = newConsistentHash(newNodeIDs, hashSeed)
 
 					if !storageNodes.CompareAndSwap(oldSnb, &snbNew) {

--- a/app/vmselect/clusternative/vmselect.go
+++ b/app/vmselect/clusternative/vmselect.go
@@ -31,7 +31,9 @@ var (
 
 // NewVMSelectServer starts new server at the given addr, which serves vmselect requests from netstorage.
 func NewVMSelectServer(addr string) (*vmselectapi.Server, error) {
-	api := &vmstorageAPI{}
+	api := &vmstorageAPI{
+		nodeID: netstorage.GetNodeID(),
+	}
 	limits := vmselectapi.Limits{
 		MaxLabelNames:                 *maxTagKeys,
 		MaxLabelValues:                *maxTagValues,
@@ -45,7 +47,9 @@ func NewVMSelectServer(addr string) (*vmselectapi.Server, error) {
 }
 
 // vmstorageAPI impelements vmselectapi.API
-type vmstorageAPI struct{}
+type vmstorageAPI struct {
+	nodeID uint64
+}
 
 func (api *vmstorageAPI) InitSearch(qt *querytracer.Tracer, sq *storage.SearchQuery, deadline uint64) (vmselectapi.BlockIterator, error) {
 	denyPartialResponse := httputils.GetDenyPartialResponse(nil)
@@ -110,6 +114,10 @@ func (api *vmstorageAPI) DeleteSeries(qt *querytracer.Tracer, sq *storage.Search
 func (api *vmstorageAPI) RegisterMetricNames(qt *querytracer.Tracer, mrs []storage.MetricRow, deadline uint64) error {
 	dl := searchutils.DeadlineFromTimestamp(deadline)
 	return netstorage.RegisterMetricNames(qt, mrs, dl)
+}
+
+func (api *vmstorageAPI) GetID() uint64 {
+	return api.nodeID
 }
 
 // blockIterator implements vmselectapi.BlockIterator

--- a/app/vmselect/netstorage/netstorage.go
+++ b/app/vmselect/netstorage/netstorage.go
@@ -9,7 +9,6 @@ import (
 	"net"
 	"net/http"
 	"os"
-	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -2958,29 +2957,10 @@ func getStorageNodes() []*storageNode {
 	return snb.sns
 }
 
-var (
-	nodeID     uint64
-	nodeIDOnce sync.Once
-)
-
-// GetNodeID returns unique identifier for underlying storage nodes.
+// GetNodeID returns unique identifier of vmselect
 func GetNodeID() uint64 {
-	nodeIDOnce.Do(func() {
-		snb := getStorageNodesBucket()
-		snIDs := make([]uint64, 0, len(snb.sns))
-		for _, sn := range snb.sns {
-			snIDs = append(snIDs, sn.id)
-		}
-		slices.Sort(snIDs)
-		idsM := make([]byte, 0)
-		for _, id := range snIDs {
-			idsM = encoding.MarshalUint64(idsM, id)
-		}
-
-		nodeID = xxhash.Sum64(idsM)
-	})
-
-	return nodeID
+	// Returns a 0 as persistent IDs are not intended to use with multi-level setup
+	return 0
 }
 
 // Init initializes storage nodes' connections to the given addrs.

--- a/app/vmstorage/main.go
+++ b/app/vmstorage/main.go
@@ -111,8 +111,8 @@ func main() {
 	blocksCount := tm.SmallBlocksCount + tm.BigBlocksCount
 	rowsCount := tm.SmallRowsCount + tm.BigRowsCount
 	sizeBytes := tm.SmallSizeBytes + tm.BigSizeBytes
-	logger.Infof("successfully opened storage %q in %.3f seconds; partsCount: %d; blocksCount: %d; rowsCount: %d; sizeBytes: %d",
-		*storageDataPath, time.Since(startTime).Seconds(), partsCount, blocksCount, rowsCount, sizeBytes)
+	logger.Infof("successfully opened storage %q (node ID: %d) in %.3f seconds; partsCount: %d; blocksCount: %d; rowsCount: %d; sizeBytes: %d",
+		*storageDataPath, strg.GetID(), time.Since(startTime).Seconds(), partsCount, blocksCount, rowsCount, sizeBytes)
 
 	// register storage metrics
 	storageMetrics := metrics.NewSet()

--- a/app/vmstorage/servers/vminsert.go
+++ b/app/vmstorage/servers/vminsert.go
@@ -101,7 +101,7 @@ func (s *VMInsertServer) run() {
 			// There is no need in response compression, since
 			// vmstorage sends only small packets to vminsert.
 			compressionLevel := 0
-			bc, err := handshake.VMInsertServer(c, compressionLevel)
+			bc, err := handshake.VMInsertServer(c, compressionLevel, s.storage.GetID())
 			if err != nil {
 				if s.isStopping() {
 					// c is stopped inside VMInsertServer.MustStop

--- a/app/vmstorage/servers/vmselect.go
+++ b/app/vmstorage/servers/vmselect.go
@@ -195,6 +195,10 @@ func (api *vmstorageAPI) setupTfss(qt *querytracer.Tracer, sq *storage.SearchQue
 	return tfss, nil
 }
 
+func (api *vmstorageAPI) GetID() uint64 {
+	return api.s.GetID()
+}
+
 // blockIterator implements vmselectapi.BlockIterator
 type blockIterator struct {
 	sr storage.Search

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -31,10 +31,13 @@ See also [LTS releases](https://docs.victoriametrics.com/lts-releases/).
 
 **Update note 1: [vmauth](https://docs.victoriametrics.com/vmauth/) HTTP response code has changed from 503 to 502 for a case when all upstream backends were not available. This was changed to align [vmauth](https://docs.victoriametrics.com/vmauth/) behaviour with other well-known reverse-proxies behaviour. **
 
+**Update note 2: release contains breaking change to inter-cluster communication. The `vmstorage` nodes with version lower than `tip` won't be able to communicate with `vmselect` and `vminsert` nodes with version lower than `tip`. See [this](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/5438) issue for the details.**
+
 * SECURITY: upgrade base docker image (Alpine) from 3.20.1 to 3.20.2. See [alpine 3.20.2 release notes](https://alpinelinux.org/posts/Alpine-3.20.2-released.html).
 
 * FEATURE: [vmauth](./vmauth.md): add `keep_original_host` option, which can be used for proxying the original `Host` header from client request to the backend. By default the backend host is used as `Host` header when proxying requests to the configured backends. See [these docs](./vmauth.md#host-http-header).
 * FEATURE: [vmauth](./vmauth.md) now returns HTTP 502 status code when all upstream backends are not available. Previously, it returned HTTP 503 status code. This change aligns vmauth behavior with other well-known reverse-proxies behavior.
+* FEATURE: [VictoriaMetrics cluster](https://docs.victoriametrics.com/cluster-victoriametrics/): use a persistent `vmstorage` node ID for consistent hashing at data write path. This allows to keep the same data distribution after `vmstorage` changes its IP address. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/5438).
 
 * BUGFIX: [vmauth](https://docs.victoriametrics.com/vmauth/): properly proxy requests to backend urls ending with `/` if the original request path equals to `/`. Previously the trailing `/` at the backend path was incorrectly removed. For example, if the request to `http://vmauth/` is configured to be proxied to `url_prefix=http://backend/foo/`, then it was proxied to `http://backend/foo`, while it should go to `http://backend/foo/`.
 * BUGFIX: [vmauth](https://docs.victoriametrics.com/vmauth/): fix `cannot read data after closing the reader` error when proxying HTTP requests without body (aka `GET` requests). The issue has been introduced in [v1.102.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.102.0) in [this commit](https://github.com/VictoriaMetrics/VictoriaMetrics/commit/7ee57974935a662896f2de40fdf613156630617d).

--- a/docs/Cluster-VictoriaMetrics.md
+++ b/docs/Cluster-VictoriaMetrics.md
@@ -1301,6 +1301,8 @@ Below is the output for `/path/to/vminsert -help`:
      Show VictoriaMetrics version
   -vmstorageDialTimeout duration
      Timeout for establishing RPC connections from vminsert to vmstorage. See also -vmstorageUserTimeout (default 3s)
+  -vmstorageUsePersistentID
+     Whether to use persistent storage node ID for -storageNode instances. If set to false uses storage node address in order to generate an ID. Using persistent node ID is useful if vmstorage node address changes over time, e.g. due to dynamic IP addresses or DNS names. 
   -vmstorageUserTimeout duration
      Network timeout for RPC connections from vminsert to vmstorage (Linux only). Lower values speed up re-rerouting recovery when some of vmstorage nodes become unavailable because of networking issues. Read more about TCP_USER_TIMEOUT at https://blog.cloudflare.com/when-tcp-sockets-refuse-to-die/ . See also -vmstorageDialTimeout (default 3s)
 ```

--- a/lib/storage/filenames.go
+++ b/lib/storage/filenames.go
@@ -10,6 +10,8 @@ const (
 
 	appliedRetentionFilename    = "appliedRetention.txt"
 	resetCacheOnStartupFilename = "reset_cache_on_startup"
+
+	nodeIDFilename = "node_id.bin"
 )
 
 const (

--- a/lib/storage/storage.go
+++ b/lib/storage/storage.go
@@ -264,6 +264,7 @@ func MustOpenStorage(path string, retention time.Duration, maxHourlySeries, maxD
 	} else {
 		nodeID := rand.Uint64()
 		s.nodeID = nodeID
+		s.mustSaveNodeID()
 	}
 
 	// Load indexdb

--- a/lib/storage/storage.go
+++ b/lib/storage/storage.go
@@ -919,8 +919,6 @@ func (s *Storage) MustClose() {
 	nextDayMetricIDs := s.nextDayMetricIDs.Load()
 	s.mustSaveNextDayMetricIDs(nextDayMetricIDs)
 
-	s.mustSaveNodeID()
-
 	// Release lock file.
 	fs.MustClose(s.flockF)
 	s.flockF = nil

--- a/lib/vmselectapi/api.go
+++ b/lib/vmselectapi/api.go
@@ -38,6 +38,9 @@ type API interface {
 
 	// Tenants returns list of tenants in the storage on the given tr.
 	Tenants(qt *querytracer.Tracer, tr storage.TimeRange, deadline uint64) ([]string, error)
+
+	// GetID returns the ID of the node.
+	GetID() uint64
 }
 
 // BlockIterator must iterate through series blocks found by VMSelect.InitSearch.

--- a/lib/vmselectapi/server.go
+++ b/lib/vmselectapi/server.go
@@ -10,6 +10,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/VictoriaMetrics/metrics"
+
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/bytesutil"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/encoding"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/fasttime"
@@ -20,7 +22,6 @@ import (
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/querytracer"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/storage"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/timerpool"
-	"github.com/VictoriaMetrics/metrics"
 )
 
 // Server processes vmselect requests.
@@ -193,7 +194,7 @@ func (s *Server) run() {
 			if s.disableResponseCompression {
 				compressionLevel = 0
 			}
-			bc, err := handshake.VMSelectServer(c, compressionLevel)
+			bc, err := handshake.VMSelectServer(c, compressionLevel, s.api.GetID())
 			if err != nil {
 				if s.isStopping() {
 					// c is closed inside Server.MustStop


### PR DESCRIPTION
### Describe Your Changes

Related issue: https://github.com/VictoriaMetrics/VictoriaMetrics/issues/5438

Added a persistent storage node ID which can be used to identify storage nodes when computing target to write data. This allows to avoid data re-distribution in case storage node address have been changed.
By default, vminsert will still use ID generated based on an address specified with `-storageNode` command-line flag.

Storage node ID is communicated as a part of vmselect and vminsert handshakes. This means that this is a breaking change to the protocol and versions before this change will not be able to perform the handshake with newer ones.

Implementation wise:

- Cluster native endpoints in [multi-level setup](https://docs.victoriametrics.com/cluster-victoriametrics/#multi-level-cluster-setup) calculate vminsert and vmselect node IDs as a hash of all underlying storage node IDs, so that it will also remain consistent in case of address changes.

- `vmselect` does not use persistent node ID apart from multi-level setup use-case

- storage node ID is persisted at `<storageDataPath>/metadata/node_id.bin` so it is included as a part of backups without additional modifications

### Checklist

The following checks are **mandatory**:

- [x] My change adheres [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/contributing/).
