### PR TITLE
docs: fix incorrect URLs for resetCache and OTel guide

### DIFF
--- a/docs/guides/getting-started-with-opentelemetry/README.md
+++ b/docs/guides/getting-started-with-opentelemetry/README.md
@@ -314,7 +314,7 @@ func newMetricsController(ctx context.Context) (*controller.Controller, error) {
 
 This controller will collect and push collected metrics to VictoriaMetrics address with interval of `10s`.
 
-See the full source code of the example [here](/guides/app.go.example).
+See the full source code of the example [here](app.go.example).
 
 ### Test metrics ingestion
 

--- a/docs/url-examples.md
+++ b/docs/url-examples.md
@@ -617,12 +617,10 @@ Single-node VictoriaMetrics:
 curl -Is http://localhost:8428/internal/resetRollupResultCache
 ```
 
-
 Cluster version of VictoriaMetrics:
 
-
 ```sh
-curl -Is http://<vmselect>:8481/select/internal/resetRollupResultCache
+curl -Is http://<vmselect>:8481/internal/resetRollupResultCache
 ```
 
 vmselect will propagate this call to the rest of the vmselects listed in its `-selectNode` cmd-line flag. If this


### PR DESCRIPTION
### Describe Your Changes

This pull request fixes incorrect URLs in two places:

1. In the OTel guide, which has been corrected in https://github.com/VictoriaMetrics/VictoriaMetrics/pull/6880, but one incorrect URL is still missing.
2. In the URL example, the cache reset endpoint for vmselect / Cluster version is `/internal/resetRollupResultCache`, but it is mistakenly noted as `/select/internal/resetRollupResultCache`, which misguides the user. （introduced in #4468)

### Checklist

The following checks are **mandatory**:

- [x] My change adheres [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/contributing/).
