### PR TITLE
Docs/cache data path cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -1302,7 +1302,7 @@ Below is the output for `/path/to/vmselect -help`:
   -blockcache.missesBeforeCaching int
      The number of cache misses before putting the block into cache. Higher values may reduce indexdb/dataBlocks cache size at the cost of higher CPU and disk read usage (default 2)
   -cacheDataPath string
-     Path to directory for cache files. By default, the cache is not persisted.
+     Path to directory for cache files. By default, the cache is not persisted. Please note that vmselect will create a `/tmp/searchResults` folder under cacheDataPath, which contains data from vmstorage nodes for search query. Ensure that `cacheDataPath/tmp/searchResults` will not be removed. Refer to issue #5770 for more details.
   -cacheExpireDuration duration
      Items are removed from in-memory caches after they aren't accessed for this duration. Lower values may reduce memory usage at the cost of higher CPU usage. See also -prevCacheRemovalPercent (default 30m0s)
   -cluster.tls

--- a/app/vmselect/main.go
+++ b/app/vmselect/main.go
@@ -43,7 +43,8 @@ var (
 	useProxyProtocol = flagutil.NewArrayBool("httpListenAddr.useProxyProtocol", "Whether to use proxy protocol for connections accepted at the given -httpListenAddr . "+
 		"See https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt . "+
 		"With enabled proxy protocol http server cannot serve regular /metrics endpoint. Use -pushmetrics.url for metrics pushing")
-	cacheDataPath         = flag.String("cacheDataPath", "", "Path to directory for cache files. By default, the cache is not persisted.")
+	cacheDataPath = flag.String("cacheDataPath", "", "Path to directory for cache files. By default, the cache is not persisted. "+
+		"Please note that vmselect will create a `/tmp/searchResults` folder under cacheDataPath, which contains data from vmstorage nodes for search query. Ensure that `cacheDataPath/tmp/searchResults` will not be removed. Refer to issue #5770 for more details.")
 	maxConcurrentRequests = flag.Int("search.maxConcurrentRequests", getDefaultMaxConcurrentRequests(), "The maximum number of concurrent search requests. "+
 		"It shouldn't be high, since a single request can saturate all the CPU cores, while many concurrently executed requests may require high amounts of memory. "+
 		"See also -search.maxQueueDuration and -search.maxMemoryPerQuery")

--- a/docs/Cluster-VictoriaMetrics.md
+++ b/docs/Cluster-VictoriaMetrics.md
@@ -1313,7 +1313,7 @@ Below is the output for `/path/to/vmselect -help`:
   -blockcache.missesBeforeCaching int
      The number of cache misses before putting the block into cache. Higher values may reduce indexdb/dataBlocks cache size at the cost of higher CPU and disk read usage (default 2)
   -cacheDataPath string
-     Path to directory for cache files. By default, the cache is not persisted.
+     Path to directory for cache files. By default, the cache is not persisted. Please note that vmselect will create a `/tmp/searchResults` folder under cacheDataPath, which contains data from vmstorage nodes for search query. Ensure that `cacheDataPath/tmp/searchResults` will not be removed. Refer to issue #5770 for more details.
   -cacheExpireDuration duration
      Items are removed from in-memory caches after they aren't accessed for this duration. Lower values may reduce memory usage at the cost of higher CPU usage. See also -prevCacheRemovalPercent (default 30m0s)
   -cluster.tls


### PR DESCRIPTION
### Describe Your Changes

vmselect will create `./tmp` dir under `cacheDataPath`. If `cacheDataPath` is set to `/`,  vmselect will use `/tmp`.

content under `/tmp` dir might be auto removed based on the OS behaviour. See: https://github.com/VictoriaMetrics/VictoriaMetrics/issues/5770

This PR add docs for flag `cacheDataPath`. It consist 3 commits for vmselect `main.go` / `README.md` / `VictoriaMetrics-Cluster.md`.

### Checklist

The following checks are **mandatory**:

- [x] My change adheres [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/contributing/).
