### PR TITLE
vmui/logs: improvements to grouped view in logs 

### DIFF
--- a/app/vmui/packages/vmui/src/components/LogsConfigurators/GroupLogsConfigurators/GroupLogsConfigurators.tsx
+++ b/app/vmui/packages/vmui/src/components/LogsConfigurators/GroupLogsConfigurators/GroupLogsConfigurators.tsx
@@ -1,0 +1,246 @@
+import React, { FC, useMemo, useState } from "preact/compat";
+import useBoolean from "../../../hooks/useBoolean";
+import { RestartIcon, SettingsIcon } from "../../Main/Icons";
+import Button from "../../Main/Button/Button";
+import Modal from "../../Main/Modal/Modal";
+import Tooltip from "../../Main/Tooltip/Tooltip";
+import { Logs } from "../../../api/types";
+import Select from "../../Main/Select/Select";
+import { useSearchParams } from "react-router-dom";
+import "./style.scss";
+import Switch from "../../Main/Switch/Switch";
+import TextField from "../../Main/TextField/TextField";
+import dayjs from "dayjs";
+import Hyperlink from "../../Main/Hyperlink/Hyperlink";
+import {
+  LOGS_DISPLAY_FIELDS,
+  LOGS_GROUP_BY,
+  LOGS_DATE_FORMAT,
+  LOGS_URL_PARAMS,
+  WITHOUT_GROUPING
+} from "../../../constants/logs";
+
+const {
+  GROUP_BY,
+  NO_WRAP_LINES,
+  COMPACT_GROUP_HEADER,
+  DISPLAY_FIELDS,
+  DATE_FORMAT
+} = LOGS_URL_PARAMS;
+
+const title = "Group view settings";
+
+interface Props {
+  logs: Logs[];
+}
+
+const GroupLogsConfigurators: FC<Props> = ({ logs }) => {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const groupBy = searchParams.get(GROUP_BY) || LOGS_GROUP_BY;
+  const noWrapLines = searchParams.get(NO_WRAP_LINES) === "true";
+  const compactGroupHeader = searchParams.get(COMPACT_GROUP_HEADER) === "true";
+  const displayFieldsString = searchParams.get(DISPLAY_FIELDS) || "";
+  const displayFields = displayFieldsString ? displayFieldsString.split(",") : [];
+
+  const [dateFormat, setDateFormat] = useState(searchParams.get(DATE_FORMAT) || LOGS_DATE_FORMAT);
+  const [errorFormat, setErrorFormat] = useState("");
+
+  const isGroupChanged = groupBy !== LOGS_GROUP_BY;
+  const isDisplayFieldsChanged = displayFields.length > 0;
+  const isTimeChanged = searchParams.get(DATE_FORMAT) !== LOGS_DATE_FORMAT;
+  const hasChanges = [
+    isGroupChanged,
+    isDisplayFieldsChanged,
+    noWrapLines,
+    compactGroupHeader,
+    isTimeChanged
+  ].some(Boolean);
+
+  const logsKeys = useMemo(() => {
+    const excludeKeys = ["_msg", "_time"];
+    const uniqKeys = Array.from(new Set(logs.map(l => Object.keys(l)).flat()));
+    return uniqKeys.filter(k => !excludeKeys.includes(k));
+  }, [logs]);
+
+  const {
+    value: openModal,
+    toggle: toggleOpen,
+    setFalse: handleClose,
+  } = useBoolean(false);
+
+  const handleSelectGroupBy = (key: string) => {
+    searchParams.set(GROUP_BY, key);
+    setSearchParams(searchParams);
+  };
+
+  const handleSelectDisplayField = (value: string) => {
+    const prev = displayFields;
+    const newDisplayFields = prev.includes(value) ? prev.filter(v => v !== value) : [...prev, value];
+    searchParams.set(DISPLAY_FIELDS, newDisplayFields.join(","));
+    setSearchParams(searchParams);
+  };
+
+  const handleResetDisplayFields = () => {
+    searchParams.delete(DISPLAY_FIELDS);
+    setSearchParams(searchParams);
+  };
+
+  const toggleWrapLines = () => {
+    searchParams.set(NO_WRAP_LINES, String(!noWrapLines));
+    setSearchParams(searchParams);
+  };
+
+  const toggleCompactGroupHeader = () => {
+    searchParams.set(COMPACT_GROUP_HEADER, String(!compactGroupHeader));
+    setSearchParams(searchParams);
+  };
+
+  const handleChangeDateFormat = (format: string) => {
+    const date = new Date();
+    if (!dayjs(date, format, true).isValid()) {
+      setErrorFormat("Invalid date format");
+    }
+    setDateFormat(format);
+  };
+
+  const handleSaveAndClose = () => {
+    searchParams.set(DATE_FORMAT, dateFormat);
+    setSearchParams(searchParams);
+    handleClose();
+  };
+
+  const tooltipContent = () => {
+    if (!hasChanges) return title;
+    return (
+      <div className="vm-group-logs-configurator__tooltip">
+        <p>{title}</p>
+        <hr/>
+        <ul>
+          {isGroupChanged && <li>Group by <code>{`"${groupBy}"`}</code></li>}
+          {isDisplayFieldsChanged && <li>Display fields: {displayFields.length || 1}</li>}
+          {noWrapLines && <li>Single-line text is enabled</li>}
+          {compactGroupHeader && <li>Compact group header is enabled</li>}
+          {isTimeChanged && <li>Date format: <code>{dateFormat}</code></li>}
+        </ul>
+      </div>
+    );
+  };
+
+  return (
+    <>
+      <div className="vm-group-logs-configurator-button">
+        <Tooltip title={tooltipContent()}>
+          <Button
+            variant="text"
+            startIcon={<SettingsIcon/>}
+            onClick={toggleOpen}
+            ariaLabel={title}
+          />
+        </Tooltip>
+        {hasChanges && <span className="vm-group-logs-configurator-button__marker"/>}
+      </div>
+      {openModal && (
+        <Modal
+          title={title}
+          onClose={handleSaveAndClose}
+        >
+          <div className="vm-group-logs-configurator">
+            <div className="vm-group-logs-configurator-item">
+              <Select
+                value={groupBy}
+                list={[WITHOUT_GROUPING, ...logsKeys]}
+                label="Group by field"
+                placeholder="Group by field"
+                onChange={handleSelectGroupBy}
+                searchable
+              />
+              <Tooltip title={"Reset grouping"}>
+                <Button
+                  variant="text"
+                  color="primary"
+                  startIcon={<RestartIcon/>}
+                  onClick={() => handleSelectGroupBy(LOGS_GROUP_BY)}
+                />
+              </Tooltip>
+              <span className="vm-group-logs-configurator-item__info">
+                Select a field to group logs by (default: <code>{LOGS_GROUP_BY}</code>).
+              </span>
+            </div>
+
+            <div className="vm-group-logs-configurator-item">
+              <Select
+                value={displayFields}
+                list={logsKeys}
+                label="Display fields"
+                placeholder="Display fields"
+                onChange={handleSelectDisplayField}
+                searchable
+              />
+              <Tooltip title={"Clear fields"}>
+                <Button
+                  variant="text"
+                  color="primary"
+                  startIcon={<RestartIcon/>}
+                  onClick={handleResetDisplayFields}
+                />
+              </Tooltip>
+              <span className="vm-group-logs-configurator-item__info">
+                Select fields to display instead of the message (default: <code>{LOGS_DISPLAY_FIELDS}</code>).
+              </span>
+            </div>
+
+            <div className="vm-group-logs-configurator-item">
+              <TextField
+                autofocus
+                label="Date format"
+                value={dateFormat}
+                onChange={handleChangeDateFormat}
+                error={errorFormat}
+              />
+              <Tooltip title={"Reset format"}>
+                <Button
+                  variant="text"
+                  color="primary"
+                  startIcon={<RestartIcon/>}
+                  onClick={() => setDateFormat(LOGS_DATE_FORMAT)}
+                />
+              </Tooltip>
+              <span className="vm-group-logs-configurator-item__info vm-group-logs-configurator-item__info_input">
+                Set the date format (e.g., <code>YYYY-MM-DD HH:mm:ss</code>).
+                Learn more in <Hyperlink
+                  href="https://day.js.org/docs/en/display/format"
+                >this documentation</Hyperlink>. <br/>
+                Your current date format: <code>{dayjs().format(dateFormat || LOGS_DATE_FORMAT)}</code>
+              </span>
+            </div>
+
+            <div className="vm-group-logs-configurator-item">
+              <Switch
+                value={noWrapLines}
+                onChange={toggleWrapLines}
+                label="Single-line message"
+              />
+              <span className="vm-group-logs-configurator-item__info">
+                Displays message in a single line and truncates it with an ellipsis if it exceeds the available space
+              </span>
+            </div>
+
+            <div className="vm-group-logs-configurator-item">
+              <Switch
+                value={compactGroupHeader}
+                onChange={toggleCompactGroupHeader}
+                label="Compact group header"
+              />
+              <span className="vm-group-logs-configurator-item__info">
+                Shows group headers in one line with a &quot;+N more&quot; badge for extra fields.
+              </span>
+            </div>
+          </div>
+        </Modal>
+      )}
+    </>
+  );
+};
+
+export default GroupLogsConfigurators;

--- a/app/vmui/packages/vmui/src/components/LogsConfigurators/GroupLogsConfigurators/style.scss
+++ b/app/vmui/packages/vmui/src/components/LogsConfigurators/GroupLogsConfigurators/style.scss
@@ -1,0 +1,48 @@
+@use "src/styles/variables" as *;
+
+.vm-group-logs-configurator {
+  display: grid;
+  gap: calc($padding-large * 2);
+  padding: $padding-global 0;
+  width: 600px;
+
+  &-item {
+    display: grid;
+    grid-template-columns: 1fr 31px;
+    align-items: center;
+    justify-content: stretch;
+    gap: 0 $padding-small;
+
+    &__info {
+      margin-top: $padding-small;
+      grid-column: 1/span 2;
+      font-size: $font-size-small;
+      color: $color-text-secondary;
+      line-height: 130%;
+
+      &_input {
+        margin-top: 0;
+      }
+    }
+  }
+
+  &-button {
+    position: relative;
+
+    &__marker {
+      position: absolute;
+      top: 6px;
+      left: 6px;
+      width: 5px;
+      height: 5px;
+      border-radius: 50%;
+      background-color: $color-secondary;
+    }
+  }
+
+  &__tooltip {
+    ul {
+      list-style-position: inside;
+    }
+  }
+}

--- a/app/vmui/packages/vmui/src/components/Main/Accordion/Accordion.tsx
+++ b/app/vmui/packages/vmui/src/components/Main/Accordion/Accordion.tsx
@@ -30,6 +30,10 @@ const Accordion: FC<AccordionProps> = ({
     onChange && onChange(isOpen);
   }, [isOpen]);
 
+  useEffect(() => {
+    setIsOpen(defaultExpanded);
+  }, [defaultExpanded]);
+
   return (
     <>
       <header

--- a/app/vmui/packages/vmui/src/components/Main/Modal/Modal.tsx
+++ b/app/vmui/packages/vmui/src/components/Main/Modal/Modal.tsx
@@ -67,11 +67,11 @@ const Modal: FC<ModalProps> = ({
       })}
       onMouseDown={onClose}
     >
-      <div className="vm-modal-content">
-        <div
-          className="vm-modal-content-header"
-          onMouseDown={handleMouseDown}
-        >
+      <div
+        className="vm-modal-content"
+        onMouseDown={handleMouseDown}
+      >
+        <div className="vm-modal-content-header">
           {title && (
             <div className="vm-modal-content-header__title">
               {title}
@@ -91,7 +91,6 @@ const Modal: FC<ModalProps> = ({
         {/* tabIndex to fix Ctrl-A */}
         <div
           className="vm-modal-content-body"
-          onMouseDown={handleMouseDown}
           tabIndex={0}
         >
           {children}

--- a/app/vmui/packages/vmui/src/components/Main/Select/style.scss
+++ b/app/vmui/packages/vmui/src/components/Main/Select/style.scss
@@ -33,9 +33,9 @@
         align-items: center;
         justify-content: center;
         background-color: $color-hover-black;
-        padding: 2px 2px 2px 6px;
+        padding: 2px 2px 2px $padding-small;
         border-radius: $border-radius-small;
-        font-size: $font-size;
+        font-size: $font-size-small;
         line-height: $font-size;
         max-width: 100%;
 

--- a/app/vmui/packages/vmui/src/constants/logs.ts
+++ b/app/vmui/packages/vmui/src/constants/logs.ts
@@ -1,2 +1,21 @@
+import { DATE_TIME_FORMAT } from "./date";
+
 export const LOGS_ENTRIES_LIMIT = 50;
 export const LOGS_BARS_VIEW = 100;
+
+// "Ungrouped" is a string that is used as a value for the "groupBy" parameter.
+export const WITHOUT_GROUPING = "Ungrouped";
+
+// Default values for the logs configurators.
+export const LOGS_GROUP_BY = "_stream";
+export const LOGS_DISPLAY_FIELDS = "_msg";
+export const LOGS_DATE_FORMAT = `${DATE_TIME_FORMAT}.SSS`;
+
+// URL parameters for the logs page.
+export const LOGS_URL_PARAMS = {
+  GROUP_BY: "groupBy",
+  DISPLAY_FIELDS: "displayFields",
+  NO_WRAP_LINES: "noWrapLines",
+  COMPACT_GROUP_HEADER: "compactGroupHeader",
+  DATE_FORMAT: "dateFormat",
+};

--- a/app/vmui/packages/vmui/src/hooks/useClickOutside.ts
+++ b/app/vmui/packages/vmui/src/hooks/useClickOutside.ts
@@ -20,7 +20,7 @@ const useClickOutside = <T extends HTMLElement = HTMLElement>(
     handler(event); // Call the handler only if the click is outside of the element passed.
   }, [ref, handler]);
 
-  useEventListener("mousedown", listener);
+  useEventListener("mouseup", listener);
   useEventListener("touchstart", listener);
 };
 

--- a/app/vmui/packages/vmui/src/pages/ExploreLogs/GroupLogs/GroupLogsFieldRow.tsx
+++ b/app/vmui/packages/vmui/src/pages/ExploreLogs/GroupLogs/GroupLogsFieldRow.tsx
@@ -68,7 +68,7 @@ const GroupLogsFieldRow: FC<Props> = ({ field, value }) => {
             />
           </Tooltip>
           <Tooltip
-            key={`${field}_${isSelectedField}`}
+            key={`${field}_${isSelectedField}_${isGroupByField}`}
             title={isSelectedField ? "Hide this field" : "Show this field instead of the message"}
           >
             <Button
@@ -82,7 +82,7 @@ const GroupLogsFieldRow: FC<Props> = ({ field, value }) => {
             />
           </Tooltip>
           <Tooltip
-            key={`${field}_${isGroupByField}`}
+            key={`${field}_${isSelectedField}_${isGroupByField}`}
             title={isGroupByField ? "Ungroup this field" : "Group by this field"}
           >
             <Button

--- a/app/vmui/packages/vmui/src/pages/ExploreLogs/GroupLogs/GroupLogsFieldRow.tsx
+++ b/app/vmui/packages/vmui/src/pages/ExploreLogs/GroupLogs/GroupLogsFieldRow.tsx
@@ -1,8 +1,10 @@
 import React, { FC, memo, useCallback, useEffect, useState } from "preact/compat";
 import Tooltip from "../../../components/Main/Tooltip/Tooltip";
 import Button from "../../../components/Main/Button/Button";
-import { CopyIcon } from "../../../components/Main/Icons";
+import { CopyIcon, StorageIcon, VisibilityIcon } from "../../../components/Main/Icons";
 import useCopyToClipboard from "../../../hooks/useCopyToClipboard";
+import { useSearchParams } from "react-router-dom";
+import { LOGS_GROUP_BY, LOGS_URL_PARAMS } from "../../../constants/logs";
 
 interface Props {
   field: string;
@@ -11,7 +13,16 @@ interface Props {
 
 const GroupLogsFieldRow: FC<Props> = ({ field, value }) => {
   const copyToClipboard = useCopyToClipboard();
+  const [searchParams, setSearchParams] = useSearchParams();
+
   const [copied, setCopied] = useState<boolean>(false);
+
+  const groupBy = searchParams.get(LOGS_URL_PARAMS.GROUP_BY) || LOGS_GROUP_BY;
+  const displayFieldsString = searchParams.get(LOGS_URL_PARAMS.DISPLAY_FIELDS) || "";
+  const displayFields = displayFieldsString ? displayFieldsString.split(",") : [];
+
+  const isSelectedField = displayFields.includes(field);
+  const isGroupByField = groupBy === field;
 
   const handleCopy = useCallback(async () => {
     if (copied) return;
@@ -22,6 +33,18 @@ const GroupLogsFieldRow: FC<Props> = ({ field, value }) => {
       console.error(e);
     }
   }, [copied, copyToClipboard]);
+
+  const handleSelectDisplayField = () => {
+    const prev = displayFields;
+    const newDisplayFields = prev.includes(field) ? prev.filter(v => v !== field) : [...prev, field];
+    searchParams.set(LOGS_URL_PARAMS.DISPLAY_FIELDS, newDisplayFields.join(","));
+    setSearchParams(searchParams);
+  };
+
+  const handleSelectGroupBy = () => {
+    isGroupByField ? searchParams.delete(LOGS_URL_PARAMS.GROUP_BY) : searchParams.set(LOGS_URL_PARAMS.GROUP_BY, field);
+    setSearchParams(searchParams);
+  };
 
   useEffect(() => {
     if (copied === null) return;
@@ -35,11 +58,40 @@ const GroupLogsFieldRow: FC<Props> = ({ field, value }) => {
         <div className="vm-group-logs-row-fields-item-controls__wrapper">
           <Tooltip title={copied ? "Copied" : "Copy to clipboard"}>
             <Button
+              className="vm-group-logs-row-fields-item-controls__button"
               variant="text"
               color="gray"
               size="small"
               startIcon={<CopyIcon/>}
               onClick={handleCopy}
+              ariaLabel="copy to clipboard"
+            />
+          </Tooltip>
+          <Tooltip
+            key={`${field}_${isSelectedField}`}
+            title={isSelectedField ? "Hide this field" : "Show this field instead of the message"}
+          >
+            <Button
+              className="vm-group-logs-row-fields-item-controls__button"
+              variant="text"
+              color={isSelectedField ? "secondary" : "gray"}
+              size="small"
+              startIcon={isSelectedField ? <VisibilityIcon/> : <VisibilityIcon/>}
+              onClick={handleSelectDisplayField}
+              ariaLabel="copy to clipboard"
+            />
+          </Tooltip>
+          <Tooltip
+            key={`${field}_${isGroupByField}`}
+            title={isGroupByField ? "Ungroup this field" : "Group by this field"}
+          >
+            <Button
+              className="vm-group-logs-row-fields-item-controls__button"
+              variant="text"
+              color={isGroupByField ? "secondary" : "gray"}
+              size="small"
+              startIcon={<StorageIcon/>}
+              onClick={handleSelectGroupBy}
               ariaLabel="copy to clipboard"
             />
           </Tooltip>

--- a/app/vmui/packages/vmui/src/pages/ExploreLogs/GroupLogs/GroupLogsHeader.tsx
+++ b/app/vmui/packages/vmui/src/pages/ExploreLogs/GroupLogs/GroupLogsHeader.tsx
@@ -1,0 +1,127 @@
+import React, { FC, useCallback, useEffect, useRef } from "preact/compat";
+import classNames from "classnames";
+import { useSearchParams } from "react-router-dom";
+import { MouseEvent, useState } from "react";
+import { useAppState } from "../../../state/common/StateContext";
+import { Logs } from "../../../api/types";
+import useEventListener from "../../../hooks/useEventListener";
+import Popper from "../../../components/Main/Popper/Popper";
+import useBoolean from "../../../hooks/useBoolean";
+import GroupLogsHeaderItem from "./GroupLogsHeaderItem";
+import { LOGS_GROUP_BY, LOGS_URL_PARAMS } from "../../../constants/logs";
+
+interface Props {
+  group: {
+    keys: string[]
+    keysString: string
+    values: Logs[]
+    pairs: string[]
+  };
+}
+
+const GroupLogsHeader: FC<Props> = ({ group }) => {
+  const { isDarkTheme } = useAppState();
+  const [searchParams] = useSearchParams();
+
+  const containerRef = useRef<HTMLDivElement>(null);
+  const moreRef = useRef<HTMLDivElement>(null);
+
+  const {
+    value: openMore,
+    toggle: handleToggleMore,
+    setFalse: handleCloseMore,
+  } = useBoolean(false);
+
+  const [hideParisCount, setHideParisCount] = useState<number>(0);
+
+  const groupBy = searchParams.get(LOGS_URL_PARAMS.GROUP_BY) || LOGS_GROUP_BY;
+  const compactGroupHeader = searchParams.get(LOGS_URL_PARAMS.COMPACT_GROUP_HEADER) === "true";
+
+  const pairs = group.pairs;
+  const hideAboveIndex = pairs.length - hideParisCount - 1;
+
+  const handleClickMore = (e: MouseEvent<HTMLDivElement>) => {
+    e.stopPropagation();
+    handleToggleMore();
+  };
+
+  const calcVisiblePairsCount = useCallback(() => {
+    if (!compactGroupHeader || !containerRef.current) {
+      setHideParisCount(0);
+      return;
+    }
+
+    const container = containerRef.current;
+    const containerSize = container.getBoundingClientRect();
+    const selector = ".vm-group-logs-section-keys__pair:not(.vm-group-logs-section-keys__pair_more)";
+    const children = Array.from(container.querySelectorAll(selector));
+    let count = 0;
+
+    for (const child of children) {
+      const { right } = (child as HTMLElement).getBoundingClientRect();
+
+      if ((right + 220) > containerSize.width) {
+        count++;
+      }
+    }
+
+    setHideParisCount(count);
+  }, [compactGroupHeader, containerRef]);
+
+  useEffect(calcVisiblePairsCount, [group.pairs, compactGroupHeader, containerRef]);
+
+  useEventListener("resize", calcVisiblePairsCount);
+
+  return (
+    <div
+      className={classNames({
+        "vm-group-logs-section-keys": true,
+        "vm-group-logs-section-keys_compact": compactGroupHeader,
+      })}
+      ref={containerRef}
+    >
+      <span className="vm-group-logs-section-keys__title">Group by <code>{groupBy}</code>:</span>
+      {pairs.map((pair, i) => (
+        <GroupLogsHeaderItem
+          key={`${group.keysString}_${pair}`}
+          pair={pair}
+          isHide={hideParisCount ? i > hideAboveIndex : false}
+        />
+      ))}
+      {hideParisCount > 0 && (
+        <>
+          <div
+            className={classNames({
+              "vm-group-logs-section-keys__pair": true,
+              "vm-group-logs-section-keys__pair_more": true,
+              "vm-group-logs-section-keys__pair_dark": isDarkTheme
+            })}
+            ref={moreRef}
+            onClick={handleClickMore}
+          >
+            +{hideParisCount} more
+          </div>
+          <Popper
+            open={openMore}
+            buttonRef={moreRef}
+            placement="bottom-left"
+            onClose={handleCloseMore}
+          >
+            <div className="vm-group-logs-section-keys vm-group-logs-section-keys_popper">
+              {pairs.slice(hideAboveIndex + 1).map((pair) => (
+                <GroupLogsHeaderItem
+                  key={`${group.keysString}_${pair}`}
+                  pair={pair}
+                />
+              ))}
+            </div>
+          </Popper>
+        </>
+      )}
+      <span className="vm-group-logs-section-keys__count">{group.values.length} entries</span>
+    </div>
+  )
+  ;
+};
+
+export default GroupLogsHeader;

--- a/app/vmui/packages/vmui/src/pages/ExploreLogs/GroupLogs/GroupLogsHeaderItem.tsx
+++ b/app/vmui/packages/vmui/src/pages/ExploreLogs/GroupLogs/GroupLogsHeaderItem.tsx
@@ -1,0 +1,59 @@
+import React, { FC, useEffect } from "preact/compat";
+import { useAppState } from "../../../state/common/StateContext";
+import Tooltip from "../../../components/Main/Tooltip/Tooltip";
+import classNames from "classnames";
+import { MouseEvent, useState } from "react";
+import useCopyToClipboard from "../../../hooks/useCopyToClipboard";
+import { useSearchParams } from "react-router-dom";
+import { LOGS_GROUP_BY, LOGS_URL_PARAMS } from "../../../constants/logs";
+
+interface Props {
+  pair: string;
+  isHide?: boolean;
+}
+
+const GroupLogsHeaderItem: FC<Props> = ({ pair, isHide }) => {
+  const { isDarkTheme } = useAppState();
+  const copyToClipboard = useCopyToClipboard();
+  const [searchParams] = useSearchParams();
+
+  const [copied, setCopied] = useState<string | null>(null);
+
+  const groupBy = searchParams.get(LOGS_URL_PARAMS.GROUP_BY) || LOGS_GROUP_BY;
+
+  const handleClickByPair = (value: string) => async (e: MouseEvent<HTMLDivElement>) => {
+    e.stopPropagation();
+    const isKeyValue = /(.+)?=(".+")/.test(value);
+    const copyValue = isKeyValue ? `${value.replace(/=/, ": ")}` : `${groupBy}: "${value}"`;
+    const isCopied = await copyToClipboard(copyValue);
+    if (isCopied) {
+      setCopied(value);
+    }
+  };
+
+  useEffect(() => {
+    if (copied === null) return;
+    const timeout = setTimeout(() => setCopied(null), 2000);
+    return () => clearTimeout(timeout);
+  }, [copied]);
+
+  return (
+    <Tooltip
+      title={copied === pair ? "Copied" : "Copy to clipboard"}
+      placement={"top-center"}
+    >
+      <div
+        className={classNames({
+          "vm-group-logs-section-keys__pair": true,
+          "vm-group-logs-section-keys__pair_hide": isHide,
+          "vm-group-logs-section-keys__pair_dark": isDarkTheme
+        })}
+        onClick={handleClickByPair(pair)}
+      >
+        {pair}
+      </div>
+    </Tooltip>
+  );
+};
+
+export default GroupLogsHeaderItem;

--- a/app/vmui/packages/vmui/src/pages/ExploreLogs/GroupLogs/style.scss
+++ b/app/vmui/packages/vmui/src/pages/ExploreLogs/GroupLogs/style.scss
@@ -1,5 +1,7 @@
 @use "src/styles/variables" as *;
 
+$font-size-logs: var(--font-size-logs, $font-size-small);
+
 .vm-group-logs {
   margin-top: calc(-1 * $padding-medium);
 
@@ -19,22 +21,44 @@
   }
 
   &-section {
+    border-bottom: $border-divider;
+
     &-keys {
+      position: relative;
       display: flex;
       align-items: center;
       flex-wrap: wrap;
       gap: $padding-small;
-      border-bottom: $border-divider;
-      padding: $padding-small 0;
+      padding: $padding-small 120px $padding-small 0;
+      font-size: $font-size-logs;
+
+      &_compact {
+        flex-wrap: nowrap;
+        overflow: hidden;
+      }
+
+      &_popper {
+        display: flex;
+        flex-wrap: nowrap;
+        flex-direction: column;
+        align-items: flex-start;
+        justify-content: flex-start;
+        padding: $padding-global;
+        max-height: 400px;
+        overflow: auto;
+      }
 
       &__title {
         font-weight: bold;
+        white-space: nowrap;
 
         code {
           font-family: monospace;
+
           &:before {
             content: "\"";
           }
+
           &:after {
             content: "\"";
           }
@@ -42,19 +66,35 @@
       }
 
       &__count {
+        position: absolute;
+        top: auto;
+        right: 0;
         flex-grow: 1;
         text-align: right;
-        font-size: $font-size-small;
+        font-size: $font-size-logs;
         color: $color-text-secondary;
         padding-right: calc($padding-large * 3);
       }
 
       &__pair {
+        order: 0;
         padding: calc($padding-global / 2) $padding-global;
         background-color: lighten($color-tropical-blue, 6%);
         color: darken($color-dodger-blue, 20%);
         border-radius: $border-radius-medium;
         transition: background-color 0.3s ease-in, transform 0.1s ease-in, opacity 0.3s ease-in;
+        white-space: nowrap;
+
+        &_hide {
+          order: 2;
+          visibility: hidden;
+          opacity: 0;
+          pointer-events: none;
+        }
+
+        &_more {
+          order: 1;
+        }
 
         &:hover {
           background-color: $color-tropical-blue;
@@ -84,13 +124,19 @@
 
   &-row {
     position: relative;
-    border-bottom: $border-divider;
+
+    &:last-child {
+      margin-bottom: $padding-small;
+    }
 
     &-content {
       position: relative;
       display: grid;
-      grid-template-columns: auto minmax(180px, max-content) 1fr;
-      padding: $padding-global 0;
+      grid-template-columns: auto max-content 1fr;
+      padding: calc($padding-small / 4) 0;
+      font-size: $font-size-logs;
+      font-variant-numeric: tabular-nums;
+      line-height: 1.3;
       cursor: pointer;
       transition: background-color 0.2s ease-in;
 
@@ -116,8 +162,7 @@
         display: flex;
         align-items: flex-start;
         justify-content: flex-end;
-        margin-right: $padding-small;
-        line-height: 1;
+        padding: 0 $padding-global 0 $padding-small;
         white-space: nowrap;
 
         &_missing {
@@ -130,7 +175,12 @@
       &__msg {
         font-family: $font-family-monospace;
         overflow-wrap: anywhere;
-        line-height: 1.1;
+
+        &_single-line {
+          overflow: hidden;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+        }
 
         &_empty-msg {
           overflow: hidden;
@@ -158,7 +208,7 @@
           border-radius: $border-radius-small;
           tab-size: 4;
           font-variant-ligatures: none;
-          margin: calc($padding-small/4) 0;
+          margin: calc($padding-small / 4) 0;
         }
 
         p {
@@ -171,7 +221,7 @@
         }
 
         code {
-          font-size: $font-size-small;
+          font-size: $font-size-logs;
           padding: calc($padding-small / 4) calc($padding-small / 2);
         }
 
@@ -194,25 +244,35 @@
 
         blockquote {
           border-left: 4px solid $color-hover-black;
-          margin: calc($padding-small/2) $padding-small;
-          padding: calc($padding-small/2) $padding-small;
+          margin: calc($padding-small / 2) $padding-small;
+          padding: calc($padding-small / 2) $padding-small;
         }
 
         ul, ol {
           list-style-position: inside;
         }
+
         /* end styles for markdown */
+      }
+
+      &__sub-msg {
+        padding-right: $padding-global;
       }
     }
 
     &-fields {
+      position: relative;
       grid-row: 2;
       padding: $padding-small 0;
-      margin-bottom: $padding-small;
+      margin: $padding-small 0 $padding-small calc($padding-global * 2);
       border: $border-divider;
       border-radius: $border-radius-small;
       overflow: auto;
-      max-height: 300px;
+      height: 300px;
+      resize: vertical;
+      font-family: $font-family-monospace;
+      font-size: $font-size-logs;
+      font-variant-numeric: tabular-nums;
 
       &-item {
         border-radius: $border-radius-small;
@@ -223,19 +283,26 @@
         }
 
         &-controls {
-          padding: 0;
+          padding: 0 calc($padding-small / 2);
 
           &__wrapper {
             display: flex;
             align-items: center;
             justify-content: center;
           }
+
+          &__button.vm-button_small {
+            width: 22px;
+            height: 22px;
+            min-height: 22px;
+          }
         }
 
         &__key,
         &__value {
           vertical-align: top;
-          padding: calc($padding-small / 2) $padding-global;
+          line-height: $font-size;
+          padding: calc($padding-small / 2);
         }
 
         &__key {

--- a/docs/VictoriaLogs/CHANGELOG.md
+++ b/docs/VictoriaLogs/CHANGELOG.md
@@ -17,6 +17,9 @@ according to [these docs](https://docs.victoriametrics.com/victorialogs/quicksta
 ## tip
 
 * FEATURE: [web UI](https://docs.victoriametrics.com/victorialogs/querying/#web-ui): updated the default graph type in the `hits panel` to bars with color fill. Removed options for `lines`, `stepped lines`, and `points`. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/7101).
+* FEATURE: [web UI](https://docs.victoriametrics.com/victorialogs/querying/#web-ui): reduce logs text size and improved styles in grouped view. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/7479).
+* FEATURE: [web UI](https://docs.victoriametrics.com/victorialogs/querying/#web-ui): add the ability to select fields for display instead of the `_msg` field. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/7419).
+* FEATURE: [web UI](https://docs.victoriametrics.com/victorialogs/querying/#web-ui): add various display configuration settings for the grouped view. See [this pull request](https://github.com/VictoriaMetrics/VictoriaMetrics/pull/7815)
 
 ## [v1.6.1](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.6.1-victorialogs)
 


### PR DESCRIPTION
### Describe Your Changes

This PR introduces improvements for the `Group view` tab:

1. **Reduced text size and improved styles**  
   Related issue: #7479
   <details>  
   <summary>Demo UI</summary>  
   
   <img src="https://github.com/user-attachments/assets/c96aed95-e668-49a5-af20-778580e8a884"/>
   
   </details>  

2. **Added the ability to select a field to display instead of `_msg`**  
   You can select fields to display in the field list or in the settings
   Related issue: #7419
   <details>  
   <summary>Demo UI</summary>  
      
      <img width="600" src="https://github.com/user-attachments/assets/b5ae1433-bf40-4151-986b-ba057791dcee"/>
      <img width="600" src="https://github.com/user-attachments/assets/2c3d8c5c-1543-43ee-8241-8fd4d4b99b1d"/>

   </details>

3. **Added date format customization**  
   <details>  
   <summary>Demo UI</summary>  
      
      <img width="400" src="https://github.com/user-attachments/assets/b095adfd-cbe3-45a6-bd7d-dc574d3edfd1"/>
      <img width="400" src="https://github.com/user-attachments/assets/0e8b0fbc-2c01-40b7-b9b8-7ef04d21ef9b"/>
      
   </details>  

4. **Added an option to display log messages in a single line**  
   <details>  
   <summary>Demo UI</summary>  
   
   <img width="400" src="https://github.com/user-attachments/assets/43d64a57-19c9-4b15-9009-13b8545d906c"/>
   <img src="https://github.com/user-attachments/assets/eaada2b1-9474-4496-ac39-b38332e637c1"/>

   </details>  

5. **Added an option to display group labels in a single line**  
   <details>  
   <summary>Demo UI</summary>  

   <img width="400" src="https://github.com/user-attachments/assets/05be097a-7b19-4e7b-9cf4-181fd802728b"/>
   <img src="https://github.com/user-attachments/assets/d4405fa6-3829-4713-8537-11edc6da5c4f"/>
   <img src="https://github.com/user-attachments/assets/90d2c48d-ba3b-4051-a645-22e7c8945dcb"/>

   </details> 
   
7. **Settings indicator for modified defaults**  
   A red marker is displayed on the settings icon if the default settings are changed. Hovering over it shows all the modified parameters.  
   <details>  
   <summary>Demo UI</summary>  

   <img src="https://github.com/user-attachments/assets/19fbaf9b-684b-4cac-ad80-2db5e63804e9"/>
   
   </details>     
   
   

