### PR TITLE
app/vmselect/promql: account for staleness when populating realPrevValue

### DIFF
--- a/app/vmselect/promql/rollup.go
+++ b/app/vmselect/promql/rollup.go
@@ -520,7 +520,8 @@ type rollupFuncArg struct {
 	// Timestamps for values.
 	timestamps []int64
 
-	// Real value preceding values without restrictions on staleness interval.
+	// Real value preceding values.
+	// Is populated if preceding value is within the staleness interval.
 	realPrevValue float64
 
 	// Real value which goes after values.
@@ -764,10 +765,12 @@ func (rc *rollupConfig) doInternal(dstValues []float64, tsm *timeseriesMap, valu
 		}
 		rfa.values = values[i:j]
 		rfa.timestamps = timestamps[i:j]
+		rfa.realPrevValue = nan
 		if i > 0 {
-			rfa.realPrevValue = values[i-1]
-		} else {
-			rfa.realPrevValue = nan
+			prevValue, prevTimestamp := values[i-1], timestamps[i-1]
+			if (tEnd - prevTimestamp) < maxPrevInterval {
+				rfa.realPrevValue = prevValue
+			}
 		}
 		if j < len(values) {
 			rfa.realNextValue = values[j]

--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -39,6 +39,7 @@ See also [LTS releases](https://docs.victoriametrics.com/lts-releases/).
 * BUGFIX: [vmselect](https://docs.victoriametrics.com/cluster-victoriametrics/): allow to override the default unique time series limit in vmstorage with command-line flags like `-search.maxUniqueTimeseries`, `-search.maxLabelsAPISeries`. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/7852).
 * BUGFIX: [vmselect](https://docs.victoriametrics.com/cluster-victoriametrics/): properly set tenancy information when evaluating numbers in a query. Previously, the tenancy information could lead to mismatch between query result and a number. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/7987) for the details.
 * BUGFIX: [vmalert](https://docs.victoriametrics.com/vmalert/): fix marshaling of request body for Alertmanager notification. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/7985) for the details.
+* BUGFIX: [Single-node VictoriaMetrics](https://docs.victoriametrics.com/) and [vmselect](https://docs.victoriametrics.com/cluster-victoriametrics/): don't take into account the last raw sample before the lookbehind window is sample exceeds the staleness interval. This affects correctness of increase, increase_pure, delta functions when preforming calculations on time series with gaps. See [this pull request](https://github.com/VictoriaMetrics/VictoriaMetrics/pull/8002) for details.
 
 ## [v1.108.1](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.108.1)
 


### PR DESCRIPTION
When vmselect process a rollup function it fetches all the raw samples on requested `start-end` interval of the query. It then loops through the raw samples, picks the range of the samples based on provided `step` interval and invokes a rollup function for each of the picked ranges of samples.

During this processing, vmselect always populates the `realPrevValue` field with the closest previous raw sample value before the picked range of samples. This `realPrevValue` is used by rollup functions like increase_pure or delta to decide whether the counter change happened or not. For example, we get the counter value == 1. If we've seen this counter before and its value was also 1 - then no change happened. If we didn't see it before, then this counter should have started with value=0 and we need to account for `1-0=1` change. All this is required to deal with situations when scrapes are missing or `step` is too small.

However, vmselect doesn't check how "old" is the `realPrevValue`. In other words, it doesn't respect the staleness interval when picking it. In result, depending on the `start` and `end` params, vmselect can use `realPrevValue` which is a couple of hours old and is unlikely to be a temporary scrape fail. In result, some increases can be incorrectly ingnored by vmselect.

This change makes sure that vmselect doesn't populate `realPrevValue` with samples that are older than staleness interval.

### Describe Your Changes

Please provide a brief description of the changes you made. Be as specific as possible to help others understand the purpose and impact of your modifications.

### Checklist

The following checks are **mandatory**:

- [ x ] My change adheres [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/contributing/).


-------------------

To reproduce, create a dataset with one metric `foo` which has samples with value=1 on interval of couple of hours and resolution 15s, and a gap for an hour in the middle:
<img width="769" alt="image" src="https://github.com/user-attachments/assets/a39b2740-b741-45f8-ad18-093b7c57c3b3" />

Then run `increase(foo[1m])` expression on this time range (disable cache):
<img width="1472" alt="image" src="https://github.com/user-attachments/assets/463cece1-f359-4c75-a96c-60092a31cab2" />

In result, there will be one increase on the beginning of the series. And no increase after the gap. Then change the time range so it starts in the middle of the gap:
<img width="1505" alt="image" src="https://github.com/user-attachments/assets/f4a460c3-9fd1-4ec7-ab47-15e716ec1019" />

Now, there is an increase>0 because the `realPrevValue` wasn't populated. This is wrong, because it hides the increase of the series.

With the fix, the original increase query on full time range should show 2 increases:
<img width="1492" alt="image" src="https://github.com/user-attachments/assets/aa9d8a6b-7b22-41f6-9eb9-83b3113a6982" />
