### PR TITLE
app/vmauth: change response code when all backend are not available

### DIFF
--- a/app/vmauth/main.go
+++ b/app/vmauth/main.go
@@ -235,7 +235,7 @@ func processRequest(w http.ResponseWriter, r *http.Request, ui *UserInfo) {
 	}
 	err := &httpserver.ErrorWithStatusCode{
 		Err:        fmt.Errorf("all the %d backends for the user %q are unavailable", up.getBackendsCount(), ui.name()),
-		StatusCode: http.StatusServiceUnavailable,
+		StatusCode: http.StatusBadGateway,
 	}
 	httpserver.Errorf(w, r, "%s", err)
 	ui.backendErrors.Inc()

--- a/app/vmauth/main_test.go
+++ b/app/vmauth/main_test.go
@@ -378,7 +378,7 @@ unauthorized_user:
 		panic(fmt.Errorf("backend handler shouldn't be called"))
 	}
 	responseExpected = `
-statusCode=503
+statusCode=502
 remoteAddr: "42.2.3.84:6789, X-Forwarded-For: 12.34.56.78"; requestURI: /foo/?de=fg; all the 2 backends for the user "" are unavailable`
 	f(cfgStr, requestURL, backendHandler, responseExpected)
 
@@ -396,7 +396,7 @@ users:
 		panic(fmt.Errorf("backend handler shouldn't be called"))
 	}
 	responseExpected = `
-statusCode=503
+statusCode=502
 remoteAddr: "42.2.3.84:6789, X-Forwarded-For: 12.34.56.78"; requestURI: /foo/?de=fg; all the 2 backends for the user "some-user" are unavailable`
 	f(cfgStr, requestURL, backendHandler, responseExpected)
 
@@ -418,7 +418,7 @@ unauthorized_user:
 		panic(fmt.Errorf("backend handler shouldn't be called"))
 	}
 	responseExpected = `
-statusCode=503
+statusCode=502
 remoteAddr: "42.2.3.84:6789, X-Forwarded-For: 12.34.56.78"; requestURI: /def/?de=fg; all the 0 backends for the user "" are unavailable`
 	f(cfgStr, requestURL, backendHandler, responseExpected)
 	netutil.Resolver = origResolver
@@ -435,7 +435,7 @@ unauthorized_user:
 		w.WriteHeader(500)
 	}
 	responseExpected = `
-statusCode=503
+statusCode=502
 remoteAddr: "42.2.3.84:6789, X-Forwarded-For: 12.34.56.78"; requestURI: /foo/?de=fg; all the 2 backends for the user "" are unavailable`
 	f(cfgStr, requestURL, backendHandler, responseExpected)
 	if n := retries.Load(); n != 2 {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -31,7 +31,10 @@ See also [LTS releases](https://docs.victoriametrics.com/lts-releases/).
 
 ## tip
 
+**Update note 1: [vmauth](https://docs.victoriametrics.com/vmauth/) HTTP response code has changed from 503 to 502 for a case when all upstream backends were not available. This was changed to align [vmauth](https://docs.victoriametrics.com/vmauth/) behaviour with other well-known reverse-proxies behaviour. **
+
 * FEATURE: [vmauth](https://docs.victoriametrics.com/vmauth/): add `keep_original_host` option, which can be used for proxying the original `Host` header from client request to the backend. By default the backend host is used as `Host` header when proxying requests to the configured backends. See [these docs](https://docs.victoriametrics.com/vmauth/#host-http-header).
+* FEATURE: [vmauth](https://docs.victoriametrics.com/vmauth/) now returns HTTP 502 status code when all upstream backends are not available. Previously, it returned HTTP 503 status code. This change aligns vmauth behavior with other well-known reverse-proxies behavior.
 
 * BUGFIX: [vmauth](https://docs.victoriametrics.com/vmauth/): properly proxy requests to backend urls ending with `/` if the original request path equals to `/`. Previously the trailing `/` at the backend path was incorrectly removed. For example, if the request to `http://vmauth/` is configured to be proxied to `url_prefix=http://backend/foo/`, then it was proxied to `http://backend/foo`, while it should go to `http://backend/foo/`.
 * BUGFIX: [vmauth](https://docs.victoriametrics.com/vmauth/): fix `cannot read data after closing the reader` error when proxying HTTP requests without body (aka `GET` requests). The issue has been introduced in [v1.102.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.102.0) in [this commit](https://github.com/VictoriaMetrics/VictoriaMetrics/commit/7ee57974935a662896f2de40fdf613156630617d).


### PR DESCRIPTION
### Describe Your Changes

Change response code to 502 to align it with behaviour of other existing reverse proxies. Currently, the following reverse proxies will return 502 in case an upstream is not available: nginx, traefik, caddy, apache.

### Checklist

The following checks are **mandatory**:

- [x] My change adheres [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/contributing/).
