### PR TITLE
fscore: rollback trailing space trim

### DIFF
--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -47,6 +47,7 @@ See also [LTS releases](https://docs.victoriametrics.com/lts-releases/).
 * BUGFIX: [MetricsQL](https://docs.victoriametrics.com/metricsql/): consistently return the first non-`NaN` value from [`range_first`](https://docs.victoriametrics.com/metricsql/#range_first) function across all the returned data points. Previously `NaN` data points weren't replaced with the first non-`NaN` value.
 * BUGFIX: [MetricsQL](https://docs.victoriametrics.com/metricsql/): consistently return the last non-`NaN` value from [`range_last`](https://docs.victoriametrics.com/metricsql/#range_last) function across all the returned data points. Previously `NaN` data points weren't replaced with the last non-`NaN` value.
 * BUGFIX: all VictoriaMetrics components: increase default value of `-loggerMaxArgLen` cmd-line flag from 1000 to 5000. This should improve visibility on errors produced by very long queries.
+* BUGFIX: all VictoriaMetrics components: trim trailing spaces when reading content from `*.passwordFile` and similar flags. It reverts changes introduced at [v1.102.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.102.0) release. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/6986) for details.
 
 ## [v1.103.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.103.0)
 

--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -47,7 +47,7 @@ See also [LTS releases](https://docs.victoriametrics.com/lts-releases/).
 * BUGFIX: [MetricsQL](https://docs.victoriametrics.com/metricsql/): consistently return the first non-`NaN` value from [`range_first`](https://docs.victoriametrics.com/metricsql/#range_first) function across all the returned data points. Previously `NaN` data points weren't replaced with the first non-`NaN` value.
 * BUGFIX: [MetricsQL](https://docs.victoriametrics.com/metricsql/): consistently return the last non-`NaN` value from [`range_last`](https://docs.victoriametrics.com/metricsql/#range_last) function across all the returned data points. Previously `NaN` data points weren't replaced with the last non-`NaN` value.
 * BUGFIX: all VictoriaMetrics components: increase default value of `-loggerMaxArgLen` cmd-line flag from 1000 to 5000. This should improve visibility on errors produced by very long queries.
-* BUGFIX: all VictoriaMetrics components: trim trailing spaces when reading content from `*.passwordFile` and similar flags. It reverts changes introduced at [v1.102.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.102.0) release. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/6986) for details.
+* BUGFIX: all VictoriaMetrics components: trim trailing spaces when reading content from `*.passwordFile` and similar flags. It reverts changes introduced at [v1.102.0-rc2](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.102.0-rc2) release. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/6986) for details.
 
 ## [v1.103.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.103.0)
 

--- a/lib/flagutil/password_test.go
+++ b/lib/flagutil/password_test.go
@@ -32,7 +32,7 @@ func TestPassword(t *testing.T) {
 
 	// read the password from file by relative path
 	localPassFile := "testdata/password.txt"
-	expectedPassword = "foo-bar-baz\n\n\n"
+	expectedPassword = "foo-bar-baz"
 	path := "file://" + localPassFile
 	if err := p.Set(path); err != nil {
 		t.Fatalf("cannot set password to file: %s", err)
@@ -52,7 +52,7 @@ func TestPassword(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
-	expectedPassword = "foo-bar-baz\n\n\n"
+	expectedPassword = "foo-bar-baz"
 	path = "file://" + localPassFile
 	if err := p.Set(path); err != nil {
 		t.Fatalf("unexpected error: %s", err)

--- a/lib/fs/fscore/fscore.go
+++ b/lib/fs/fscore/fscore.go
@@ -7,6 +7,8 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
+	"unicode"
 )
 
 // ReadPasswordFromFileOrHTTP reads password for the give path.
@@ -17,7 +19,8 @@ func ReadPasswordFromFileOrHTTP(path string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return string(data), nil
+	pass := strings.TrimRightFunc(string(data), unicode.IsSpace)
+	return pass, nil
 }
 
 // ReadFileOrHTTP reads path either from local filesystem or from http if path starts with http or https.


### PR DESCRIPTION
Previous commit 201fd6de1eb0dd03cf5c24787d6a550d07b1390a removed trailing space trim from data read from file. But common practice is to remove such trailing space. And it leaded to the authorization errors for the major group of users.

 In first place, this change must help to mitigate an issue with kubernetes. When authorization information was read from Secret content.
Changes to the operator was made to mitigate such problem at commit https://github.com/VictoriaMetrics/operator/commit/1cf64358c8dd3963d0233b6c966de149ad7d522c

We could introduce later optional flag for VictoriaMetrics to disable trim space behavior.

Related issues:
https://github.com/VictoriaMetrics/VictoriaMetrics/issues/6986
https://github.com/VictoriaMetrics/VictoriaMetrics/issues/7089 
https://github.com/VictoriaMetrics/VictoriaMetrics/issues/6947

