### PR TITLE
app/vmselect/netstorage: prevent panic due to closing traces

### DIFF
--- a/app/vmselect/netstorage/netstorage.go
+++ b/app/vmselect/netstorage/netstorage.go
@@ -3274,10 +3274,13 @@ func execSearchQuery(qt *querytracer.Tracer, sq *storage.SearchQuery, cb func(qt
 		requestData = sq.MarshaWithoutTenant(requestData)
 		qtL := qt
 		if sq.IsMultiTenant && qt.Enabled() {
+			if qt.IsDone() {
+				return results
+			}
 			qtL = qt.NewChild("query for tenant: %s", sq.TenantTokens[i].String())
 		}
 		r := cb(qtL, requestData, sq.TenantTokens[i])
-		if sq.IsMultiTenant {
+		if sq.IsMultiTenant && qt.Enabled() {
 			qtL.Done()
 		}
 		results = append(results, r)

--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -26,6 +26,7 @@ See also [LTS releases](https://docs.victoriametrics.com/lts-releases/).
 * BUGFIX: [vmsingle](https://docs.victoriametrics.com/single-server-victoriametrics/), `vminsert` in [VictoriaMetrics cluster](https://docs.victoriametrics.com/cluster-victoriametrics/) and [vmagent](https://docs.victoriametrics.com/vmagent/): allow ingesting histograms with missing `_sum` metric via [OpenTelemetry ingestion protocol](https://docs.victoriametrics.com/#sending-data-via-opentelemetry) in the same way as Prometheus does.
 * BUGFIX: all VictoriaMetrics [enterprise](https://docs.victoriametrics.com/enterprise/) components: properly trim whitespaces at the end of license provided via `-license` and `-licenseFile` command-line flags. Previously, the trailing whitespaces could cause the license verification to fail.
 * BUGFIX: [vmauth](https://docs.victoriametrics.com/vmauth/): fix possible runtime panic during requests processing under heavy load. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8051) for details.
+* BUGFIX: [vmselect](https://docs.victoriametrics.com/cluster-victoriametrics/): prevent panic when `vmselect` receives an error response from `vmstorage` during the query execution and request processing for other `vmstorage` nodes is still in progress. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8114) for the details.
 
 ## [v1.109.1](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.109.1)
 

--- a/lib/querytracer/tracer.go
+++ b/lib/querytracer/tracer.go
@@ -66,6 +66,14 @@ func (t *Tracer) Enabled() bool {
 	return t != nil
 }
 
+// IsDone returns true if t is done.
+func (t *Tracer) IsDone() bool {
+	if !t.Enabled() {
+		return false
+	}
+	return t.isDone.Load()
+}
+
 // NewChild adds a new child Tracer to t with the given fmt.Sprintf(format, args...) message.
 //
 // The returned child must be closed via Done or Donef calls.

--- a/lib/querytracer/tracer.go
+++ b/lib/querytracer/tracer.go
@@ -66,14 +66,6 @@ func (t *Tracer) Enabled() bool {
 	return t != nil
 }
 
-// IsDone returns true if t is done.
-func (t *Tracer) IsDone() bool {
-	if !t.Enabled() {
-		return false
-	}
-	return t.isDone.Load()
-}
-
 // NewChild adds a new child Tracer to t with the given fmt.Sprintf(format, args...) message.
 //
 // The returned child must be closed via Done or Donef calls.


### PR DESCRIPTION
### Describe Your Changes

It is possible that qt would be cancelled by `snr.collectResults`, but concurrently running workers will continue execution even though results will be discarded later on.

Synchronize tracers closing with workers asynchronously processing jobs in order to avoid panic at `qt.NewChild`.

`cancelled` is passed to each `execSearchQuery` in order to allow early exit before processing requests for all tenants.

See: https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8114

### Checklist

The following checks are **mandatory**:

- [x] My change adheres [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/contributing/).
