### PR TITLE
ADD: add `rate_over_delta` support for Counters reported by delta types

### DIFF
--- a/app/vmselect/promql/rollup_test.go
+++ b/app/vmselect/promql/rollup_test.go
@@ -661,6 +661,7 @@ func TestRollupNewRollupFuncSuccess(t *testing.T) {
 	f("timestamp_with_name", 0.13)
 	f("mode_over_time", 34)
 	f("rate_over_sum", 4520)
+	f("rate_over_delta", 3536)
 }
 
 func TestRollupNewRollupFuncError(t *testing.T) {
@@ -1436,6 +1437,24 @@ func TestRollupFuncsNoWindow(t *testing.T) {
 			t.Fatalf("expecting 35 samplesScanned from rollupConfig.Do; got %d", samplesScanned)
 		}
 		valuesExpected := []float64{nan, 2775, 5262.5, 3862.5, 1800}
+		timestampsExpected := []int64{0, 40, 80, 120, 160}
+		testRowsEqual(t, values, rc.Timestamps, valuesExpected, timestampsExpected)
+	})
+	t.Run("rate_over_delta", func(t *testing.T) {
+		rc := rollupConfig{
+			Func:               rollupRateOverDelta,
+			Start:              0,
+			End:                160,
+			Step:               40,
+			Window:             80,
+			MaxPointsPerSeries: 1e4,
+		}
+		rc.Timestamps = rc.getTimestamps()
+		values, samplesScanned := rc.Do(nil, testValues, testTimestamps)
+		if samplesScanned != 35 {
+			t.Fatalf("expecting 35 samplesScanned from rollupConfig.Do; got %d", samplesScanned)
+		}
+		valuesExpected := []float64{nan, 3193.548387096774, 3973.3333333333335, 3678.5714285714284, 2880}
 		timestampsExpected := []int64{0, 40, 80, 120, 160}
 		testRowsEqual(t, values, rc.Timestamps, valuesExpected, timestampsExpected)
 	})

--- a/docs/MetricsQL.md
+++ b/docs/MetricsQL.md
@@ -741,6 +741,16 @@ This function is supported by PromQL.
 
 See also [irate](#irate) and [rollup_rate](#rollup_rate).
 
+#### rate_over_delta
+
+`rate_over_sum(series_selector[d])` is a [rollup function](#rollup-functions), which calculates per-second rate over the delta [raw samples](./keyConcepts.md#raw-samples)
+on the given lookbehind window `d`. The calculations are performed individually per each time series returned
+from the given [series_selector](./keyConcepts.md#filtering).
+
+when a counter is reported as a delta, the function will be helpful.
+
+Metric names are stripped from the resulting rollups. Add [keep_metric_names](#keep_metric_names) modifier in order to keep metric names.
+
 #### rate_over_sum
 
 `rate_over_sum(series_selector[d])` is a [rollup function](#rollup-functions), which calculates per-second rate over the sum of [raw samples](./keyConcepts.md#raw-samples)

--- a/go.mod
+++ b/go.mod
@@ -134,3 +134,6 @@ require (
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/utils v0.0.0-20240711033017-18e509b52bc8 // indirect
 )
+
+// just for dev before metricsql is merged into VictoriaMetrics
+replace github.com/VictoriaMetrics/metricsql => github.com/changshun-shi/metricsql v0.0.0-20240725044341-f9471f2c0be7

--- a/go.sum
+++ b/go.sum
@@ -74,8 +74,6 @@ github.com/VictoriaMetrics/fastcache v1.12.2/go.mod h1:AmC+Nzz1+3G2eCPapF6UcsnkT
 github.com/VictoriaMetrics/metrics v1.34.0/go.mod h1:r7hveu6xMdUACXvB8TYdAj8WEsKzWB0EkpJN+RDtOf8=
 github.com/VictoriaMetrics/metrics v1.35.1 h1:o84wtBKQbzLdDy14XeskkCZih6anG+veZ1SwJHFGwrU=
 github.com/VictoriaMetrics/metrics v1.35.1/go.mod h1:r7hveu6xMdUACXvB8TYdAj8WEsKzWB0EkpJN+RDtOf8=
-github.com/VictoriaMetrics/metricsql v0.76.0 h1:hl7vqJqyH2d8zKImzalkFrkFiD5q4ACF8gl3s86DqKA=
-github.com/VictoriaMetrics/metricsql v0.76.0/go.mod h1:1g4hdCwlbJZ851PU9VN65xy9Rdlzupo6fx3SNZ8Z64U=
 github.com/VividCortex/ewma v1.2.0 h1:f58SaIzcDXrSy3kWaHNvuJgJ3Nmz59Zji6XoJR/q1ow=
 github.com/VividCortex/ewma v1.2.0/go.mod h1:nz4BbCtbLyFDeC9SUHbtcT5644juEuWfUAUnGx7j5l4=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
@@ -143,6 +141,8 @@ github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XL
 github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/changshun-shi/metricsql v0.0.0-20240725044341-f9471f2c0be7 h1:7tvy2zKqQCRcv+LJAUPl4k+iH1vwXUF1xysga6jkPLQ=
+github.com/changshun-shi/metricsql v0.0.0-20240725044341-f9471f2c0be7/go.mod h1:1g4hdCwlbJZ851PU9VN65xy9Rdlzupo6fx3SNZ8Z64U=
 github.com/cheggaaa/pb/v3 v3.1.5 h1:QuuUzeM2WsAqG2gMqtzaWithDJv0i+i6UlnwSCI4QLk=
 github.com/cheggaaa/pb/v3 v3.1.5/go.mod h1:CrxkeghYTXi1lQBEI7jSn+3svI3cuc19haAj6jM60XI=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=

--- a/vendor/github.com/VictoriaMetrics/metricsql/rollup.go
+++ b/vendor/github.com/VictoriaMetrics/metricsql/rollup.go
@@ -55,6 +55,7 @@ var rollupFuncs = map[string]bool{
 	"quantiles_over_time":     true,
 	"range_over_time":         true,
 	"rate":                    true,
+	"rate_over_delta":         true,
 	"rate_over_sum":           true,
 	"resets":                  true,
 	"rollup":                  true,

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -118,7 +118,7 @@ github.com/VictoriaMetrics/fastcache
 # github.com/VictoriaMetrics/metrics v1.35.1
 ## explicit; go 1.17
 github.com/VictoriaMetrics/metrics
-# github.com/VictoriaMetrics/metricsql v0.76.0
+# github.com/VictoriaMetrics/metricsql v0.76.0 => github.com/changshun-shi/metricsql v0.0.0-20240725044341-f9471f2c0be7
 ## explicit; go 1.13
 github.com/VictoriaMetrics/metricsql
 github.com/VictoriaMetrics/metricsql/binaryop
@@ -886,3 +886,4 @@ k8s.io/klog/v2/internal/sloghandler
 # k8s.io/utils v0.0.0-20240711033017-18e509b52bc8
 ## explicit; go 1.18
 k8s.io/utils/clock
+# github.com/VictoriaMetrics/metricsql => github.com/changshun-shi/metricsql v0.0.0-20240725044341-f9471f2c0be7


### PR DESCRIPTION
### Describe Your Changes

Related to https://github.com/VictoriaMetrics/VictoriaMetrics/issues/5631, 
Our metric data is ingest by agent which developed base `otel`. we chose delta for counters.
When we cal `rate` for these metrics, we find `rate_over_sum` can work in our sense. however, when the window is small, there will be big fluctuations.
So we add `rate_over_delta`, which works better in this case.

Performance between `rate_over_sum` and `rate_over_delta` are as follows:
<img width="2545" alt="image" src="https://github.com/user-attachments/assets/3a866961-6aa0-46b1-9869-7a6989080d5e">

The calculation logic of `rate_over_delta[window]` is as follows:
Use the sum of deltas div the duration, which the counter increase in the window.
While `rate_over_sum[window]` is Use the sum of deltas div window

### Checklist

- [FEATURE] support `rate_over_delta`, when report delta counters instead of cumulative counters.

The following checks are **mandatory**:

- [x]  My change adheres [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/contributing/).
