### PR TITLE
docs/vlogs: replace reference to fluentbit with vector

### DIFF
--- a/docs/VictoriaLogs/QuickStart.md
+++ b/docs/VictoriaLogs/QuickStart.md
@@ -146,4 +146,4 @@ Here are a Docker-compose demos, which start VictoriaLogs and push logs to it vi
 - [Promtail demo](https://github.com/VictoriaMetrics/VictoriaMetrics/tree/master/deployment/docker/victorialogs/promtail)
 
 You can use [this Helm chart](https://github.com/VictoriaMetrics/helm-charts/blob/master/charts/victoria-logs-single/README.md)
-as a demo for running Fluentbit in Kubernetes with VictoriaLogs.
+as a demo for running Vector in Kubernetes with VictoriaLogs.


### PR DESCRIPTION
### Describe Your Changes

the helm chart being referenced switched from fluentbit to vector in a1aea5d694ff725c350b325205e3372b52242639, so update the docs to match

### Checklist

The following checks are **mandatory**:

- [X] My change adheres [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/contributing/).
