### PR TITLE
vmalert: properly set `group_name` and `file` fields for recording rules

### DIFF
--- a/app/vmalert/web_types.go
+++ b/app/vmalert/web_types.go
@@ -215,8 +215,10 @@ func recordingToAPI(rr *rule.RecordingRule) apiRule {
 		Updates:           rule.GetAllRuleState(rr),
 
 		// encode as strings to avoid rounding
-		ID:      fmt.Sprintf("%d", rr.ID()),
-		GroupID: fmt.Sprintf("%d", rr.GroupID),
+		ID:        fmt.Sprintf("%d", rr.ID()),
+		GroupID:   fmt.Sprintf("%d", rr.GroupID),
+		GroupName: rr.GroupName,
+		File:      rr.File,
 	}
 	if lastState.Err != nil {
 		r.LastError = lastState.Err.Error()

--- a/app/vmalert/web_types_test.go
+++ b/app/vmalert/web_types_test.go
@@ -1,8 +1,55 @@
 package main
 
 import (
+	"fmt"
+	"github.com/VictoriaMetrics/VictoriaMetrics/app/vmalert/config"
+	"github.com/VictoriaMetrics/VictoriaMetrics/app/vmalert/datasource"
+	"github.com/VictoriaMetrics/VictoriaMetrics/app/vmalert/rule"
+	"reflect"
 	"testing"
 )
+
+func TestRecordingToApi(t *testing.T) {
+	fq := &datasource.FakeQuerier{}
+	fq.Add(datasource.Metric{
+		Values: []float64{1}, Timestamps: []int64{0},
+	})
+	g := &rule.Group{
+		Name:        "group",
+		File:        "rules.yaml",
+		Concurrency: 1,
+	}
+
+	entriesLimit := 44
+	rr := rule.NewRecordingRule(fq, g, config.Rule{
+		ID:                 1248,
+		Record:             "record_name",
+		Expr:               "up",
+		Labels:             map[string]string{"label": "value"},
+		UpdateEntriesLimit: &entriesLimit,
+	})
+
+	expectedRes := apiRule{
+		Name:           "record_name",
+		Query:          "up",
+		Labels:         map[string]string{"label": "value"},
+		Health:         "ok",
+		Type:           ruleTypeRecording,
+		DatasourceType: "prometheus",
+		ID:             "1248",
+		GroupID:        fmt.Sprintf("%d", g.ID()),
+		GroupName:      "group",
+		File:           "rules.yaml",
+		MaxUpdates:     44,
+		Updates:        make([]rule.StateEntry, 0),
+	}
+
+	res := recordingToAPI(rr)
+
+	if !reflect.DeepEqual(res, expectedRes) {
+		t.Fatalf("expected to have: \n%v;\ngot: \n%v", expectedRes, res)
+	}
+}
 
 func TestUrlValuesToStrings(t *testing.T) {
 	mapQueryParams := map[string][]string{

--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -18,6 +18,8 @@ See also [LTS releases](https://docs.victoriametrics.com/lts-releases/).
 
 ## tip
 
+* BUGFIX: [vmalert](https://docs.victoriametrics.com/vmalert): properly set `group_name` and `file` fields for recording rules in `/api/v1/rules`.
+
 ## [v1.105.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.105.0)
 
 Released at 2024-10-21


### PR DESCRIPTION
### Describe Your Changes

Adds group_name and file fields for recording rules where they were previously left blank.

See issue #7297

### Checklist

The following checks are **mandatory**:

- [x] My change adheres [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/contributing/).
