### PR TITLE
vmui: web: fixed favicon name

### DIFF
--- a/app/vmui/packages/vmui/web/main.go
+++ b/app/vmui/packages/vmui/web/main.go
@@ -10,7 +10,7 @@ import (
 // specific files
 // static content
 //
-//go:embed favicon-32x32.png robots.txt index.html manifest.json asset-manifest.json
+//go:embed favicon.svg robots.txt index.html manifest.json asset-manifest.json
 //go:embed static
 var files embed.FS
 


### PR DESCRIPTION
### Describe Your Changes

Seems `favicon-32x32.png` removed in #6972

Fixes this:

```shell
√ build % go build -x -buildmode="pie" -trimpath -mod="readonly" -modcacherw -ldflags "-linkmode external"
WORK=/var/folders/mj/r83hky151tzbqsvml0hxts_w0000gn/T/go-build2937230855
main.go:13:12: pattern favicon-32x32.png: no matching files found
```

### Checklist

The following checks are **mandatory**:

- [x] My change adheres [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/contributing/).
