### PR TITLE
vmui/logs: fix transparency for bars in hits chart

### DIFF
--- a/app/vmui/packages/vmui/src/api/types.ts
+++ b/app/vmui/packages/vmui/src/api/types.ts
@@ -46,7 +46,7 @@ export interface Logs {
 export interface LogHits {
   timestamps: string[];
   values: number[];
-  total?: number;
+  total: number;
   fields: { [key: string]: string; };
   _isOther: boolean;
 }

--- a/app/vmui/packages/vmui/src/components/Chart/BarHitsChart/BarHitsTooltip/BarHitsTooltip.tsx
+++ b/app/vmui/packages/vmui/src/components/Chart/BarHitsChart/BarHitsTooltip/BarHitsTooltip.tsx
@@ -122,7 +122,7 @@ const BarHitsTooltip: FC<Props> = ({ data, focusDataIdx, uPlotInst }) => {
         </div>
       )}
       <div className="vm-chart-tooltip-header">
-        <div className="vm-chart-tooltip-header__title">
+        <div className="vm-chart-tooltip-header__title vm-bar-hits-tooltip__date">
           {tooltipData.timestamp}
         </div>
       </div>

--- a/app/vmui/packages/vmui/src/components/Chart/BarHitsChart/BarHitsTooltip/style.scss
+++ b/app/vmui/packages/vmui/src/components/Chart/BarHitsChart/BarHitsTooltip/style.scss
@@ -24,4 +24,8 @@
       white-space: nowrap;
     }
   }
+
+  &__date {
+    white-space: nowrap;
+  }
 }

--- a/app/vmui/packages/vmui/src/components/Chart/BarHitsChart/hooks/useBarHitsOptions.ts
+++ b/app/vmui/packages/vmui/src/components/Chart/BarHitsChart/hooks/useBarHitsOptions.ts
@@ -76,7 +76,7 @@ const useBarHitsOptions = ({
         width: strokeWidth[graphOptions.graphStyle],
         spanGaps: true,
         stroke: color,
-        fill: graphOptions.fill ? color + "80" : "",
+        fill: graphOptions.fill ? color + (target?._isOther ? "" : "80") : "",
         paths: getSeriesPaths(graphOptions.graphStyle),
       };
     });

--- a/app/vmui/packages/vmui/src/pages/ExploreLogs/hooks/useFetchLogHits.ts
+++ b/app/vmui/packages/vmui/src/pages/ExploreLogs/hooks/useFetchLogHits.ts
@@ -66,7 +66,7 @@ export const useFetchLogHits = (server: string, query: string) => {
         setError(error);
       }
 
-      setLogHits(hits.map(hit => ({ ...hit, _isOther: isEmptyObject(hit.fields) })));
+      setLogHits(hits.map(markIsOther).sort(sortHits));
     } catch (e) {
       if (e instanceof Error && e.name !== "AbortError") {
         setError(String(e));
@@ -84,4 +84,19 @@ export const useFetchLogHits = (server: string, query: string) => {
     fetchLogHits,
     abortController: abortControllerRef.current
   };
+};
+
+
+// Helper function to check if a hit is "other"
+const markIsOther = (hit: LogHits) => ({
+  ...hit,
+  _isOther: isEmptyObject(hit.fields)
+});
+
+// Comparison function for sorting hits
+const sortHits = (a: LogHits, b: LogHits) => {
+  if (a._isOther !== b._isOther) {
+    return a._isOther ? -1 : 1; // "Other" hits first to avoid graph overlap
+  }
+  return b.total - a.total; // Sort remaining by total for better visibility
 };

--- a/docs/VictoriaLogs/CHANGELOG.md
+++ b/docs/VictoriaLogs/CHANGELOG.md
@@ -20,6 +20,7 @@ according to [these docs](https://docs.victoriametrics.com/victorialogs/quicksta
 * FEATURE: reduce VictoriaLogs startup time by multiple times when it opens a large datastore with big [retention](https://docs.victoriametrics.com/victorialogs/#retention).
 
 * BUGFIX: [data ingestion](https://docs.victoriametrics.com/victorialogs/data-ingestion/): drop log entries with too long field names and log the dropped log entries with the `ignoring log entry with too long field name` message, so human operators could notice and fix the ingestion of incorrect logs ASAP. Previously too long field names were silently truncated to shorter values. This isn't what most users expect. See [why VictoriaLogs has a limit on the field name length](https://docs.victoriametrics.com/victorialogs/faq/#what-is-the-maximum-supported-field-name-length).
+* BUGFIX: [web UI](https://docs.victoriametrics.com/victorialogs/querying/#web-ui): fix transparency for bars in the hits bar chart to improve visibility. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8152).
 
 ## [v1.8.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.8.0-victorialogs)
 


### PR DESCRIPTION
### Describe Your Changes

Restored transparency for bars in the hits chart to improve visibility. Ref issue: #8152

| State  | Preview |
|--------|---------|
| Before | ![image](https://github.com/user-attachments/assets/2f95cdd9-0b39-4420-9bf7-011274eadc86) |
| After  | ![image](https://github.com/user-attachments/assets/9123d8e7-e615-41ab-9193-4c50ce262e7f) |

### Checklist

The following checks are **mandatory**:

- [ ] My change adheres [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/contributing/).
