### PR TITLE
lib/flagutil: rename Duration to RetentionDuration

### DIFF
--- a/app/vlstorage/main.go
+++ b/app/vlstorage/main.go
@@ -18,12 +18,12 @@ import (
 )
 
 var (
-	retentionPeriod = flagutil.NewDuration("retentionPeriod", "7d", "Log entries with timestamps older than now-retentionPeriod are automatically deleted; "+
+	retentionPeriod = flagutil.NewRetentionDuration("retentionPeriod", "7d", "Log entries with timestamps older than now-retentionPeriod are automatically deleted; "+
 		"log entries with timestamps outside the retention are also rejected during data ingestion; the minimum supported retention is 1d (one day); "+
 		"see https://docs.victoriametrics.com/victorialogs/#retention ; see also -retention.maxDiskSpaceUsageBytes")
 	maxDiskSpaceUsageBytes = flagutil.NewBytes("retention.maxDiskSpaceUsageBytes", 0, "The maximum disk space usage at -storageDataPath before older per-day "+
 		"partitions are automatically dropped; see https://docs.victoriametrics.com/victorialogs/#retention-by-disk-space-usage ; see also -retentionPeriod")
-	futureRetention = flagutil.NewDuration("futureRetention", "2d", "Log entries with timestamps bigger than now+futureRetention are rejected during data ingestion; "+
+	futureRetention = flagutil.NewRetentionDuration("futureRetention", "2d", "Log entries with timestamps bigger than now+futureRetention are rejected during data ingestion; "+
 		"see https://docs.victoriametrics.com/victorialogs/#retention")
 	storageDataPath = flag.String("storageDataPath", "victoria-logs-data", "Path to directory where to store VictoriaLogs data; "+
 		"see https://docs.victoriametrics.com/victorialogs/#storage")

--- a/app/vmselect/promql/eval.go
+++ b/app/vmselect/promql/eval.go
@@ -44,7 +44,7 @@ var (
 		"See also -search.logSlowQueryDuration and -search.maxMemoryPerQuery")
 	noStaleMarkers = flag.Bool("search.noStaleMarkers", false, "Set this flag to true if the database doesn't contain Prometheus stale markers, "+
 		"so there is no need in spending additional CPU time on its handling. Staleness markers may exist only in data obtained from Prometheus scrape targets")
-	minWindowForInstantRollupOptimization = flagutil.NewDuration("search.minWindowForInstantRollupOptimization", "3h", "Enable cache-based optimization for repeated queries "+
+	minWindowForInstantRollupOptimization = flag.Duration("search.minWindowForInstantRollupOptimization", time.Hour*3, "Enable cache-based optimization for repeated queries "+
 		"to /api/v1/query (aka instant queries), which contain rollup functions with lookbehind window exceeding the given value")
 )
 

--- a/app/vmstorage/main.go
+++ b/app/vmstorage/main.go
@@ -27,11 +27,11 @@ import (
 )
 
 var (
-	retentionPeriod   = flagutil.NewDuration("retentionPeriod", "1", "Data with timestamps outside the retentionPeriod is automatically deleted. The minimum retentionPeriod is 24h or 1d. See also -retentionFilter")
+	retentionPeriod   = flagutil.NewRetentionDuration("retentionPeriod", "1", "Data with timestamps outside the retentionPeriod is automatically deleted. The minimum retentionPeriod is 24h or 1d. See also -retentionFilter")
 	snapshotAuthKey   = flagutil.NewPassword("snapshotAuthKey", "authKey, which must be passed in query string to /snapshot* pages. It overrides -httpAuth.*")
 	forceMergeAuthKey = flagutil.NewPassword("forceMergeAuthKey", "authKey, which must be passed in query string to /internal/force_merge pages. It overrides -httpAuth.*")
 	forceFlushAuthKey = flagutil.NewPassword("forceFlushAuthKey", "authKey, which must be passed in query string to /internal/force_flush pages. It overrides -httpAuth.*")
-	snapshotsMaxAge   = flagutil.NewDuration("snapshotsMaxAge", "0", "Automatically delete snapshots older than -snapshotsMaxAge if it is set to non-zero duration. Make sure that backup process has enough time to finish the backup before the corresponding snapshot is automatically deleted")
+	snapshotsMaxAge   = flagutil.NewRetentionDuration("snapshotsMaxAge", "0", "Automatically delete snapshots older than -snapshotsMaxAge if it is set to non-zero duration. Make sure that backup process has enough time to finish the backup before the corresponding snapshot is automatically deleted")
 	_                 = flag.Duration("snapshotCreateTimeout", 0, "Deprecated: this flag does nothing")
 
 	precisionBits = flag.Int("precisionBits", 64, "The number of precision bits to store per each value. Lower precision bits improves data compression at the cost of precision loss")

--- a/lib/flagutil/duration.go
+++ b/lib/flagutil/duration.go
@@ -10,13 +10,13 @@ import (
 	"github.com/VictoriaMetrics/metricsql"
 )
 
-// NewDuration returns new `duration` flag with the given name, defaultValue and description.
+// NewRetentionDuration returns new `duration` flag with the given name, defaultValue and description.
 //
 // DefaultValue is in months.
-func NewDuration(name string, defaultValue string, description string) *Duration {
+func NewRetentionDuration(name string, defaultValue string, description string) *RetentionDuration {
 	description += "\nThe following optional suffixes are supported: s (second), h (hour), d (day), w (week), y (year). " +
 		"If suffix isn't set, then the duration is counted in months"
-	d := &Duration{}
+	d := &RetentionDuration{}
 	if err := d.Set(defaultValue); err != nil {
 		panic(fmt.Sprintf("BUG: can not parse default value %s for flag %s", defaultValue, name))
 	}
@@ -24,8 +24,8 @@ func NewDuration(name string, defaultValue string, description string) *Duration
 	return d
 }
 
-// Duration is a flag for holding duration.
-type Duration struct {
+// RetentionDuration is a flag for holding duration for retention period.
+type RetentionDuration struct {
 	// msecs contains parsed duration in milliseconds.
 	msecs int64
 
@@ -33,22 +33,24 @@ type Duration struct {
 }
 
 // Duration returns d as time.Duration
-func (d *Duration) Duration() time.Duration {
+func (d *RetentionDuration) Duration() time.Duration {
 	return time.Millisecond * time.Duration(d.msecs)
 }
 
 // Milliseconds returns d in milliseconds
-func (d *Duration) Milliseconds() int64 {
+func (d *RetentionDuration) Milliseconds() int64 {
 	return d.msecs
 }
 
 // String implements flag.Value interface
-func (d *Duration) String() string {
+func (d *RetentionDuration) String() string {
 	return d.valueString
 }
 
 // Set implements flag.Value interface
-func (d *Duration) Set(value string) error {
+// It assumes that value without unit should be parsed as `month` duration.
+// It returns an error iv value has `m` unit.
+func (d *RetentionDuration) Set(value string) error {
 	if value == "" {
 		d.msecs = 0
 		d.valueString = ""

--- a/lib/flagutil/duration_test.go
+++ b/lib/flagutil/duration_test.go
@@ -9,7 +9,7 @@ import (
 func TestDurationSetFailure(t *testing.T) {
 	f := func(value string) {
 		t.Helper()
-		var d Duration
+		var d RetentionDuration
 		if err := d.Set(value); err == nil {
 			t.Fatalf("expecting non-nil error in d.Set(%q)", value)
 		}
@@ -31,14 +31,14 @@ func TestDurationSetFailure(t *testing.T) {
 	f("-1")
 	f("-34h")
 
-	// Duration in minutes is confused with duration in months
+	// RetentionDuration in minutes is confused with duration in months
 	f("1m")
 }
 
 func TestDurationSetSuccess(t *testing.T) {
 	f := func(value string, expectedMsecs int64) {
 		t.Helper()
-		var d Duration
+		var d RetentionDuration
 		if err := d.Set(value); err != nil {
 			t.Fatalf("unexpected error in d.Set(%q): %s", value, err)
 		}
@@ -66,7 +66,7 @@ func TestDurationSetSuccess(t *testing.T) {
 func TestDurationDuration(t *testing.T) {
 	f := func(value string, expected time.Duration) {
 		t.Helper()
-		var d Duration
+		var d RetentionDuration
 		if err := d.Set(value); err != nil {
 			t.Fatalf("unexpected error in d.Set(%q): %s", value, err)
 		}


### PR DESCRIPTION
The purpose of this change is to reduce confusion between using `flag.Duration` and `flagutils.Duration`. The reason is that `flagutils.Duration` was mistakenly used for cases that required `m` support. See https://github.com/VictoriaMetrics/VictoriaMetrics/commit/ab0d31a7b0050b58781b618b87c07308c880ecac

The change in name should clearly indicate the purpose of this data type.

### Describe Your Changes

Please provide a brief description of the changes you made. Be as specific as possible to help others understand the purpose and impact of your modifications.

### Checklist

The following checks are **mandatory**:

- [ ] My change adheres [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/contributing/).
