### PR TITLE
RemoteWriteConnectionIsSaturated alert: add another saturation cause to the alert description

### DIFF
--- a/deployment/docker/rules/alerts-vmagent.yml
+++ b/deployment/docker/rules/alerts-vmagent.yml
@@ -81,7 +81,9 @@ groups:
           description: "The remote write connection between vmagent \"{{ $labels.job }}\" (instance {{ $labels.instance }}) and destination \"{{ $labels.url }}\"
             is saturated by more than 90% and vmagent won't be able to keep up.\n
             This usually means that `-remoteWrite.queues` command-line flag must be increased in order to increase
-            the number of connections per each remote storage."
+            the number of connections per each remote storage.\n
+            Another reason could be that the vminsert can't keep up with incoming data, possibly because the vmstorage can't accept it.
+            Therefore checking vminsert and vmstorage dashboards can also be helpful in identifying the root cause of saturation."
 
       - alert: PersistentQueueForWritesIsSaturated
         expr: rate(vm_persistentqueue_write_duration_seconds_total[5m]) > 0.9

--- a/deployment/docker/rules/alerts-vmagent.yml
+++ b/deployment/docker/rules/alerts-vmagent.yml
@@ -80,10 +80,9 @@ groups:
           summary: "Remote write connection from \"{{ $labels.job }}\" (instance {{ $labels.instance }}) to {{ $labels.url }} is saturated"
           description: "The remote write connection between vmagent \"{{ $labels.job }}\" (instance {{ $labels.instance }}) and destination \"{{ $labels.url }}\"
             is saturated by more than 90% and vmagent won't be able to keep up.\n
-            This usually means that `-remoteWrite.queues` command-line flag must be increased in order to increase
-            the number of connections per each remote storage.\n
-            Another reason could be that the vminsert can't keep up with incoming data, possibly because the vmstorage can't accept it.
-            Therefore checking vminsert and vmstorage dashboards can also be helpful in identifying the root cause of saturation."
+            There could be the following reasons for this:\n
+             * vmagent can't send data fast enough through the existing network connections. Increase `-remoteWrite.queues` cmd-line flag value to establish more connections per destination.\n
+             * remote destination can't accept data fast enough. Check if remote destination has enough resources for processing."
 
       - alert: PersistentQueueForWritesIsSaturated
         expr: rate(vm_persistentqueue_write_duration_seconds_total[5m]) > 0.9


### PR DESCRIPTION
### Describe Your Changes

Currently the alert descrption considers only one end of the connection (vmagent). While saturation can also be caused by slowness of the receiving components (vminsert, vmstorage). Update the alert description with a brief suggestion to also check the dashboards of these components. 

### Checklist

The following checks are **mandatory**:

- [x] My change adheres [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/contributing/).
