### PR TITLE
vmctl: fixed import duplicate data when query result contains multiple series

### DIFF
--- a/app/vmctl/influx.go
+++ b/app/vmctl/influx.go
@@ -146,7 +146,7 @@ func (ip *influxProcessor) do(s *influx.Series) error {
 	}
 
 	for {
-		time, values, err := cr.Next()
+		time, values, err := cr.Next(s)
 		if err != nil {
 			if err == io.EOF {
 				return nil

--- a/app/vmctl/influx/influx.go
+++ b/app/vmctl/influx/influx.go
@@ -199,7 +199,7 @@ func (cr *ChunkedResponse) Close() error {
 
 // Next reads the next part/chunk of time series.
 // Returns io.EOF when time series was read entirely.
-func (cr *ChunkedResponse) Next() ([]int64, []float64, error) {
+func (cr *ChunkedResponse) Next(s *Series) ([]int64, []float64, error) {
 	resp, err := cr.cr.NextResponse()
 	if err != nil {
 		return nil, nil, err
@@ -210,7 +210,7 @@ func (cr *ChunkedResponse) Next() ([]int64, []float64, error) {
 	if len(resp.Results) != 1 {
 		return nil, nil, fmt.Errorf("unexpected number of results in response: %d", len(resp.Results))
 	}
-	results, err := parseResult(resp.Results[0])
+	results, err := parseResultCheckTags(s, resp.Results[0])
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
### Describe Your Changes

Fix https://github.com/VictoriaMetrics/VictoriaMetrics/issues/7301

When querying with condition like `WHERE a=1` (looking for series A), InfluxDB can return data with the tag `a=1` (series A) and data with the tag `a=1,b=1` (series B).

However, series B is will be queried later and it's data should not be combined into series A's data. 

This PR filter those series that are not identical to the original query condition.

### Checklist

The following checks are **mandatory**:

- [x] My change adheres [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/contributing/).
