### PR TITLE
vmctl: add docs migrating from cluster to single with --vm-native-disable-binary-protocol

### DIFF
--- a/docs/vmctl.md
+++ b/docs/vmctl.md
@@ -869,6 +869,10 @@ Importing tips:
    --vm-native-src-addr=http://<src-vmselect>:8481/select/0/prometheus
    --vm-native-dst-addr=http://<dst-vminsert>:8480/insert/0/prometheus
    ```
+1. When migrating data from VM cluster to Single-node VictoriaMetrics, vmctl will use the `/api/v1/export/native` API of the VM cluster, 
+   which attaches `vm_account_id` and `vm_project_id` labels to each time series. If you don't need to distinguish between tenants 
+   or simply want to remove these labels, try setting the `--vm-native-disable-binary-protocol` flag, which will use the `/api/v1/export` API, 
+   exporting and importing data in JSON format.
 1. Migrating data from VM cluster which had replication (`-replicationFactor` > 1) enabled won't produce the same amount
    of data copies for the destination database, and will result only in creating duplicates. To remove duplicates,
    destination database need to be configured with `-dedup.minScrapeInterval=1ms`. To restore the replication factor

--- a/docs/vmctl.md
+++ b/docs/vmctl.md
@@ -872,7 +872,7 @@ Importing tips:
 1. When migrating data from VM cluster to Single-node VictoriaMetrics, vmctl will use the `/api/v1/export/native` API of the VM cluster, 
    which attaches `vm_account_id` and `vm_project_id` labels to each time series. If you don't need to distinguish between tenants 
    or simply want to remove these labels, try setting the `--vm-native-disable-binary-protocol` flag, which will use the `/api/v1/export` API, 
-   exporting and importing data in JSON format.
+   exporting and importing data in JSON format. Deduplication should be enabled at `-vm-native-src-addr` side if needed.
 1. Migrating data from VM cluster which had replication (`-replicationFactor` > 1) enabled won't produce the same amount
    of data copies for the destination database, and will result only in creating duplicates. To remove duplicates,
    destination database need to be configured with `-dedup.minScrapeInterval=1ms`. To restore the replication factor


### PR DESCRIPTION
### Describe Your Changes

when migrating from cluster to single, the native export API attach `vm_account_id` and `vm_project_id` labels. `--vm-native-disable-binary-protocol` is a workaround to remove them, which is available since v1.93.0 but did not documented in vmctl doc.

See: https://github.com/VictoriaMetrics/VictoriaMetrics/pull/4716

### Checklist

The following checks are **mandatory**:

- [x] My change adheres [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/contributing/).
