### PR TITLE
Fix flaky test TestWriteRead/read/graphite/subquery-aggregation

### DIFF
--- a/app/victoria-metrics/testdata/graphite/subquery-aggregation.json
+++ b/app/victoria-metrics/testdata/graphite/subquery-aggregation.json
@@ -2,10 +2,10 @@
   "name": "subquery-aggregation",
   "issue": "https://github.com/VictoriaMetrics/VictoriaMetrics/issues/184",
   "data": [
-    "forms_daily_count;item=x 1 {TIME_S-1m}",
-    "forms_daily_count;item=x 2 {TIME_S-2m}",
-    "forms_daily_count;item=y 3 {TIME_S-1m}",
-    "forms_daily_count;item=y 4 {TIME_S-2m}"],
+    "forms_daily_count;item=x 1 {TIME_S-59s}",
+    "forms_daily_count;item=x 2 {TIME_S-1m59s}",
+    "forms_daily_count;item=y 3 {TIME_S-59s}",
+    "forms_daily_count;item=y 4 {TIME_S-1m59s}"],
   "query": ["/api/v1/query?query=min%20by%20(item)%20(min_over_time(forms_daily_count[10m:1m]))&time={TIME_S-1m}&latency_offset=1ms"],
   "result_query": {
     "status":"success",


### PR DESCRIPTION
### Describe Your Changes

Fix the flaky test by adjusting test data, see #6983.

Test in question: `TestWriteRead/read/graphite2/subquery-aggregation`

Its config (query and data):

```
$ cat app/victoria-metrics/testdata/graphite/subquery-aggregation.json 
{
  "name": "subquery-aggregation",
  "issue": "https://github.com/VictoriaMetrics/VictoriaMetrics/issues/184",
  "data": [
    "forms_daily_count;item=x 1 {TIME_S-1m}",
    "forms_daily_count;item=x 2 {TIME_S-2m}",
    "forms_daily_count;item=y 3 {TIME_S-1m}",
    "forms_daily_count;item=y 4 {TIME_S-2m}"],
  "query": ["/api/v1/query?query=min%20by%20(item)%20(min_over_time(forms_daily_count[10m:1m]))&time={TIME_S-1m}&latency_offset=1ms"],
  "result_query": {
    "status":"success",
    "data":{"resultType":"vector","result":[{"metric":{"item":"x"},"value":["{TIME_S-1m}","2"]},{"metric":{"item":"y"},"value":["{TIME_S-1m}","4"]}]}
  }
}
```

The test fails under certain circumstances. Namely, when the test execution falls on the first second of a minute. For example, the test passes when it runs at `TIME_S=06:59:01Z` but fails when run at `TIME_S=06:59:00Z`. This is due to how VictoriaMetrics implements subqueries.

Let's consider an example. Say we have the following samples:

```
curl http://localhost:8428/api/v1/import/prometheus -d "metric1 1 1730357880"
curl http://localhost:8428/api/v1/import/prometheus -d "metric2 1 1730357881"
curl http://localhost:8428/api/v1/import/prometheus -d "metric1 2 1730357820"
curl http://localhost:8428/api/v1/import/prometheus -d "metric2 2 1730357821"
```

![data](https://github.com/user-attachments/assets/acdab3e3-8382-4a95-a47d-036af23343e4)


Let's execute the innermost query `metric1[10m:1m]` (which is the default_rollup with custom precision?) at `06:58:00Z`:

```
curl http://localhost:8428/prometheus/api/v1/query -d 'query=metric1[10m:1m]' -d 'time=2024-10-31T06:58:00Z' -d 'step=5m' | jq .
curl http://localhost:8428/prometheus/api/v1/query -d 'query=metric2[10m:1m]' -d 'time=2024-10-31T06:58:00Z' -d 'step=5m' | jq .
```

![vmui-1](https://github.com/user-attachments/assets/0cfd4875-6103-4cc5-ad03-ea4ba371e7f9)


We get 2 points for metric1 and one for metric2. This is expected because the metric2 second point is out of range.

Now let's execute the innermost query `metric1[10m:1m]` at `06:58:01Z`:

```
curl http://localhost:8428/prometheus/api/v1/query -d 'query=metric1[10m:1m]' -d 'time=2024-10-31T06:58:01Z' -d 'step=5m' | jq .
curl http://localhost:8428/prometheus/api/v1/query -d 'query=metric2[10m:1m]' -d 'time=2024-10-31T06:58:01Z' -d 'step=5m' | jq .
```

![vmui-2](https://github.com/user-attachments/assets/acfedf2c-0217-442f-9e68-cd005389f520)
 
We get 2 points for metric1 and metric2. This is expected too because now the metric2 second point is within the range.

Now let's add another rollup function: `min_over_time(metric1[10m:1m])`. At this point `metric1[10m:1m]` becomes a subquery. Let's execute it at `06:58:01Z`

```
curl http://localhost:8428/prometheus/api/v1/query -d 'query=min_over_time(metric1[10m:1m])' -d 'time=2024-10-31T06:58:01Z' -d 'step=5m' | jq .
curl http://localhost:8428/prometheus/api/v1/query -d 'query=min_over_time(metric2[10m:1m])' -d 'time=2024-10-31T06:58:01Z' -d 'step=5m' | jq .
```

![vmui-3](https://github.com/user-attachments/assets/7dde484d-d297-4353-acff-bd410f6ebb85)

We get value 1 for metric1 and value 2 for metric2. The result for metric2 may seem unexpected - it should be 1, because it is still included into the range. However, when VictoriaMetrics evaluates subqueries, it aligns the time range to the length of the step (`1m`). So the range is not `[06:49:01 .. 06:58:01]` but `[06:49:00 .. 06:58:00]`. Thus, the metric2's value 1 becomes out of range again.

And this seems to be expected behavior. You can find it [here](https://github.com/VictoriaMetrics/VictoriaMetrics/blob/06621995bddbbc286545880a1f8d2e3d0b6a4646/app/vmselect/promql/eval.go#L940) and the last time it was revisited was at e706e59d498e9058e56fbbc9bded1ac625218df1 where the test's testdata is explicitly changed to expect (2 and 4 instead of 1 and 3).

What the test does not account for is when the `TIME_S` is exactly the minute (without seconds), such as 6:58:00. Because in this case the time range does not need to be aligned. And the query will return 1 and 3, not 2 and 4.

I am afraid I don't have the authority to judge whether this implementation is correct or not. So I assume this is the correct behavior and therefore propose changing the testdata. Namely, inserting data not in `1m`  but at `59s` intervals so the subquery range always excludes the last samples:

TIME_S | Timestamp (TIME_S - 59s) | Query time (TIME_S - 1m) | Subquery range [10m:1m]
-----------|--------------------------------------|-------------------------------------|-----------------------
06:59:01 |  06:58:02 | 06:58:01 | 06:49:00 .. 06:58:00
06:59:00 |  06:58:01 | 06:58:00 | 06:49:00 .. 06:58:00
06:58:59 |  06:58:00 | 06:57:59 | 06:48:00 .. 06:57:00

### Checklist

The following checks are **mandatory**:

- [x ] My change adheres [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/contributing/).
