### PR TITLE
vmui: refactor clipboard handling with useCopyToClipboard hook

### DIFF
--- a/app/vmui/packages/vmui/src/components/Main/CodeExample/CodeExample.tsx
+++ b/app/vmui/packages/vmui/src/components/Main/CodeExample/CodeExample.tsx
@@ -4,13 +4,16 @@ import { useState } from "react";
 import Tooltip from "../Tooltip/Tooltip";
 import Button from "../Button/Button";
 import { CopyIcon } from "../Icons";
+import useCopyToClipboard from "../../../hooks/useCopyToClipboard";
 
 enum CopyState { copy = "Copy", copied = "Copied" }
 
 const CodeExample: FC<{code: string}> = ({ code }) => {
+  const copyToClipboard = useCopyToClipboard();
+
   const [tooltip, setTooltip] = useState(CopyState.copy);
-  const handlerCopy = () => {
-    navigator.clipboard.writeText(code);
+  const handlerCopy = async () => {
+    await copyToClipboard(code);
     setTooltip(CopyState.copied);
   };
 

--- a/app/vmui/packages/vmui/src/components/Table/Table.tsx
+++ b/app/vmui/packages/vmui/src/components/Table/Table.tsx
@@ -5,6 +5,7 @@ import { getComparator, stableSort } from "./helpers";
 import Tooltip from "../Main/Tooltip/Tooltip";
 import Button from "../Main/Button/Button";
 import { useEffect } from "preact/compat";
+import useCopyToClipboard from "../../hooks/useCopyToClipboard";
 
 type OrderDir = "asc" | "desc"
 
@@ -22,6 +23,8 @@ interface TableProps<T> {
 }
 
 const Table = <T extends object>({ rows, columns, defaultOrderBy, defaultOrderDir, copyToClipboard, paginationOffset }: TableProps<T>) => {
+  const handleCopyToClipboard = useCopyToClipboard();
+
   const [orderBy, setOrderBy] = useState<keyof T>(defaultOrderBy);
   const [orderDir, setOrderDir] = useState<OrderDir>(defaultOrderDir || "desc");
   const [copied, setCopied] = useState<number | null>(null);
@@ -42,7 +45,7 @@ const Table = <T extends object>({ rows, columns, defaultOrderBy, defaultOrderDi
   const createCopyHandler = (copyValue:  string | number, rowIndex: number) => async () => {
     if (copied === rowIndex) return;
     try {
-      await navigator.clipboard.writeText(String(copyValue));
+      await handleCopyToClipboard(String(copyValue));
       setCopied(rowIndex);
     } catch (e) {
       console.error(e);

--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -20,7 +20,7 @@ See also [LTS releases](https://docs.victoriametrics.com/lts-releases/).
 
 * FEATURE: [Single-node VictoriaMetrics](https://docs.victoriametrics.com/) and [vmstorage](https://docs.victoriametrics.com/cluster-victoriametrics/): improve startup times when opening a storage with the [retention](https://docs.victoriametrics.com/#retention) exceeding a few months.
 
-* BUGFIX: [vmui](https://docs.victoriametrics.com/#vmui): replaced `await navigator.clipboard.writeText` with `useCopyToClipboard` hook. See [this pull request](https://github.com/VictoriaMetrics/VictoriaMetrics/pull/7778).
+* BUGFIX: [vmui](https://docs.victoriametrics.com/#vmui): improve clipboard error handling in tables and code snippets by showing detailed messages with possible reasons. See [this pull request](https://github.com/VictoriaMetrics/VictoriaMetrics/pull/7778).
 
 ## [v1.102.12](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.102.12)
 

--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -20,6 +20,8 @@ See also [LTS releases](https://docs.victoriametrics.com/lts-releases/).
 
 * FEATURE: [Single-node VictoriaMetrics](https://docs.victoriametrics.com/) and [vmstorage](https://docs.victoriametrics.com/cluster-victoriametrics/): improve startup times when opening a storage with the [retention](https://docs.victoriametrics.com/#retention) exceeding a few months.
 
+* BUGFIX: [vmui](https://docs.victoriametrics.com/#vmui): replaced `await navigator.clipboard.writeText` with `useCopyToClipboard` hook. See [this pull request](https://github.com/VictoriaMetrics/VictoriaMetrics/pull/7778).
+
 ## [v1.102.12](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.102.12)
 
 Released at 2025-01-28


### PR DESCRIPTION
### Describe Your Changes

Replaced `await navigator.clipboard.writeText` with `useCopyToClipboard` hook.  
See [this pull request](https://github.com/VictoriaMetrics/VictoriaMetrics/pull/7778) for details.

### Checklist

The following checks are **mandatory**:

- [ ] My change adheres [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/contributing/).
