### PR TITLE
make: add darwin builds for cluster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,16 @@ vmcluster-windows-amd64: \
 	vmselect-windows-amd64 \
 	vmstorage-windows-amd64
 
+vmcluster-darwin-amd64: \
+	vminsert-darwin-amd64 \
+	vmselect-darwin-amd64 \
+	vmstorage-darwin-amd64
+
+vmcluster-darwin-arm64: \
+	vminsert-darwin-arm64 \
+	vmselect-darwin-arm64 \
+	vmstorage-darwin-arm64
+
 crossbuild: vmcluster-crossbuild
 
 vmcluster-crossbuild:
@@ -113,7 +123,9 @@ release-vmcluster: \
 	release-vmcluster-linux-arm64 \
 	release-vmcluster-freebsd-amd64 \
 	release-vmcluster-openbsd-amd64 \
-	release-vmcluster-windows-amd64
+	release-vmcluster-windows-amd64 \
+	release-vmcluster-darwin-amd64 \
+	release-vmcluster-darwin-arm64
 
 release-vmcluster-linux-amd64:
 	GOOS=linux GOARCH=amd64 $(MAKE) release-vmcluster-goos-goarch
@@ -129,6 +141,12 @@ release-vmcluster-openbsd-amd64:
 
 release-vmcluster-windows-amd64:
 	GOARCH=amd64 $(MAKE) release-vmcluster-windows-goarch
+
+release-vmcluster-darwin-amd64:
+	GOOS=darwin GOARCH=amd64 $(MAKE) release-vmcluster-goos-goarch
+
+release-vmcluster-darwin-arm64:
+	 GOOS=darwin GOARCH=arm64 $(MAKE) release-vmcluster-goos-goarch
 
 release-vmcluster-goos-goarch: \
 	vminsert-$(GOOS)-$(GOARCH)-prod \

--- a/app/vminsert/Makefile
+++ b/app/vminsert/Makefile
@@ -39,6 +39,12 @@ vminsert-openbsd-amd64-prod:
 vminsert-windows-amd64-prod:
 	APP_NAME=vminsert $(MAKE) app-via-docker-windows-amd64
 
+vminsert-darwin-amd64-prod:
+	APP_NAME=vminsert $(MAKE) app-via-docker-darwin-amd64
+
+vminsert-darwin-arm64-prod:
+	APP_NAME=vminsert $(MAKE) app-via-docker-darwin-arm64
+
 vminsert-prod-race:
 	APP_NAME=vminsert RACE=-race $(MAKE) app-via-docker
 
@@ -98,6 +104,12 @@ vminsert-openbsd-amd64:
 
 vminsert-windows-amd64:
 	GOARCH=amd64 APP_NAME=vminsert $(MAKE) app-local-windows-goarch
+
+vminsert-darwin-amd64:
+	APP_NAME=vminsert CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 $(MAKE) app-local-goos-goarch
+
+vminsert-darwin-arm64:
+	APP_NAME=vminsert CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 $(MAKE) app-local-goos-goarch
 
 vminsert-pure:
 	APP_NAME=vminsert $(MAKE) app-local-pure

--- a/app/vmselect/Makefile
+++ b/app/vmselect/Makefile
@@ -40,6 +40,12 @@ vmselect-freebsd-amd64-prod:
 vmselect-openbsd-amd64-prod:
 	APP_NAME=vmselect $(MAKE) app-via-docker-openbsd-amd64
 
+vmselect-darwin-amd64-prod:
+	APP_NAME=vmselect $(MAKE) app-via-docker-darwin-amd64
+
+vmselect-darwin-arm64-prod:
+	APP_NAME=vmselect $(MAKE) app-via-docker-darwin-arm64
+
 vmselect-windows-amd64-prod:
 	APP_NAME=vmselect $(MAKE) app-via-docker-windows-amd64
 
@@ -102,6 +108,12 @@ vmselect-openbsd-amd64:
 
 vmselect-windows-amd64:
 	GOARCH=amd64 APP_NAME=vmselect $(MAKE) app-local-windows-goarch
+
+vmselect-darwin-amd64:
+	APP_NAME=vmselect CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 $(MAKE) app-local-goos-goarch
+
+vmselect-darwin-arm64:
+	APP_NAME=vmselect CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 $(MAKE) app-local-goos-goarch
 
 vmselect-pure:
 	APP_NAME=vmselect $(MAKE) app-local-pure

--- a/app/vmstorage/Makefile
+++ b/app/vmstorage/Makefile
@@ -43,6 +43,12 @@ vmstorage-openbsd-amd64-prod:
 vmstorage-windows-amd64-prod:
 	APP_NAME=vmstorage $(MAKE) app-via-docker-windows-amd64
 
+vmstorage-darwin-amd64-prod:
+	APP_NAME=vmstorage $(MAKE) app-via-docker-darwin-amd64
+
+vmstorage-darwin-arm64-prod:
+	APP_NAME=vmstorage $(MAKE) app-via-docker-darwin-arm64
+
 vmstorage-prod-race:
 	APP_NAME=vmstorage RACE=-race $(MAKE) app-via-docker
 
@@ -102,6 +108,12 @@ vmstorage-openbsd-amd64:
 
 vmstorage-windows-amd64:
 	GOARCH=amd64 APP_NAME=vmstorage $(MAKE) app-local-windows-goarch
+
+vmstorage-darwin-amd64:
+	APP_NAME=vmstorage CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 $(MAKE) app-local-goos-goarch
+
+vmstorage-darwin-arm64:
+	APP_NAME=vmstorage CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 $(MAKE) app-local-goos-goarch
 
 vmstorage-pure:
 	APP_NAME=vmstorage $(MAKE) app-local-pure

--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -18,6 +18,8 @@ See also [LTS releases](https://docs.victoriametrics.com/lts-releases/).
 
 ## tip
 
+* FEATURE: add Darwin binaries for [VictoriaMetrics cluster](https://docs.victoriametrics.com/cluster-victoriametrics/) to the release flow. The binaries will be available in the new release.
+
 ## [v1.104.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.104.0)
 
 Released at 2024-10-02


### PR DESCRIPTION
### Describe Your Changes

Add darwin `amd64` and `arm64` builds for cluster binaries build.

### Checklist

The following checks are **mandatory**:

- [x] My change adheres [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/contributing/).
