### PR TITLE
lib/protoparser/opentelemetry: do not drop histogram buckets, when sum is absent

### DIFF
--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -33,7 +33,7 @@ Released at 2025-01-17
 * BUGFIX: [Single-node VictoriaMetrics](https://docs.victoriametrics.com/) and [vmselect](https://docs.victoriametrics.com/cluster-victoriametrics/): fix incorrect behavior of increase, increase_pure, delta caused by [this pull request](https://github.com/VictoriaMetrics/VictoriaMetrics/pull/8002). This fix reverts to the previous behavior before [v1.109.0](https://docs.victoriametrics.com/changelog/#v11090). But allows controlling staleness detection for these functions explicitly via `-search.maxStalenessInterval`.
 * BUGFIX: all VictoriaMetrics [enterprise](https://docs.victoriametrics.com/enterprise/) components: remove unnecessary delay before failing if all online verification attempts have failed. This should reduce the time required for the component to proceed if all online verification attempts have failed.
 
-* BUGFIX: [vmsingle](https://docs.victoriametrics.com/single-server-victoriametrics/), `vminsert` in [VictoriaMetrics cluster](https://docs.victoriametrics.com/cluster-victoriametrics/) and [vmagent](https://docs.victoriametrics.com/vmagent/): do not skip OpenTelemetry histogram bucket metrics if histogram sum is absent.
+* BUGFIX: [vmsingle](https://docs.victoriametrics.com/single-server-victoriametrics/), `vminsert` in [VictoriaMetrics cluster](https://docs.victoriametrics.com/cluster-victoriametrics/) and [vmagent](https://docs.victoriametrics.com/vmagent/): allow ingesting histograms with missing `_sum` metric via [OpenTelemetry ingestion protocol](https://docs.victoriametrics.com/#sending-data-via-opentelemetry) in the same way as Prometheus does.
 
 ## [v1.109.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.109.0)
 

--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -33,6 +33,8 @@ Released at 2025-01-17
 * BUGFIX: [Single-node VictoriaMetrics](https://docs.victoriametrics.com/) and [vmselect](https://docs.victoriametrics.com/cluster-victoriametrics/): fix incorrect behavior of increase, increase_pure, delta caused by [this pull request](https://github.com/VictoriaMetrics/VictoriaMetrics/pull/8002). This fix reverts to the previous behavior before [v1.109.0](https://docs.victoriametrics.com/changelog/#v11090). But allows controlling staleness detection for these functions explicitly via `-search.maxStalenessInterval`.
 * BUGFIX: all VictoriaMetrics [enterprise](https://docs.victoriametrics.com/enterprise/) components: remove unnecessary delay before failing if all online verification attempts have failed. This should reduce the time required for the component to proceed if all online verification attempts have failed.
 
+* BUGFIX: [vmsingle](https://docs.victoriametrics.com/single-server-victoriametrics/), `vminsert` in [VictoriaMetrics cluster](https://docs.victoriametrics.com/cluster-victoriametrics/) and [vmagent](https://docs.victoriametrics.com/vmagent/): do not skip OpenTelemetry histogram bucket metrics if histogram sum is absent.
+
 ## [v1.109.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.109.0)
 
 Released at 2025-01-14

--- a/lib/protoparser/opentelemetry/stream/streamparser.go
+++ b/lib/protoparser/opentelemetry/stream/streamparser.go
@@ -138,6 +138,7 @@ func (wr *writeContext) appendSamplesFromSummary(metricName string, p *pb.Summar
 }
 
 // appendSamplesFromHistogram appends histogram p to wr.tss
+// histograms are processed according to spec at https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#histogram
 func (wr *writeContext) appendSamplesFromHistogram(metricName string, p *pb.HistogramDataPoint) {
 	if len(p.BucketCounts) == 0 {
 		// nothing to append
@@ -154,6 +155,7 @@ func (wr *writeContext) appendSamplesFromHistogram(metricName string, p *pb.Hist
 	wr.pointLabels = appendAttributesToPromLabels(wr.pointLabels[:0], p.Attributes)
 	wr.appendSample(metricName+"_count", t, float64(p.Count), isStale)
 	if p.Sum != nil {
+		// A Histogram MetricPoint SHOULD contain Sum
 		wr.appendSample(metricName+"_sum", t, *p.Sum, isStale)
 	}
 

--- a/lib/protoparser/opentelemetry/stream/streamparser.go
+++ b/lib/protoparser/opentelemetry/stream/streamparser.go
@@ -153,15 +153,9 @@ func (wr *writeContext) appendSamplesFromHistogram(metricName string, p *pb.Hist
 	isStale := (p.Flags)&uint32(1) != 0
 	wr.pointLabels = appendAttributesToPromLabels(wr.pointLabels[:0], p.Attributes)
 	wr.appendSample(metricName+"_count", t, float64(p.Count), isStale)
-	if p.Sum == nil {
-		// fast path, convert metric as simple counter.
-		// given buckets cannot be used for histogram functions.
-		// Negative threshold buckets MAY be used, but then the Histogram MetricPoint MUST NOT contain a sum value as it would no longer be a counter semantically.
-		// https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#histogram
-		return
+	if p.Sum != nil {
+		wr.appendSample(metricName+"_sum", t, *p.Sum, isStale)
 	}
-
-	wr.appendSample(metricName+"_sum", t, *p.Sum, isStale)
 
 	var cumulative uint64
 	for index, bound := range p.ExplicitBounds {

--- a/lib/protoparser/opentelemetry/stream/streamparser_timing_test.go
+++ b/lib/protoparser/opentelemetry/stream/streamparser_timing_test.go
@@ -11,7 +11,7 @@ import (
 func BenchmarkParseStream(b *testing.B) {
 	samples := []*pb.Metric{
 		generateGauge("my-gauge", ""),
-		generateHistogram("my-histogram", ""),
+		generateHistogram("my-histogram", "", true),
 		generateSum("my-sum", "", false),
 		generateSummary("my-summary", ""),
 	}


### PR DESCRIPTION
Despite requirement in OpenTelemetry spec that histograms should contain sum, [OpenTelemetry collector promremotewrite translator](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/37c8044abfaace7077a18a643d70057aa475fe65/pkg/translator/prometheusremotewrite/helper.go#L222) and [Prometheus OpenTelemetry parsing](https://github.com/prometheus/prometheus/blob/d52e689a20da7aa248291f0c0ea86fc4b8dbb189/storage/remote/otlptranslator/prometheusremotewrite/helper.go#L264) skip only sum if it's absent. Our current implementation drops buckets if sum is absent, which causes issues for users, that are expecting a similar to Prometheus behaviour 

### Describe Your Changes

Please provide a brief description of the changes you made. Be as specific as possible to help others understand the purpose and impact of your modifications.

### Checklist

The following checks are **mandatory**:

- [ ] My change adheres [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/contributing/).
