### PR TITLE
Confirm that changing retention period can cause previous indexDB deletion

### DIFF
--- a/lib/storage/storage_test.go
+++ b/lib/storage/storage_test.go
@@ -491,6 +491,7 @@ func TestNextRetentionDeadlineSeconds(t *testing.T) {
 
 	// The test cases below confirm that it is possible to pick a retention
 	// period such that the previous IndexDB may be removed earlier than it should be.
+	// See https://github.com/VictoriaMetrics/VictoriaMetrics/issues/7609
 
 	// Cluster is configured with 12 month retentionPeriod on 2023-01-01.
 	f("2023-01-01T00:00:00Z", 365*24*time.Hour, 0, "2023-12-19T04:00:00Z")


### PR DESCRIPTION
### Describe Your Changes

Add test cases proving that it is possible to lose indexDB after changing the retention period. See #7609 

### Checklist

The following checks are **mandatory**:

- [x ] My change adheres [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/contributing/).
