### PR TITLE
vmalert-tool: add more syntax checks for `input_series` and `exp_samples`

### DIFF
--- a/app/vmalert-tool/unittest/input.go
+++ b/app/vmalert-tool/unittest/input.go
@@ -43,18 +43,33 @@ func httpWrite(address string, r io.Reader) {
 // writeInputSeries send input series to vmstorage and flush them
 func writeInputSeries(input []series, interval *promutils.Duration, startStamp time.Time, dst string) error {
 	r := testutil.WriteRequest{}
+	var err error
+	r.Timeseries, err = parseInputSeries(input, interval, startStamp)
+	if err != nil {
+		return err
+	}
+
+	data := testutil.Compress(r)
+	// write input series to vm
+	httpWrite(dst, bytes.NewBuffer(data))
+	vmstorage.Storage.DebugFlush()
+	return nil
+}
+
+func parseInputSeries(input []series, interval *promutils.Duration, startStamp time.Time) ([]testutil.TimeSeries, error) {
+	var res []testutil.TimeSeries
 	for _, data := range input {
 		expr, err := metricsql.Parse(data.Series)
 		if err != nil {
-			return fmt.Errorf("failed to parse series %s: %v", data.Series, err)
+			return res, fmt.Errorf("failed to parse series %s: %v", data.Series, err)
 		}
 		promvals, err := parseInputValue(data.Values, true)
 		if err != nil {
-			return fmt.Errorf("failed to parse input series value %s: %v", data.Values, err)
+			return res, fmt.Errorf("failed to parse input series value %s: %v", data.Values, err)
 		}
 		metricExpr, ok := expr.(*metricsql.MetricExpr)
-		if !ok {
-			return fmt.Errorf("failed to parse series %s to metric expr: %v", data.Series, err)
+		if !ok || len(metricExpr.LabelFilterss) != 1 {
+			return res, fmt.Errorf("got invalid input series %s: %v", data.Series, err)
 		}
 		samples := make([]testutil.Sample, 0, len(promvals))
 		ts := startStamp
@@ -71,14 +86,9 @@ func writeInputSeries(input []series, interval *promutils.Duration, startStamp t
 		for _, filter := range metricExpr.LabelFilterss[0] {
 			ls = append(ls, testutil.Label{Name: filter.Label, Value: filter.Value})
 		}
-		r.Timeseries = append(r.Timeseries, testutil.TimeSeries{Labels: ls, Samples: samples})
+		res = append(res, testutil.TimeSeries{Labels: ls, Samples: samples})
 	}
-
-	data := testutil.Compress(r)
-	// write input series to vm
-	httpWrite(dst, bytes.NewBuffer(data))
-	vmstorage.Storage.DebugFlush()
-	return nil
+	return res, nil
 }
 
 // parseInputValue support input like "1", "1+1x1 _ -4 3+20x1", see more examples in test.

--- a/app/vmalert-tool/unittest/recording.go
+++ b/app/vmalert-tool/unittest/recording.go
@@ -57,16 +57,18 @@ Outer:
 					continue Outer
 				}
 				metricsqlMetricExpr, ok := metricsqlExpr.(*metricsql.MetricExpr)
-				if !ok {
+				if !ok || len(metricsqlMetricExpr.LabelFilterss) > 1 {
 					checkErrs = append(checkErrs, fmt.Errorf("\n    expr: %q, time: %s, err: %v", mt.Expr,
-						mt.EvalTime.Duration().String(), fmt.Errorf("got unsupported metricsql type")))
+						mt.EvalTime.Duration().String(), fmt.Errorf("got invalid exp_samples: %q", s.Labels)))
 					continue Outer
 				}
-				for _, l := range metricsqlMetricExpr.LabelFilterss[0] {
-					expLb = append(expLb, datasource.Label{
-						Name:  l.Label,
-						Value: l.Value,
-					})
+				if len(metricsqlMetricExpr.LabelFilterss) > 0 {
+					for _, l := range metricsqlMetricExpr.LabelFilterss[0] {
+						expLb = append(expLb, datasource.Label{
+							Name:  l.Label,
+							Value: l.Value,
+						})
+					}
 				}
 			}
 			sort.Slice(expLb, func(i, j int) bool {

--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -30,8 +30,7 @@ See also [LTS releases](https://docs.victoriametrics.com/lts-releases/).
 * BUGFIX: [vmui](https://docs.victoriametrics.com/#vmui): fix error messages rendering from overflowing the screen with long messages. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/7207).
 * BUGFIX: [vmctl](https://docs.victoriametrics.com/vmctl/): properly add metrics tags for `opentsdb` migration source. Previously it could have empty values. See [this PR](https://github.com/VictoriaMetrics/VictoriaMetrics/pull/7161).
 * BUGFIX: [vmalert-tool](https://docs.victoriametrics.com/vmalert-tool/): reduce the initial health check interval for datasource. This reduces the time spent on evaluating rules by vmalert-tool. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/6970).
-
-* BUGFIX: [vmalert-tool](https://docs.victoriametrics.com/vmalert-tool/): add more syntax checks for `input_series` and `exp_samples`.
+* BUGFIX: [vmalert-tool](https://docs.victoriametrics.com/vmalert-tool/): allow specifying empty labels list `labels: '{}'` in the same way as promtool does. This improves compatibility between these tools.
 
 ## [v1.104.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.104.0)
 

--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -31,6 +31,8 @@ See also [LTS releases](https://docs.victoriametrics.com/lts-releases/).
 * BUGFIX: [vmctl](https://docs.victoriametrics.com/vmctl/): properly add metrics tags for `opentsdb` migration source. Previously it could have empty values. See [this PR](https://github.com/VictoriaMetrics/VictoriaMetrics/pull/7161).
 * BUGFIX: [vmalert-tool](https://docs.victoriametrics.com/vmalert-tool/): reduce the initial health check interval for datasource. This reduces the time spent on evaluating rules by vmalert-tool. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/6970).
 
+* BUGFIX: [vmalert-tool](https://docs.victoriametrics.com/vmalert-tool/): add more syntax checks for `input_series` and `exp_samples`.
+
 ## [v1.104.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.104.0)
 
 Released at 2024-10-02


### PR DESCRIPTION
address https://github.com/VictoriaMetrics/VictoriaMetrics/issues/7224, allow using 
```
        exp_samples:
          - labels: '{}'
```
for prometheus compatibility.