### PR TITLE
vmctl: Increase backoff for retries

### DIFF
--- a/app/vmctl/backoff/backoff.go
+++ b/app/vmctl/backoff/backoff.go
@@ -11,9 +11,9 @@ import (
 )
 
 const (
-	backoffRetries     = 10
-	backoffFactor      = 1.8
-	backoffMinDuration = time.Second * 2
+	backoffRetries     = 5
+	backoffFactor      = 3
+	backoffMinDuration = time.Second * 30
 )
 
 // retryableFunc describes call back which will repeat on errors


### PR DESCRIPTION
Less retries but starting from a longer base and higher backoff factor so that any ongoing slow queries have time to finish before we abort.

### Describe Your Changes

Please provide a brief description of the changes you made. Be as specific as possible to help others understand the purpose and impact of your modifications.

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/contributing/).

Addresses issue #6622 