### PR TITLE
Introducing VictoriaMetrics Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![Go Report](https://goreportcard.com/badge/github.com/VictoriaMetrics/VictoriaMetrics)](https://goreportcard.com/report/github.com/VictoriaMetrics/VictoriaMetrics)
 [![Build Status](https://github.com/VictoriaMetrics/VictoriaMetrics/workflows/main/badge.svg)](https://github.com/VictoriaMetrics/VictoriaMetrics/actions)
 [![codecov](https://codecov.io/gh/VictoriaMetrics/VictoriaMetrics/branch/master/graph/badge.svg)](https://codecov.io/gh/VictoriaMetrics/VictoriaMetrics)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20VictoriaMetrics%20Guru-006BFF)](https://gurubase.io/g/victoriametrics)
 
 <picture>
   <source srcset="docs/logo_white.webp" media="(prefers-color-scheme: dark)">


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [VictoriaMetrics Guru](https://gurubase.io/g/victoriametrics) to Gurubase. VictoriaMetrics Guru uses the data from this repo and data from the [docs](https://docs.victoriametrics.com/quick-start/) to answer questions by leveraging the LLM.

In this PR, I showcased the "VictoriaMetrics Guru", which highlights that VictoriaMetrics now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable VictoriaMetrics Guru in Gurubase, just let me know that's totally fine.