### PR TITLE
docs/vmbackup: add a note for azure identity

### DIFF
--- a/docs/vmbackup.md
+++ b/docs/vmbackup.md
@@ -210,7 +210,8 @@ Obtaining credentials from env variables.
    - `AZURE_STORAGE_ACCOUNT_CONNECTION_STRING`: use a connection string (must be either SAS Token or Account/Key)
    - `AZURE_STORAGE_ACCOUNT_NAME` and `AZURE_STORAGE_ACCOUNT_KEY`: use a specific account name and key (either primary or secondary)
    - `AZURE_USE_DEFAULT_CREDENTIAL` and `AZURE_STORAGE_ACCOUNT_NAME`: use the `DefaultAzureCredential` to allow the Azure library
-     to search for multiple options (for example, managed identity related variables).
+     to search for multiple options (for example, managed identity related variables). Note that if multiple credentials are available,
+     it is required to specify the `AZURE_CLIENT_ID` to select specific credentials.
 
   The `AZURE_STORAGE_DOMAIN` can be used for optionally overriding the default domain for the Azure storage service.
 


### PR DESCRIPTION
### Describe Your Changes

Add a note to clarify usage of azure credentials when multiple credentials are available.

The user is required to specify AZURE_CLIENT_ID as otherwise Azure API will return an error: "Multiple user assigned identities exist, please specify the clientId / resourceId of the identity in the token request"

### Checklist

The following checks are **mandatory**:

- [x] My change adheres [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/contributing/).
