### PR TITLE
fix(vmselect): expose /-/healthy and /-/ready endpoints on full Prometheus path

### DIFF
--- a/app/vmselect/main.go
+++ b/app/vmselect/main.go
@@ -412,6 +412,16 @@ func selectHandler(qt *querytracer.Tracer, startTime time.Time, w http.ResponseW
 			return true
 		}
 		return true
+	case "prometheus/-/healthy":
+		// This is needed for Prometheus compatibility
+		// See https://github.com/VictoriaMetrics/VictoriaMetrics/issues/1833
+		fmt.Fprintf(w, "VictoriaMetrics is Healthy.\n")
+		return true
+	case "prometheus/-/ready":
+		// This is needed for Prometheus compatibility
+		// See https://github.com/VictoriaMetrics/VictoriaMetrics/issues/1833
+		fmt.Fprintf(w, "VictoriaMetrics is Ready.\n")
+		return true
 	case "graphite/metrics/find", "graphite/metrics/find/":
 		graphiteMetricsFindRequests.Inc()
 		httpserver.EnableCORS(w, r)

--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -20,6 +20,7 @@ See also [LTS releases](https://docs.victoriametrics.com/lts-releases/).
 
 * FEATURE: [Single-node VictoriaMetrics](https://docs.victoriametrics.com/) and [vmstorage](https://docs.victoriametrics.com/cluster-victoriametrics/): improve startup times when opening a storage with the [retention](https://docs.victoriametrics.com/#retention) exceeding a few months.
 * FEATURE: [vmui](https://docs.victoriametrics.com/#vmui): add the ability to switch the heatmap to a line chart. Now, vmui would suggest to switch to line graph display if heatmap can't be properly rendered. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8057).
+* FEATURE: expose `/-/healthy` and `/-/ready` endpoints as Prometheus does on vmselect endpoints, thus achieving full Prometheus compatibility for external dependencies.
 
 * BUGFIX: [vmagent](https://docs.victoriametrics.com/vmagent/): properly perform graceful shutdown for kafka client.
 * BUGFIX: [vmagent](https://docs.victoriametrics.com/vmagent/): properly add message metadata headers for kafka remoteWrite target.
@@ -154,7 +155,6 @@ Released at 2025-01-14
 * BUGFIX: [vmauth](https://docs.victoriametrics.com/vmauth/): properly handle discovery for ipv6 addresses. Thanks to @badie for the [pull request](https://github.com/VictoriaMetrics/VictoriaMetrics/pull/7955).
 * BUGFIX: [vmctl](https://docs.victoriametrics.com/vmctl/): fix support for migrating influx series without any tag. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/7921). Thanks to @bitbidu for reporting.
 * BUGFIX: `vminsert` in [VictoriaMetrics cluster](https://docs.victoriametrics.com/cluster-victoriametrics/): storage nodes defined in `-storageNode` are now sorted, ensuring that varying node orders across different vminsert instances do not result in inconsistent replication.
-
 
 ## [v1.97.15](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.97.15)
 


### PR DESCRIPTION
### Describe Your Changes
Improves integration with third-party solutions who rely on non-root endpoints (i.e. MinIO) when the vmselect path has been specified in the configured Prometheus URL like: `http://vmselect.:8481/select/0/prometheus`

Comparable change has been done before (b885a3b6e95a9b68db0bba1c2ffa00fdeaab4019), however only takes care of the root path. This means endpoints `-/healthy` and `-/ready` are still not available on full vmselect Prometheus paths, resulting in unsupported path requests.

This change makes these endpoints available on the full paths like: `/select/0/prometheus/-/healthy` and `/select/0/prometheus/-/ready`, thus achieving full Prometheus compatibility for external dependencies.

### Related issues
- https://github.com/minio/console/issues/2829
- https://github.com/VictoriaMetrics/VictoriaMetrics/issues/1833

### Checklist

The following checks are **mandatory**:

- [x] My change adheres [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/contributing/).
