### PR TITLE
vmagent: fix `vm_streamaggr_flushed_samples_total` counter

### DIFF
--- a/lib/streamaggr/avg.go
+++ b/lib/streamaggr/avg.go
@@ -84,3 +84,7 @@ func (as *avgAggrState) flushState(ctx *flushCtx, resetState bool) {
 		return true
 	})
 }
+
+func (as *avgAggrState) getSuffix() string {
+	return "avg"
+}

--- a/lib/streamaggr/count_samples.go
+++ b/lib/streamaggr/count_samples.go
@@ -81,3 +81,7 @@ func (as *countSamplesAggrState) flushState(ctx *flushCtx, resetState bool) {
 		return true
 	})
 }
+
+func (as *countSamplesAggrState) getSuffix() string {
+	return "count_samples"
+}

--- a/lib/streamaggr/count_series.go
+++ b/lib/streamaggr/count_series.go
@@ -90,3 +90,7 @@ func (as *countSeriesAggrState) flushState(ctx *flushCtx, resetState bool) {
 		return true
 	})
 }
+
+func (as *countSeriesAggrState) getSuffix() string {
+	return "count_series"
+}

--- a/lib/streamaggr/histogram_bucket.go
+++ b/lib/streamaggr/histogram_bucket.go
@@ -117,3 +117,7 @@ func roundDurationToSecs(d time.Duration) uint64 {
 	secs := d.Seconds()
 	return uint64(math.Ceil(secs))
 }
+
+func (as *histogramBucketAggrState) getSuffix() string {
+	return "histogram_bucket"
+}

--- a/lib/streamaggr/last.go
+++ b/lib/streamaggr/last.go
@@ -86,3 +86,7 @@ func (as *lastAggrState) flushState(ctx *flushCtx, resetState bool) {
 		return true
 	})
 }
+
+func (as *lastAggrState) getSuffix() string {
+	return "last"
+}

--- a/lib/streamaggr/max.go
+++ b/lib/streamaggr/max.go
@@ -83,3 +83,7 @@ func (as *maxAggrState) flushState(ctx *flushCtx, resetState bool) {
 		return true
 	})
 }
+
+func (as *maxAggrState) getSuffix() string {
+	return "max"
+}

--- a/lib/streamaggr/min.go
+++ b/lib/streamaggr/min.go
@@ -82,3 +82,7 @@ func (as *minAggrState) flushState(ctx *flushCtx, resetState bool) {
 		return true
 	})
 }
+
+func (as *minAggrState) getSuffix() string {
+	return "min"
+}

--- a/lib/streamaggr/quantiles.go
+++ b/lib/streamaggr/quantiles.go
@@ -95,3 +95,7 @@ func (as *quantilesAggrState) flushState(ctx *flushCtx, resetState bool) {
 		return true
 	})
 }
+
+func (as *quantilesAggrState) getSuffix() string {
+	return "quantiles"
+}

--- a/lib/streamaggr/rate.go
+++ b/lib/streamaggr/rate.go
@@ -159,3 +159,7 @@ func (as *rateAggrState) flushState(ctx *flushCtx, _ bool) {
 	ctx.a.staleOutputSamples[as.suffix].Add(staleOutputSamples)
 	ctx.a.staleInputSamples[as.suffix].Add(staleInputSamples)
 }
+
+func (as *rateAggrState) getSuffix() string {
+	return as.suffix
+}

--- a/lib/streamaggr/stddev.go
+++ b/lib/streamaggr/stddev.go
@@ -84,3 +84,7 @@ func (as *stddevAggrState) flushState(ctx *flushCtx, resetState bool) {
 		return true
 	})
 }
+
+func (as *stddevAggrState) getSuffix() string {
+	return "stddev"
+}

--- a/lib/streamaggr/stdvar.go
+++ b/lib/streamaggr/stdvar.go
@@ -83,3 +83,7 @@ func (as *stdvarAggrState) flushState(ctx *flushCtx, resetState bool) {
 		return true
 	})
 }
+
+func (as *stdvarAggrState) getSuffix() string {
+	return "stdvar"
+}

--- a/lib/streamaggr/sum_samples.go
+++ b/lib/streamaggr/sum_samples.go
@@ -81,3 +81,7 @@ func (as *sumSamplesAggrState) flushState(ctx *flushCtx, resetState bool) {
 		return true
 	})
 }
+
+func (as *sumSamplesAggrState) getSuffix() string {
+	return "sum_samples"
+}

--- a/lib/streamaggr/total.go
+++ b/lib/streamaggr/total.go
@@ -185,3 +185,7 @@ func (as *totalAggrState) flushState(ctx *flushCtx, resetState bool) {
 		return true
 	})
 }
+
+func (as *totalAggrState) getSuffix() string {
+	return as.suffix
+}

--- a/lib/streamaggr/unique_samples.go
+++ b/lib/streamaggr/unique_samples.go
@@ -85,3 +85,7 @@ func (as *uniqueSamplesAggrState) flushState(ctx *flushCtx, resetState bool) {
 		return true
 	})
 }
+
+func (as *uniqueSamplesAggrState) getSuffix() string {
+	return "unique_samples"
+}


### PR DESCRIPTION
`vm_streamaggr_flushed_samples_total` was overcounted, and doesn't account for `output_relabel_configs`.