### PR TITLE
lib/storage: update dedup tests

### DIFF
--- a/lib/storage/dedup_test.go
+++ b/lib/storage/dedup_test.go
@@ -81,7 +81,7 @@ func TestDeduplicateSamplesWithIdenticalTimestamps(t *testing.T) {
 	f(time.Second, []int64{1001, 1001}, []float64{2, 1}, []int64{1001}, []float64{2})
 	f(time.Second, []int64{1000, 1001, 1001, 1001, 2001}, []float64{1, 2, 5, 3, 0}, []int64{1000, 1001, 2001}, []float64{1, 5, 0})
 
-	// position of decimal.StaleNaN in the interval shouldn't matter during deduplication
+	// position of decimal.StaleNaN shouldn't matter during deduplication
 	// see https://github.com/VictoriaMetrics/VictoriaMetrics/issues/7674
 	f(time.Second, []int64{1000, 1000}, []float64{2, decimal.StaleNaN}, []int64{1000}, []float64{decimal.StaleNaN})
 	f(time.Second, []int64{1000, 1000}, []float64{decimal.StaleNaN, 2}, []int64{1000}, []float64{decimal.StaleNaN})
@@ -90,7 +90,7 @@ func TestDeduplicateSamplesWithIdenticalTimestamps(t *testing.T) {
 	f(time.Second, []int64{1000, 1000}, []float64{math.Inf(1), decimal.StaleNaN}, []int64{1000}, []float64{decimal.StaleNaN})
 	f(time.Second, []int64{1000, 1000}, []float64{decimal.StaleNaN, math.Inf(1)}, []int64{1000}, []float64{decimal.StaleNaN})
 	f(time.Second, []int64{1000, 1000, 1000}, []float64{math.Inf(1), decimal.StaleNaN, math.Inf(-1)}, []int64{1000}, []float64{decimal.StaleNaN})
-	// verify decimal.StaleNaN is preferred only within deduplicationInterval
+	// verify decimal.StaleNaN is preferred only on timestamp conflicts
 	f(time.Second, []int64{1000, 1000, 2000}, []float64{1, decimal.StaleNaN, 2}, []int64{1000, 2000}, []float64{decimal.StaleNaN, 2})
 	f(time.Second, []int64{1000, 1000, 2000, 2000}, []float64{1, decimal.StaleNaN, 2, 3}, []int64{1000, 2000}, []float64{decimal.StaleNaN, 3})
 	f(time.Second, []int64{1000, 1000, 1000, 2000, 2000}, []float64{1, decimal.StaleNaN, 6, 2, 3}, []int64{1000, 2000}, []float64{decimal.StaleNaN, 3})
@@ -125,7 +125,7 @@ func TestDeduplicateSamplesDuringMergeWithIdenticalTimestamps(t *testing.T) {
 	f(time.Second, []int64{1000, 1001, 1001, 1001, 2001}, []int64{1, 2, 5, 3, 0}, []int64{1000, 1001, 2001}, []int64{1, 5, 0})
 
 	staleNaN, _ := decimal.FromFloat(decimal.StaleNaN)
-	// position of decimal.StaleNaN in the interval shouldn't matter during deduplication
+	// position of decimal.StaleNaN shouldn't matter during deduplication
 	// see https://github.com/VictoriaMetrics/VictoriaMetrics/issues/7674
 	f(time.Second, []int64{1000, 1000}, []int64{2, staleNaN}, []int64{1000}, []int64{staleNaN})
 	f(time.Second, []int64{1000, 1000}, []int64{staleNaN, 2}, []int64{1000}, []int64{staleNaN})
@@ -134,7 +134,7 @@ func TestDeduplicateSamplesDuringMergeWithIdenticalTimestamps(t *testing.T) {
 	f(time.Second, []int64{1000, 1000}, []int64{math.MaxInt64, staleNaN}, []int64{1000}, []int64{staleNaN})
 	f(time.Second, []int64{1000, 1000}, []int64{staleNaN, math.MaxInt64}, []int64{1000}, []int64{staleNaN})
 	f(time.Second, []int64{1000, 1000, 1000}, []int64{math.MaxInt64, staleNaN, math.MaxInt64}, []int64{1000}, []int64{staleNaN})
-	// verify decimal.StaleNaN is preferred only within deduplicationInterval
+	// verify decimal.StaleNaN is preferred only on timestamp conflicts
 	f(time.Second, []int64{1000, 1000, 2000}, []int64{1, staleNaN, 2}, []int64{1000, 2000}, []int64{staleNaN, 2})
 	f(time.Second, []int64{1000, 1000, 2000, 2000}, []int64{1, staleNaN, 2, 3}, []int64{1000, 2000}, []int64{staleNaN, 3})
 	f(time.Second, []int64{1000, 1000, 1000, 2000, 2000}, []int64{1, staleNaN, math.MaxInt64, 2, 3}, []int64{1000, 2000}, []int64{staleNaN, 3})

--- a/lib/storage/dedup_timing_test.go
+++ b/lib/storage/dedup_timing_test.go
@@ -11,10 +11,15 @@ func BenchmarkDeduplicateSamples(b *testing.B) {
 	timestamps := make([]int64, blockSize)
 	values := make([]float64, blockSize)
 	for i := 0; i < len(timestamps); i++ {
-		timestamps[i] = int64(i) * 1e3
+		isDuplicate := i%2 == 1
+		ts := int64(i) * 1e3
+		if isDuplicate {
+			ts = int64(i-1) * 1e3
+		}
+		timestamps[i] = ts
 		values[i] = float64(i)
 	}
-	for _, minScrapeInterval := range []time.Duration{time.Second, 2 * time.Second, 5 * time.Second, 10 * time.Second} {
+	for _, minScrapeInterval := range []time.Duration{3 * time.Second, 4 * time.Second, 10 * time.Second} {
 		b.Run(fmt.Sprintf("minScrapeInterval=%s", minScrapeInterval), func(b *testing.B) {
 			dedupInterval := minScrapeInterval.Milliseconds()
 			b.ReportAllocs()
@@ -40,10 +45,14 @@ func BenchmarkDeduplicateSamplesDuringMerge(b *testing.B) {
 	timestamps := make([]int64, blockSize)
 	values := make([]int64, blockSize)
 	for i := 0; i < len(timestamps); i++ {
-		timestamps[i] = int64(i) * 1e3
-		values[i] = int64(i)
+		isDuplicate := i%2 == 1
+		ts := int64(i) * 1e3
+		if isDuplicate {
+			ts = int64(i-1) * 1e3
+		}
+		timestamps[i] = ts
 	}
-	for _, minScrapeInterval := range []time.Duration{time.Second, 2 * time.Second, 5 * time.Second, 10 * time.Second} {
+	for _, minScrapeInterval := range []time.Duration{3 * time.Second, 4 * time.Second, 10 * time.Second} {
 		b.Run(fmt.Sprintf("minScrapeInterval=%s", minScrapeInterval), func(b *testing.B) {
 			dedupInterval := minScrapeInterval.Milliseconds()
 			b.ReportAllocs()


### PR DESCRIPTION
* update misleading comments about preferring NaNs on intervals. NaNs are only preferred on timestamp conflicts
* add conflicting timestamps to the benchmark test. Previously, benchmark wasn't checking the timestamp conflict code branch. The updated results after https://github.com/VictoriaMetrics/VictoriaMetrics/commit/c0fcfd6b97d347ce5c59c9b187edcddefb0f0bbb are the following:
```
benchstat old.txt new.txt

goos: darwin
goarch: arm64
pkg: github.com/VictoriaMetrics/VictoriaMetrics/lib/storage
cpu: Apple M4 Pro
                                                       │   old.txt    │               new.txt                │
                                                       │    sec/op    │    sec/op     vs base                │
DeduplicateSamples/minScrapeInterval=3s-14               889.7n ± ∞ ¹   904.3n ± ∞ ¹       ~ (p=1.000 n=1) ²
DeduplicateSamples/minScrapeInterval=4s-14               735.9n ± ∞ ¹   748.7n ± ∞ ¹       ~ (p=1.000 n=1) ²
DeduplicateSamples/minScrapeInterval=10s-14              637.7n ± ∞ ¹   659.3n ± ∞ ¹       ~ (p=1.000 n=1) ²
DeduplicateSamplesDuringMerge/minScrapeInterval=3s-14    838.8n ± ∞ ¹   810.4n ± ∞ ¹       ~ (p=1.000 n=1) ²
DeduplicateSamplesDuringMerge/minScrapeInterval=4s-14    765.2n ± ∞ ¹   735.1n ± ∞ ¹       ~ (p=1.000 n=1) ²
DeduplicateSamplesDuringMerge/minScrapeInterval=10s-14   673.1n ± ∞ ¹   622.4n ± ∞ ¹       ~ (p=1.000 n=1) ²
geomean                                                  751.7n         741.0n        -1.42%
```

### Describe Your Changes

Please provide a brief description of the changes you made. Be as specific as possible to help others understand the purpose and impact of your modifications.

### Checklist

The following checks are **mandatory**:

- [ ] My change adheres [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/contributing/).
