### PR TITLE
docs/victorialogs/data-ingestion: removed FluentBit Elasticsearch from examples

### DIFF
--- a/docs/VictoriaLogs/data-ingestion/Fluentbit.md
+++ b/docs/VictoriaLogs/data-ingestion/Fluentbit.md
@@ -15,29 +15,8 @@ aliases:
 # Fluentbit setup
 
 VictoriaLogs supports given below Fluentbit outputs:
-- [Elasticsearch](#elasticsearch)
 - [Loki](#loki)
 - [HTTP JSON](#http)
-
-## Elasticsearch
-
-Specify [elasticsearch output](https://docs.fluentbit.io/manual/pipeline/outputs/elasticsearch) section in the `fluentbit.conf`
-for sending the collected logs to [VictoriaLogs](https://docs.victoriametrics.com/victorialogs/):
-
-```conf
-[Output]
-    Name es
-    Match *
-    host victorialogs
-    port 9428
-    compress gzip
-    path /insert/elasticsearch
-    header AccountID 0
-    header ProjectID 0
-    header VL-Stream-Fields path
-    header VL-Msg-Field log
-    header VL-Time-Field @timestamp
-```
 
 ## Loki
 


### PR DESCRIPTION
removed FluentBit Elasticsearch example from docs as custom headers are not supported by elasticsearch output till https://github.com/fluent/fluent-bit/pull/9416 is merged and released

fixes https://github.com/VictoriaMetrics/VictoriaMetrics/issues/6985

### Describe Your Changes

Please provide a brief description of the changes you made. Be as specific as possible to help others understand the purpose and impact of your modifications.

### Checklist

The following checks are **mandatory**:

- [ ] My change adheres [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/contributing/).
