### PR TITLE
Use golangci-lint-action instead of `make golangci-lint` for main.yml workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,12 +6,14 @@ on:
       - cluster
       - master
     paths:
+      - '.github/workflows/main.yml'
       - '**.go'
   pull_request:
     branches:
       - cluster
       - master
     paths:
+      - '.github/workflows/main.yml'
       - '**.go'
 
 permissions:
@@ -46,10 +48,20 @@ jobs:
           key: go-artifacts-${{ runner.os }}-check-all-${{ steps.go.outputs.go-version }}-${{ hashFiles('go.sum', 'Makefile', 'app/**/Makefile') }}
           restore-keys: go-artifacts-${{ runner.os }}-check-all-
 
-      - name: Run check-all
-        run: |
-          make check-all
-          git diff --exit-code
+      - name: Run fmt
+        run: make fmt
+
+      - name: Run vet
+        run: make vet
+
+      - name: Run golangci-lint
+        run: make golangci-lint
+
+      - name: Run govulncheck
+        run: make govulncheck
+
+      - name: Check diff
+        run: git diff --exit-code
 
   test:
     name: test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,7 +59,8 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.59
+          # The version must match "install-golangci-lint" Makefile target version.
+          version: v1.59.1
 
       - name: Run govulncheck
         run: make govulncheck

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,9 +53,13 @@ jobs:
 
       - name: Run vet
         run: make vet
-
+      
+        # Use action instead of `make golangci-lint` to speed up the process
+        # as it caches data between builds.
       - name: Run golangci-lint
-        run: make golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: v1.59
 
       - name: Run govulncheck
         run: make govulncheck

--- a/Makefile
+++ b/Makefile
@@ -493,6 +493,7 @@ golangci-lint: install-golangci-lint
 	golangci-lint run
 
 install-golangci-lint:
+	# The version must match GitHub main.yml lint job "Run golangci-lint" step version.
 	which golangci-lint || curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(shell go env GOPATH)/bin v1.59.1
 
 remove-golangci-lint:


### PR DESCRIPTION
### Describe Your Changes

This PR splits `main.yml` lint job `Run check-all` step into multiple steps and switches to [golangci-lint action](https://github.com/golangci/golangci-lint-action) (see the [Performance](https://github.com/golangci/golangci-lint-action?tab=readme-ov-file#performance) section)

### Checklist

The following checks are **mandatory**:

- [x] My change adheres [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/contributing/).
