### PR TITLE
docs: changed typo in label (enterpriSe instead of enterpriZe)

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -41,7 +41,7 @@ We use [labels](https://docs.github.com/en/issues/using-labels-and-milestones-to
 to categorize GitHub issues. We have the following labels:
 1. A component label: vmalert, vmagent, etc. Add this label to the issue if it is related to a specific component.
 1. An issue type: `bug`, `enhancement`, `question`.
-1. `enterprize`, assigned to issues related to ENT features
+1. `enterprise`, assigned to issues related to ENT features
 1. `need more info`, assigned to issues which require elaboration from the issue creator.
   For example, if we weren't able to reproduce the reported bug based on the ticket description then we ask additional
   questions which could help to reproduce the issue and add `need more info` label. This label helps other maintainers


### PR DESCRIPTION
### Describe Your Changes

Fixed typo in contributing.md (enterpriZe -> enterpriSe in the label name)

### Checklist

The following checks are **mandatory**:

- [x] My change adheres [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/contributing/).
