### PR TITLE
Use NPROCESSORS_ONLN in Makefile on SunOS platform

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,10 @@
 PKG_PREFIX := github.com/VictoriaMetrics/VictoriaMetrics
 
+ifeq ($(shell uname -s),SunOS)
+MAKE_CONCURRENCY ?= $(shell getconf NPROCESSORS_ONLN)
+else
 MAKE_CONCURRENCY ?= $(shell getconf _NPROCESSORS_ONLN)
+endif
 MAKE_PARALLEL := $(MAKE) -j $(MAKE_CONCURRENCY)
 DATEINFO_TAG ?= $(shell date -u +'%Y%m%d-%H%M%S')
 BUILDINFO_TAG ?= $(shell echo $$(git describe --long --all | tr '/' '-')$$( \


### PR DESCRIPTION
On illumos, which is derived from SunOS, there is no _NPROCESSORS_ONLN parameter for getconf [1].

[1] https://github.com/illumos/illumos-gate/blob/master/usr/src/cmd/getconf/getconf.c#L761-L766