### PR TITLE
app/vmauth: properly log `host` at debugInfo function

### DIFF
--- a/app/vmauth/main.go
+++ b/app/vmauth/main.go
@@ -213,7 +213,7 @@ func processRequest(w http.ResponseWriter, r *http.Request, ui *UserInfo) {
 			missingRouteRequests.Inc()
 			var di string
 			if ui.DumpRequestOnErrors {
-				di = debugInfo(u, r.Header)
+				di = debugInfo(u, r)
 			}
 			httpserver.Errorf(w, r, "missing route for %q%s", u.String(), di)
 			return
@@ -668,13 +668,13 @@ func (rtb *readTrackingBody) Close() error {
 	return nil
 }
 
-func debugInfo(u *url.URL, h http.Header) string {
+func debugInfo(u *url.URL, r *http.Request) string {
 	s := &strings.Builder{}
-	fmt.Fprintf(s, " (host: %q; ", u.Host)
+	fmt.Fprintf(s, " (host: %q; ", r.Host)
 	fmt.Fprintf(s, "path: %q; ", u.Path)
 	fmt.Fprintf(s, "args: %q; ", u.Query().Encode())
 	fmt.Fprint(s, "headers:")
-	_ = h.WriteSubset(s, nil)
+	_ = r.Header.WriteSubset(s, nil)
 	fmt.Fprint(s, ")")
 	return s.String()
 }

--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -20,6 +20,8 @@ See also [LTS releases](https://docs.victoriametrics.com/lts-releases/).
 
 ## [v1.108.1](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.108.1)
 
+* BUGFIX: [vmauth](https://docs.victoriametrics.com/vmauth/): properly set `host` field at debug information formatted with `dump_request_on_errors: true` setting. 
+
 Released at 2024-12-18
 
 * BUGFIX: [vmsingle](https://docs.victoriametrics.com/single-server-victoriametrics/) properly apply `-relabelConfig` rules for data ingestion protocols. Issue was introduced at [v1.108.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.108.0) and only affects vmsingle.


### PR DESCRIPTION
vmauth started to use request.Host after commit f4776fec1b8fb67974471d2d0dcf246b2ebbf568 for`src_hosts` routing rules.

This commit adds http.Request.Host to the debugInfo output in order to be consistent with routing logic.

### Describe Your Changes

Please provide a brief description of the changes you made. Be as specific as possible to help others understand the purpose and impact of your modifications.

### Checklist

The following checks are **mandatory**:

- [ ] My change adheres [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/contributing/).
