### PR TITLE
{docs,deployment}: use explicit version tag instead of "latest"

### DIFF
--- a/deployment/docker/victorialogs/compose-base.yml
+++ b/deployment/docker/victorialogs/compose-base.yml
@@ -45,7 +45,7 @@ services:
       replicas: 0
 
   victoriametrics:
-    image: victoriametrics/victoria-metrics:latest
+    image: victoriametrics/victoria-metrics:v1.109.1
     ports:
       - '8428:8428'
     command:

--- a/docs/Quick-Start.md
+++ b/docs/Quick-Start.md
@@ -55,8 +55,8 @@ under the current directory:
 
 
 ```sh
-docker pull victoriametrics/victoria-metrics:latest
-docker run -it --rm -v `pwd`/victoria-metrics-data:/victoria-metrics-data -p 8428:8428 victoriametrics/victoria-metrics:latest
+docker pull victoriametrics/victoria-metrics:v1.109.1
+docker run -it --rm -v `pwd`/victoria-metrics-data:/victoria-metrics-data -p 8428:8428 victoriametrics/victoria-metrics:v1.109.1
 ```
 
 


### PR DESCRIPTION

### Describe Your Changes

Using latest leads to inconsistent results between runs and might also lead to data corruption since "latest" can be updated by any development build.


### Checklist

The following checks are **mandatory**:

- [x] My change adheres [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/contributing/).
