### PR TITLE
lib/logstorage: improve performance of getColumnNameIDs by removing duplicate column id check

### DIFF
--- a/lib/logstorage/column_names.go
+++ b/lib/logstorage/column_names.go
@@ -27,27 +27,19 @@ func mustReadColumnNames(r filestream.ReadCloser) ([]string, map[string]uint64) 
 		logger.Panicf("FATAL: %s: %s", r.Path(), err)
 	}
 
-	columnNameIDs, err := getColumnNameIDs(columnNames)
-	if err != nil {
-		logger.Panicf("BUG: %s: %s; columnNames=%v", r.Path(), err, columnNameIDs)
-	}
+	columnNameIDs := getColumnNameIDs(columnNames)
 
 	return columnNames, columnNameIDs
 }
 
-func getColumnNameIDs(columnNames []string) (map[string]uint64, error) {
-	m := make(map[uint64]string, len(columnNames))
+func getColumnNameIDs(columnNames []string) map[string]uint64 {
 	columnNameIDs := make(map[string]uint64, len(columnNames))
 	for i, name := range columnNames {
 		id := uint64(i)
-		if prevName, ok := m[id]; ok {
-			return nil, fmt.Errorf("duplicate column name id=%d for columns %q and %q", id, prevName, name)
-		}
-		m[id] = name
 		columnNameIDs[name] = id
 	}
 
-	return columnNameIDs, nil
+	return columnNameIDs
 }
 
 func marshalColumnNames(dst []byte, columnNames []string) []byte {

--- a/lib/logstorage/column_names_test.go
+++ b/lib/logstorage/column_names_test.go
@@ -52,3 +52,27 @@ func TestColumnNameIDGenerator(t *testing.T) {
 		}
 	}
 }
+
+func TestGetColumnNameIDs(t *testing.T) {
+	testColumns := [][]string{
+		{},
+		{""},
+		{"", "foo", "bar.baz", "asdf dsf dfs"},
+		{"asdf.sdf.dsfds.f fds. fds ", "foo", "bar.sdfsdf.fd", "", "aso apaa"},
+	}
+
+	for _, col := range testColumns {
+		colmnNames := getColumnNameIDs(col)
+		if len(colmnNames) != len(col) {
+			t.Errorf("unexpected map length; got %d; want %d", len(colmnNames), len(col))
+		}
+
+		m := make(map[uint64]string, len(col))
+		for name, id := range colmnNames {
+			if prevName, ok := m[id]; ok {
+				t.Errorf("duplicate column name id=%d for columns %q and %q", id, prevName, name)
+			}
+			m[id] = name
+		}
+	}
+}

--- a/lib/logstorage/column_names_timing_test.go
+++ b/lib/logstorage/column_names_timing_test.go
@@ -1,0 +1,18 @@
+package logstorage
+
+import (
+	"testing"
+)
+
+func BenchmarkGetColumnNameIDs(b *testing.B) {
+	a := []string{"", "foo", "bar.baz", "asdf dsf dfs"}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		m := getColumnNameIDs(a)
+		if len(m) != len(a) {
+			b.Errorf("unexpected map length; got %d; want %d", len(m), len(a))
+		}
+	}
+}


### PR DESCRIPTION
### Describe Your Changes

Function getColumnNameIDs contains a check that column name id must be unique for each column name. Since this function just converts a string slice to a map, there is no case when id can be the same (correct me if I'm wrong), even if it contains the same column names. 

This function uses two maps for debugging purposes, so to improve performance and memory usage, we can leave just one. 
See heap pprof from users here: https://github.com/VictoriaMetrics/VictoriaMetrics/issues/7937

```
goos: windows
goarch: amd64
pkg: github.com/VictoriaMetrics/VictoriaMetrics/lib/logstorage
cpu: 11th Gen Intel(R) Core(TM) i9-11900K @ 3.50GHz
=== RUN   BenchmarkGetColumnNameIDs
BenchmarkGetColumnNameIDs
# Old
BenchmarkGetColumnNameIDs-16         5346204               205.9 ns/op           256 B/op          2 allocs/op
# New
BenchmarkGetColumnNameIDs-16        24099918                49.55 ns/op            0 B/op          0 allocs/op
```
### Checklist

The following checks are **mandatory**:

- [ ] My change adheres [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/contributing/).
