### PR TITLE
lib/storage: Fix cardinality limiting for cases when insertion takes fast path

### DIFF
--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -26,6 +26,7 @@ See also [LTS releases](https://docs.victoriametrics.com/lts-releases/).
 * BUGFIX: [vmui](https://docs.victoriametrics.com/#vmui): improve clipboard error handling in tables and code snippets by showing detailed messages with possible reasons. See [this pull request](https://github.com/VictoriaMetrics/VictoriaMetrics/pull/7778).
 * BUGFIX: [vmui](https://docs.victoriametrics.com/#vmui) for [VictoriaMetrics enterprise](https://docs.victoriametrics.com/enterprise.html) components: properly display enterprise features when the enterprise version is used.
 * BUGFIX: [Single-node VictoriaMetrics](https://docs.victoriametrics.com/) and [vmselect](https://docs.victoriametrics.com/cluster-victoriametrics/): fix discrepancies when using `or` binary operator. See [this](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/7759) and [this](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/7640) issues for details.
+* FEATURE: [vmsingle](https://docs.victoriametrics.com/single-server-victoriametrics/) and `vmstorage` in [VictoriaMetrics cluster](https://docs.victoriametrics.com/cluster-victoriametrics/): properly update number of unique series for [cardinality limiter](https://docs.victoriametrics.com/#cardinality-limiter) on ingestion. Previously, limit could undercount the real number of the ingested unique series. 
 
 ## [v1.102.12](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.102.12)
 

--- a/lib/storage/storage.go
+++ b/lib/storage/storage.go
@@ -1879,7 +1879,7 @@ func (s *Storage) add(rows []rawRow, dstMrs []*MetricRow, mrs []MetricRow, preci
 			// contain MetricName->TSID entries for deleted time series.
 			// See Storage.DeleteSeries code for details.
 
-			if !s.registerSeriesCardinality(r.TSID.MetricID, mr.MetricNameRaw) {
+			if !s.registerSeriesCardinality(genTSID.TSID.MetricID, mr.MetricNameRaw) {
 				// Skip row, since it exceeds cardinality limit
 				j--
 				continue

--- a/lib/storage/storage_test.go
+++ b/lib/storage/storage_test.go
@@ -1492,50 +1492,79 @@ func TestStorageRowsNotAdded(t *testing.T) {
 func TestStorageRowsNotAdded_SeriesLimitExceeded(t *testing.T) {
 	defer testRemoveAll(t)
 
-	f := func(name string, maxHourlySeries int, maxDailySeries int) {
+	f := func(t *testing.T, numRows uint64, maxHourlySeries, maxDailySeries int) {
 		t.Helper()
 
 		rng := rand.New(rand.NewSource(1))
-		numRows := uint64(1000)
 		minTimestamp := time.Now().UnixMilli()
 		maxTimestamp := minTimestamp + 1000
 		mrs := testGenerateMetricRows(rng, numRows, minTimestamp, maxTimestamp)
 
-		var gotMetrics Metrics
-		path := fmt.Sprintf("%s/%s", t.Name(), name)
-		s := MustOpenStorage(path, 0, maxHourlySeries, maxDailySeries)
-		defer s.MustClose()
+		// Insert metrics into the empty storage. The insertion will take the slow path.
+		s := MustOpenStorage(t.Name(), 0, maxHourlySeries, maxDailySeries)
 		s.AddRows(mrs, defaultPrecisionBits)
 		s.DebugFlush()
-		s.UpdateMetrics(&gotMetrics)
 
-		if got, want := gotMetrics.RowsReceivedTotal, numRows; got != want {
-			t.Fatalf("unexpected Metrics.RowsReceivedTotal: got %d, want %d", got, want)
-		}
-		if got := gotMetrics.HourlySeriesLimitRowsDropped; maxHourlySeries > 0 && got <= 0 {
-			t.Fatalf("unexpected Metrics.HourlySeriesLimitRowsDropped: got %d, want > 0", got)
-		}
-		if got := gotMetrics.DailySeriesLimitRowsDropped; maxDailySeries > 0 && got <= 0 {
-			t.Fatalf("unexpected Metrics.DailySeriesLimitRowsDropped: got %d, want > 0", got)
+		assertCounts := func(pathName string) {
+			var gotMetrics Metrics
+			s.UpdateMetrics(&gotMetrics)
+
+			if got, want := gotMetrics.RowsReceivedTotal, numRows; got != want {
+				t.Fatalf("[%s] unexpected Metrics.RowsReceivedTotal: got %d, want %d", pathName, got, want)
+			}
+			if got := gotMetrics.HourlySeriesLimitRowsDropped; maxHourlySeries > 0 && got <= 0 {
+				t.Fatalf("[%s] unexpected Metrics.HourlySeriesLimitRowsDropped: got %d, want > 0", pathName, got)
+			}
+			if got := gotMetrics.DailySeriesLimitRowsDropped; maxDailySeries > 0 && got <= 0 {
+				t.Fatalf("[%s] unexpected Metrics.DailySeriesLimitRowsDropped: got %d, want > 0", pathName, got)
+			}
+
+			want := numRows - (gotMetrics.HourlySeriesLimitRowsDropped + gotMetrics.DailySeriesLimitRowsDropped)
+			if got := testCountAllMetricNames(s, TimeRange{minTimestamp, maxTimestamp}); uint64(got) != want {
+				t.Fatalf("[%s] unexpected metric name count: %d, want %d", pathName, got, want)
+			}
+
+			if got := gotMetrics.RowsAddedTotal; got != want {
+				t.Fatalf("[%s] unexpected Metrics.RowsAddedTotal: got %d, want %d", pathName, got, want)
+			}
 		}
 
-		want := numRows - (gotMetrics.HourlySeriesLimitRowsDropped + gotMetrics.DailySeriesLimitRowsDropped)
-		if got := testCountAllMetricNames(s, TimeRange{minTimestamp, maxTimestamp}); uint64(got) != want {
-			t.Fatalf("unexpected metric name count: %d, want %d", got, want)
-		}
+		assertCounts("Slow Path")
+		s.MustClose()
 
-		if got := gotMetrics.RowsAddedTotal; got != want {
-			t.Fatalf("unexpected Metrics.RowsAddedTotal: got %d, want %d", got, want)
-		}
+		// Open the storage again and insert the same metrics again.
+		// This time tsidCache should have the metric names and the fast path
+		// branch will be executed.
+		s = MustOpenStorage(t.Name(), 0, maxHourlySeries, maxDailySeries)
+		s.AddRows(mrs, defaultPrecisionBits)
+		s.DebugFlush()
+		assertCounts("Fast Path")
+		s.MustClose()
+
+		// Open the storage again, drop tsidCache, and insert the same metrics
+		// again. This time tsidCache should not have the metric names so they
+		// will be searched in index. Thus, the insertion takes the slower path.
+		s = MustOpenStorage(t.Name(), 0, maxHourlySeries, maxDailySeries)
+		s.resetAndSaveTSIDCache()
+		s.AddRows(mrs, defaultPrecisionBits)
+		s.DebugFlush()
+		assertCounts("Slower Path")
+		s.MustClose()
 	}
 
-	maxHourlySeries := 1
-	maxDailySeries := 0 // No limit
-	f("HourlyLimitExceeded", maxHourlySeries, maxDailySeries)
+	const (
+		numRows         = 1000
+		maxHourlySeries = 500
+		maxDailySeries  = 500
+	)
 
-	maxHourlySeries = 0 // No limit
-	maxDailySeries = 1
-	f("DailyLimitExceeded", maxHourlySeries, maxDailySeries)
+	t.Run("HourlyLimitExceeded", func(t *testing.T) {
+		f(t, numRows, maxHourlySeries, 0)
+	})
+
+	t.Run("DailyLimitExceeded", func(t *testing.T) {
+		f(t, numRows, 0, maxDailySeries)
+	})
 }
 
 // testCountAllMetricNames is a test helper function that counts the names of


### PR DESCRIPTION
### Describe Your Changes

The cardinality limiter in this case does not receive the actual metricID but some other value found in r.TSID.MetricID and is not initialized. Depending on the system and/or go runtime implementation, this value can be 0 or some garbage value (which shouldn't have too wide a range). Thus, there basically no limit for inserted metricIDs.

### Checklist

The following checks are **mandatory**:

- [x] My change adheres [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/contributing/).
