### PR TITLE
{docs,app/vmctl}: clarify how vm-rate-limit is applied

### DIFF
--- a/app/vmctl/flags.go
+++ b/app/vmctl/flags.go
@@ -596,7 +596,8 @@ var (
 		&cli.Int64Flag{
 			Name: vmRateLimit,
 			Usage: "Optional data transfer rate limit in bytes per second.\n" +
-				"By default, the rate limit is disabled. It can be useful for limiting load on source or destination databases.",
+				"By default, the rate limit is disabled. It can be useful for limiting load on source or destination databases. \n" +
+				"Rate limit is applied per worker, see `--vm-concurrency`.",
 		},
 		&cli.BoolFlag{
 			Name: vmInterCluster,

--- a/docs/vmctl.md
+++ b/docs/vmctl.md
@@ -1080,7 +1080,8 @@ results such as `average`, `rate`, etc.
 ### Rate limiting
 
 Limiting the rate of data transfer could help to reduce pressure on disk or on destination database.
-The rate limit may be set in bytes-per-second via `--vm-rate-limit` flag.
+The rate limit may be set in bytes-per-second via `--vm-rate-limit` flag. Note that the rate limit is applied per worker,
+see `--vm-concurrency` flag.
 
 Please note, you can also use [vmagent](https://docs.victoriametrics.com/vmagent/)
 as a proxy between `vmctl` and destination with `-remoteWrite.rateLimit` flag enabled.
@@ -1399,7 +1400,8 @@ Flags available only for the `vm-native` command:
      Flag can be set multiple times, to add few additional labels.
    --vm-rate-limit value
      Optional data transfer rate limit in bytes per second.
-     By default, the rate limit is disabled. It can be useful for limiting load on source or destination databases. (default: 0)
+     By default, the rate limit is disabled. It can be useful for limiting load on source or destination databases.
+     Rate limit is applied per worker, see --vm-concurrency. (default: 0)
    --vm-intercluster  Enables cluster-to-cluster migration mode with automatic tenants data migration.
      In this mode --vm-native-src-addr flag format is: 'http://vmselect:8481/'. --vm-native-dst-addr flag format is: http://vminsert:8480/. 
      TenantID will be appended automatically after discovering tenants from src. (default: false)


### PR DESCRIPTION
### Describe Your Changes

Explicitly mention that `--vm-rate-limit` is used for each individual worker defined by `--vm-concurrency`.

### Checklist

The following checks are **mandatory**:

- [x] My change adheres [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/contributing/).
