### PR TITLE
app/vmselect/promql:  set tenant information for numbers

### DIFF
--- a/app/vmselect/promql/eval.go
+++ b/app/vmselect/promql/eval.go
@@ -1986,6 +1986,10 @@ func evalNumber(ec *EvalConfig, n float64) []*timeseries {
 	for i := range timestamps {
 		values[i] = n
 	}
+	if !ec.IsMultiTenant {
+		ts.MetricName.AccountID = ec.AuthTokens[0].AccountID
+		ts.MetricName.ProjectID = ec.AuthTokens[0].ProjectID
+	}
 	ts.Values = values
 	ts.Timestamps = timestamps
 	return []*timeseries{&ts}

--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -35,6 +35,7 @@ See also [LTS releases](https://docs.victoriametrics.com/lts-releases/).
 replication.
 * BUGFIX: [vmsingle](https://docs.victoriametrics.com/single-server-victoriametrics/) and `vminsert` in [VictoriaMetrics cluster](https://docs.victoriametrics.com/cluster-victoriametrics/): properly ingest `influx` line protocol metrics with empty tags. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/7933) for details.
 * BUGFIX: [vmselect](https://docs.victoriametrics.com/cluster-victoriametrics/): allow to override the default unique time series limit in vmstorage with command-line flags like `-search.maxUniqueTimeseries`, `-search.maxLabelsAPISeries`. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/7852).
+* BUGFIX: [vmselect](https://docs.victoriametrics.com/cluster-victoriametrics/): properly set tenancy information when evaluating numbers in a query. Previously, the tenancy information could lead to mismatch between query result and a number. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/7987) for the details.
 
 ## [v1.108.1](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.108.1)
 


### PR DESCRIPTION
### Describe Your Changes

Since https://github.com/VictoriaMetrics/VictoriaMetrics/commit/44b071296d4bb98a5d425d0350636b4dfdc3c4b9 `evalNumber` function no longer updating MetricName tenancy information. This leads to mismatch in metric names between the query result and evaluated number for all tenants other than 0:0.

For example, query `count(up) or 0` will return different results for tenants 0:0 and 1:1 (assuming up is present for both tenants):
- tenant 0:0 - will only contain result of `count(up)`
- tenant 1:1 - will return both `count(up)` and `0` since metric names will not be matched

This restores setting of tenancy information for metric name for single-tenant queries.

Also see: https://github.com/VictoriaMetrics/VictoriaMetrics/issues/7987

### Checklist

The following checks are **mandatory**:

- [x] My change adheres [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/contributing/).
