### PR TITLE
Update VictoriaLogs FAQ: add a section about max log record length

### DIFF
--- a/docs/VictoriaLogs/FAQ.md
+++ b/docs/VictoriaLogs/FAQ.md
@@ -180,7 +180,7 @@ And for the following log, its `_msg` will be `foo bar in body`:
 
 VictoriaLogs is optimized for logs with records of rather small length.
 Specifically, the total length of of all fields in a log record shouldn't
-exceed a few kilobytes. The max length the VictoriaLogs is capable of
+exceed a few kilobytes. The max length of a single log record the VictoriaLogs is capable of
 handling efficiently is `2MiB`. This limit is hadrcoded and is unlikely to
 change.
 

--- a/docs/VictoriaLogs/FAQ.md
+++ b/docs/VictoriaLogs/FAQ.md
@@ -175,3 +175,21 @@ And for the following log, its `_msg` will be `foo bar in body`:
   "body": "foo bar in body"
 }
 ```
+
+## What is the max size of a log record?
+
+VictoriaLogs is optimized for logs with records of rather small length.
+Specifically, the total length of of all fields in a log record shouldn't
+exceed a few kilobytes. The max length the VictoriaLogs is capable of
+handling efficiently is `2MiB`. This limit is hadrcoded and is unlikely to
+change.
+
+Why 2MiB? VictoriaLogs stores log data in blocks which are processed
+(compressed during ingestion and decompressed during retrieval) independently.
+While bigger blocks are compressed more effectively, they result in greater
+search costs because in order to find a single record an entire block needs to
+be decompressed. So the size should be a compromise between the compression rate
+and search costs. The optimal size seems to be 2MiB. No benchmarks have been
+performed to check this, but 2MiB is the size of L2 cache in most of the
+contemporary CPUs. Therefore, the blocks that have size up to 2MiB will be
+processed faster than blocks whose size is > 2MiB.

--- a/docs/VictoriaLogs/FAQ.md
+++ b/docs/VictoriaLogs/FAQ.md
@@ -178,18 +178,9 @@ And for the following log, its `_msg` will be `foo bar in body`:
 
 ## What is the max size of a log record?
 
-VictoriaLogs is optimized for logs with records of rather small length.
-Specifically, the total length of of all fields in a log record shouldn't
-exceed a few kilobytes. The max length of a single log record the VictoriaLogs is capable of
-handling efficiently is `2MiB`. This limit is hadrcoded and is unlikely to
-change.
+The max length of a single log record the VictoriaLogs is capable of handling
+efficiently is `2MiB`. This limit is hadrcoded and is unlikely to change.
 
-Why 2MiB? VictoriaLogs stores log data in blocks which are processed
-(compressed during ingestion and decompressed during retrieval) independently.
-While bigger blocks are compressed more effectively, they result in greater
-search costs because in order to find a single record an entire block needs to
-be decompressed. So the size should be a compromise between the compression rate
-and search costs. The optimal size seems to be 2MiB. No benchmarks have been
-performed to check this, but 2MiB is the size of L2 cache in most of the
-contemporary CPUs. Therefore, the blocks that have size up to 2MiB will be
-processed faster than blocks whose size is > 2MiB.
+This is because VictoriaLogs stores log data in blocks that are processed
+atomically and the block size limit is 2MiB. Blocks of this size fit the L2
+cache of a typical CPU, which gives an optimal processing performance.

--- a/docs/VictoriaLogs/FAQ.md
+++ b/docs/VictoriaLogs/FAQ.md
@@ -176,11 +176,19 @@ And for the following log, its `_msg` will be `foo bar in body`:
 }
 ```
 
-## What is the max size of a log record?
+## What length a log record is expected to have?
 
-The max length of a single log record the VictoriaLogs is capable of handling
-efficiently is `2MiB`. This limit is hadrcoded and is unlikely to change.
+VictoriaLogs works optimally with log records of up to `10KB`. It works OK with
+log records of up to `100KB`. It works not so optimal with log records exceeding
+`100KB`.
 
-This is because VictoriaLogs stores log data in blocks that are processed
-atomically and the block size limit is 2MiB. Blocks of this size fit the L2
-cache of a typical CPU, which gives an optimal processing performance.
+The max size of a log record VictoriaLogs can handle is `2MB`. This is
+because VictoriaLogs stores log records in blocks and `2MB` is the max size of a
+block. Blocks of this size fit the L2 cache of a typical CPU, which gives an
+optimal processing performance.
+
+However, log records whose size is close to `2MB` aren't handled efficiently by
+VictoriaLogs because per-block overhead translates to a single log record, and
+this overhead is big. 
+
+The `2MB` limit is hadrcoded and is unlikely to change.


### PR DESCRIPTION
### Describe Your Changes

There has been a question in our public Slack on whether the length limit of a log record is going to be changed. See: https://victoriametrics.slack.com/archives/C05UNTPAEDN/p1736156255119689

This PR documents the max length and explains why it has been chosen. This FAQ section could serve as an answer to more questions like this.

### Checklist

The following checks are **mandatory**:

- [x] My change adheres [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/contributing/).
