### PR TITLE
Optimize CI workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,56 @@
+name: build
+
+on:
+  push:
+    branches:
+      - cluster
+      - master
+    paths-ignore:
+      - '**.md'
+      - 'dashboards/**'
+      - 'deployment/**.yml'
+      - 'docs/**'
+  pull_request:
+    branches:
+      - cluster
+      - master
+    paths-ignore:
+      - '**.md'
+      - 'dashboards/**'
+      - 'deployment/**.yml'
+      - 'docs/**'
+
+permissions:
+  contents: read
+
+concurrency:
+  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Code checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        id: go
+        uses: actions/setup-go@v5
+        with:
+          go-version: stable
+          cache: false
+
+      - name: Cache Go artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/bin
+            ~/go/pkg/mod
+          key: go-artifacts-${{ runner.os }}-crossbuild-${{ steps.go.outputs.go-version }}-${{ hashFiles('go.sum', 'Makefile', 'app/**/Makefile') }}
+          restore-keys: go-artifacts-${{ runner.os }}-crossbuild-
+
+      - name: Run crossbuild
+        run: make crossbuild

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,20 +5,18 @@ on:
     branches:
       - cluster
       - master
-    paths-ignore:
-      - '**.md'
-      - 'dashboards/**'
-      - 'deployment/**.yml'
-      - 'docs/**'
+    paths:
+      - '**.go'
+      - '**/Dockerfile*' # The trailing * is for app/vmui/Dockerfile-*.
+      - '**/Makefile'
   pull_request:
     branches:
       - cluster
       - master
-    paths-ignore:
-      - '**.md'
-      - 'dashboards/**'
-      - 'deployment/**.yml'
-      - 'docs/**'
+    paths:
+      - '**.go'
+      - '**/Dockerfile*' # The trailing * is for app/vmui/Dockerfile-*.
+      - '**/Makefile'
 
 permissions:
   contents: read

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,29 +1,25 @@
 name: main
+
 on:
   push:
     branches:
-      - master
       - cluster
-    paths-ignore:
-      - "docs/**"
-      - "**.md"
-      - "dashboards/**"
-      - "deployment/**.yml"
+      - master
+    paths:
+      - '**.go'
   pull_request:
     branches:
-      - master
       - cluster
-    paths-ignore:
-      - "docs/**"
-      - "**.md"
-      - "dashboards/**"
-      - "deployment/**.yml"
+      - master
+    paths:
+      - '**.go'
+
 permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
 
 jobs:
   lint:
@@ -45,8 +41,8 @@ jobs:
         with:
           path: |
             ~/.cache/go-build
-            ~/go/pkg/mod
             ~/go/bin
+            ~/go/pkg/mod
           key: go-artifacts-${{ runner.os }}-check-all-${{ steps.go.outputs.go-version }}-${{ hashFiles('go.sum', 'Makefile', 'app/**/Makefile') }}
           restore-keys: go-artifacts-${{ runner.os }}-check-all-
 
@@ -55,41 +51,18 @@ jobs:
           make check-all
           git diff --exit-code
 
-  build:
-    needs: lint
-    name: build
-    runs-on: ubuntu-latest
-    steps:
-      - name: Code checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Go
-        id: go
-        uses: actions/setup-go@v5
-        with:
-          go-version: stable
-          cache: false
-
-      - name: Cache Go artifacts
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-            ~/go/bin
-          key: go-artifacts-${{ runner.os }}-crossbuild-${{ steps.go.outputs.go-version }}-${{ hashFiles('go.sum', 'Makefile', 'app/**/Makefile') }}
-          restore-keys: go-artifacts-${{ runner.os }}-crossbuild-
-
-      - name: Build
-        run: make crossbuild
-
   test:
+    name: test
     needs: lint
+    runs-on: ubuntu-latest
+
     strategy:
       matrix:
-        scenario: ["test-full", "test-pure", "test-full-386"]
-    name: test
-    runs-on: ubuntu-latest
+        scenario:
+          - 'test-full'
+          - 'test-full-386'
+          - 'test-pure'
+
     steps:
       - name: Code checkout
         uses: actions/checkout@v4
@@ -106,12 +79,12 @@ jobs:
         with:
           path: |
             ~/.cache/go-build
-            ~/go/pkg/mod
             ~/go/bin
+            ~/go/pkg/mod
           key: go-artifacts-${{ runner.os }}-${{ matrix.scenario }}-${{ steps.go.outputs.go-version }}-${{ hashFiles('go.sum', 'Makefile', 'app/**/Makefile') }}
           restore-keys: go-artifacts-${{ runner.os }}-${{ matrix.scenario }}-
 
-      - name: run tests
+      - name: Run tests
         run: make ${{ matrix.scenario}}
 
       - name: Publish coverage

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,8 +33,8 @@ jobs:
         id: go
         uses: actions/setup-go@v5
         with:
-          go-version: stable
           cache: false
+          go-version: stable
 
       - name: Cache Go artifacts
         uses: actions/cache@v4
@@ -71,8 +71,8 @@ jobs:
         id: go
         uses: actions/setup-go@v5
         with:
-          go-version: stable
           cache: false
+          go-version: stable
 
       - name: Cache Go artifacts
         uses: actions/cache@v4


### PR DESCRIPTION
### Describe Your Changes

This PR is aimed to change the currently in place configuration of running Go related jobs for code changes that don't contain actual Go files ([example 1](https://github.com/VictoriaMetrics/VictoriaMetrics/pull/6517/checks) - 2m32s , [example 2](https://github.com/VictoriaMetrics/VictoriaMetrics/pull/6543/checks) - 4m11s).

In order to do that the `build` workflow was extracted from Go related workflow (now it doesn't require lint as a `need` step -- let me know if it's something we want to keep). It will run upon the same triggers as before the change.

The `main` workflow now will be triggered by `**.go` pattern only and contains lint/test steps that are relevant for Go file changes.

I expect this PR + https://github.com/VictoriaMetrics/VictoriaMetrics/pull/6540 to improve CI minutes usage.

### Checklist

The following checks are **mandatory**:

- [x] My change adheres [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/contributing/).
