### PR TITLE
vmui: prevent accordion collapse on text selection in headers 

### DIFF
--- a/app/vmui/packages/vmui/src/components/Main/Accordion/Accordion.tsx
+++ b/app/vmui/packages/vmui/src/components/Main/Accordion/Accordion.tsx
@@ -21,7 +21,7 @@ const Accordion: FC<AccordionProps> = ({
   const toggleOpen = () => {
     const selection = window.getSelection();
     if (selection && selection.toString()) {
-      return; // Если текст выделен, отменяем выполнение toggle
+      return; // If the text is selected, cancel the execution of toggle.
     }
     setIsOpen(prev => !prev);
   };

--- a/app/vmui/packages/vmui/src/components/Main/Accordion/Accordion.tsx
+++ b/app/vmui/packages/vmui/src/components/Main/Accordion/Accordion.tsx
@@ -19,6 +19,10 @@ const Accordion: FC<AccordionProps> = ({
   const [isOpen, setIsOpen] = useState(defaultExpanded);
 
   const toggleOpen = () => {
+    const selection = window.getSelection();
+    if (selection && selection.toString()) {
+      return; // Если текст выделен, отменяем выполнение toggle
+    }
     setIsOpen(prev => !prev);
   };
 

--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -26,6 +26,7 @@ See also [LTS releases](https://docs.victoriametrics.com/lts-releases/).
 * BUGFIX: [Single-node VictoriaMetrics](https://docs.victoriametrics.com/) and `vmstorage` in [VictoriaMetrics cluster](https://docs.victoriametrics.com/cluster-victoriametrics/): properly schedule historical data de-duplication at enterprise version with `-dedup.minScrapeInterval` configured. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/7764) for details. Issue was introduced at [v1.106.1](https://docs.victoriametrics.com/changelog/#v11061) release.
 * BUGFIX: [vmauth](https://docs.victoriametrics.com/vmauth/): fix requests routing by host when using `src_hosts`. Previously, request header could be ignored.
 * BUGFIX: [vmbackupmanager](https://docs.victoriametrics.com/vmbackupmanager/): prevent backup scheduler from scheduling two backups immediately one after another.
+* BUGFIX: [vmui](https://docs.victoriametrics.com/#vmui): prevent accordion from collapsing when selecting text in headers. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/7742).
 
 ## [v1.107.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.107.0)
 


### PR DESCRIPTION
### Describe Your Changes

Prevent accordion from collapsing when selecting text in headers.
Related issue: #7742
