### PR TITLE
added retention filters to Victorialogs roadmap

### DIFF
--- a/docs/VictoriaLogs/Roadmap.md
+++ b/docs/VictoriaLogs/Roadmap.md
@@ -24,3 +24,4 @@ The following functionality is planned in the future versions of VictoriaLogs:
 - [ ] Cluster version of VictoriaLogs.
 - [ ] Ability to store data to object storage (such as S3, GCS, Minio).
 - [ ] Data migration tool from Grafana Loki to VictoriaLogs (similar to [vmctl](https://docs.victoriametrics.com/vmctl/)).
+- [ ] Retention filters based on tenant and stream fields similar to [Victoriametrics](https://docs.victoriametrics.com/#retention-filters) (Enterprise only)


### PR DESCRIPTION
### Describe Your Changes

Fixes #8019 and adds retention filters to victorialogs roadmap as an enterprise feature

### Checklist

The following checks are **mandatory**:

- [X] My change adheres [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/contributing/).
