### PR TITLE
fixed using denyPartialResponse for graphite requests

### DIFF
--- a/app/vmselect/graphite/eval.go
+++ b/app/vmselect/graphite/eval.go
@@ -19,11 +19,12 @@ var maxGraphiteSeries = flag.Int("search.maxGraphiteSeries", 300e3, "The maximum
 	"See https://docs.victoriametrics.com/#graphite-render-api-usage")
 
 type evalConfig struct {
-	at          *auth.Token
-	startTime   int64
-	endTime     int64
-	storageStep int64
-	deadline    searchutils.Deadline
+	at                  *auth.Token
+	startTime           int64
+	endTime             int64
+	storageStep         int64
+	denyPartialResponse bool
+	deadline            searchutils.Deadline
 
 	currentTime time.Time
 
@@ -155,8 +156,7 @@ func evalMetricExpr(ec *evalConfig, me *graphiteql.MetricExpr) (nextSeriesFunc, 
 }
 
 func newNextSeriesForSearchQuery(ec *evalConfig, sq *storage.SearchQuery, expr graphiteql.Expr) (nextSeriesFunc, error) {
-	denyPartialResponse := true
-	rss, _, err := netstorage.ProcessSearchQuery(nil, denyPartialResponse, sq, ec.deadline)
+	rss, _, err := netstorage.ProcessSearchQuery(nil, ec.denyPartialResponse, sq, ec.deadline)
 	if err != nil {
 		return nil, fmt.Errorf("cannot fetch data for %q: %w", sq, err)
 	}

--- a/app/vmselect/graphite/render_api.go
+++ b/app/vmselect/graphite/render_api.go
@@ -11,6 +11,7 @@ import (
 	"github.com/VictoriaMetrics/VictoriaMetrics/app/vmselect/searchutils"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/auth"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/bufferedwriter"
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/httputils"
 	"github.com/VictoriaMetrics/metrics"
 )
 
@@ -94,19 +95,21 @@ func RenderHandler(startTime time.Time, at *auth.Token, w http.ResponseWriter, r
 	if err != nil {
 		return fmt.Errorf("cannot setup tag filters: %w", err)
 	}
+	denyPartialResponse := httputils.GetDenyPartialResponse(r)
 	var nextSeriess []nextSeriesFunc
 	targets := r.Form["target"]
 	for _, target := range targets {
 		ec := &evalConfig{
-			at:            at,
-			startTime:     fromTime,
-			endTime:       untilTime,
-			storageStep:   storageStep,
-			deadline:      deadline,
-			currentTime:   startTime,
-			xFilesFactor:  xFilesFactor,
-			etfs:          etfs,
-			originalQuery: target,
+			at:                  at,
+			startTime:           fromTime,
+			endTime:             untilTime,
+			storageStep:         storageStep,
+			denyPartialResponse: denyPartialResponse,
+			deadline:            deadline,
+			currentTime:         startTime,
+			xFilesFactor:        xFilesFactor,
+			etfs:                etfs,
+			originalQuery:       target,
 		}
 		nextSeries, err := execExpr(ec, target)
 		if err != nil {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -37,6 +37,7 @@ See also [LTS releases](https://docs.victoriametrics.com/lts-releases/).
 * BUGFIX: [vmalert](https://docs.victoriametrics.com/vmalert): respect HTTP headers defined in [notifier configuration file](https://docs.victoriametrics.com/vmalert/#notifier-configuration-file) for each request to notifiers. Previously, this param was ignored by mistake.
 * BUGFIX: [stream aggregation](https://docs.victoriametrics.com/stream-aggregation/): correctly apply `-streamAggr.dropInputLabels` when global stream deduplication is enabled without `-streamAggr.config`. Previously, `-remoteWrite.streamAggr.dropInputLabels` was used instead.
 * BUGFIX: [stream aggregation](https://docs.victoriametrics.com/stream-aggregation/): fix command-line flag `-remoteWrite.streamAggr.ignoreFirstIntervals` to accept multiple values and be applied per each corresponding `-remoteWrite.url`. Previously, this flag only could have been used globally for all URLs. 
+* BUGFIX: [graphite](https://docs.victoriametrics.com/#graphite-render-api-usage): respect `-search.denyPartialResponse` cmd-line flag and `deny_partial_response` query GET param when serving requests via Graphite API. Before, partial responses were always denied. Thanks to @penguinlav for the [pull request](https://github.com/VictoriaMetrics/VictoriaMetrics/pull/6748).
 
 ## [v1.102.1](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.102.1)
 


### PR DESCRIPTION
### Describe Your Changes

VM has different responses to equivalent queries for MetricsQL and GraphiteQL in case of failed access to one of vmstorage node of the cluster vmstorage nodes. For GraphiteQL, the denyPartialResponse feature is not used, it is always true, which is not always correct (depending on the configuration).

In the PR I have removed the hardcoded denyPartialResponse for GraphiteQL, just like MetricsQL does.

### Checklist

The following checks are **mandatory**:

- [x] My change adheres [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/contributing/).
