### PR TITLE
app/vminsert: properly apply relabeling at ingestion

### DIFF
--- a/app/vminsert/common/insert_ctx.go
+++ b/app/vminsert/common/insert_ctx.go
@@ -73,7 +73,7 @@ func (ctx *InsertCtx) TryPrepareLabels(hasRelabeling bool) bool {
 	if timeserieslimits.Enabled() && timeserieslimits.IsExceeding(ctx.Labels) {
 		return false
 	}
-	ctx.SortLabelsIfNeeded()
+	ctx.sortLabelsIfNeeded()
 
 	return true
 }

--- a/app/vminsert/common/insert_ctx.go
+++ b/app/vminsert/common/insert_ctx.go
@@ -79,18 +79,9 @@ func (ctx *InsertCtx) TryPrepareLabels(hasRelabeling bool) bool {
 }
 
 // WriteDataPoint writes (timestamp, value) with the given prefix and labels into ctx buffer.
-func (ctx *InsertCtx) WriteDataPoint(prefix []byte, hasRelabeling bool, labels []prompbmarshal.Label, timestamp int64, value float64) error {
-	if !ctx.TryPrepareLabels(hasRelabeling) {
-		return nil
-	}
-	metricNameRaw := ctx.marshalMetricNameRaw(prefix, labels)
-	return ctx.addRow(metricNameRaw, timestamp, value)
-}
-
-// WriteDataPointUnchecked writes (timestamp, value) with the given prefix and labels into ctx buffer.
 //
 // caller should invoke TryPrepareLabels before using this function if needed
-func (ctx *InsertCtx) WriteDataPointUnchecked(prefix []byte, labels []prompbmarshal.Label, timestamp int64, value float64) error {
+func (ctx *InsertCtx) WriteDataPoint(prefix []byte, labels []prompbmarshal.Label, timestamp int64, value float64) error {
 	metricNameRaw := ctx.marshalMetricNameRaw(prefix, labels)
 	return ctx.addRow(metricNameRaw, timestamp, value)
 }

--- a/app/vminsert/common/sort_labels.go
+++ b/app/vminsert/common/sort_labels.go
@@ -12,8 +12,8 @@ var sortLabels = flag.Bool("sortLabels", false, `Whether to sort labels for inco
 	`For example, if m{k1="v1",k2="v2"} may be sent as m{k2="v2",k1="v1"}. `+
 	`Enabled sorting for labels can slow down ingestion performance a bit`)
 
-// SortLabelsIfNeeded sorts labels if -sortLabels command-line flag is set
-func (ctx *InsertCtx) SortLabelsIfNeeded() {
+// sortLabelsIfNeeded sorts labels if -sortLabels command-line flag is set
+func (ctx *InsertCtx) sortLabelsIfNeeded() {
 	if *sortLabels {
 		sort.Sort(&ctx.Labels)
 	}

--- a/app/vminsert/common/streamaggr.go
+++ b/app/vminsert/common/streamaggr.go
@@ -267,7 +267,7 @@ func pushAggregateSeries(tss []prompbmarshal.TimeSeries) {
 			ctx.AddLabel(name, label.Value)
 		}
 		value := ts.Samples[0].Value
-		if err := ctx.WriteDataPointUnchecked(nil, ctx.Labels, currentTimestamp, value); err != nil {
+		if err := ctx.WriteDataPoint(nil, ctx.Labels, currentTimestamp, value); err != nil {
 			logger.Errorf("cannot store aggregate series: %s", err)
 			// Do not continue pushing the remaining samples, since it is likely they will return the same error.
 			return

--- a/app/vminsert/csvimport/request_handler.go
+++ b/app/vminsert/csvimport/request_handler.go
@@ -46,7 +46,10 @@ func insertRows(rows []parser.Row, extraLabels []prompbmarshal.Label) error {
 			label := &extraLabels[j]
 			ctx.AddLabel(label.Name, label.Value)
 		}
-		if err := ctx.WriteDataPoint(nil, hasRelabeling, ctx.Labels, r.Timestamp, r.Value); err != nil {
+		if !ctx.TryPrepareLabels(hasRelabeling) {
+			continue
+		}
+		if err := ctx.WriteDataPoint(nil, ctx.Labels, r.Timestamp, r.Value); err != nil {
 			return err
 		}
 	}

--- a/app/vminsert/graphite/request_handler.go
+++ b/app/vminsert/graphite/request_handler.go
@@ -36,7 +36,10 @@ func insertRows(rows []parser.Row) error {
 			tag := &r.Tags[j]
 			ctx.AddLabel(tag.Key, tag.Value)
 		}
-		if err := ctx.WriteDataPoint(nil, hasRelabeling, ctx.Labels, r.Timestamp, r.Value); err != nil {
+		if !ctx.TryPrepareLabels(hasRelabeling) {
+			continue
+		}
+		if err := ctx.WriteDataPoint(nil, ctx.Labels, r.Timestamp, r.Value); err != nil {
 			return err
 		}
 	}

--- a/app/vminsert/influx/request_handler.go
+++ b/app/vminsert/influx/request_handler.go
@@ -14,6 +14,7 @@ import (
 	parser "github.com/VictoriaMetrics/VictoriaMetrics/lib/protoparser/influx"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/protoparser/influx/stream"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/storage"
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/timeserieslimits"
 	"github.com/VictoriaMetrics/metrics"
 )
 
@@ -69,6 +70,7 @@ func insertRows(db string, rows []parser.Row, extraLabels []prompbmarshal.Label)
 	ic.Reset(rowsLen)
 	rowsTotal := 0
 	hasRelabeling := relabel.HasRelabeling()
+	hasLimitsEnabled := timeserieslimits.Enabled()
 	for i := range rows {
 		r := &rows[i]
 		rowsTotal += len(r.Fields)
@@ -108,7 +110,7 @@ func insertRows(db string, rows []parser.Row, extraLabels []prompbmarshal.Label)
 				metricGroup := bytesutil.ToUnsafeString(ctx.metricGroupBuf)
 				ic.Labels = append(ic.Labels[:0], ctx.originLabels...)
 				ic.AddLabel("", metricGroup)
-				if !ic.TryPrepareLabels(hasRelabeling) {
+				if !ic.TryPrepareLabels(true) {
 					continue
 				}
 				if err := ic.WriteDataPoint(nil, ic.Labels, r.Timestamp, f.Value); err != nil {
@@ -116,6 +118,9 @@ func insertRows(db string, rows []parser.Row, extraLabels []prompbmarshal.Label)
 				}
 			}
 		} else {
+			if !ic.TryPrepareLabels(false) {
+				continue
+			}
 			ctx.metricNameBuf = storage.MarshalMetricNameRaw(ctx.metricNameBuf[:0], ic.Labels)
 			labelsLen := len(ic.Labels)
 			for j := range r.Fields {
@@ -126,8 +131,12 @@ func insertRows(db string, rows []parser.Row, extraLabels []prompbmarshal.Label)
 				metricGroup := bytesutil.ToUnsafeString(ctx.metricGroupBuf)
 				ic.Labels = ic.Labels[:labelsLen]
 				ic.AddLabel("", metricGroup)
-				if !ic.TryPrepareLabels(hasRelabeling) {
-					continue
+				if hasLimitsEnabled {
+					// special case for optimisation above
+					// check only __name__ label value limits
+					if timeserieslimits.IsExceeding(ic.Labels[len(ic.Labels)-1:]) {
+						continue
+					}
 				}
 				if err := ic.WriteDataPoint(ctx.metricNameBuf, ic.Labels[len(ic.Labels)-1:], r.Timestamp, f.Value); err != nil {
 					return err

--- a/app/vminsert/native/request_handler.go
+++ b/app/vminsert/native/request_handler.go
@@ -68,7 +68,7 @@ func insertRows(block *stream.Block, extraLabels []prompbmarshal.Label) error {
 		timestamp := timestamps[j]
 		// TODO: @f41gh7 looks like it's better to use WriteDataPointExt
 		// since metricName never changes inside insertRows call
-		if err := ic.WriteDataPointUnchecked(ctx.metricNameBuf, ic.Labels, timestamp, value); err != nil {
+		if err := ic.WriteDataPoint(ctx.metricNameBuf, ic.Labels, timestamp, value); err != nil {
 			return err
 		}
 	}

--- a/app/vminsert/newrelic/request_handler.go
+++ b/app/vminsert/newrelic/request_handler.go
@@ -58,7 +58,10 @@ func insertRows(rows []newrelic.Row, extraLabels []prompbmarshal.Label) error {
 				label := &extraLabels[k]
 				ctx.AddLabel(label.Name, label.Value)
 			}
-			if err := ctx.WriteDataPoint(nil, hasRelabeling, ctx.Labels, r.Timestamp, s.Value); err != nil {
+			if !ctx.TryPrepareLabels(hasRelabeling) {
+				continue
+			}
+			if err := ctx.WriteDataPoint(nil, ctx.Labels, r.Timestamp, s.Value); err != nil {
 				return err
 			}
 		}

--- a/app/vminsert/opentsdb/request_handler.go
+++ b/app/vminsert/opentsdb/request_handler.go
@@ -36,7 +36,10 @@ func insertRows(rows []parser.Row) error {
 			tag := &r.Tags[j]
 			ctx.AddLabel(tag.Key, tag.Value)
 		}
-		if err := ctx.WriteDataPoint(nil, hasRelabeling, ctx.Labels, r.Timestamp, r.Value); err != nil {
+		if !ctx.TryPrepareLabels(hasRelabeling) {
+			continue
+		}
+		if err := ctx.WriteDataPoint(nil, ctx.Labels, r.Timestamp, r.Value); err != nil {
 			return err
 		}
 	}

--- a/app/vminsert/opentsdbhttp/request_handler.go
+++ b/app/vminsert/opentsdbhttp/request_handler.go
@@ -54,7 +54,10 @@ func insertRows(rows []parser.Row, extraLabels []prompbmarshal.Label) error {
 			label := &extraLabels[j]
 			ctx.AddLabel(label.Name, label.Value)
 		}
-		if err := ctx.WriteDataPoint(nil, hasRelabeling, ctx.Labels, r.Timestamp, r.Value); err != nil {
+		if !ctx.TryPrepareLabels(hasRelabeling) {
+			continue
+		}
+		if err := ctx.WriteDataPoint(nil, ctx.Labels, r.Timestamp, r.Value); err != nil {
 			return err
 		}
 	}

--- a/app/vminsert/prometheusimport/request_handler.go
+++ b/app/vminsert/prometheusimport/request_handler.go
@@ -54,7 +54,10 @@ func insertRows(rows []parser.Row, extraLabels []prompbmarshal.Label) error {
 			label := &extraLabels[j]
 			ctx.AddLabel(label.Name, label.Value)
 		}
-		if err := ctx.WriteDataPoint(nil, hasRelabeling, ctx.Labels, r.Timestamp, r.Value); err != nil {
+		if !ctx.TryPrepareLabels(hasRelabeling) {
+			continue
+		}
+		if err := ctx.WriteDataPoint(nil, ctx.Labels, r.Timestamp, r.Value); err != nil {
 			return err
 		}
 	}

--- a/app/vminsert/vmimport/request_handler.go
+++ b/app/vminsert/vmimport/request_handler.go
@@ -69,7 +69,7 @@ func insertRows(rows []parser.Row, extraLabels []prompbmarshal.Label) error {
 		}
 		for j, value := range values {
 			timestamp := timestamps[j]
-			if err := ic.WriteDataPointUnchecked(ctx.metricNameBuf, nil, timestamp, value); err != nil {
+			if err := ic.WriteDataPoint(ctx.metricNameBuf, nil, timestamp, value); err != nil {
 				return err
 			}
 		}

--- a/apptest/tests/relabeling_test.go
+++ b/apptest/tests/relabeling_test.go
@@ -91,7 +91,7 @@ func TestSingleIngestionWithRelabeling(t *testing.T) {
 		query: `{label="foo"}[120ms]`,
 		qtime: "1707123456800", // 2024-02-05T08:57:36.800Z
 		wantMetrics: []map[string]string{
-			map[string]string{
+			{
 				"__name__":           "series",
 				"label":              "foo",
 				"label1":             "value1",

--- a/apptest/tests/relabeling_test.go
+++ b/apptest/tests/relabeling_test.go
@@ -106,7 +106,7 @@ func TestSingleIngestionWithRelabeling(t *testing.T) {
 		},
 	})
 
-	// write influx with multie field set series1 and series2 in order to test
+	// write influx with multi field set series1 and series2 in order to test
 	// memory optimisation at vminsert side
 	sut.InfluxWrite(t, []string{
 		`influxline,label=foo1 series1=10,series2=30 1707123456700`, // 2024-02-05T08:57:36.700Z

--- a/apptest/tests/relabeling_test.go
+++ b/apptest/tests/relabeling_test.go
@@ -1,0 +1,204 @@
+package tests
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+
+	at "github.com/VictoriaMetrics/VictoriaMetrics/apptest"
+	pb "github.com/VictoriaMetrics/VictoriaMetrics/lib/prompbmarshal"
+)
+
+func TestSingleIngestionWithRelabeling(t *testing.T) {
+	tc := at.NewTestCase(t)
+	defer tc.Stop()
+	const relabelFileName = "relabel_config.yaml"
+	relabelingRules := `
+# add 4 labels in order to call memory allocation
+- replacement: value1
+  target_label: label1
+- replacement: value2
+  target_label: label2
+- replacement: value3
+  target_label: label3
+- replacement: value4
+  target_label: label4
+
+# drop specific timeseries by name prefix
+- action: drop
+  if: '{__name__=~"^must_drop.+"}'
+
+# strip prefix from metric name
+# and write it into special label
+- source_labels: [__name__]
+  regex: '^(.+)_(.+)'
+  replacement: $1
+  target_label: ingestion_protocol
+- source_labels: [__name__]
+  regex: '^(.+)_(.+)'
+  replacement: $2
+  target_label: __name__
+  `
+	relabelFilePath := fmt.Sprintf("%s/%s", t.TempDir(), relabelFileName)
+	if err := os.WriteFile(relabelFilePath, []byte(relabelingRules), os.ModePerm); err != nil {
+		t.Fatalf("cannot create file=%q: %s", relabelFilePath, err)
+	}
+	sut := tc.MustStartVmsingle("relabeling-ingest",
+		[]string{fmt.Sprintf(`-relabelConfig=%s`, relabelFilePath),
+			`-retentionPeriod=100y`})
+
+	type opts struct {
+		query       string
+		qtime       string
+		step        string
+		wantMetrics []map[string]string
+		wantSamples []*at.Sample
+	}
+	f := func(sut at.PrometheusQuerier, opts *opts) {
+		t.Helper()
+		wantResult := []*at.QueryResult{}
+		for idx, wm := range opts.wantMetrics {
+			wantResult = append(wantResult, &at.QueryResult{
+				Metric:  wm,
+				Samples: []*at.Sample{opts.wantSamples[idx]},
+			})
+
+		}
+		tc.Assert(&at.AssertOptions{
+			Msg: "unexpected /api/v1/query response",
+			Got: func() any {
+				return sut.PrometheusAPIV1Query(t, opts.query, at.QueryOpts{
+					Time: opts.qtime,
+					Step: opts.step,
+				})
+			},
+			Want: &at.PrometheusAPIV1QueryResponse{Data: &at.QueryData{Result: wantResult}},
+			CmpOpts: []cmp.Option{
+				cmpopts.IgnoreFields(at.PrometheusAPIV1QueryResponse{}, "Status", "Data.ResultType"),
+			},
+		})
+	}
+
+	sut.PrometheusAPIV1ImportPrometheus(t, []string{
+		`importprometheus_series{label="foo"} 10 1707123456700`, // 2024-02-05T08:57:36.700Z
+		`must_drop_series{label="foo"} 20 1707123456800`,        // 2024-02-05T08:57:36.800Z
+	}, at.QueryOpts{})
+	sut.ForceFlush(t)
+	f(sut, &opts{
+		query: `{label="foo"}[120ms]`,
+		qtime: "1707123456800", // 2024-02-05T08:57:36.800Z
+		wantMetrics: []map[string]string{
+			map[string]string{
+				"__name__":           "series",
+				"label":              "foo",
+				"label1":             "value1",
+				"label2":             "value2",
+				"label3":             "value3",
+				"label4":             "value4",
+				"ingestion_protocol": "importprometheus",
+			},
+		},
+		wantSamples: []*at.Sample{
+			{Timestamp: 1707123456700, Value: 10},
+		},
+	})
+
+	// write influx with multie field set series1 and series2 in order to test
+	// memory optimisation at vminsert side
+	sut.InfluxWrite(t, []string{
+		`influxline,label=foo1 series1=10,series2=30 1707123456700`, // 2024-02-05T08:57:36.700Z
+		`must_drop,label=foo1 series1=20,series2=40 1707123456800`,  // 2024-02-05T08:57:36.800Z
+	}, at.QueryOpts{})
+	sut.ForceFlush(t)
+	f(sut, &opts{
+		query: `{label="foo1"}[120ms]`,
+		qtime: "1707123456800", // 2024-02-05T08:57:36.800Z
+		wantMetrics: []map[string]string{
+			{
+				"__name__":           "series1",
+				"label":              "foo1",
+				"label1":             "value1",
+				"label2":             "value2",
+				"label3":             "value3",
+				"label4":             "value4",
+				"ingestion_protocol": "influxline",
+			},
+			{
+				"__name__":           "series2",
+				"label":              "foo1",
+				"label1":             "value1",
+				"label2":             "value2",
+				"label3":             "value3",
+				"label4":             "value4",
+				"ingestion_protocol": "influxline"},
+		},
+		wantSamples: []*at.Sample{
+			{Timestamp: 1707123456700, Value: 10},
+			{Timestamp: 1707123456700, Value: 30},
+		},
+	})
+
+	pbData := []pb.TimeSeries{
+		{
+			Labels: []pb.Label{
+				{
+					Name:  "__name__",
+					Value: "prometheusrw_series",
+				},
+				{
+					Name:  "label",
+					Value: "foo2",
+				},
+			},
+			Samples: []pb.Sample{
+				{
+					Value:     10,
+					Timestamp: 1707123456700, // 2024-02-05T08:57:36.700Z
+
+				},
+			},
+		},
+		{
+			Labels: []pb.Label{
+				{
+					Name:  "__name__",
+					Value: "must_drop_series",
+				},
+				{
+					Name:  "label",
+					Value: "foo2",
+				},
+			},
+			Samples: []pb.Sample{
+				{
+					Value:     20,
+					Timestamp: 1707123456800, // 2024-02-05T08:57:36.800Z
+				},
+			},
+		},
+	}
+	sut.PrometheusAPIV1Write(t, pbData, at.QueryOpts{})
+	sut.ForceFlush(t)
+	f(sut, &opts{
+		query: `{label="foo2"}[120ms]`,
+		qtime: "1707123456800", // 2024-02-05T08:57:36.800Z
+		wantMetrics: []map[string]string{
+			{
+				"__name__":           "series",
+				"label":              "foo2",
+				"label1":             "value1",
+				"label2":             "value2",
+				"label3":             "value3",
+				"label4":             "value4",
+				"ingestion_protocol": "prometheusrw",
+			},
+		},
+		wantSamples: []*at.Sample{
+			{Timestamp: 1707123456700, Value: 10}, // 2024-02-05T08:57:36.700Z
+		},
+	})
+
+}

--- a/apptest/vmsingle.go
+++ b/apptest/vmsingle.go
@@ -26,6 +26,7 @@ type Vmsingle struct {
 	forceFlushURL string
 
 	// vminsert URLs.
+	influxLineWriteURL                 string
 	prometheusAPIV1ImportPrometheusURL string
 	prometheusAPIV1WriteURL            string
 
@@ -64,6 +65,7 @@ func StartVmsingle(instance string, flags []string, cli *Client) (*Vmsingle, err
 		httpListenAddr:  stderrExtracts[1],
 
 		forceFlushURL:                      fmt.Sprintf("http://%s/internal/force_flush", stderrExtracts[1]),
+		influxLineWriteURL:                 fmt.Sprintf("http://%s/influx/write", stderrExtracts[1]),
 		prometheusAPIV1ImportPrometheusURL: fmt.Sprintf("http://%s/prometheus/api/v1/import/prometheus", stderrExtracts[1]),
 		prometheusAPIV1WriteURL:            fmt.Sprintf("http://%s/prometheus/api/v1/write", stderrExtracts[1]),
 		prometheusAPIV1ExportURL:           fmt.Sprintf("http://%s/prometheus/api/v1/export", stderrExtracts[1]),
@@ -79,6 +81,18 @@ func (app *Vmsingle) ForceFlush(t *testing.T) {
 	t.Helper()
 
 	app.cli.Get(t, app.forceFlushURL, http.StatusOK)
+}
+
+// InfluxWrite is a test helper function that inserts a
+// collection of records in Influx line format by sending a HTTP
+// POST request to /influx/write vmsingle endpoint.
+//
+// See https://docs.victoriametrics.com/url-examples/#influxwrite
+func (app *Vmsingle) InfluxWrite(t *testing.T, records []string, _ QueryOpts) {
+	t.Helper()
+
+	data := []byte(strings.Join(records, "\n"))
+	app.cli.Post(t, app.influxLineWriteURL, "text/plain", data, http.StatusNoContent)
 }
 
 // PrometheusAPIV1Write is a test helper function that inserts a

--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -18,6 +18,8 @@ See also [LTS releases](https://docs.victoriametrics.com/lts-releases/).
 
 ## tip
 
+* BUGFIX: [vmsingle](https://docs.victoriametrics.com/single-server-victoriametrics/) properly apply `-relabelConfig` rules for data ingestion protocols. Issue was introduced at [v1.108.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.108.0)
+ release. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/7865) for details.
 * BUGFIX: [vmsingle](https://docs.victoriametrics.com/single-server-victoriametrics/), `vmselect` in [VictoriaMetrics cluster](https://docs.victoriametrics.com/cluster-victoriametrics/): make instant query results consistent. VictoriaMetrics detects and adjusts scrape interval and while this is very useful for range queries (i.e. this eliminates gaps on the graph), it may cause instant queries to return a non-empty result when no result is expected. The fix is to disable scrape interval detection and always use the step as the scrape interval in instant queries. This will guarantee that the samples are searched within the (time-step, time] interval. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/5796) for details.
 
 ## [v1.108.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.108.0)

--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -18,7 +18,7 @@ See also [LTS releases](https://docs.victoriametrics.com/lts-releases/).
 
 ## tip
 
-* BUGFIX: [vmsingle](https://docs.victoriametrics.com/single-server-victoriametrics/) properly apply `-relabelConfig` rules for data ingestion protocols. Issue was introduced at [v1.108.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.108.0)
+* BUGFIX: [vmsingle](https://docs.victoriametrics.com/single-server-victoriametrics/) properly apply `-relabelConfig` rules for data ingestion protocols. Issue was introduced at [v1.108.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.108.0) and only affects vmsingle.
  release. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/7865) for details.
 * BUGFIX: [vmsingle](https://docs.victoriametrics.com/single-server-victoriametrics/), `vmselect` in [VictoriaMetrics cluster](https://docs.victoriametrics.com/cluster-victoriametrics/): make instant query results consistent. VictoriaMetrics detects and adjusts scrape interval and while this is very useful for range queries (i.e. this eliminates gaps on the graph), it may cause instant queries to return a non-empty result when no result is expected. The fix is to disable scrape interval detection and always use the step as the scrape interval in instant queries. This will guarantee that the samples are searched within the (time-step, time] interval. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/5796) for details.
 


### PR DESCRIPTION
Regression was introduced at 564e6ea024112fdfc65121ae889977aee251f668 after implementing: https://github.com/VictoriaMetrics/VictoriaMetrics/issues/6928

 ctx.Labels array could be incorrectly updated and changes to it after relabeling rules can be lost.
 E.g. ctx.Labels passed to WriteDataPoint function as slice copy, but results of relabeling only changed an actual slice at ctx.Labels.

 This commit replaces implicit relabeling call with explicit `TryPrepareLabels` function.
It also reduces code diffs with cluster version.

 related issue:
https://github.com/VictoriaMetrics/VictoriaMetrics/issues/7865

### Describe Your Changes

Please provide a brief description of the changes you made. Be as specific as possible to help others understand the purpose and impact of your modifications.

### Checklist

The following checks are **mandatory**:

- [ ] My change adheres [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/contributing/).
