### PR TITLE
docs: [VictoriaLogs] OTel Collector elasticsearchexporter header note

### DIFF
--- a/docs/VictoriaLogs/data-ingestion/opentelemetry.md
+++ b/docs/VictoriaLogs/data-ingestion/opentelemetry.md
@@ -56,6 +56,8 @@ exporters:
   elasticsearch:
     endpoints:
       - http://victorialogs:9428/insert/elasticsearch
+    headers:
+      VL-Msg-Field: "Body" # Optional.
 receivers:
   filelog:
     include: [/tmp/logs/*.log]
@@ -67,6 +69,15 @@ service:
       receivers: [filelog]
       exporters: [elasticsearch]
 ```
+
+Please note that every ingested log entry **must** contain at least a `_msg` field with the actual log message. By default, 
+the Elasticsearch exporter may place the log message in the `Body` field. In this case, you can specify the field mapping via:
+```yaml
+    headers:
+      VL-Msg-Field: "Body"
+```
+
+VictoriaLogs also support specify `AccountID`, `ProjectID`, log timestamp and other fields via [HTTP headers](https://docs.victoriametrics.com/victorialogs/data-ingestion/#http-headers).
 
 ### Loki
 
@@ -104,7 +115,7 @@ exporters:
   otlphttp:
     logs_endpoint: http://localhost:9428/insert/opentelemetry/v1/logs
     headers:
-     VL-Stream-Fields: telemetry.sdk.language,severity
+      VL-Stream-Fields: telemetry.sdk.language,severity
 ```
 
 See also [HTTP headers](https://docs.victoriametrics.com/victorialogs/data-ingestion/#http-headers)


### PR DESCRIPTION
### Describe Your Changes

By default, the `elasticsearchexporter` in OTel Collector puts the log message under a field other than `_msg` (e.g., `Body`). Without specifying via an HTTP header, those logs may not be queried correctly. See also: https://github.com/VictoriaMetrics/VictoriaMetrics/issues/6785.

This pull request updates the example configuration and notes for the `elasticsearchexporter`.

### Checklist

The following checks are **mandatory**:

- [X] My change adheres [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/contributing/).
