### PR TITLE
app/vlinsert: added -syslog.streamFields.tcp and -syslog.streamFields.udp flags to override default stream fields

### DIFF
--- a/app/vlinsert/insertutils/common_params.go
+++ b/app/vlinsert/insertutils/common_params.go
@@ -111,25 +111,6 @@ func getExtraFields(r *http.Request) ([]logstorage.Field, error) {
 	return extraFields, nil
 }
 
-// GetCommonParamsForSyslog returns common params needed for parsing syslog messages and storing them to the given tenantID.
-func GetCommonParamsForSyslog(tenantID logstorage.TenantID) *CommonParams {
-	// See https://docs.victoriametrics.com/victorialogs/logsql/#unpack_syslog-pipe
-	cp := &CommonParams{
-		TenantID:  tenantID,
-		TimeField: "timestamp",
-		MsgFields: []string{
-			"message",
-		},
-		StreamFields: []string{
-			"hostname",
-			"app_name",
-			"proc_id",
-		},
-	}
-
-	return cp
-}
-
 // LogMessageProcessor is an interface for log message processors.
 type LogMessageProcessor interface {
 	// AddRow must add row to the LogMessageProcessor with the given timestamp and the given fields.

--- a/docs/VictoriaLogs/CHANGELOG.md
+++ b/docs/VictoriaLogs/CHANGELOG.md
@@ -26,6 +26,7 @@ Released at 2024-11-06
 * FEATURE: add [`block_stats` pipe](https://docs.victoriametrics.com/victorialogs/logsql/#block_stats-pipe) for returning various per-block stats. This pipe is useful for debugging.
 * FEATURE: [web UI](https://docs.victoriametrics.com/victorialogs/querying/#web-ui): add sorting of logs by groups and within each group by time in desc order. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/7184) and [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/7045).
 * FEATURE: add support for receiving DataDog logs over network. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/6632).
+* FEATURE: add `-syslog.streamFields.tcp` and `-syslog.streamFields.udp` flags to override default Syslog stream fields. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/7480).
 
 * BUGFIX: properly sort fields with floating-point numbers by [`sort` pipe](https://docs.victoriametrics.com/victorialogs/logsql/#sort-pipe). Previously floating-point numbers could be improperly sorted because they were treated as strings, and [natural sorting](https://en.wikipedia.org/wiki/Natural_sort_order) was incorrectly applied to them. For example, `0.123` was treated as bigger than `0.9`.
 

--- a/docs/VictoriaLogs/data-ingestion/syslog.md
+++ b/docs/VictoriaLogs/data-ingestion/syslog.md
@@ -42,7 +42,7 @@ from the received Syslog lines:
 - [`_time`](https://docs.victoriametrics.com/victorialogs/keyconcepts/#time-field) - log timestamp. See also [log timestamps](#log-timestamps)
 - [`_msg`](https://docs.victoriametrics.com/victorialogs/keyconcepts/#message-field) - the `MESSAGE` field from the supported syslog formats above
 - `hostname`, `app_name` and `proc_id` - [stream fields](https://docs.victoriametrics.com/victorialogs/keyconcepts/#stream-fields) for unique identification
-  over every log stream
+  over every log stream, which can be changed using `-syslog.streamFields.tcp` or `-syslog.streamFields.udp` flag.
 - `priority`, `facility` and `severity` - these fields are extracted from `<PRI>` field
 - `format` - this field is set to either `rfc3164` or `rfc5424` depending on the format of the parsed syslog line
 - `msg_id` - `MSGID` field from log line in `RFC5424` format.
@@ -70,6 +70,7 @@ See also:
 - [Log timestamps](#log-timestamps)
 - [Security](#security)
 - [Compression](#compression)
+- [Stream fields](#stream-fields)
 - [Multitenancy](#multitenancy)
 - [Data ingestion troubleshooting](https://docs.victoriametrics.com/victorialogs/data-ingestion/#troubleshooting).
 - [How to query VictoriaLogs](https://docs.victoriametrics.com/victorialogs/querying/).
@@ -120,6 +121,13 @@ For example, the following command starts VictoriaLogs, which accepts gzip-compr
 ```sh
 ./victoria-logs -syslog.listenAddr.tcp=:514 -syslog.compressMethod.tcp=gzip
 ```
+
+## Stream fields
+
+By default VictoriaLogs uses `hostname`, `app_name` and `proc_id` as stream fields for all TCP and UTP ports. To override default behavior use
+`-syslog.streamFields.tcp` and `-syslog.streamFields.udp` flags. To pass multiple stream fields to a single port use `^^` separator. Comma separates fields for different
+ports. Example: `-syslog.streamFields.tcp=hostname^^app_name,hostname^^proc_id` - passes `hostname`, `app_name` stream fields for first syslog TCP server and
+`hostname`, `proc_id` for a second syslog TCP server.
 
 ## Multitenancy
 


### PR DESCRIPTION
### Describe Your Changes

Added `-syslog.streamFields.tcp` and `-syslog.streamFields.udp` to override default syslog stream fields, as we have the same opportunity for journald parser
related issue https://github.com/VictoriaMetrics/VictoriaMetrics/issues/7480

### Checklist

The following checks are **mandatory**:

- [ ] My change adheres [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/contributing/).
