### PR TITLE
Move rowsAddedTotal counter to Storage

### DIFF
--- a/lib/storage/storage.go
+++ b/lib/storage/storage.go
@@ -40,6 +40,8 @@ const (
 
 // Storage represents TSDB storage.
 type Storage struct {
+	rowsAddedTotal atomic.Uint64
+
 	tooSmallTimestampRows atomic.Uint64
 	tooBigTimestampRows   atomic.Uint64
 
@@ -552,7 +554,7 @@ func (m *Metrics) Reset() {
 
 // UpdateMetrics updates m with metrics from s.
 func (s *Storage) UpdateMetrics(m *Metrics) {
-	m.RowsAddedTotal = rowsAddedTotal.Load()
+	m.RowsAddedTotal += s.rowsAddedTotal.Load()
 	m.DedupsDuringMerge = dedupsDuringMerge.Load()
 	m.SnapshotsCount += uint64(s.mustGetSnapshotsCount())
 
@@ -1606,8 +1608,6 @@ func (s *Storage) ForceMergePartitions(partitionNamePrefix string) error {
 	return s.tb.ForceMergePartitions(partitionNamePrefix)
 }
 
-var rowsAddedTotal atomic.Uint64
-
 // AddRows adds the given mrs to s.
 //
 // The caller should limit the number of concurrent AddRows calls to the number
@@ -1629,7 +1629,7 @@ func (s *Storage) AddRows(mrs []MetricRow, precisionBits uint8) {
 			mrs = nil
 		}
 		s.add(ic.rrs, ic.tmpMrs, mrsBlock, precisionBits)
-		rowsAddedTotal.Add(uint64(len(mrsBlock)))
+		s.rowsAddedTotal.Add(uint64(len(mrsBlock)))
 	}
 	putMetricRowsInsertCtx(ic)
 }


### PR DESCRIPTION
### Describe Your Changes

Reduced the scope of rowsAddedTotal variable from global to Storage.

This metric clearly belongs to a given Storage object as it counts the number of records added by a given Storage instance.
Reducing the scope improves the incapsulation and allows to reset this variable during the unit tests (i.e. every time a new Storage object is created by a test, that object gets a new variable).

This has previously been done in #6663, but that PR is still in review and I need this change for my other PRs that are still in development.

### Checklist

The following checks are **mandatory**:

- [ x] My change adheres [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/contributing/).
