### PR TITLE
app/vlselect/logsql: add offset query option

### DIFF
--- a/docs/VictoriaLogs/CHANGELOG.md
+++ b/docs/VictoriaLogs/CHANGELOG.md
@@ -15,6 +15,8 @@ according to [these docs](https://docs.victoriametrics.com/victorialogs/quicksta
 
 ## tip
 
+* FEATURE: allow specifying a custom `offset` in milliseconds for the [`/select/logsql/tail` HTTP endpoint](https://docs.victoriametrics.com/victorialogs/querying/#live-tailing). See `offset` argument in [these docs](https://docs.victoriametrics.com/victorialogs/querying/#live-tailing).
+
 ## [v0.41.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v0.41.0-victorialogs)
 
 Released at 2024-11-06

--- a/docs/VictoriaLogs/querying/README.md
+++ b/docs/VictoriaLogs/querying/README.md
@@ -155,6 +155,13 @@ which were ingested into VictoriaLogs during the last hour, before starting live
 curl -N http://localhost:9428/select/logsql/tail -d 'query=*' -d 'start_offset=1h'
 ```
 
+Live tailing performs a continuous best-effort search for matching logs in real time. Out of order or late logs may not appear in the live tailing results.
+As a workaround, VictoriaLogs applies a small query delay of 1 second by default. This delay can be changed by passing an `offset` argument in seconds:
+
+```sh
+curl -N http://localhost:9428/select/logsql/tail -d 'query=*' -d 'offset=30s'
+```
+
 **Performance tip**: live tailing works the best if it matches newly ingested logs at relatively slow rate (e.g. up to 1K matching logs per second),
 e.g. it is optimized for the case when real humans inspect the output of live tailing in the real time. If live tailing returns logs at too high rate,
 then it is recommended adding more specific [filters](https://docs.victoriametrics.com/victorialogs/logsql/#filters) to the `<query>`, so it matches less logs.


### PR DESCRIPTION
* offset the tailing window to be at least 1 second behind real-time
* allow adjusting the offset to an arbitrary value to fit custom use-cases where ingestion of logs is randomized or delayed
* limit the length of the time window to prevent out of memory situations
* use `slices.SortStableFunc` over `sort.SliceStable` in `sortLogRows` to improve performance
* re-use `resultRows`, `tailRows`, and `perStreamRows` instead of re-allocating them during every iteration
* use `slices.BinarySearchFunc` over linear search to find where to skip to