### PR TITLE
docs/{vmauth,VictoriaLogs}: add examples of using headers per-user

### DIFF
--- a/docs/VictoriaLogs/README.md
+++ b/docs/VictoriaLogs/README.md
@@ -247,6 +247,37 @@ VictoriaLogs has very low overhead for per-tenant management, so it is OK to hav
 
 VictoriaLogs doesn't perform per-tenant authorization. Use [vmauth](https://docs.victoriametrics.com/vmauth/) or similar tools for per-tenant authorization.
 
+### Multitenancy access control
+
+Enforce access control for tenants by using [vmauth](https://docs.victoriametrics.com/vmauth/). Access control can be configured for each tenant by setting up the following rules:
+
+```yaml
+users:
+  - username: "foo"
+    password: "bar"
+    url_map:
+      - src_paths:
+        - "/select/.*"
+        - "/insert/.*"
+        headers:
+          - "AccountID: 1"
+          - "ProjectID: 0"
+        url_prefix:
+          - "http://localhost:9428/"
+
+  - username: "baz"
+    password: "bar"
+    url_map:
+      - src_paths: ["/select/.*"]
+        headers:
+          - "AccountID: 2"
+          - "ProjectID: 0"
+        url_prefix:
+          - "http://localhost:9428/"
+```
+
+This configuration allows `foo` to use the `/select/.*` and `/insert/.*` endpoints with `AccountID: 1` and `ProjectID: 0`, while `baz` can only use the `/select/.*` endpoint with `AccountID: 2` and `ProjectID: 0`.
+
 ## Security
 
 It is expected that VictoriaLogs runs in a protected environment, which is unreachable from the Internet without proper authorization.

--- a/docs/vmauth.md
+++ b/docs/vmauth.md
@@ -661,6 +661,19 @@ unauthorized_user:
   headers:
   - "TenantID: foobar"
   - "X-Forwarded-For:"
+
+users:
+  - username: "foo"
+    password: "bar"
+    dump_request_on_errors: true
+    url_map:
+      - src_paths: ["/select/.*"]
+        headers:
+          - "AccountID: 1"
+          - "ProjectID: 0"
+        url_prefix:
+          - "http://backend:9428/"
+
 ```
 
 `vmauth` also supports the ability to set and remove HTTP response headers before returning the response from the backend to client.


### PR DESCRIPTION


### Describe Your Changes
- add example a generic example to vmauth docs
- add an multi-tenancy usage example to VictoriaLogs docs
### Checklist

The following checks are **mandatory**:

- [x] My change adheres [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/contributing/).
