### PR TITLE
vmalert-tool: exit immediately when rule group execute failed

### DIFF
--- a/app/vmalert-tool/unittest/unittest.go
+++ b/app/vmalert-tool/unittest/unittest.go
@@ -304,6 +304,7 @@ func (tg *testGroup) test(evalInterval time.Duration, groupOrderMap map[string]i
 				if err != nil {
 					checkErrs = append(checkErrs, fmt.Errorf("\nfailed to exec group: %q, time: %s, err: %w", g.Name,
 						ts, err))
+					return
 				}
 			}
 			// flush series after each group evaluation


### PR DESCRIPTION
g.ExecOnce() shouldn't be failed at all. If it fails, it might be bug or something wrong with tmp vm datasource, exit immediately. 