### PR TITLE
clarify `flagutil.Duration` docs

### DIFF
--- a/lib/flagutil/duration.go
+++ b/lib/flagutil/duration.go
@@ -14,7 +14,7 @@ import (
 //
 // DefaultValue is in months.
 func NewDuration(name string, defaultValue string, description string) *Duration {
-	description += "\nThe following optional suffixes are supported: s (second), m (minute), h (hour), d (day), w (week), y (year). " +
+	description += "\nThe following optional suffixes are supported: s (second), h (hour), d (day), w (week), y (year). " +
 		"If suffix isn't set, then the duration is counted in months"
 	d := &Duration{}
 	if err := d.Set(defaultValue); err != nil {


### PR DESCRIPTION
### Describe Your Changes

`flagutil.Duration` docs state that `m` suffix stands for `minute`, but in fact this suffix is not supported due to ambiguity with `month`

### Checklist

The following checks are **mandatory**:

- [x] My change adheres [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/contributing/).
