### PR TITLE
operator/setup.md: minor fix for image patch

### DIFF
--- a/docs/operator/setup.md
+++ b/docs/operator/setup.md
@@ -24,7 +24,7 @@ For installing VictoriaMetrics operator with helm-chart follow the instructions 
 ([this](https://github.com/VictoriaMetrics/helm-charts/blob/master/charts/victoria-metrics-operator/README.md)
 or [this](https://github.com/VictoriaMetrics/helm-charts/blob/master/charts/victoria-metrics-k8s-stack/README.md)).
 
-in addition, you can use [quickstart guide](./quick-start.md) for 
+in addition, you can use [quickstart guide](./quick-start.md) for
 installing VictoriaMetrics operator with helm-chart.
 
 ## Installing by Kustomize
@@ -45,7 +45,8 @@ resources:
 namespace: ${NAMESPACE}
 
 images:
-- name: victoriametrics/operator
+- name: manager
+  newName: victoriametrics/operator
   newTag: ${VM_VERSION}
 EOF
 ```


### PR DESCRIPTION
### Describe Your Changes

In the current version (v0.46.4) (and probably in some earlier versions), the docker image somehow changed from `victoriametrics/operator` to `manager`. For this reason, the patch should revert them to available image from in docker registry.

### Checklist

The following checks are **mandatory**:

- [x] My change adheres [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/contributing/).
