### PR TITLE
vmui/logs: update default graph to bars with color fill #7101

### DIFF
--- a/app/vmui/packages/vmui/src/components/Chart/BarHitsChart/BarHitsOptions/BarHitsOptions.tsx
+++ b/app/vmui/packages/vmui/src/components/Chart/BarHitsChart/BarHitsOptions/BarHitsOptions.tsx
@@ -5,7 +5,6 @@ import "./style.scss";
 import useStateSearchParams from "../../../../hooks/useStateSearchParams";
 import { useSearchParams } from "react-router-dom";
 import Button from "../../../Main/Button/Button";
-import classNames from "classnames";
 import { SettingsIcon, VisibilityIcon, VisibilityOffIcon } from "../../../Main/Icons";
 import Tooltip from "../../../Main/Tooltip/Tooltip";
 import Popper from "../../../Main/Popper/Popper";
@@ -24,27 +23,20 @@ const BarHitsOptions: FC<Props> = ({ onChange }) => {
     setFalse: handleCloseOptions,
   } = useBoolean(false);
 
-  const [graphStyle, setGraphStyle] = useStateSearchParams(GRAPH_STYLES.LINE_STEPPED, "graph");
   const [stacked, setStacked] = useStateSearchParams(false, "stacked");
-  const [fill, setFill] = useStateSearchParams(false, "fill");
+  const [fill, setFill] = useStateSearchParams("true", "fill");
   const [hideChart, setHideChart] = useStateSearchParams(false, "hide_chart");
 
   const options: GraphOptions = useMemo(() => ({
-    graphStyle,
+    graphStyle: GRAPH_STYLES.BAR,
     stacked,
-    fill,
+    fill: fill === "true",
     hideChart,
-  }), [graphStyle, stacked, fill, hideChart]);
-
-  const handleChangeGraphStyle = (val: string) => () => {
-    setGraphStyle(val as GRAPH_STYLES);
-    searchParams.set("graph", val);
-    setSearchParams(searchParams);
-  };
+  }), [stacked, fill, hideChart]);
 
   const handleChangeFill = (val: boolean) => {
-    setFill(val);
-    val ? searchParams.set("fill", "true") : searchParams.delete("fill");
+    setFill(`${val}`);
+    searchParams.set("fill", `${val}`);
     setSearchParams(searchParams);
   };
 
@@ -97,21 +89,6 @@ const BarHitsOptions: FC<Props> = ({ onChange }) => {
         title={"Graph settings"}
       >
         <div className="vm-bar-hits-options-settings">
-          <div className="vm-bar-hits-options-settings-item vm-bar-hits-options-settings-item_list">
-            <p className="vm-bar-hits-options-settings-item__title">Graph style:</p>
-            {Object.values(GRAPH_STYLES).map(style => (
-              <div
-                key={style}
-                className={classNames({
-                  "vm-list-item": true,
-                  "vm-list-item_active": graphStyle === style,
-                })}
-                onClick={handleChangeGraphStyle(style)}
-              >
-                {style}
-              </div>
-            ))}
-          </div>
           <div className="vm-bar-hits-options-settings-item">
             <Switch
               label={"Stacked"}
@@ -122,7 +99,7 @@ const BarHitsOptions: FC<Props> = ({ onChange }) => {
           <div className="vm-bar-hits-options-settings-item">
             <Switch
               label={"Fill"}
-              value={fill}
+              value={fill === "true"}
               onChange={handleChangeFill}
             />
           </div>

--- a/app/vmui/packages/vmui/src/components/Chart/BarHitsChart/BarHitsOptions/style.scss
+++ b/app/vmui/packages/vmui/src/components/Chart/BarHitsChart/BarHitsOptions/style.scss
@@ -11,12 +11,12 @@
   &-settings {
     display: grid;
     align-items: flex-start;
-    gap: $padding-global;
     min-width: 200px;
+    gap: $padding-global;
+    padding-bottom: $padding-global;
 
     &-item {
-      border-bottom: $border-divider;
-      padding: 0 $padding-global $padding-global;
+      padding: 0 $padding-global;
 
       &_list {
         padding: 0;

--- a/docs/VictoriaLogs/CHANGELOG.md
+++ b/docs/VictoriaLogs/CHANGELOG.md
@@ -16,6 +16,9 @@ according to [these docs](https://docs.victoriametrics.com/victorialogs/quicksta
 
 ## tip
 
+* FEATURE: [web UI](https://docs.victoriametrics.com/victorialogs/querying/#web-ui): updated the default graph type in the `hits panel` to bars with color fill. Removed options for `lines`, `stepped lines`, and `points`. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/7101).
+
+
 * BUGFIX: [LogsQL](https://docs.victoriametrics.com/victorialogs/logsql/): properly apply multiple [log stream filters](https://docs.victoriametrics.com/victorialogs/logsql/#stream-filter). For example, `{foo="bar"} AND {baz="x"}` must correctly return logs with `foo="bar"` and `baz="x"` [log stream fields](https://docs.victoriametrics.com/victorialogs/keyconcepts/#stream-fields). See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8037).
 
 ## [v1.6.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.6.0-victorialogs)


### PR DESCRIPTION
### Describe Your Changes

Updated the default graph type in the hits panel to bars with color fill for better readability. Removed options for lines, stepped lines, and points. 

<img src="https://github.com/user-attachments/assets/62522c97-7e5e-426a-b597-8457b2360f7e" width="400"/>

