### PR TITLE
docs: removed redundant 'VictoriaLogs' from title

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 .vscode
 *.test
 *.swp
+/vmdocs
 /gocache-for-docker
 /victoria-logs-data
 /victoria-metrics-data

--- a/docs/VictoriaLogs/CHANGELOG.md
+++ b/docs/VictoriaLogs/CHANGELOG.md
@@ -1,7 +1,7 @@
 ---
 sort: 7
 weight: 7
-title: VictoriaLogs changelog
+title: CHANGELOG
 menu:
   docs:
     identifier: "victorialogs-changelog"

--- a/docs/VictoriaLogs/FAQ.md
+++ b/docs/VictoriaLogs/FAQ.md
@@ -1,7 +1,7 @@
 ---
 sort: 6
 weight: 6
-title: VictoriaLogs FAQ
+title: FAQ
 menu:
   docs:
     identifier: "victorialogs-faq"

--- a/docs/VictoriaLogs/QuickStart.md
+++ b/docs/VictoriaLogs/QuickStart.md
@@ -1,7 +1,7 @@
 ---
 sort: 1
 weight: 1
-title: VictoriaLogs Quick Start
+title: Quick Start
 menu:
   docs:
     parent: "victorialogs"

--- a/docs/VictoriaLogs/Roadmap.md
+++ b/docs/VictoriaLogs/Roadmap.md
@@ -1,7 +1,7 @@
 ---
 sort: 8
 weight: 8
-title: VictoriaLogs roadmap
+title: Roadmap
 disableToc: true
 menu:
   docs:

--- a/docs/VictoriaLogs/keyConcepts.md
+++ b/docs/VictoriaLogs/keyConcepts.md
@@ -1,7 +1,7 @@
 ---
 sort: 2
 weight: 2
-title: VictoriaLogs key concepts
+title: Key concepts
 menu:
   docs:
     parent: "victorialogs"


### PR DESCRIPTION
### Describe Your Changes

After breadcrumb was added to docs.victoriametrics.com there's no need to specify parent page name in a title

<img width="1437" alt="Screenshot 2024-07-27 at 10 20 09" src="https://github.com/user-attachments/assets/733f41f4-a727-4f52-a7c0-6019edf1b803">

Also added vmdocs to gitignore to avoid committing it

### Checklist

The following checks are **mandatory**:

- [ ] My change adheres [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/contributing/).
