### PR TITLE
make: bump golangci-lint to v1.63.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -567,7 +567,7 @@ golangci-lint: install-golangci-lint
 	golangci-lint run
 
 install-golangci-lint:
-	which golangci-lint || curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(shell go env GOPATH)/bin v1.60.3
+	which golangci-lint || curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(shell go env GOPATH)/bin v1.63.4
 
 remove-golangci-lint:
 	rm -rf `which golangci-lint`

--- a/app/vmalert/manager.go
+++ b/app/vmalert/manager.go
@@ -160,8 +160,8 @@ func (m *manager) update(ctx context.Context, groupsCfg []config.Group, restore 
 			// it is important to call InterruptEval before the update, because cancel fn
 			// can be re-assigned during the update.
 			item.old.InterruptEval()
-			go func(old *rule.Group, new *rule.Group) {
-				old.UpdateWith(new)
+			go func(oldGroup *rule.Group, newGroup *rule.Group) {
+				oldGroup.UpdateWith(newGroup)
 				wg.Done()
 			}(item.old, item.new)
 		}

--- a/app/vmalert/rule/group.go
+++ b/app/vmalert/rule/group.go
@@ -443,8 +443,8 @@ func (g *Group) Start(ctx context.Context, nts func() []notifier.Notifier, rw re
 }
 
 // UpdateWith inserts new group to updateCh
-func (g *Group) UpdateWith(new *Group) {
-	g.updateCh <- new
+func (g *Group) UpdateWith(newGroup *Group) {
+	g.updateCh <- newGroup
 }
 
 // DeepCopy returns a deep copy of group

--- a/app/vmctl/prometheus/prometheus.go
+++ b/app/vmctl/prometheus/prometheus.go
@@ -40,15 +40,15 @@ type filter struct {
 	labelValue string
 }
 
-func (f filter) inRange(min, max int64) bool {
+func (f filter) inRange(minV, maxV int64) bool {
 	fmin, fmax := f.min, f.max
-	if min == 0 {
-		fmin = min
+	if minV == 0 {
+		fmin = minV
 	}
 	if fmax == 0 {
-		fmax = max
+		fmax = maxV
 	}
-	return min <= fmax && fmin <= max
+	return minV <= fmax && fmin <= maxV
 }
 
 // NewClient creates and validates new Client
@@ -59,13 +59,13 @@ func NewClient(cfg Config) (*Client, error) {
 		return nil, fmt.Errorf("failed to open snapshot %q: %s", cfg.Snapshot, err)
 	}
 	c := &Client{DBReadOnly: db}
-	min, max, err := parseTime(cfg.Filter.TimeMin, cfg.Filter.TimeMax)
+	minTime, maxTime, err := parseTime(cfg.Filter.TimeMin, cfg.Filter.TimeMax)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse time in filter: %s", err)
 	}
 	c.filter = filter{
-		min:        min,
-		max:        max,
+		min:        minTime,
+		max:        maxTime,
 		label:      cfg.Filter.Label,
 		labelValue: cfg.Filter.LabelValue,
 	}

--- a/app/vmselect/graphite/aggr.go
+++ b/app/vmselect/graphite/aggr.go
@@ -98,13 +98,13 @@ func aggrMin(values []float64) float64 {
 	if pos < 0 {
 		return nan
 	}
-	min := values[pos]
+	minV := values[pos]
 	for _, v := range values[pos+1:] {
-		if !math.IsNaN(v) && v < min {
-			min = v
+		if !math.IsNaN(v) && v < minV {
+			minV = v
 		}
 	}
-	return min
+	return minV
 }
 
 func aggrMax(values []float64) float64 {
@@ -112,13 +112,13 @@ func aggrMax(values []float64) float64 {
 	if pos < 0 {
 		return nan
 	}
-	max := values[pos]
+	maxV := values[pos]
 	for _, v := range values[pos+1:] {
-		if !math.IsNaN(v) && v > max {
-			max = v
+		if !math.IsNaN(v) && v > maxV {
+			maxV = v
 		}
 	}
-	return max
+	return maxV
 }
 
 func aggrDiff(values []float64) float64 {
@@ -177,12 +177,12 @@ func aggrCount(values []float64) float64 {
 }
 
 func aggrRange(values []float64) float64 {
-	min := aggrMin(values)
-	if math.IsNaN(min) {
+	minV := aggrMin(values)
+	if math.IsNaN(minV) {
 		return nan
 	}
-	max := aggrMax(values)
-	return max - min
+	maxV := aggrMax(values)
+	return maxV - minV
 }
 
 func aggrMultiply(values []float64) float64 {

--- a/app/vmselect/promql/aggr.go
+++ b/app/vmselect/promql/aggr.go
@@ -295,13 +295,13 @@ func aggrFuncMin(tss []*timeseries) []*timeseries {
 	}
 	dst := tss[0]
 	for i := range dst.Values {
-		min := dst.Values[i]
+		minV := dst.Values[i]
 		for _, ts := range tss {
-			if math.IsNaN(min) || ts.Values[i] < min {
-				min = ts.Values[i]
+			if math.IsNaN(minV) || ts.Values[i] < minV {
+				minV = ts.Values[i]
 			}
 		}
-		dst.Values[i] = min
+		dst.Values[i] = minV
 	}
 	return tss[:1]
 }
@@ -313,13 +313,13 @@ func aggrFuncMax(tss []*timeseries) []*timeseries {
 	}
 	dst := tss[0]
 	for i := range dst.Values {
-		max := dst.Values[i]
+		maxV := dst.Values[i]
 		for _, ts := range tss {
-			if math.IsNaN(max) || ts.Values[i] > max {
-				max = ts.Values[i]
+			if math.IsNaN(maxV) || ts.Values[i] > maxV {
+				maxV = ts.Values[i]
 			}
 		}
-		dst.Values[i] = max
+		dst.Values[i] = maxV
 	}
 	return tss[:1]
 }
@@ -793,7 +793,7 @@ func fillNaNsAtIdx(idx int, k float64, tss []*timeseries) {
 	}
 }
 
-func getIntK(k float64, max int) int {
+func getIntK(k float64, maxV int) int {
 	if math.IsNaN(k) {
 		return 0
 	}
@@ -801,38 +801,38 @@ func getIntK(k float64, max int) int {
 	if kn < 0 {
 		return 0
 	}
-	if kn > max {
-		return max
+	if kn > maxV {
+		return maxV
 	}
 	return kn
 }
 
 func minValue(values []float64) float64 {
-	min := nan
-	for len(values) > 0 && math.IsNaN(min) {
-		min = values[0]
+	minV := nan
+	for len(values) > 0 && math.IsNaN(minV) {
+		minV = values[0]
 		values = values[1:]
 	}
 	for _, v := range values {
-		if !math.IsNaN(v) && v < min {
-			min = v
+		if !math.IsNaN(v) && v < minV {
+			minV = v
 		}
 	}
-	return min
+	return minV
 }
 
 func maxValue(values []float64) float64 {
-	max := nan
-	for len(values) > 0 && math.IsNaN(max) {
-		max = values[0]
+	maxV := nan
+	for len(values) > 0 && math.IsNaN(maxV) {
+		maxV = values[0]
 		values = values[1:]
 	}
 	for _, v := range values {
-		if !math.IsNaN(v) && v > max {
-			max = v
+		if !math.IsNaN(v) && v > maxV {
+			maxV = v
 		}
 	}
-	return max
+	return maxV
 }
 
 func avgValue(values []float64) float64 {

--- a/app/vmselect/promql/rollup.go
+++ b/app/vmselect/promql/rollup.go
@@ -1685,9 +1685,9 @@ func rollupRateOverSum(rfa *rollupFuncArg) float64 {
 }
 
 func rollupRange(rfa *rollupFuncArg) float64 {
-	max := rollupMax(rfa)
-	min := rollupMin(rfa)
-	return max - min
+	maxV := rollupMax(rfa)
+	minV := rollupMin(rfa)
+	return maxV - minV
 }
 
 func rollupSum2(rfa *rollupFuncArg) float64 {
@@ -2195,38 +2195,38 @@ func rollupClose(rfa *rollupFuncArg) float64 {
 
 func rollupHigh(rfa *rollupFuncArg) float64 {
 	values := getCandlestickValues(rfa)
-	max := getFirstValueForCandlestick(rfa)
-	if math.IsNaN(max) {
+	maxV := getFirstValueForCandlestick(rfa)
+	if math.IsNaN(maxV) {
 		if len(values) == 0 {
 			return nan
 		}
-		max = values[0]
+		maxV = values[0]
 		values = values[1:]
 	}
 	for _, v := range values {
-		if v > max {
-			max = v
+		if v > maxV {
+			maxV = v
 		}
 	}
-	return max
+	return maxV
 }
 
 func rollupLow(rfa *rollupFuncArg) float64 {
 	values := getCandlestickValues(rfa)
-	min := getFirstValueForCandlestick(rfa)
-	if math.IsNaN(min) {
+	minV := getFirstValueForCandlestick(rfa)
+	if math.IsNaN(minV) {
 		if len(values) == 0 {
 			return nan
 		}
-		min = values[0]
+		minV = values[0]
 		values = values[1:]
 	}
 	for _, v := range values {
-		if v < min {
-			min = v
+		if v < minV {
+			minV = v
 		}
 	}
-	return min
+	return minV
 }
 
 func rollupModeOverTime(rfa *rollupFuncArg) float64 {

--- a/lib/protoparser/datadogsketches/parser.go
+++ b/lib/protoparser/datadogsketches/parser.go
@@ -273,17 +273,17 @@ func (d *Dogsketch) unmarshalProtobuf(src []byte) (err error) {
 			}
 			d.Cnt = cnt
 		case 3:
-			min, ok := fc.Double()
+			v, ok := fc.Double()
 			if !ok {
 				return fmt.Errorf("cannot read min")
 			}
-			d.Min = min
+			d.Min = v
 		case 4:
-			max, ok := fc.Double()
+			v, ok := fc.Double()
 			if !ok {
 				return fmt.Errorf("cannot read max")
 			}
-			d.Max = max
+			d.Max = v
 		case 6:
 			sum, ok := fc.Double()
 			if !ok {

--- a/lib/protoparser/opentelemetry/pb/metrics.go
+++ b/lib/protoparser/opentelemetry/pb/metrics.go
@@ -792,17 +792,17 @@ func (dp *ExponentialHistogramDataPoint) unmarshalProtobuf(src []byte) (err erro
 			}
 			dp.Flags = flags
 		case 12:
-			min, ok := fc.Double()
+			v, ok := fc.Double()
 			if !ok {
 				return fmt.Errorf("cannot read Min")
 			}
-			dp.Min = &min
+			dp.Min = &v
 		case 13:
-			max, ok := fc.Double()
+			v, ok := fc.Double()
 			if !ok {
 				return fmt.Errorf("cannot read Max")
 			}
-			dp.Max = &max
+			dp.Max = &v
 		case 14:
 			zeroThreshold, ok := fc.Double()
 			if !ok {

--- a/lib/streamaggr/max.go
+++ b/lib/streamaggr/max.go
@@ -67,13 +67,13 @@ func (as *maxAggrState) flushState(ctx *flushCtx) {
 
 		sv := v.(*maxStateValue)
 		sv.mu.Lock()
-		max := sv.max
+		maxV := sv.max
 		// Mark the entry as deleted, so it won't be updated anymore by concurrent pushSample() calls.
 		sv.deleted = true
 		sv.mu.Unlock()
 
 		key := k.(string)
-		ctx.appendSeries(key, "max", max)
+		ctx.appendSeries(key, "max", maxV)
 		return true
 	})
 }

--- a/lib/streamaggr/min.go
+++ b/lib/streamaggr/min.go
@@ -67,12 +67,12 @@ func (as *minAggrState) flushState(ctx *flushCtx) {
 
 		sv := v.(*minStateValue)
 		sv.mu.Lock()
-		min := sv.min
+		minV := sv.min
 		// Mark the entry as deleted, so it won't be updated anymore by concurrent pushSample() calls.
 		sv.deleted = true
 		sv.mu.Unlock()
 		key := k.(string)
-		ctx.appendSeries(key, "min", min)
+		ctx.appendSeries(key, "min", minV)
 		return true
 	})
 }


### PR DESCRIPTION
New version has additional checks and reduced resource consumption, so it doesn't timeout for our internal repos.

To make linter happy, I addressed "redefinition of the built-in function" lint error.

### Describe Your Changes

Please provide a brief description of the changes you made. Be as specific as possible to help others understand the purpose and impact of your modifications.

### Checklist

The following checks are **mandatory**:

- [ ] My change adheres [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/contributing/).
