### PR TITLE
Vmauth query relative time

### DIFF
--- a/app/vmauth/auth_config.go
+++ b/app/vmauth/auth_config.go
@@ -164,6 +164,9 @@ type URLMap struct {
 	// SrcHeaders is an optional list of headers, which must match request headers.
 	SrcHeaders []*Header `yaml:"src_headers,omitempty"`
 
+	// RelativeTimeRangeConfig defines a relative time range.
+	RelativeTimeRangeConfig *RelativeTimeRangeConfig `yaml:"relative_time_range,omitempty"`
+
 	// UrlPrefix contains backend url prefixes for the proxied request url.
 	URLPrefix *URLPrefix `yaml:"url_prefix,omitempty"`
 
@@ -223,6 +226,40 @@ func (qa *QueryArg) UnmarshalYAML(f func(any) error) error {
 // MarshalYAML marshals qa to yaml.
 func (qa *QueryArg) MarshalYAML() (any, error) {
 	return qa.sOriginal, nil
+}
+
+// RelativeTimeRangeConfig configures durations relative from "now"
+type RelativeTimeRangeConfig struct {
+	Start *time.Duration `yaml:"start"`
+	End   *time.Duration `yaml:"end"`
+}
+
+func (tr *RelativeTimeRangeConfig) TimeWindow() (time.Time, time.Time) {
+	now := time.Now()
+	var start, end time.Time
+	if tr.Start != nil {
+		start = now.Add(*tr.Start)
+	}
+	if tr.End != nil {
+		end = now.Add(*tr.End)
+	}
+	return start, end
+}
+
+// UnmarshalYAML implements the yaml.Unmarshaler interface.
+func (tr *RelativeTimeRangeConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	type plain RelativeTimeRangeConfig
+	if err := unmarshal((*plain)(tr)); err != nil {
+		return err
+	}
+	return tr.validate()
+}
+
+func (tr *RelativeTimeRangeConfig) validate() error {
+	if tr.End != nil && tr.Start != nil && *tr.End < *tr.Start {
+		return fmt.Errorf("RelativeTimeRangeConfig: End must be after start")
+	}
+	return nil
 }
 
 // URLPrefix represents passed `url_prefix`
@@ -893,8 +930,8 @@ func (ui *UserInfo) initURLs() error {
 		}
 	}
 	for _, e := range ui.URLMaps {
-		if len(e.SrcPaths) == 0 && len(e.SrcHosts) == 0 && len(e.SrcQueryArgs) == 0 && len(e.SrcHeaders) == 0 {
-			return fmt.Errorf("missing `src_paths`, `src_hosts`, `src_query_args` and `src_headers` in `url_map`")
+		if len(e.SrcPaths) == 0 && len(e.SrcHosts) == 0 && len(e.SrcQueryArgs) == 0 && len(e.SrcHeaders) == 0 && e.RelativeTimeRangeConfig == nil {
+			return fmt.Errorf("missing `src_paths`, `src_hosts`, `src_query_args` and `src_headers` and `relative_time_range` in `url_map`")
 		}
 		if e.URLPrefix == nil {
 			return fmt.Errorf("missing `url_prefix` in `url_map`")

--- a/app/vmauth/auth_config_test.go
+++ b/app/vmauth/auth_config_test.go
@@ -3,10 +3,9 @@ package main
 import (
 	"bytes"
 	"fmt"
+	"gopkg.in/yaml.v2"
 	"net/url"
 	"testing"
-
-	"gopkg.in/yaml.v2"
 
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/logger"
 )

--- a/app/vmauth/main.go
+++ b/app/vmauth/main.go
@@ -180,7 +180,7 @@ func processUserRequest(w http.ResponseWriter, r *http.Request, ui *UserInfo) {
 
 func processRequest(w http.ResponseWriter, r *http.Request, ui *UserInfo) {
 	u := normalizeURL(r.URL)
-	up, hc := ui.getURLPrefixAndHeaders(u, r.Header, r)
+	up, hc := ui.getURLPrefixAndHeaders(u, r.Header, getQueryRangeTime(r))
 	isDefault := false
 	if up == nil {
 		if ui.DefaultURL == nil {

--- a/app/vmauth/main.go
+++ b/app/vmauth/main.go
@@ -180,7 +180,7 @@ func processUserRequest(w http.ResponseWriter, r *http.Request, ui *UserInfo) {
 
 func processRequest(w http.ResponseWriter, r *http.Request, ui *UserInfo) {
 	u := normalizeURL(r.URL)
-	up, hc := ui.getURLPrefixAndHeaders(u, r.Header)
+	up, hc := ui.getURLPrefixAndHeaders(u, r.Header, r)
 	isDefault := false
 	if up == nil {
 		if ui.DefaultURL == nil {

--- a/app/vmauth/target_url_test.go
+++ b/app/vmauth/target_url_test.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/netutil"
 )
@@ -421,6 +422,46 @@ func TestCreateTargetURLFailure(t *testing.T) {
 	}, "/api/v1/write")
 }
 
+func TestMatchRelativeTimeRange(t *testing.T) {
+	f := func(ui *UserInfo, requestURI string, start int64, end int64, time int64, expectedTarget string) {
+		t.Helper()
+		u, err := url.Parse(requestURI)
+		if err != nil {
+			t.Fatalf("cannot parse %q: %s", requestURI, err)
+		}
+		u = normalizeURL(u)
+		params := make(map[string]int64)
+		params["start"] = start
+		params["end"] = end
+		params["time"] = time
+		up, _ := ui.getURLPrefixAndHeaders(u, nil, params)
+		if up == nil {
+			t.Fatalf("cannot match available backend: %s", err)
+		}
+		bu := up.getBackendURL()
+		target := mergeURLs(bu.url, u, up.dropSrcPathPrefixParts)
+		bu.put()
+
+		gotTarget := target.String()
+		if gotTarget != expectedTarget {
+			t.Fatalf("unexpected target\ngot:\n%q\nwant\n%q", gotTarget, expectedTarget)
+		}
+	}
+	ui := &UserInfo{
+		URLMaps: []URLMap{
+			{
+				RelativeTimeRangeConfig: getRelativeTimeRange(-8*time.Hour, +1*time.Hour),
+				URLPrefix:               mustParseURL("http://srv+vmselect"),
+			},
+		},
+		URLPrefix: mustParseURL("http://non-exist-dns-addr"),
+	}
+	f(ui, `/select/0/prometheus/api/v1/query?query=up`, time.Now().UnixMilli()-7*3600*1000, time.Now().UnixMilli(), 0, "http://srv+vmselect/select/0/prometheus/api/v1/query?query=up")
+	f(ui, `/select/0/prometheus/api/v1/query?query=up`, time.Now().UnixMilli()-11*3600*1000, time.Now().UnixMilli(), 0, "http://non-exist-dns-addr/select/0/prometheus/api/v1/query?query=up")
+	f(ui, `/select/0/prometheus/api/v1/query?query=up`, 0, 0, time.Now().UnixMilli()-4*3600*1000, "http://srv+vmselect/select/0/prometheus/api/v1/query?query=up")
+	f(ui, `/select/0/prometheus/api/v1/query?query=up`, 0, 0, time.Now().UnixMilli()-9*3600*1000, "http://non-exist-dns-addr/select/0/prometheus/api/v1/query?query=up")
+}
+
 func headersToString(hs []*Header) string {
 	a := make([]string, len(hs))
 	for i, h := range hs {
@@ -453,4 +494,8 @@ func (r *fakeResolver) LookupIPAddr(_ context.Context, host string) ([]net.IPAdd
 
 func (r *fakeResolver) LookupMX(_ context.Context, _ string) ([]*net.MX, error) {
 	return nil, nil
+}
+
+func getRelativeTimeRange(start time.Duration, end time.Duration) *RelativeTimeRangeConfig {
+	return &RelativeTimeRangeConfig{&start, &end}
 }

--- a/app/vmauth/target_url_test.go
+++ b/app/vmauth/target_url_test.go
@@ -95,7 +95,7 @@ func TestCreateTargetURLSuccess(t *testing.T) {
 			t.Fatalf("cannot parse %q: %s", requestURI, err)
 		}
 		u = normalizeURL(u)
-		up, hc := ui.getURLPrefixAndHeaders(u, nil)
+		up, hc := ui.getURLPrefixAndHeaders(u, nil, nil)
 		if up == nil {
 			t.Fatalf("cannot match available backend: %s", err)
 		}
@@ -273,7 +273,7 @@ func TestUserInfoGetBackendURL_SRV(t *testing.T) {
 			t.Fatalf("cannot parse %q: %s", requestURI, err)
 		}
 		u = normalizeURL(u)
-		up, _ := ui.getURLPrefixAndHeaders(u, nil)
+		up, _ := ui.getURLPrefixAndHeaders(u, nil, nil)
 		if up == nil {
 			t.Fatalf("cannot match available backend: %s", err)
 		}
@@ -351,7 +351,7 @@ func TestUserInfoGetBackendURL_SRVZeroBackends(t *testing.T) {
 			t.Fatalf("cannot parse %q: %s", requestURI, err)
 		}
 		u = normalizeURL(u)
-		up, _ := ui.getURLPrefixAndHeaders(u, nil)
+		up, _ := ui.getURLPrefixAndHeaders(u, nil, nil)
 		if up == nil {
 			t.Fatalf("cannot match available backend: %s", err)
 		}
@@ -399,7 +399,7 @@ func TestCreateTargetURLFailure(t *testing.T) {
 			t.Fatalf("cannot parse %q: %s", requestURI, err)
 		}
 		u = normalizeURL(u)
-		up, hc := ui.getURLPrefixAndHeaders(u, nil)
+		up, hc := ui.getURLPrefixAndHeaders(u, nil, nil)
 		if up != nil {
 			t.Fatalf("unexpected non-empty up=%#v", up)
 		}

--- a/lib/httputils/time.go
+++ b/lib/httputils/time.go
@@ -1,7 +1,9 @@
 package httputils
 
 import (
+	"bytes"
 	"fmt"
+	"io"
 	"math"
 	"net/http"
 	"time"
@@ -39,6 +41,19 @@ func GetTime(r *http.Request, argKey string, defaultMs int64) (int64, error) {
 		msecs = maxTimeMsecs
 	}
 	return msecs, nil
+}
+
+// DumpRequest returns a copy of r with Body replaced with a new io.ReadCloser, as deep copy of the original body.
+func DumpRequest(r *http.Request) (*http.Request, error) {
+	dump := r.Clone(r.Context())
+	var b bytes.Buffer
+	_, err := b.ReadFrom(r.Body)
+	if err != nil {
+		return nil, err
+	}
+	r.Body = io.NopCloser(&b)
+	dump.Body = io.NopCloser(bytes.NewReader(b.Bytes()))
+	return dump, nil
 }
 
 var (

--- a/lib/httputils/time.go
+++ b/lib/httputils/time.go
@@ -46,13 +46,15 @@ func GetTime(r *http.Request, argKey string, defaultMs int64) (int64, error) {
 // DumpRequest returns a copy of r with Body replaced with a new io.ReadCloser, as deep copy of the original body.
 func DumpRequest(r *http.Request) (*http.Request, error) {
 	dump := r.Clone(r.Context())
-	var b bytes.Buffer
-	_, err := b.ReadFrom(r.Body)
-	if err != nil {
-		return nil, err
+	if r.Body != nil {
+		var b bytes.Buffer
+		_, err := b.ReadFrom(r.Body)
+		if err != nil {
+			return nil, err
+		}
+		r.Body = io.NopCloser(&b)
+		dump.Body = io.NopCloser(bytes.NewReader(b.Bytes()))
 	}
-	r.Body = io.NopCloser(&b)
-	dump.Body = io.NopCloser(bytes.NewReader(b.Bytes()))
 	return dump, nil
 }
 


### PR DESCRIPTION
### Describe Your Changes

I have two cluster to support multi-retention storage, one cluster for 30 days retention, and the other support 6 month retention. In this case, I want to make user query to 30 days cluster if query time is between [now-30d,now]. I found promxy support this feature but most of our promql is not available in promxy(maybe our query is not so formal). So I want vmauth support relative time query to achieve my purpose

### Checklist

The following checks are **mandatory**:

- [ ] My change adheres [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/contributing/).
