### PR TITLE
vlinsert: parse loki JSON body if msg_fields are defined

### DIFF
--- a/app/vlinsert/loki/loki_json_test.go
+++ b/app/vlinsert/loki/loki_json_test.go
@@ -7,65 +7,68 @@ import (
 )
 
 func TestParseJSONRequest_Failure(t *testing.T) {
-	f := func(s string) {
+	f := func(s string, msgFields []string) {
 		t.Helper()
 
 		tlp := &insertutils.TestLogMessageProcessor{}
-		if err := parseJSONRequest([]byte(s), tlp, false); err == nil {
+		if err := parseJSONRequest([]byte(s), msgFields, tlp, false); err == nil {
 			t.Fatalf("expecting non-nil error")
 		}
 		if err := tlp.Verify(nil, ""); err != nil {
 			t.Fatalf("unexpected error: %s", err)
 		}
 	}
-	f(``)
+	f(``, nil)
 
 	// Invalid json
-	f(`{}`)
-	f(`[]`)
-	f(`"foo"`)
-	f(`123`)
+	f(`{}`, nil)
+	f(`[]`, nil)
+	f(`"foo"`, nil)
+	f(`123`, nil)
 
 	// invalid type for `streams` item
-	f(`{"streams":123}`)
+	f(`{"streams":123}`, nil)
 
 	// Missing `values` item
-	f(`{"streams":[{}]}`)
+	f(`{"streams":[{}]}`, nil)
 
 	// Invalid type for `values` item
-	f(`{"streams":[{"values":"foobar"}]}`)
+	f(`{"streams":[{"values":"foobar"}]}`, nil)
 
 	// Invalid type for `stream` item
-	f(`{"streams":[{"stream":[],"values":[]}]}`)
+	f(`{"streams":[{"stream":[],"values":[]}]}`, nil)
 
 	// Invalid type for `values` individual item
-	f(`{"streams":[{"values":[123]}]}`)
+	f(`{"streams":[{"values":[123]}]}`, nil)
 
 	// Invalid length of `values` individual item
-	f(`{"streams":[{"values":[[]]}]}`)
-	f(`{"streams":[{"values":[["123"]]}]}`)
-	f(`{"streams":[{"values":[["123","456","789","8123"]]}]}`)
+	f(`{"streams":[{"values":[[]]}]}`, nil)
+	f(`{"streams":[{"values":[["123"]]}]}`, nil)
+	f(`{"streams":[{"values":[["123","456","789","8123"]]}]}`, nil)
 
 	// Invalid type for timestamp inside `values` individual item
-	f(`{"streams":[{"values":[[123,"456"]}]}`)
+	f(`{"streams":[{"values":[[123,"456"]}]}`, nil)
 
 	// Invalid type for log message
-	f(`{"streams":[{"values":[["123",1234]]}]}`)
+	f(`{"streams":[{"values":[["123",1234]]}]}`, nil)
 
 	// invalid structured metadata type
-	f(`{"streams":[{"values":[["1577836800000000001", "foo bar", ["metadata_1", "md_value"]]]}]}`)
+	f(`{"streams":[{"values":[["1577836800000000001", "foo bar", ["metadata_1", "md_value"]]]}]}`, nil)
 
 	// structured metadata with unexpected value type
-	f(`{"streams":[{"values":[["1577836800000000001", "foo bar", {"metadata_1": 1}]] }]}`)
+	f(`{"streams":[{"values":[["1577836800000000001", "foo bar", {"metadata_1": 1}]] }]}`, nil)
+
+	// json message
+	f(`{"streams":[{"values":[["1577836800000000001", {"message": "foo bar"}, {"metadata_1": 1}]] }]}`, []string{"message"})
 }
 
 func TestParseJSONRequest_Success(t *testing.T) {
-	f := func(s string, timestampsExpected []int64, resultExpected string) {
+	f := func(s string, msgFields []string, timestampsExpected []int64, resultExpected string) {
 		t.Helper()
 
 		tlp := &insertutils.TestLogMessageProcessor{}
 
-		if err := parseJSONRequest([]byte(s), tlp, false); err != nil {
+		if err := parseJSONRequest([]byte(s), msgFields, tlp, false); err != nil {
 			t.Fatalf("unexpected error: %s", err)
 		}
 		if err := tlp.Verify(timestampsExpected, resultExpected); err != nil {
@@ -74,14 +77,14 @@ func TestParseJSONRequest_Success(t *testing.T) {
 	}
 
 	// Empty streams
-	f(`{"streams":[]}`, nil, ``)
-	f(`{"streams":[{"values":[]}]}`, nil, ``)
-	f(`{"streams":[{"stream":{},"values":[]}]}`, nil, ``)
-	f(`{"streams":[{"stream":{"foo":"bar"},"values":[]}]}`, nil, ``)
+	f(`{"streams":[]}`, nil, nil, ``)
+	f(`{"streams":[{"values":[]}]}`, nil, nil, ``)
+	f(`{"streams":[{"stream":{},"values":[]}]}`, nil, nil, ``)
+	f(`{"streams":[{"stream":{"foo":"bar"},"values":[]}]}`, nil, nil, ``)
 
 	// Empty stream labels
-	f(`{"streams":[{"values":[["1577836800000000001", "foo bar"]]}]}`, []int64{1577836800000000001}, `{"_msg":"foo bar"}`)
-	f(`{"streams":[{"stream":{},"values":[["1577836800000000001", "foo bar"]]}]}`, []int64{1577836800000000001}, `{"_msg":"foo bar"}`)
+	f(`{"streams":[{"values":[["1577836800000000001", "foo bar"]]}]}`, nil, []int64{1577836800000000001}, `{"_msg":"foo bar"}`)
+	f(`{"streams":[{"stream":{},"values":[["1577836800000000001", "foo bar"]]}]}`, nil, []int64{1577836800000000001}, `{"_msg":"foo bar"}`)
 
 	// Non-empty stream labels
 	f(`{"streams":[{"stream":{
@@ -91,7 +94,7 @@ func TestParseJSONRequest_Success(t *testing.T) {
 	["1577836800000000001", "foo bar"],
 	["1477836900005000002", "abc"],
 	["147.78369e9", "foobar"]
-]}]}`, []int64{1577836800000000001, 1477836900005000002, 147783690000}, `{"label1":"value1","label2":"value2","_msg":"foo bar"}
+]}]}`, nil, []int64{1577836800000000001, 1477836900005000002, 147783690000}, `{"label1":"value1","label2":"value2","_msg":"foo bar"}
 {"label1":"value1","label2":"value2","_msg":"abc"}
 {"label1":"value1","label2":"value2","_msg":"foobar"}`)
 
@@ -117,11 +120,11 @@ func TestParseJSONRequest_Success(t *testing.T) {
 			]
 		}
 	]
-}`, []int64{1577836800000000001, 1577836900005000002, 1877836900005000002}, `{"foo":"bar","a":"b","_msg":"foo bar"}
+}`, nil, []int64{1577836800000000001, 1577836900005000002, 1877836900005000002}, `{"foo":"bar","a":"b","_msg":"foo bar"}
 {"foo":"bar","a":"b","_msg":"abc"}
 {"x":"y","_msg":"yx"}`)
 
 	// values with metadata
-	f(`{"streams":[{"values":[["1577836800000000001", "foo bar", {"metadata_1": "md_value"}]]}]}`, []int64{1577836800000000001}, `{"_msg":"foo bar","metadata_1":"md_value"}`)
-	f(`{"streams":[{"values":[["1577836800000000001", "foo bar", {}]]}]}`, []int64{1577836800000000001}, `{"_msg":"foo bar"}`)
+	f(`{"streams":[{"values":[["1577836800000000001", "foo bar", {"metadata_1": "md_value"}]]}]}`, nil, []int64{1577836800000000001}, `{"_msg":"foo bar","metadata_1":"md_value"}`)
+	f(`{"streams":[{"values":[["1577836800000000001", "foo bar", {}]]}]}`, nil, []int64{1577836800000000001}, `{"_msg":"foo bar"}`)
 }

--- a/app/vlinsert/loki/loki_json_timing_test.go
+++ b/app/vlinsert/loki/loki_json_timing_test.go
@@ -28,7 +28,7 @@ func benchmarkParseJSONRequest(b *testing.B, streams, rows, labels int) {
 	b.RunParallel(func(pb *testing.PB) {
 		data := getJSONBody(streams, rows, labels)
 		for pb.Next() {
-			if err := parseJSONRequest(data, blp, false); err != nil {
+			if err := parseJSONRequest(data, nil, blp, false); err != nil {
 				panic(fmt.Errorf("unexpected error: %w", err))
 			}
 		}

--- a/app/vlinsert/loki/loki_protobuf_test.go
+++ b/app/vlinsert/loki/loki_protobuf_test.go
@@ -53,7 +53,7 @@ func TestParseProtobufRequest_Success(t *testing.T) {
 		t.Helper()
 
 		tlp := &testLogMessageProcessor{}
-		if err := parseJSONRequest([]byte(s), tlp, false); err != nil {
+		if err := parseJSONRequest([]byte(s), nil, tlp, false); err != nil {
 			t.Fatalf("unexpected error: %s", err)
 		}
 		if len(tlp.pr.Streams) != len(timestampsExpected) {

--- a/docs/VictoriaLogs/CHANGELOG.md
+++ b/docs/VictoriaLogs/CHANGELOG.md
@@ -17,6 +17,7 @@ according to [these docs](https://docs.victoriametrics.com/victorialogs/quicksta
 ## tip
 
 * FEATURE: [Datadog data ingestion](https://docs.victoriametrics.com/victorialogs/data-ingestion/datadog-agent/): added `-datadog.streamFields` and `-datadog.ignoreFields` flags to configured default stream and ignore fields. Useful for Datadog serverless plugin, which doesn't allow to provide extra headers of query args.
+* FEATURE: [Loki data ingestion](https://docs.victoriametrics.com/victorialogs/data-ingestion/datadog-agent/): parse JSON in message field if at least one `VL-Msg-Field` value is set.
 
 * BUGFIX: [Datadog data ingestion](https://docs.victoriametrics.com/victorialogs/data-ingestion/datadog-agent/): accepts `message` field as both string and object type to fix compatibility with Datadog serverless extension, which sends logs data in format, which is not documented. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/7761).
 * BUGFIX: [vlinsert](https://docs.victoriametrics.com/victorialogs/): order of VL-Msg-Field values now defines a priority of these fields and it's now obvious for a user which field will be picked if multiple msg_field values exist in a row.

--- a/docs/VictoriaLogs/data-ingestion/README.md
+++ b/docs/VictoriaLogs/data-ingestion/README.md
@@ -172,7 +172,7 @@ The response by default contains all the [log fields](https://docs.victoriametri
 See [how to query specific fields](https://docs.victoriametrics.com/victorialogs/logsql/#querying-specific-fields).
 
 The `/insert/loki/api/v1/push` accepts various http parameters, which can change the data ingestion behavior - [these docs](#http-parameters) for details.
-There is no need in specifying `_msg_field` and `_time_field` query args, since VictoriaLogs automatically extracts log message and timestamp from the ingested Loki data.
+If `_msg_field` is defined message body will be parsed if it contains JSON, otherwise whole message body will be stored in `_msg` field. There's no need to define `_time_field` query arg, since VictoriaLogs automatically extracts timestamp from the ingested Loki data.
 
 The `_stream_fields` arg is optional. If it isn't set, then all the labels inside the `"stream":{...}` are treated
 as [log stream fields](https://docs.victoriametrics.com/victorialogs/keyconcepts/#stream-fields). Use `_stream_fields` query arg for overriding the list of stream fields.

--- a/lib/logstorage/json_parser.go
+++ b/lib/logstorage/json_parser.go
@@ -78,6 +78,19 @@ func (p *JSONParser) ParseLogMessage(msg []byte) error {
 	return nil
 }
 
+// ParseLogMessageValue parses the given JSON log message msg from fastjson.Value into p.Fields.
+//
+// The p.Fields remains valid until the next call to ParseLogMessage() or PutJSONParser().
+func (p *JSONParser) ParseLogMessageValue(msgV *fastjson.Value) error {
+	p.reset()
+
+	if t := msgV.Type(); t != fastjson.TypeObject {
+		return fmt.Errorf("expecting json dictionary; got %s", t)
+	}
+	p.Fields, p.buf, p.prefixBuf = appendLogFields(p.Fields, p.buf, p.prefixBuf, msgV)
+	return nil
+}
+
 func appendLogFields(dst []Field, dstBuf, prefixBuf []byte, v *fastjson.Value) ([]Field, []byte, []byte) {
 	o := v.GetObject()
 	o.Visit(func(k []byte, v *fastjson.Value) {


### PR DESCRIPTION
### Describe Your Changes

Parse JSON from Loki message field if at least one msg_field is defined

related issues:
https://github.com/VictoriaMetrics/VictoriaMetrics/issues/7932

### Checklist

The following checks are **mandatory**:

- [ ] My change adheres [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/contributing/).
