### PR TITLE
lib/storage: properly unmarshal SearchQuery

### DIFF
--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -28,7 +28,7 @@ See also [LTS releases](https://docs.victoriametrics.com/lts-releases/).
 
 * BUGFIX: [vmgateway](https://docs.victoriametrics.com/vmgateway/): fix possible panic during parsing of a token without `vm_access` claim. This issue was introduced in v1.104.0.
 * BUGFIX: [vmui](https://docs.victoriametrics.com/#vmui): fix error messages rendering from overflowing the screen with long messages. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/7207).
-* BUGFIX: `vmselect` in [VictoriaMetrics cluster](https://docs.victoriametrics.com/cluster-victoriametrics/): properly query metrics at multi-level cluster setup. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/7270) for details.
+* BUGFIX: `vmselect` in [VictoriaMetrics cluster](https://docs.victoriametrics.com/cluster-victoriametrics/): properly process response in [multi-level cluster setup](https://docs.victoriametrics.com/cluster-victoriametrics/#multi-level-cluster-setup). Before, vmselect could return no data in multi-level setup. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/7270) for details. The issue was introduced in [v1.104.0](https://docs.victoriametrics.com/changelog/#v11040).
 
 ## [v1.104.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.104.0)
 

--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -28,6 +28,7 @@ See also [LTS releases](https://docs.victoriametrics.com/lts-releases/).
 
 * BUGFIX: [vmgateway](https://docs.victoriametrics.com/vmgateway/): fix possible panic during parsing of a token without `vm_access` claim. This issue was introduced in v1.104.0.
 * BUGFIX: [vmui](https://docs.victoriametrics.com/#vmui): fix error messages rendering from overflowing the screen with long messages. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/7207).
+* BUGFIX: `vmselect` in [VictoriaMetrics cluster](https://docs.victoriametrics.com/cluster-victoriametrics/): properly query metrics at multi-level cluster setup. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/7270) for details.
 
 ## [v1.104.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.104.0)
 

--- a/lib/storage/search.go
+++ b/lib/storage/search.go
@@ -277,9 +277,9 @@ type SearchQuery struct {
 	AccountID uint32
 	ProjectID uint32
 
-	// TenantTokens and IsMultiTenant is artifical fields
-	// it's only exist at runtime and cannot be transefered
-	// via network calls due to keep communitcation protocol compatible
+	// TenantTokens and IsMultiTenant is artificial fields
+	// they're only exist at runtime and cannot be transferred
+	// via network calls for keeping communication protocol compatibility
 	// TODO:@f41gh7 introduce breaking change to the protocol later
 	// and use TenantTokens instead of AccountID and ProjectID
 	TenantTokens  []TenantToken

--- a/lib/storage/search.go
+++ b/lib/storage/search.go
@@ -314,8 +314,6 @@ func NewSearchQuery(accountID, projectID uint32, start, end int64, tagFilterss [
 		maxMetrics = 2e9
 	}
 	return &SearchQuery{
-		AccountID:    accountID,
-		ProjectID:    projectID,
 		MinTimestamp: start,
 		MaxTimestamp: end,
 		TagFilterss:  tagFilterss,

--- a/lib/storage/search.go
+++ b/lib/storage/search.go
@@ -277,6 +277,11 @@ type SearchQuery struct {
 	AccountID uint32
 	ProjectID uint32
 
+	// TenantTokens and IsMultiTenant is artifical fields
+	// it's only exist at runtime and cannot be transefered
+	// via network calls due to keep communitcation protocol compatible
+	// TODO:@f41gh7 introduce breaking change to the protocol later
+	// and use TenantTokens instead of AccountID and ProjectID
 	TenantTokens  []TenantToken
 	IsMultiTenant bool
 
@@ -309,6 +314,8 @@ func NewSearchQuery(accountID, projectID uint32, start, end int64, tagFilterss [
 		maxMetrics = 2e9
 	}
 	return &SearchQuery{
+		AccountID:    accountID,
+		ProjectID:    projectID,
 		MinTimestamp: start,
 		MaxTimestamp: end,
 		TagFilterss:  tagFilterss,
@@ -505,6 +512,7 @@ func (sq *SearchQuery) Unmarshal(src []byte) ([]byte, error) {
 	sq.ProjectID = encoding.UnmarshalUint32(src)
 	src = src[4:]
 
+	sq.TenantTokens = []TenantToken{{AccountID: sq.AccountID, ProjectID: sq.ProjectID}}
 	minTs, nSize := encoding.UnmarshalVarInt64(src)
 	if nSize <= 0 {
 		return src, fmt.Errorf("cannot unmarshal MinTimestamp from varint")


### PR DESCRIPTION
After adding multitenant query feature at v1.104.0, searchQuery wasn't properly unmarshalled at bottom vmselect in multi-level cluster setup. It resulted into empty query responses.

 This commit adds fallback to Unmarshal method of SearchQuery to fill TenantTokens. It allows to properly execute search requests
at vmselect side.

Related issue: https://github.com/VictoriaMetrics/VictoriaMetrics/issues/7270

### Describe Your Changes

Please provide a brief description of the changes you made. Be as specific as possible to help others understand the purpose and impact of your modifications.

### Checklist

The following checks are **mandatory**:

- [ ] My change adheres [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/contributing/).
