### PR TITLE
docs/vmanomaly:quickstart example fix

### DIFF
--- a/docs/anomaly-detection/QuickStart.md
+++ b/docs/anomaly-detection/QuickStart.md
@@ -77,10 +77,11 @@ Here is an example of config file that will run [Facebook Prophet](https://faceb
 
 
 ```yaml
-scheduler:
-  infer_every: "1m"
-  fit_every: "2h"
-  fit_window: "14d"
+schedulers:
+  2w_1m:
+    infer_every: '1m'
+    fit_every: '2h'
+    fit_window: '14d'
 
 models:
   prophet_model:


### PR DESCRIPTION
- Fixed config example in QuickStart vmanomaly docs for 1.13 version compatibility

- [x] My change adheres [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/contributing/).
