### PR TITLE
docs: fix example links in getting started with OpenTelemetry

### DIFF
--- a/docs/guides/getting-started-with-opentelemetry/README.md
+++ b/docs/guides/getting-started-with-opentelemetry/README.md
@@ -100,7 +100,7 @@ Metrics could be sent to VictoriaMetrics via OpenTelemetry instrumentation libra
 In our example, we'll create a WEB server in [Golang](https://go.dev/) and instrument it with metrics.
 
 ### Building the Go application instrumented with metrics
-Copy the go file from [here](/guides/app.go-collector.example). This will give you a basic implementation of a dice roll WEB server with the urls for opentelemetry-collector pointing to localhost:4318. 
+Copy the go file from [here](app.go-collector.example). This will give you a basic implementation of a dice roll WEB server with the urls for opentelemetry-collector pointing to localhost:4318. 
 In the same directory run the following command to create the `go.mod` file:
 ```sh
 go mod init vm/otel
@@ -167,7 +167,7 @@ In our example, we'll create a WEB server in [Golang](https://go.dev/) and instr
 
 ### Building the Go application instrumented with metrics
 
-See the full source code of the example [here](/guides/app.go.example).
+See the full source code of the example [here](app.go.example).
 
 The list of OpenTelemetry dependencies for `go.mod` is the following:
 


### PR DESCRIPTION
### Describe Your Changes

Fix broken link on: https://docs.victoriametrics.com/guides/getting-started-with-opentelemetry/index.html#building-the-go-application-instrumented-with-metrics
- https://docs.victoriametrics.com/guides/app.go-collector.example
- https://docs.victoriametrics.com/guides/app.go.example

The valid links **could be**:
- https://docs.victoriametrics.com/guides/getting-started-with-opentelemetry/app.go-collector.example
- https://docs.victoriametrics.com/guides/getting-started-with-opentelemetry/app.go.example

Also went throught `/guides` folder and did not found doc with same issue. Please advice if you know more.

### Checklist

The following checks are **mandatory**:

- [x] My change adheres [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/contributing/).
