### PR TITLE
vmui: fix incorrect message in Table tab

### DIFF
--- a/app/vmui/packages/vmui/src/pages/CustomPanel/InstantQueryTip/InstantQueryTip.tsx
+++ b/app/vmui/packages/vmui/src/pages/CustomPanel/InstantQueryTip/InstantQueryTip.tsx
@@ -1,5 +1,6 @@
 import React, { FC } from "preact/compat";
 import Hyperlink from "../../../components/Main/Hyperlink/Hyperlink";
+import { useGraphState } from "../../../state/graph/GraphStateContext";
 
 const last_over_time = <Hyperlink
   text="last_over_time"
@@ -13,15 +14,19 @@ const instant_query = <Hyperlink
   underlined
 />;
 
-const InstantQueryTip: FC = () => (
-  <div>
-    <p>
-      This tab shows {instant_query} results for the last 5 minutes ending at the selected time range.
-    </p>
-    <p>
-      Please wrap the query into {last_over_time} if you need results over arbitrary lookbehind interval.
-    </p>
-  </div>
-);
+const InstantQueryTip: FC = () => {
+  const { customStep } = useGraphState();
+
+  return (
+    <div>
+      <p>
+        This tab shows {instant_query} results for the last {customStep || "5m"} (defined by the <code>step</code>) ending at the selected time range.
+      </p>
+      <p>
+        Please wrap the query into {last_over_time} if you need results over arbitrary lookbehind interval.
+      </p>
+    </div>
+  );
+};
 
 export default InstantQueryTip;

--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -26,6 +26,7 @@ See also [LTS releases](https://docs.victoriametrics.com/lts-releases/).
 * BUGFIX: [Single-node VictoriaMetrics](https://docs.victoriametrics.com/) and `vmstorage` in [VictoriaMetrics cluster](https://docs.victoriametrics.com/cluster-victoriametrics/): properly schedule historical data de-duplication at enterprise version with `-dedup.minScrapeInterval` configured. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/7764) for details. Issue was introduced at [v1.106.1](https://docs.victoriametrics.com/changelog/#v11061) release.
 * BUGFIX: [vmauth](https://docs.victoriametrics.com/vmauth/): fix requests routing by host when using `src_hosts`. Previously, request header could be ignored.
 * BUGFIX: [vmbackupmanager](https://docs.victoriametrics.com/vmbackupmanager/): prevent backup scheduler from scheduling two backups immediately one after another.
+* BUGFIX: [vmui](https://docs.victoriametrics.com/#vmui): fix query interval display in the instant query info. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/7401).
 
 ## [v1.107.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.107.0)
 


### PR DESCRIPTION
### Describe Your Changes

Updated the message in the “Table” tab of the VictoriaMetrics UI. It now correctly displays the step value based on the actual configuration.

Related issue: #7401

![Screenshot 2024-12-10 at 00 30 56](https://github.com/user-attachments/assets/c7eed3bd-5ec6-4338-b761-988a077d9c4e)
