### PR TITLE
Add note about stream aggregation and load balancing

### DIFF
--- a/docs/stream-aggregation.md
+++ b/docs/stream-aggregation.md
@@ -1080,6 +1080,22 @@ These issues can be fixed in the following ways:
 - By specifying the `staleness_interval` option at [stream aggregation config](#stream-aggregation-config), so it covers the expected
   delays in data ingestion pipelines. By default, the `staleness_interval` equals to `2 x interval`.
 
+### Partial data aggregation
+
+Otherwise, if you see issues such as
+
+- unexpected spikes for [total](#total) and [increase](#increase) outputs, or
+- heatmaps for bucket metrics displayed as being all over the map, including impossible negative values,
+
+it might be that your vmagent is calculating totals for counters and buckets based on partial data, causing the values to jump higher and lower depending on which samples get aggregated. This easily happens if you use clustered VictoriaMetrics in kubernetes with multiple vmagent pods behind a load balancer which distributes incoming requests randomly across pods.
+
+Possible solutions include:
+
+- using a single vmagent pod for your cluster (simplest);
+- using multiple layers of vmagent so that all the metrics from one cluster or job (or other subdivision meaningful for your aggregations) go to the same vmagent pod before being load balanced;
+- altering your load balancer so that the result is the same as above;
+- switching from a remote-writing model to a scraping model where all vmagent pods scrape all targets to get a full copy of the data to be aggregated.
+
 ### High resource usage
 
 The following solutions can help reducing memory usage and CPU usage durting streaming aggregation:

--- a/docs/stream-aggregation.md
+++ b/docs/stream-aggregation.md
@@ -1087,7 +1087,7 @@ Otherwise, if you see issues such as
 - unexpected spikes for [total](#total) and [increase](#increase) outputs, or
 - heatmaps for bucket metrics displayed as being all over the map, including impossible negative values,
 
-it might be that your vmagent is calculating totals for counters and buckets based on partial data, causing the values to jump higher and lower depending on which samples get aggregated. This easily happens if you use clustered VictoriaMetrics in kubernetes with multiple vmagent pods behind a load balancer which distributes incoming requests randomly across pods.
+it might be that your vmagent is calculating totals for counters and buckets based on partial data, causing the values to jump higher and lower depending on which samples get aggregated. This easily happens if you use clustered VictoriaMetrics in kubernetes with multiple vmagent pods [behind a load balancer](https://docs.victoriametrics.com/victoriametrics/stream-aggregation/#put-aggregator-behind-load-balancer) which distributes incoming requests randomly across pods.
 
 Possible solutions include:
 


### PR DESCRIPTION
Stream aggregation is powerful but it still needs to be mathematically meaningful. It's easy to obtain nonsense results by aggregating random subsets of the data.

### Example with hubble metrics

The dashboard for hubble metrics showed ridiculous rates before switching to a single vmagent pod, then it became reasonable again.

![Screenshot_20240625_145336](https://github.com/VictoriaMetrics/VictoriaMetrics/assets/901528/39a68ac4-0924-4626-9b68-fda7c545ceb8)
![Screenshot_20240625_145320](https://github.com/VictoriaMetrics/VictoriaMetrics/assets/901528/78aaa5c2-6903-4be8-885b-3b10edc5b191)

The configuration was a simple
```
- match: '{job="hubble-metrics", __name__=~".+total", source!="", destination!=""}'
  interval: 60s
  without: [source, destination]
  keep_metric_names: true
  outputs: [total]
```

(to drop cardinality by several orders of magnitude without having thousand of distinct source and destination IP addresses in labels).

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/contributing/).
