### PR TITLE
VMINSERT: unexpected filter no tag metrics

### DIFF
--- a/app/vminsert/common/insert_ctx.go
+++ b/app/vminsert/common/insert_ctx.go
@@ -99,9 +99,6 @@ func (ctx *InsertCtx) TryPrepareLabels(hasRelabeling bool) bool {
 	if hasRelabeling {
 		ctx.ApplyRelabeling()
 	}
-	if len(ctx.Labels) == 0 {
-		return false
-	}
 	if timeserieslimits.Enabled() && timeserieslimits.IsExceeding(ctx.Labels) {
 		return false
 	}


### PR DESCRIPTION
Fixes #7933 
actually, vminsert filter `no tag metrics` no matter what datatype it is. 