### PR TITLE
deployment/docker: rename victorialogs-datasource to victoriametrics-logs-datasource

### DIFF
--- a/deployment/docker/docker-compose-victorialogs.yml
+++ b/deployment/docker/docker-compose-victorialogs.yml
@@ -10,14 +10,14 @@ services:
       - 3000:3000
     volumes:
       - grafanadata:/var/lib/grafana
-      - ./provisioning/datasources/victorialogs-datasource:/etc/grafana/provisioning/datasources
+      - ./provisioning/datasources/victoriametrics-logs-datasource:/etc/grafana/provisioning/datasources
       - ./provisioning/dashboards:/etc/grafana/provisioning/dashboards
       - ./provisioning/plugins/:/var/lib/grafana/plugins
       - ./../../dashboards/victoriametrics.json:/var/lib/grafana/dashboards/vm.json
       - ./../../dashboards/victorialogs.json:/var/lib/grafana/dashboards/vl.json
     environment:
-      - "GF_INSTALL_PLUGINS=https://github.com/VictoriaMetrics/victorialogs-datasource/releases/download/v0.11.1/victorialogs-datasource-v0.11.1.zip;victorialogs-datasource"
-      - "GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS=victorialogs-datasource"
+      - "GF_INSTALL_PLUGINS=https://github.com/VictoriaMetrics/victorialogs-datasource/releases/download/v0.13.0/victoriametrics-logs-datasource-v0.13.0.zip;victoriametrics-logs-datasource"
+      - "GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS=victoriametrics-logs-datasource"
     networks:
       - vm_net
     restart: always

--- a/deployment/docker/provisioning/datasources/victoriametrics-logs-datasource/victoriametrics-logs-datasource.yml
+++ b/deployment/docker/provisioning/datasources/victoriametrics-logs-datasource/victoriametrics-logs-datasource.yml
@@ -2,7 +2,7 @@ apiVersion: 1
 
 datasources:
   - name: VictoriaLogs
-    type: victorialogs-datasource
+    type: victoriametrics-logs-datasource
     access: proxy
     url:  http://victorialogs:9428
 


### PR DESCRIPTION
### Describe Your Changes

Renamed victorialogs-datasource to victoriametrics-logs-datasource.

We prepared the victorialogs Grafana plugin for sign and updated the plugin ID. This action require to update configs in our ops repository

Please check this [release](https://github.com/VictoriaMetrics/victorialogs-datasource/releases/tag/v0.13.0) and https://github.com/VictoriaMetrics/victorialogs-datasource/pull/161 with changes

### Checklist

The following checks are **mandatory**:

- [X] My change adheres [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/contributing/).
