### PR TITLE
Remove -v flag from integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -528,7 +528,7 @@ test-full-386:
 	DISABLE_FSYNC_FOR_TESTING=1 GOARCH=386 go test -coverprofile=coverage.txt -covermode=atomic ./lib/... ./app/...
 
 integration-test: victoria-metrics vmagent vmalert vmauth
-	go test ./apptest/... -skip="^TestCluster.*" -v
+	go test ./apptest/... -skip="^TestCluster.*"
 
 benchmark:
 	go test -bench=. ./lib/...


### PR DESCRIPTION
### Describe Your Changes

This is a follow-up PR for #7523. Disabling the verbosity in integration tests after confirming that the tests run in both master and cluster branches.

### Checklist

The following checks are **mandatory**:

- [x] My change adheres [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/contributing/).
