### PR TITLE
fix: [vmctl] fix support for influx series without tag

### DIFF
--- a/app/vmctl/influx/influx.go
+++ b/app/vmctl/influx/influx.go
@@ -197,11 +197,16 @@ func (c *Client) Explore() ([]*Series, error) {
 // getEmptyTags returns tags of a measurement that are missing in a specific series.
 // Tags represent all tags of a measurement. LabelPairs represent tags of a specific series.
 func getEmptyTags(tags map[string]struct{}, LabelPairs []LabelPair) []string {
+	if len(tags) == 0 {
+		// fast path: the measurement does not contain any tag
+		return nil
+	}
+
 	labelMap := make(map[string]struct{})
 	for _, pair := range LabelPairs {
 		labelMap[pair.Name] = struct{}{}
 	}
-	result := make([]string, 0, len(labelMap)-len(LabelPairs))
+	result := make([]string, 0, len(labelMap))
 	for tag := range tags {
 		if _, ok := labelMap[tag]; !ok {
 			result = append(result, tag)

--- a/app/vmctl/influx/influx.go
+++ b/app/vmctl/influx/influx.go
@@ -206,7 +206,7 @@ func getEmptyTags(tags map[string]struct{}, LabelPairs []LabelPair) []string {
 	for _, pair := range LabelPairs {
 		labelMap[pair.Name] = struct{}{}
 	}
-	result := make([]string, 0, len(labelMap))
+	result := make([]string, 0)
 	for tag := range tags {
 		if _, ok := labelMap[tag]; !ok {
 			result = append(result, tag)

--- a/app/vmctl/influx/influx.go
+++ b/app/vmctl/influx/influx.go
@@ -180,11 +180,7 @@ func (c *Client) Explore() ([]*Series, error) {
 			log.Printf("skip measurement %q since it has no fields", s.Measurement)
 			continue
 		}
-		tags, ok := measurementTags[s.Measurement]
-		if !ok {
-			return nil, fmt.Errorf("failed to find tags of measurement %s", s.Measurement)
-		}
-		emptyTags := getEmptyTags(tags, s.LabelPairs)
+		emptyTags := getEmptyTags(measurementTags[s.Measurement], s.LabelPairs)
 		for _, field := range fields {
 			is := &Series{
 				Measurement: s.Measurement,

--- a/app/vmctl/influx/influx.go
+++ b/app/vmctl/influx/influx.go
@@ -206,7 +206,7 @@ func getEmptyTags(tags map[string]struct{}, LabelPairs []LabelPair) []string {
 	for _, pair := range LabelPairs {
 		labelMap[pair.Name] = struct{}{}
 	}
-	result := make([]string, 0)
+	var result []string
 	for tag := range tags {
 		if _, ok := labelMap[tag]; !ok {
 			result = append(result, tag)

--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -25,7 +25,8 @@ See also [LTS releases](https://docs.victoriametrics.com/lts-releases/).
 * FEATURE: [Single-node VictoriaMetrics](https://docs.victoriametrics.com/): support `-maxIngestionRate` cmd-line flag to ratelimit samples/sec ingested. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/7377) for details.
 * FEATURE: [vminsert](https://docs.victoriametrics.com/vminsert/): Storage nodes defined in `-storageNode` are now sorted, ensuring that varying node orders across different vminsert instances do not result in inconsistent replication.
 
-* BUGFIX: [vmauth](https://docs.victoriametrics.com/vmauth/): properly set `host` field at debug information formatted with `dump_request_on_errors: true` setting. 
+* BUGFIX: [vmauth](https://docs.victoriametrics.com/vmauth/): properly set `host` field at debug information formatted with `dump_request_on_errors: true` setting.
+* BUGFIX: [vmctl](https://docs.victoriametrics.com/vmctl/): fix support for migrating influx series without any tag. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/7921). Thanks to @bitbidu for reporting.
 
 ## [v1.108.1](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.108.1)
 


### PR DESCRIPTION
### Describe Your Changes

Previously, vmctl expect that tag must exist for each measurement, but it's actually not necessary.

https://github.com/VictoriaMetrics/VictoriaMetrics/blob/f16a58f14c43663ca35093b6583539934bdc6544/app/vmctl/influx/influx.go#L183-L186

This pull request fix it by removing the check. For influx series `measurement1_value1{}`, it will be represented as:
```go
Series{
  Measurement: "measurement1",
  Field:       "value1",
  LabelPairs:  []LabelPair{},
  EmptyTags:   []string{},
}
```
and searched by the following query:
```sql
select "value1" from "measurement1"
``` 
### Checklist

The following checks are **mandatory**:

- [x] My change adheres [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/contributing/).
