### PR TITLE
vmagent: resolve the issue where usePromCompatibleNaming is not working

### DIFF
--- a/app/vmagent/remotewrite/remotewrite.go
+++ b/app/vmagent/remotewrite/remotewrite.go
@@ -441,7 +441,7 @@ func tryPush(at *auth.Token, wr *prompbmarshal.WriteRequest, forceDropSamplesOnF
 	var rctx *relabelCtx
 	rcs := allRelabelConfigs.Load()
 	pcsGlobal := rcs.global
-	if pcsGlobal.Len() > 0 {
+	if pcsGlobal.Len() > 0 || *usePromCompatibleNaming {
 		rctx = getRelabelCtx()
 		defer putRelabelCtx(rctx)
 	}


### PR DESCRIPTION
Describe Your Changes
When I use usePromCompatibleNaming with vmagent to process data that needs to be formatted from different sources such as InfluxDB, I find that it doesn’t work

However, it works in vminsert. I found that vminsert uses the HasRelabeling method to determine whether to relabel.
```go
func HasRelabeling() bool {
	pcs := pcsGlobal.Load()
	return pcs.Len() > 0 || *usePromCompatibleNaming
}
```
in vmagent, the decision to relabel is determined only by pcsGlobal.Len() > 0. However, in the applyRelabeling method, the usePromCompatibleNaming logic is also used to determine whether to relabel in the error handling.
```go
func (rctx *relabelCtx) applyRelabeling(tss []prompbmarshal.TimeSeries, pcs *promrelabel.ParsedConfigs) []prompbmarshal.TimeSeries {
	if pcs.Len() == 0 && !*usePromCompatibleNaming {
		// Nothing to change.
		return tss
	}
```
So I think that the logic for determining whether to relabel in vmagent is not as expected.

Checklist
The following checks are mandatory:

[✅]My change adheres [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/contributing/).