### PR TITLE
docs: fix resetRollupResultCache api url in cluster version of vmselect

### DIFF
--- a/docs/url-examples.md
+++ b/docs/url-examples.md
@@ -622,7 +622,7 @@ Cluster version of VictoriaMetrics:
 
 
 ```sh
-curl -Is http://<vmselect>:8481/select/internal/resetRollupResultCache
+curl -Is http://<vmselect>:8481/internal/resetRollupResultCache
 ```
 
 vmselect will propagate this call to the rest of the vmselects listed in its `-selectNode` cmd-line flag. If this


### PR DESCRIPTION
### Describe Your Changes
resetRollupResultCache API URL is explained differently for single-node and cluster-version in [document](https://docs.victoriametrics.com/url-examples/#internalresetrollupresultcache).
(single-node: `:8428/internal/resetRollupResultCache`, cluster-version: `:8481/select/internal/resetRollupResultCache`)

The cluster version only supports the same `/internal/resetRollupResultCache` URL as the single node.

```
$curl -I "http://{vmselect-in-cluster-version-victoriametrics}:8481/select/internal/resetRollupResultCache"
remoteAddr: "{address}"; requestURI: /select/internal/resetRollupResultCache; auth error: cannot parse accountID from "internal": strconv.ParseUint: parsing "internal": invalid syntax

$ curl -Is "http://{vmselect-in-cluster-version-victoriametrics}:8481/internal/resetRollupResultCache"
HTTP/1.1 200 OK
```
* background slack conversaion: https://victoriametrics.slack.com/archives/CGZF1H6L9/p1724743770289809
### Checklist

The following checks are **mandatory**:

- [ ] My change adheres [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/contributing/).
