### PR TITLE
docs: Added grafana version requirement for vm+vl datasorce

### DIFF
--- a/docs/VictoriaLogs/victorialogs-datasource.md
+++ b/docs/VictoriaLogs/victorialogs-datasource.md
@@ -20,6 +20,7 @@ The VictoriaLogs datasource plugin allows you to query and visualize
 * [Installation](#installation)
 * [How to make new release](#how-to-make-new-release)
 * [Notes](#notes)
+* [Frequently Asked Questions](#faq)
 * [License](#license)
 
 ## Installation
@@ -307,6 +308,12 @@ This command will build frontend part and backend part or the plugin and locate 
 In the `plugin.json` file of our plugin, the `metrics` field is set to `true`. This is not to support metric queries in the classical sense but to ensure our plugin can be selected in the Grafana panel editor.
 
 For more information on the fields in `plugin.json`, please refer to the [Grafana documentation](https://grafana.com/developers/plugin-tools/reference-plugin-json#properties).
+
+## FAQ
+
+### Which version of Grafana is required in order to use VictoriaLogs datasource?
+
+[10.0.3](https://grafana.com/grafana/download/10.0.3) or newer.
 
 ## License
 

--- a/docs/victoriametrics-datasource.md
+++ b/docs/victoriametrics-datasource.md
@@ -414,6 +414,10 @@ If datasource is configured via Grafana variable, then change variable to Victor
 
 Grafana doesn't allow forwarding Alert requests to alerting API /api/v1/rules for plugins which are not of Prometheus or Loki type. See more details [here](https://github.com/VictoriaMetrics/victoriametrics-datasource/issues/59#issuecomment-1541456768).
 
+### Which version of Grafana is required in order to use VictoriaMetrics datasource? 
+
+[8.3.0](https://grafana.com/grafana/download/8.3.0) or newer.
+
 ## License
 
 This project is licensed under


### PR DESCRIPTION
### Describe Your Changes

https://victoriametrics.slack.com/archives/C05UNTPAEDN/p1722833182319299

Sometimes users may use the wrong (lower) version of Grafana when setting up the VictoriaLogs datasource. 

It would be good to document the requirements of Grafana versions to use VictoriaMetrics/VictoriaLogs datasource.

### Checklist

The following checks are **mandatory**:

- [X] My change adheres [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/contributing/).
