### PR TITLE
Code tooltip updates

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -617,13 +617,13 @@ VictoriaMetrics performs the following transformations to the ingested InfluxDB 
 
 For example, the following InfluxDB line:
 
-```raw
+```influxtextmetric
 foo,tag1=value1,tag2=value2 field1=12,field2=40
 ```
 
 is converted into the following Prometheus data points:
 
-```raw
+```promtextmetric
 foo_field1{tag1="value1", tag2="value2"} 12
 foo_field2{tag1="value1", tag2="value2"} 40
 ```

--- a/docs/Single-server-VictoriaMetrics.md
+++ b/docs/Single-server-VictoriaMetrics.md
@@ -625,13 +625,13 @@ VictoriaMetrics performs the following transformations to the ingested InfluxDB 
 
 For example, the following InfluxDB line:
 
-```raw
+```influxtextmetric
 foo,tag1=value1,tag2=value2 field1=12,field2=40
 ```
 
 is converted into the following Prometheus data points:
 
-```raw
+```promtextmetric
 foo_field1{tag1="value1", tag2="value2"} 12
 foo_field2{tag1="value1", tag2="value2"} 40
 ```

--- a/docs/stream-aggregation.md
+++ b/docs/stream-aggregation.md
@@ -1031,7 +1031,7 @@ specified individually per each `-remoteWrite.url`:
   # match also can contain a list of series selectors. Then the incoming samples are aggregated
   # if they match at least a single series selector.
   #
-- match: 'http_request_duration_seconds_bucket{env=~"prod|staging"}'
+  match: 'http_request_duration_seconds_bucket{env=~"prod|staging"}'
 
   # interval is the interval for the aggregation.
   # The aggregated stats is sent to remote storage once per interval.


### PR DESCRIPTION
### Describe Your Changes

recently added custom `promtextmetric` and `influxtextmetric` prismjs plugins to vmdocs to convert this
<img width="1081" alt="Screenshot 2024-07-17 at 12 13 29" src="https://github.com/user-attachments/assets/66d4ea18-10fe-45ef-80b4-989d0eb3bd92">
to this
<img width="1087" alt="Screenshot 2024-07-17 at 12 24 34" src="https://github.com/user-attachments/assets/60d4ab44-79e5-4c63-b966-54b989ead1aa">




### Checklist

The following checks are **mandatory**:

- [ ] My change adheres [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/contributing/).
