### PR TITLE
app/vminsert: improve rerouting behavior with configurable delay

### DIFF
--- a/app/vminsert/netstorage/insert_ctx.go
+++ b/app/vminsert/netstorage/insert_ctx.go
@@ -186,8 +186,14 @@ func (ctx *InsertCtx) GetStorageNodeIdx(at *auth.Token, labels []prompbmarshal.L
 	h := xxhash.Sum64(buf)
 	ctx.labelsBuf = buf
 
-	// Do not exclude unavailable storage nodes in order to properly account for rerouted rows in storageNode.push().
-	idx := ctx.snb.nodesHash.getNodeIdx(h, nil)
+	// Exclude long-broken storage nodes.
+	var excludeIdxs []int
+	for i := range ctx.snb.sns {
+		if ctx.snb.sns[i].isExcluded() {
+			excludeIdxs = append(excludeIdxs, i)
+		}
+	}
+	idx := ctx.snb.nodesHash.getNodeIdx(h, excludeIdxs)
 	return idx
 }
 

--- a/app/vminsert/netstorage/insert_ctx.go
+++ b/app/vminsert/netstorage/insert_ctx.go
@@ -188,9 +188,11 @@ func (ctx *InsertCtx) GetStorageNodeIdx(at *auth.Token, labels []prompbmarshal.L
 
 	// Exclude long-broken storage nodes.
 	var excludeIdxs []int
-	for i := range ctx.snb.sns {
-		if ctx.snb.sns[i].isExcluded() {
-			excludeIdxs = append(excludeIdxs, i)
+	if !*dropSamplesOnOverload {
+		for i := range ctx.snb.sns {
+			if ctx.snb.sns[i].isExcluded() {
+				excludeIdxs = append(excludeIdxs, i)
+			}
 		}
 	}
 	idx := ctx.snb.nodesHash.getNodeIdx(h, excludeIdxs)

--- a/app/vminsert/netstorage/netstorage.go
+++ b/app/vminsert/netstorage/netstorage.go
@@ -332,8 +332,8 @@ func tryReplicateBufToStorages(sns []*storageNode, br *bufRows, snIdx, replicas 
 		cannotReplicateLogger.Warnf("cannot push %d bytes with %d rows to degraded node %s, %d/%d nodes are replicated", len(br.buf), br.rows, sns[snIdx].dialer.Addr(), len(usedStorageNodes), replicas)
 		return false
 	} else if previousSuccessLen != len(usedStorageNodes) && len(usedStorageNodes) < replicas {
-		incompleteReplicationLogger.Warnf("dropping %d rows (%d bytes) as cannot make a copy #%d out of %d copies according to -replicationFactor=%d, since a part of storage nodes is temporarily unavailable", br.rows, len(br.buf), len(usedStorageNodes), replicas, *replicationFactor)
 		rowsIncompletelyReplicatedTotal.Add(br.rows)
+		incompleteReplicationLogger.Warnf("dropping %d rows (%d bytes) as cannot make a copy #%d out of %d copies according to -replicationFactor=%d, since a part of storage nodes is temporarily unavailable", br.rows, len(br.buf), len(usedStorageNodes), replicas, *replicationFactor)
 		return true
 	}
 

--- a/app/vminsert/netstorage/netstorage.go
+++ b/app/vminsert/netstorage/netstorage.go
@@ -58,7 +58,7 @@ func (sn *storageNode) isExcluded() bool {
 }
 
 func (sn *storageNode) setBroken(isBroken bool) {
-	if sn.isBroken.Swap(isBroken) {
+	if !sn.isBroken.Swap(isBroken) && isBroken {
 		sn.brokenAt.Store(fasttime.UnixTimestamp())
 	}
 }

--- a/app/vminsert/netstorage/netstorage.go
+++ b/app/vminsert/netstorage/netstorage.go
@@ -824,23 +824,6 @@ func (sn *storageNode) trySendBuf(buf []byte, rows int) bool {
 	return sent
 }
 
-func (sn *storageNode) sendBufMayBlock(buf []byte) bool {
-	sn.brLock.Lock()
-	for len(sn.br.buf)+len(buf) > maxBufSizePerStorageNode {
-		select {
-		case <-sn.stopCh:
-			sn.brLock.Unlock()
-			return false
-		default:
-		}
-		sn.brCond.Wait()
-	}
-	sn.br.buf = append(sn.br.buf, buf...)
-	sn.br.rows++
-	sn.brLock.Unlock()
-	return true
-}
-
 func (sn *storageNode) readOnlyChecker() {
 	d := timeutil.AddJitterToDuration(time.Second * 30)
 	ticker := time.NewTicker(d)

--- a/app/vminsert/netstorage/netstorage.go
+++ b/app/vminsert/netstorage/netstorage.go
@@ -135,9 +135,9 @@ again:
 		}
 
 		// Wait for the vmstorage node to change its state to ready, or timeout.
-		// sn.brCond.Wait() will be woken up at 200ms intervals.
+		// sn.brCond.Wait() will be woken up at ~200ms intervals by the health checker.
 	waitLoop:
-		for sn.isBroken.Load() || timeoutAt > fasttime.UnixTimestamp() {
+		for sn.isBroken.Load() && timeoutAt > fasttime.UnixTimestamp() {
 			sn.brCond.Wait()
 
 			select {

--- a/app/vminsert/netstorage/netstorage.go
+++ b/app/vminsert/netstorage/netstorage.go
@@ -54,7 +54,7 @@ func (sn *storageNode) isReady() bool {
 }
 
 func (sn *storageNode) isExcluded() bool {
-	return sn.isBroken.Load() && fasttime.UnixTimestamp()-sn.brokenAt.Load() > uint64(*rerouteDelay/time.Second)
+	return (sn.isBroken.Load() && fasttime.UnixTimestamp()-sn.brokenAt.Load() > uint64(*rerouteDelay/time.Second)) || sn.isReadOnly.Load()
 }
 
 func (sn *storageNode) setBroken(isBroken bool) {


### PR DESCRIPTION
Fixes https://github.com/VictoriaMetrics/VictoriaMetrics/issues/7738

### Describe Your Changes

* Deprecate `-disableRerouting` flag in favor of more specific controls.
* Add `-rerouteDelay` flag (default 15s) to control how long to wait before rerouting data to other storage nodes when a node becomes unavailable
* Track broken node timestamps to make rerouting decisions more deterministic.
* Only exclude nodes that have been broken longer than `rerouteDelay`

### Checklist

The following checks are **mandatory**:

- [x] My change adheres [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/contributing/).
