### PR TITLE
lib/storage: reduce test suite batch size

### DIFF
--- a/lib/storage/storage_test.go
+++ b/lib/storage/storage_test.go
@@ -1822,8 +1822,8 @@ func testStorageVariousDataPatternsConcurrently(t *testing.T, registerOnly bool,
 func testStorageVariousDataPatterns(t *testing.T, registerOnly bool, op func(s *Storage, mrs []MetricRow), concurrency int, splitBatches bool) {
 	f := func(t *testing.T, sameBatchMetricNames, sameRowMetricNames, sameBatchDates, sameRowDates bool) {
 		batches, wantCounts := testGenerateMetricRowBatches(&batchOptions{
-			numBatches:           4,
-			numRowsPerBatch:      100,
+			numBatches:           3,
+			numRowsPerBatch:      30,
 			registerOnly:         registerOnly,
 			sameBatchMetricNames: sameBatchMetricNames,
 			sameRowMetricNames:   sameRowMetricNames,


### PR DESCRIPTION
Commit eef6943084e3cca6995b8603003de6ca7a25fbf6  added new test functions. Which checks various cases for metricName registration at data ingestion.
 Initial dataset size had 4 batches with 100 rows each. It works fine at machines with 5GB+ memory.
But i386 architecture supports only 4GB of memory per process.

 Due to given limitations, batch size should be reduced to 3 batches and 30 rows. It keeps the same
test funtionality, but reduces overall memory usage to ~3GB.

