### PR TITLE
VictoriaLogs/keyConcepts.md: fix broken anchor to #other-fields

### DIFF
--- a/docs/VictoriaLogs/keyConcepts.md
+++ b/docs/VictoriaLogs/keyConcepts.md
@@ -110,7 +110,7 @@ Unicode chars must be encoded with [UTF-8](https://en.wikipedia.org/wiki/UTF-8) 
 VictoriaLogs automatically indexes all the fields in all the [ingested](https://docs.victoriametrics.com/victorialogs/data-ingestion/) logs.
 This enables [full-text search](https://docs.victoriametrics.com/victorialogs/logsql/) across all the fields.
 
-VictoriaLogs supports the following special fields additionally to arbitrary [other fields](#other-field):
+VictoriaLogs supports the following special fields additionally to arbitrary [other fields](#other-fields):
 
 * [`_msg` field](#message-field)
 * [`_time` field](#time-field)


### PR DESCRIPTION
### Describe Your Changes

The anchor to "Other fields" section should be #other-fields (instead of #other-field)

### Checklist

The following checks are **mandatory**:

- [x] My change adheres [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/contributing/).
