### PR TITLE
vmalert-dashboard: replace variable query metric

### DIFF
--- a/dashboards/vm/vmalert.json
+++ b/dashboards/vm/vmalert.json
@@ -3527,14 +3527,14 @@
           "type": "victoriametrics-datasource",
           "uid": "$ds"
         },
-        "definition": "label_values(vmalert_iteration_duration_seconds{job=~\"$job\", instance=~\"$instance\"}, group)",
+        "definition": "label_values(vmalert_iteration_total{job=~\"$job\", instance=~\"$instance\"}, group)",
         "hide": 0,
         "includeAll": true,
         "multi": true,
         "name": "group",
         "options": [],
         "query": {
-          "query": "label_values(vmalert_iteration_duration_seconds{job=~\"$job\", instance=~\"$instance\"}, group)",
+          "query": "label_values(vmalert_iteration_total{job=~\"$job\", instance=~\"$instance\"}, group)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,

--- a/dashboards/vmalert.json
+++ b/dashboards/vmalert.json
@@ -3526,14 +3526,14 @@
           "type": "prometheus",
           "uid": "$ds"
         },
-        "definition": "label_values(vmalert_iteration_duration_seconds{job=~\"$job\", instance=~\"$instance\"}, group)",
+        "definition": "label_values(vmalert_iteration_total{job=~\"$job\", instance=~\"$instance\"}, group)",
         "hide": 0,
         "includeAll": true,
         "multi": true,
         "name": "group",
         "options": [],
         "query": {
-          "query": "label_values(vmalert_iteration_duration_seconds{job=~\"$job\", instance=~\"$instance\"}, group)",
+          "query": "label_values(vmalert_iteration_total{job=~\"$job\", instance=~\"$instance\"}, group)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,


### PR DESCRIPTION
`vmalert_iteration_total` series number is 4 time less than `vmalert_iteration_duration_seconds`, queries will be lighter.