### PR TITLE
lib/logstorage: fixes panic at Block.MustInitFromRows

### DIFF
--- a/docs/VictoriaLogs/CHANGELOG.md
+++ b/docs/VictoriaLogs/CHANGELOG.md
@@ -21,6 +21,7 @@ according to [these docs](https://docs.victoriametrics.com/victorialogs/quicksta
 * FEATURE: [vmui](https://docs.victoriametrics.com/#vmui): add support for template alias in predefined panels. This allows creating more readable metric names in the legend using constructions like `{{label_name}}`, where `label_name` is the name of the label. [See this commit](https://github.com/VictoriaMetrics/VictoriaMetrics/commit/116101da78a4dee8bd7c4ba0e66458fd05a10469#diff-95141489b32468cf852d2705d96eaa48c50a8b1cdd0424a29e7ca289912a6dcbR140-R151)
 
 * BUGFIX: [vmui](https://docs.victoriametrics.com/#vmui): fix for `showLegend` and `alias` flags in predefined panels. [See this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/7565)
+* BUGFIX: fix panic at high volume log ingestion with unique fields. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/7568) for details.
 
 ## [v1.0.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.0.0-victorialogs)
 

--- a/docs/VictoriaLogs/CHANGELOG.md
+++ b/docs/VictoriaLogs/CHANGELOG.md
@@ -21,7 +21,7 @@ according to [these docs](https://docs.victoriametrics.com/victorialogs/quicksta
 * FEATURE: [vmui](https://docs.victoriametrics.com/#vmui): add support for template alias in predefined panels. This allows creating more readable metric names in the legend using constructions like `{{label_name}}`, where `label_name` is the name of the label. [See this commit](https://github.com/VictoriaMetrics/VictoriaMetrics/commit/116101da78a4dee8bd7c4ba0e66458fd05a10469#diff-95141489b32468cf852d2705d96eaa48c50a8b1cdd0424a29e7ca289912a6dcbR140-R151)
 
 * BUGFIX: [vmui](https://docs.victoriametrics.com/#vmui): fix for `showLegend` and `alias` flags in predefined panels. [See this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/7565)
-* BUGFIX: fix panic at high volume log ingestion with unique fields. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/7568) for details.
+* BUGFIX: fix `oo big number of columns detected in the block` panic when the ingested logs contain more than 2000 fields with different names per every [log stream](https://docs.victoriametrics.com/victorialogs/keyconcepts/#stream-fields). See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/7568) for details.
 
 ## [v1.0.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.0.0-victorialogs)
 

--- a/lib/logstorage/block.go
+++ b/lib/logstorage/block.go
@@ -274,7 +274,6 @@ func (b *block) mustInitFromRows(timestamps []int64, rows [][]Field) (offset int
 	columnIdxs := getColumnIdxs()
 	for i := range rows {
 		fields := rows[i]
-		// split rows by the limit
 		if len(columnIdxs)+len(fields) > maxColumnsPerBlock {
 			break
 		}
@@ -286,6 +285,8 @@ func (b *block) mustInitFromRows(timestamps []int64, rows [][]Field) (offset int
 		}
 		offset++
 	}
+
+	// keep only rows that fit maxColumnsPerBlock limit
 	rows = rows[:offset]
 	timestamps = timestamps[:offset]
 

--- a/lib/logstorage/block_stream_writer.go
+++ b/lib/logstorage/block_stream_writer.go
@@ -335,8 +335,12 @@ func (bsw *blockStreamWriter) MustWriteRows(sid *streamID, timestamps []int64, r
 	}
 
 	b := getBlock()
-	b.MustInitFromRows(timestamps, rows)
-	bsw.MustWriteBlock(sid, b)
+	for len(rows) > 0 {
+		rowsOffset := b.MustInitFromRows(timestamps, rows)
+		timestamps, rows = timestamps[rowsOffset:], rows[rowsOffset:]
+		bsw.MustWriteBlock(sid, b)
+	}
+
 	putBlock(b)
 }
 

--- a/lib/logstorage/block_stream_writer.go
+++ b/lib/logstorage/block_stream_writer.go
@@ -337,8 +337,8 @@ func (bsw *blockStreamWriter) MustWriteRows(sid *streamID, timestamps []int64, r
 	b := getBlock()
 	for len(rows) > 0 {
 		rowsOffset := b.MustInitFromRows(timestamps, rows)
-		timestamps, rows = timestamps[rowsOffset:], rows[rowsOffset:]
 		bsw.MustWriteBlock(sid, b)
+		timestamps, rows = timestamps[rowsOffset:], rows[rowsOffset:]
 	}
 
 	putBlock(b)

--- a/lib/logstorage/block_timing_test.go
+++ b/lib/logstorage/block_timing_test.go
@@ -21,7 +21,10 @@ func benchmarkBlockMustInitFromRows(b *testing.B, rowsPerBlock int) {
 		block := getBlock()
 		defer putBlock(block)
 		for pb.Next() {
-			block.MustInitFromRows(timestamps, rows)
+			offset := block.MustInitFromRows(timestamps, rows)
+			if offset != len(rows) {
+				b.Fatalf("expected offset: %d to match processed rows: %d", offset, len(rows))
+			}
 			if n := block.Len(); n != len(timestamps) {
 				panic(fmt.Errorf("unexpected block length; got %d; want %d", n, len(timestamps)))
 			}


### PR DESCRIPTION
 Previously Block columns wasn't properly limited by maxColumnsPerBlock.
And it was possible a case, when more columns per block added than expected.
 For example, if ingested log stream has many unuqie fields
and it's sum exceed maxColumnsPerBlock.
 We only enforce fieldsPerBlock limit during row parsing, which limits
isn't enough to mitigate this issue. Also it
would be very expensive to apply maxColumnsPerBlock limit during ingestion, since it requires to track all possible field tags combinations.

 This commit adds check for maxColumnsPerBlock limit during
MustInitFromRows function call. And it returns offset of the rows and timestamps added to the block.
 Function caller must create another block and ingest remaining rows
into it.

Related issue:
https://github.com/VictoriaMetrics/VictoriaMetrics/issues/7568

### Describe Your Changes

Please provide a brief description of the changes you made. Be as specific as possible to help others understand the purpose and impact of your modifications.

### Checklist

The following checks are **mandatory**:

- [ ] My change adheres [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/contributing/).
