### PR TITLE
Initial version of integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -192,10 +192,12 @@ pprof-cpu:
 fmt:
 	gofmt -l -w -s ./lib
 	gofmt -l -w -s ./app
+	gofmt -l -w -s ./apptest
 
 vet:
 	go vet ./lib/...
 	go vet ./app/...
+	go vet ./apptest/...
 
 check-all: fmt vet golangci-lint govulncheck
 
@@ -215,6 +217,9 @@ test-full:
 
 test-full-386:
 	DISABLE_FSYNC_FOR_TESTING=1 GOARCH=386 go test -coverprofile=coverage.txt -covermode=atomic ./lib/... ./app/...
+
+integration-test: all
+	go test ./apptest/...
 
 benchmark:
 	go test -bench=. ./lib/...

--- a/apptest/README.md
+++ b/apptest/README.md
@@ -1,0 +1,40 @@
+# App Integration Tests
+
+The `apptest` package contains the integration tests for the VictoriaMetrics
+applications (such as vmstorage, vminsert, and vmselect).
+
+An integration test aims at verifying the behavior of an application as a whole,
+as apposed to a unit test that verifies the behavior of a building block of an
+application.
+
+To achieve that an integration test starts an application in a separate process
+and then issues HTTP requets to it and verifies the responses, examines the
+metrics the app exposes and/or files it creates, etc.
+
+Note that an object of testing may be not just a single app, but several apps
+working together. A good example is VictoriaMetrics cluster. An integration test
+may reproduce an arbitrary cluster configuration and verify how the components
+work together as a system.
+
+The package provides a collection of helpers to start applications and make
+queries to them:
+
+-   `app.go` - contains the generic code for staring an application and should
+    not be used by integration tests directly.
+-   `{vmstorage,vminsert,etc}.go` - build on top of `app.go` and provide the
+    code for staring a specific application.
+-   `client.go` - provides helper functions for sending HTTP requests to
+    applications.
+
+The integration tests themselves reside in `*_test.go` files. Apart from having
+the `_test` suffix, there are no strict rules of how to name a file, but the
+name should reflect the prevailing purpose of the tests located in that file.
+For example, `sharding_test.go` aims at testing data sharding.
+
+Since integration tests start applications in a separate process, they require
+the application binary files to be built and put into the `bin` directory. The
+build rule used for running integration tests, `make integration-test`,
+accounts for that, it builds all application binaries before running the tests.
+But if you want to run the tests without `make`, i.e. by executing
+`go test ./app/apptest`, you will need to build the binaries first (for example,
+by executing `make all`).

--- a/apptest/app.go
+++ b/apptest/app.go
@@ -1,0 +1,236 @@
+package apptest
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"os/exec"
+	"reflect"
+	"regexp"
+	"strings"
+	"time"
+)
+
+// Regular expressions for runtime information to extract from the app logs.
+var (
+	storageDataPathRE = regexp.MustCompile(`successfully opened storage "(.*)"`)
+	httpListenAddrRE  = regexp.MustCompile(`started server at http://(.*:\d{1,5})/`)
+	vminsertAddrRE    = regexp.MustCompile(`accepting vminsert conns at (.*:\d{1,5})$`)
+	vmselectAddrRE    = regexp.MustCompile(`accepting vmselect conns at (.*:\d{1,5})$`)
+)
+
+// app represents an instance of some VictoriaMetrics server (such as vmstorage,
+// vminsert, or vmselect).
+type app struct {
+	instance string
+	binary   string
+	flags    []string
+	process  *os.Process
+}
+
+// appOptions holds the optional configuration of an app, such as default flags
+// to set and things to extract from the app's log.
+type appOptions struct {
+	defaultFlags map[string]string
+	extractREs   []*regexp.Regexp
+}
+
+// startApp starts an instance of an app using the app binary file path and
+// flags. When the opts are set, it also sets the default flag values and
+// extracts runtime information from the app's log.
+//
+// If the app has started successfully and all the requested items has been
+// extracted from logs, the function returns the instance of the app and the
+// extracted items. The extracted items are returned in the same order as the
+// corresponding extract regular expression have been provided in the opts.
+//
+// The function returns an error if the application has failed to start or the
+// function has timed out extracting items from the log (normally because no log
+// records match the regular expression).
+func startApp(instance string, binary string, flags []string, opts *appOptions) (*app, []string, error) {
+	flags = setDefaultFlags(flags, opts.defaultFlags)
+
+	cmd := exec.Command(binary, flags...)
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, nil, err
+	}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		return nil, nil, err
+	}
+	if err := cmd.Start(); err != nil {
+		return nil, nil, err
+	}
+
+	app := &app{
+		instance: instance,
+		binary:   binary,
+		flags:    flags,
+		process:  cmd.Process,
+	}
+
+	go app.processOutput("stdout", stdout, app.writeToStderr)
+
+	lineProcessors := make([]lineProcessor, len(opts.extractREs))
+	reExtractors := make([]*reExtractor, len(opts.extractREs))
+	timeout := time.NewTimer(5 * time.Second).C
+	for i, re := range opts.extractREs {
+		reExtractors[i] = newREExtractor(re, timeout)
+		lineProcessors[i] = reExtractors[i].extractRE
+	}
+	go app.processOutput("stderr", stderr, append(lineProcessors, app.writeToStderr)...)
+
+	extracts, err := extractREs(reExtractors, timeout)
+	if err != nil {
+		app.stop()
+		return nil, nil, err
+	}
+
+	return app, extracts, nil
+}
+
+// setDefaultFlags adds flags with default values to `flags` if it does not
+// initially contain them.
+func setDefaultFlags(flags []string, defaultFlags map[string]string) []string {
+	for _, flag := range flags {
+		for name := range defaultFlags {
+			if strings.HasPrefix(flag, name) {
+				delete(defaultFlags, name)
+				continue
+			}
+		}
+	}
+	for name, value := range defaultFlags {
+		flags = append(flags, name+"="+value)
+	}
+	return flags
+}
+
+// stop sends the app process a SIGINT signal and waits until it terminates
+// gracefully.
+func (app *app) stop() {
+	if err := app.process.Signal(os.Interrupt); err != nil {
+		log.Fatalf("Could not send SIGINT signal to %s process: %v", app.instance, err)
+	}
+	if _, err := app.process.Wait(); err != nil {
+		log.Fatalf("Could not wait for %s process completion: %v", app.instance, err)
+	}
+}
+
+func (app *app) String() string {
+	return fmt.Sprintf("{instance: %q binary: %q flags: %q}", app.instance, app.binary, app.flags)
+}
+
+// lineProcessor is a function that is applied to the each line of the app
+// output (stdout or stderr). The function returns true to indicate the caller
+// that it has completed its work and should not be called again.
+type lineProcessor func(line string) (done bool)
+
+// processOutput invokes a set of processors on each line of app output (stdout
+// or stderr). Once a line processor is done (returns true) it is never invoked
+// again.
+//
+// A simple use case for this is to pipe the output of the child process to the
+// output of the parent process. A more sophisticated one is to retrieve some
+// runtime information from the child process logs, such as the server's
+// host:port.
+func (app *app) processOutput(outputName string, output io.Reader, lps ...lineProcessor) {
+	activeLPs := map[int]lineProcessor{}
+	for i, lp := range lps {
+		activeLPs[i] = lp
+	}
+
+	scanner := bufio.NewScanner(output)
+	for scanner.Scan() {
+		line := scanner.Text()
+		for i, process := range activeLPs {
+			if process(line) {
+				delete(activeLPs, i)
+			}
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		log.Printf("could not scan %s %s: %v", app.instance, outputName, err)
+	}
+}
+
+// writeToStderr is a line processor that writes the line to the stderr.
+// The function always returns false to indicate its caller that each line must
+// be written to the stderr.
+func (app *app) writeToStderr(line string) bool {
+	fmt.Fprintf(os.Stderr, "%s %s\n", app.instance, line)
+	return false
+}
+
+// extractREs waits until all reExtractors return the result and then returns
+// the combined result with items ordered the same way as reExtractors.
+//
+// The function returns an error if timeout occurs sooner then all reExtractors
+// finish its work.
+func extractREs(reExtractors []*reExtractor, timeout <-chan time.Time) ([]string, error) {
+	n := len(reExtractors)
+	extracts := make([]string, n)
+	cases := make([]reflect.SelectCase, n+1)
+	for i, x := range reExtractors {
+		cases[i] = x.selectCase
+	}
+	cases[n] = reflect.SelectCase{
+		Dir:  reflect.SelectRecv,
+		Chan: reflect.ValueOf(timeout),
+	}
+
+	for notFound := n; notFound > 0; {
+		i, value, _ := reflect.Select(cases)
+		if i == n {
+			return nil, fmt.Errorf("could not extract some or all items from stderr: %q", extracts)
+		}
+		extracts[i] = value.String()
+		notFound--
+	}
+	return extracts, nil
+}
+
+// reExtractor extracts some information based on a regular expression from the
+// app output within a timeout.
+type reExtractor struct {
+	re         *regexp.Regexp
+	result     chan string
+	timeout    <-chan time.Time
+	selectCase reflect.SelectCase
+}
+
+// newREExtractor create a new reExtractor based on a regexp and a timeout.
+func newREExtractor(re *regexp.Regexp, timeout <-chan time.Time) *reExtractor {
+	result := make(chan string)
+	return &reExtractor{
+		re:      re,
+		result:  result,
+		timeout: timeout,
+		selectCase: reflect.SelectCase{
+			Dir:  reflect.SelectRecv,
+			Chan: reflect.ValueOf(result),
+		},
+	}
+}
+
+// extractRE is a line processor that extracts some information from a line
+// based on a regular expression. The function returns trun (to request the
+// caller to not to be called again) either when the match is found or due to
+// the timeout. The found match is written to the x.result channel and it is
+// important that this channel is monitored by a separate goroutine, otherwise
+// the function will block.
+func (x *reExtractor) extractRE(line string) bool {
+	submatch := x.re.FindSubmatch([]byte(line))
+	if len(submatch) == 2 {
+		select {
+		case x.result <- string(submatch[1]):
+		case <-x.timeout:
+		}
+		return true
+	}
+	return false
+}

--- a/apptest/client.go
+++ b/apptest/client.go
@@ -1,0 +1,141 @@
+package apptest
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// client is used for interacting with the apps over the network.
+//
+// At the moment it only supports HTTP protocol but may be exptended to support
+// RPCs, etc.
+type client struct {
+	httpCli *http.Client
+}
+
+// newClient creates a new client.
+func newClient() *client {
+	return &client{
+		httpCli: &http.Client{
+			Transport: &http.Transport{},
+		},
+	}
+}
+
+// closeConnections closes client connections.
+func (c *client) closeConnections() {
+	c.httpCli.CloseIdleConnections()
+}
+
+// apiV1Series retrieves the value of a metric that is made available by an app
+// at /metrics URL.
+func (c *client) getMetric(t *testing.T, metricsURL, metricName string) float64 {
+	t.Helper()
+
+	metrics := c.get(t, metricsURL, http.StatusOK)
+	for _, metric := range strings.Split(metrics, "\n") {
+		value, found := strings.CutPrefix(metric, metricName)
+		if found {
+			value = strings.Trim(value, " ")
+			res, err := strconv.ParseFloat(value, 64)
+			if err != nil {
+				t.Fatalf("could not parse metric value %s: %v", metric, err)
+			}
+			return res
+		}
+	}
+	t.Fatalf("metic not found: %s", metricName)
+	return 0
+}
+
+// apiV1SeriesResponse is an inmemory representation of the /api/v1/series
+// response.
+type apiV1SeriesResponse struct {
+	Status    string
+	IsPartial bool
+	Data      []map[string]string
+}
+
+// apiV1Series sends a query to a /api/v1/series endpoint and returns the list
+// of time series that match the query.
+func (c *client) apiV1Series(t *testing.T, seriesURL, matchQuery string) *apiV1SeriesResponse {
+	t.Helper()
+
+	values := url.Values{}
+	values.Add("match[]", matchQuery)
+	jsonRes := c.postForm(t, seriesURL, values, http.StatusOK)
+	var res apiV1SeriesResponse
+	if err := json.Unmarshal([]byte(jsonRes), &res); err != nil {
+		t.Fatalf("could not unmarshal /api/v1/series response: %v", err)
+	}
+	return &res
+}
+
+// postForm sends a HTTP GET request. Once the function receives a response, it
+// checks whether the response status code matches the expected one and returns
+// the response body to the caller.
+func (c *client) get(t *testing.T, url string, wantStatusCode int) string {
+	t.Helper()
+	return c.do(t, http.MethodGet, url, "", "", wantStatusCode)
+}
+
+// postForm sends a HTTP POST request. Once the function receives a response, it
+// checks whether the response status code matches the expected one and returns
+// the response body to the caller.
+func (c *client) post(t *testing.T, url, contentType, data string, wantStatusCode int) string {
+	t.Helper()
+	return c.do(t, http.MethodPost, url, contentType, data, wantStatusCode)
+}
+
+// postForm sends a HTTP POST request containing the POST-form data. Once the
+// function receives a response, it checks whether the response status code
+// matches the expected one and returns the response body to the caller.
+func (c *client) postForm(t *testing.T, url string, data url.Values, wantStatusCode int) string {
+	t.Helper()
+	return c.post(t, url, "application/x-www-form-urlencoded", data.Encode(), wantStatusCode)
+}
+
+// do prepares a HTTP request, sends it to the server, receives the response
+// from the server, ensures then response code matches the expected one, reads
+// the rentire response body and returns it to the caller.
+func (c *client) do(t *testing.T, method, url, contentType, data string, wantStatusCode int) string {
+	t.Helper()
+
+	req, err := http.NewRequest(method, url, strings.NewReader(data))
+	if err != nil {
+		t.Fatalf("could not create a HTTP request: %v", err)
+	}
+
+	if len(contentType) > 0 {
+		req.Header.Add("Content-Type", contentType)
+	}
+	res, err := c.httpCli.Do(req)
+	if err != nil {
+		t.Fatalf("could not send HTTP request: %v", err)
+	}
+
+	body := readAllAndClose(t, res.Body)
+
+	if got, want := res.StatusCode, wantStatusCode; got != want {
+		t.Fatalf("unexpected response code: got %d, want %d (body: %s)", got, want, body)
+	}
+
+	return body
+}
+
+// readAllAndClose reads everything from the response body and then closes it.
+func readAllAndClose(t *testing.T, responseBody io.ReadCloser) string {
+	t.Helper()
+
+	defer responseBody.Close()
+	b, err := io.ReadAll(responseBody)
+	if err != nil {
+		t.Fatalf("could not read response body: %d", err)
+	}
+	return string(b)
+}

--- a/apptest/sharding_test.go
+++ b/apptest/sharding_test.go
@@ -1,0 +1,95 @@
+package apptest
+
+import (
+	"fmt"
+	"math/rand/v2"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/fs"
+)
+
+func TestVminsertShardsDataVmselectBuildsFullResultFromShards(t *testing.T) {
+	defer testRemoveAll(t)
+
+	// Set up the following cluster configuration:
+	//
+	// - two vmstorage instances
+	// - vminsert points to the two vmstorages, its replication setting
+	//   is off which means it will only shard the incoming data across the two
+	//   vmstorages.
+	// - vmselect points to the two vmstorages and is expected to query both
+	//   vmstorages and build the full result out of the two partial results.
+
+	vmstorage1 := mustStartVmstorage(t, "vmstorage-1", []string{
+		"-storageDataPath=" + t.Name() + "/vmstorage-1",
+	})
+	defer vmstorage1.stop()
+	vmstorage2 := mustStartVmstorage(t, "vmstorage-2", []string{
+		"-storageDataPath=" + t.Name() + "/vmstorage-2",
+	})
+	defer vmstorage2.stop()
+	vminsert := mustStartVminsert(t, "vminsert", []string{
+		"-storageNode=" + vmstorage1.vminsertAddr + "," + vmstorage2.vminsertAddr,
+	})
+	defer vminsert.stop()
+	vmselect := mustStartVmselect(t, "vmselect", []string{
+		"-storageNode=" + vmstorage1.vmselectAddr + "," + vmstorage2.vmselectAddr,
+	})
+	defer vmselect.stop()
+
+	cli := newClient()
+	defer cli.closeConnections()
+
+	// Insert 1000 unique time series and verify the that inserted data has been
+	// indeed sharded by checking various metrics exposed by vminsert and
+	// vmstorage.
+	// Also wait for 2 seconds to let vminsert and vmstorage servers to update
+	// the values of the metrics they expose and to let vmstorages flush pending
+	// items so they become searchable.
+
+	const numMetrics = 1000
+	var records strings.Builder
+	for i := range numMetrics {
+		rec := fmt.Sprintf("metric_%d %d\n", i, rand.IntN(1000))
+		records.WriteString(rec)
+	}
+	insertURL := fmt.Sprintf("http://%s/insert/0/prometheus/api/v1/import/prometheus", vminsert.httpListenAddr)
+	cli.post(t, insertURL, "text/plain", records.String(), http.StatusNoContent)
+	time.Sleep(2 * time.Second)
+
+	numMetrics1 := int(cli.getMetric(t, vmstorage1.metricsURL, "vm_vminsert_metrics_read_total"))
+	if numMetrics1 == 0 {
+		t.Fatalf("storage-1 has no time series")
+	}
+	numMetrics2 := int(cli.getMetric(t, vmstorage2.metricsURL, "vm_vminsert_metrics_read_total"))
+	if numMetrics2 == 0 {
+		t.Fatalf("storage-2 has no time series")
+	}
+	if numMetrics1+numMetrics2 != numMetrics {
+		t.Fatalf("unxepected total number of metrics: vmstorage-1 (%d) + vmstorage-2 (%d) != %d", numMetrics1, numMetrics2, numMetrics)
+	}
+
+	// Retrieve all time series and verify that vmselect serves the complete set
+	//of time series.
+
+	selectURL := fmt.Sprintf("http://%s/select/0/prometheus/api/v1/series", vmselect.httpListenAddr)
+	series := cli.apiV1Series(t, selectURL, `{__name__=~".*"}`)
+	if got, want := series.Status, "success"; got != want {
+		t.Fatalf("unexpected /ap1/v1/series response status: got %s, want %s", got, want)
+	}
+	if got, want := series.IsPartial, false; got != want {
+		t.Fatalf("unexpected /ap1/v1/series response isPartial value: got %t, want %t", got, want)
+	}
+	if got, want := len(series.Data), numMetrics; got != want {
+		t.Fatalf("unexpected /ap1/v1/series response series count: got %d, want %d", got, want)
+	}
+}
+
+func testRemoveAll(t *testing.T) {
+	if !t.Failed() {
+		fs.MustRemoveAll(t.Name())
+	}
+}

--- a/apptest/vminsert.go
+++ b/apptest/vminsert.go
@@ -1,0 +1,46 @@
+package apptest
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+)
+
+type vminsert struct {
+	*app
+	httpListenAddr string
+}
+
+func mustStartVminsert(t *testing.T, instance string, flags []string) *vminsert {
+	t.Helper()
+
+	app, err := startVminsert(instance, flags)
+	if err != nil {
+		t.Fatalf("Could not start %s: %v", instance, err)
+	}
+
+	return app
+}
+
+func startVminsert(instance string, flags []string) (*vminsert, error) {
+	app, stderrExtracts, err := startApp(instance, "../bin/vminsert", flags, &appOptions{
+		defaultFlags: map[string]string{
+			"-httpListenAddr": "127.0.0.1:0",
+		},
+		extractREs: []*regexp.Regexp{
+			httpListenAddrRE,
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &vminsert{
+		app:            app,
+		httpListenAddr: stderrExtracts[0],
+	}, nil
+}
+
+func (app *vminsert) String() string {
+	return fmt.Sprintf("{app: %s httpListenAddr: %q}", app.app, app.httpListenAddr)
+}

--- a/apptest/vmselect.go
+++ b/apptest/vmselect.go
@@ -1,0 +1,46 @@
+package apptest
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+)
+
+type vmselect struct {
+	*app
+	httpListenAddr string
+}
+
+func mustStartVmselect(t *testing.T, instance string, flags []string) *vmselect {
+	t.Helper()
+
+	app, err := startVmselect(instance, flags)
+	if err != nil {
+		t.Fatalf("Could not start %s: %v", instance, err)
+	}
+
+	return app
+}
+
+func startVmselect(instance string, flags []string) (*vmselect, error) {
+	app, stderrExtracts, err := startApp(instance, "../bin/vmselect", flags, &appOptions{
+		defaultFlags: map[string]string{
+			"-httpListenAddr": "127.0.0.1:0",
+		},
+		extractREs: []*regexp.Regexp{
+			httpListenAddrRE,
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &vmselect{
+		app:            app,
+		httpListenAddr: stderrExtracts[0],
+	}, nil
+}
+
+func (app *vmselect) String() string {
+	return fmt.Sprintf("{app: %s httpListenAddr: %q}", app.app, app.httpListenAddr)
+}

--- a/apptest/vmstorage.go
+++ b/apptest/vmstorage.go
@@ -1,0 +1,63 @@
+package apptest
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"testing"
+	"time"
+)
+
+type vmstorage struct {
+	*app
+	storageDataPath string
+	httpListenAddr  string
+	vminsertAddr    string
+	vmselectAddr    string
+	metricsURL      string
+}
+
+func mustStartVmstorage(t *testing.T, instance string, flags []string) *vmstorage {
+	t.Helper()
+
+	app, err := startVmstorage(instance, flags)
+	if err != nil {
+		t.Fatalf("Could not start %s: %v", instance, err)
+	}
+
+	return app
+}
+
+func startVmstorage(instance string, flags []string) (*vmstorage, error) {
+	app, stderrExtracts, err := startApp(instance, "../bin/vmstorage", flags, &appOptions{
+		defaultFlags: map[string]string{
+			"-storageDataPath": fmt.Sprintf("%s/%s-%d", os.TempDir(), instance, time.Now().UnixNano()),
+			"-httpListenAddr":  "127.0.0.1:0",
+			"-vminsertAddr":    "127.0.0.1:0",
+			"-vmselectAddr":    "127.0.0.1:0",
+		},
+		extractREs: []*regexp.Regexp{
+			storageDataPathRE,
+			httpListenAddrRE,
+			vminsertAddrRE,
+			vmselectAddrRE,
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &vmstorage{
+		app:             app,
+		storageDataPath: stderrExtracts[0],
+		httpListenAddr:  stderrExtracts[1],
+		vminsertAddr:    stderrExtracts[2],
+		vmselectAddr:    stderrExtracts[3],
+		metricsURL:      fmt.Sprintf("http://%s/metrics", stderrExtracts[1]),
+	}, nil
+}
+
+func (app *vmstorage) String() string {
+	return fmt.Sprintf("{app: %s storageDataPath: %q httpListenAddr: %q vminsertAddr: %q vmselectAddr: %q}", []any{
+		app.app, app.storageDataPath, app.httpListenAddr, app.vminsertAddr, app.vmselectAddr}...)
+}

--- a/lib/httpserver/httpserver.go
+++ b/lib/httpserver/httpserver.go
@@ -114,12 +114,6 @@ func serve(addr string, useProxyProtocol bool, rh RequestHandler, idx int) {
 	if tlsEnable.GetOptionalArg(idx) {
 		scheme = "https"
 	}
-	hostAddr := addr
-	if strings.HasPrefix(hostAddr, ":") {
-		hostAddr = "127.0.0.1" + hostAddr
-	}
-	logger.Infof("starting server at %s://%s/", scheme, hostAddr)
-	logger.Infof("pprof handlers are exposed at %s://%s/debug/pprof/", scheme, hostAddr)
 	var tlsConfig *tls.Config
 	if tlsEnable.GetOptionalArg(idx) {
 		certFile := tlsCertFile.GetOptionalArg(idx)
@@ -134,6 +128,9 @@ func serve(addr string, useProxyProtocol bool, rh RequestHandler, idx int) {
 	ln, err := netutil.NewTCPListener(scheme, addr, useProxyProtocol, tlsConfig)
 	if err != nil {
 		logger.Fatalf("cannot start http server at %s: %s", addr, err)
+	} else {
+		logger.Infof("started server at %s://%s/", scheme, ln.Addr())
+		logger.Infof("pprof handlers are exposed at %s://%s/debug/pprof/", scheme, ln.Addr())
 	}
 	serveWithListener(addr, ln, rh)
 }


### PR DESCRIPTION
### Describe Your Changes

Related issue: #7199 

This is the initial version of the integration tests for cluster. See `README.md` for details.

Currently cluster only, but it can also be used for vm-single if needed.

The code has been added to the apptest package that resides in the root directory of the VM codebase. This is done to exclude the integration tests from regular testing build targets because:

- Most of the test variants do not apply to integration testing (such as pure or race).
- The integtation tests may also be slow because each test must wait for 2 seconds so vmstorage flushes pending content). It may be okay when there are a few tests but when there is a 100 of them running tests will require much more time which will affect the developer wait time and CI workflows.
- Finally, the integration tests may be flaky especially short term.

An alternative approach would be placing apptest under app package and exclude apptest from packages under test, but that is not trivial.

The integration tests rely on retrieving some application runtime info from the application logs, namely the application's host:port. Therefore some changes to lib/httpserver/httpserver.go were necessary, such as reporting the effective host:port instead the one from the flag.

### Checklist

The following checks are **mandatory**:

- [x] My change adheres [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/contributing/).
