### PR TITLE
Sorting graphite metrics by default

### DIFF
--- a/app/vmselect/graphite/eval.go
+++ b/app/vmselect/graphite/eval.go
@@ -151,7 +151,12 @@ func evalMetricExpr(ec *evalConfig, me *graphiteql.MetricExpr) (nextSeriesFunc, 
 	}}
 	tfss := joinTagFilterss(tfs, ec.etfs)
 	sq := storage.NewSearchQuery(ec.at.AccountID, ec.at.ProjectID, ec.startTime, ec.endTime, tfss, *maxGraphiteSeries)
-	return newNextSeriesForSearchQuery(ec, sq, me)
+	ss, err := newNextSeriesForSearchQuery(ec, sq, me)
+	if err != nil {
+		return nil, err
+	}
+
+	return nextSeriesSortedByName(ss, me, false, false)
 }
 
 func newNextSeriesForSearchQuery(ec *evalConfig, sq *storage.SearchQuery, expr graphiteql.Expr) (nextSeriesFunc, error) {

--- a/app/vmselect/graphite/transform.go
+++ b/app/vmselect/graphite/transform.go
@@ -1341,6 +1341,7 @@ func aggregateSeriesListsGeneric(ec *evalConfig, fe *graphiteql.FuncExpr, funcNa
 // See https://graphite.readthedocs.io/en/latest/functions.html#graphite.render.functions.aggregateSeriesLists
 func transformAggregateSeriesLists(ec *evalConfig, fe *graphiteql.FuncExpr) (nextSeriesFunc, error) {
 	args := fe.Args
+
 	if len(args) != 3 && len(args) != 4 {
 		return nil, fmt.Errorf("unexpected number of args; got %d; want 3 or 4", len(args))
 	}
@@ -4894,6 +4895,11 @@ func transformSortByName(ec *evalConfig, fe *graphiteql.FuncExpr) (nextSeriesFun
 	if err != nil {
 		return nil, err
 	}
+	return nextSeriesSortedByName(nextSeries, fe, reverse, natural)
+}
+
+func nextSeriesSortedByName(nextSeries nextSeriesFunc, expr graphiteql.Expr, reverse, natural bool) (nextSeriesFunc, error) {
+
 	type seriesWithName struct {
 		s    *series
 		name string
@@ -4905,7 +4911,7 @@ func transformSortByName(ec *evalConfig, fe *graphiteql.FuncExpr) (nextSeriesFun
 			s:    s,
 			name: name,
 		})
-		s.expr = fe
+		s.expr = expr
 		return s, nil
 	})
 	if _, err := drainAllSeries(f); err != nil {


### PR DESCRIPTION
Multiple graphite functions rely on order to join metrics, since it can depend on vmstorage response order, this order is not deterministic. 

This follows https://github.com/VictoriaMetrics/VictoriaMetrics/issues/5810

### Describe Your Change

This pull request adds an alphanumerical sort at each metrics query to make the result deterministic. This is the same behaviour as in graphite web as you can see [here](https://github.com/graphite-project/graphite-web/blob/master/webapp/graphite/render/datalib.py#L272)
