### PR TITLE
vmui: add legend customization options

### DIFF
--- a/app/vmui/packages/vmui/src/components/Chart/Heatmap/LegendHeatmap/LegendHeatmap.tsx
+++ b/app/vmui/packages/vmui/src/components/Chart/Heatmap/LegendHeatmap/LegendHeatmap.tsx
@@ -1,22 +1,18 @@
 import React, { FC, useEffect, useMemo, useState } from "preact/compat";
 import { gradMetal16 } from "../../../../utils/uplot";
-import { SeriesItem, LegendItemType } from "../../../../types";
 import "./style.scss";
-import LegendItem from "../../Line/Legend/LegendItem/LegendItem";
 import { ChartTooltipProps } from "../../ChartTooltip/ChartTooltip";
 
 interface LegendHeatmapProps {
   min: number
   max: number
   legendValue: ChartTooltipProps | null,
-  series: SeriesItem[]
 }
 
 const LegendHeatmap: FC<LegendHeatmapProps> = ({
   min,
   max,
   legendValue,
-  series
 }) => {
 
   const [percent, setPercent] = useState(0);
@@ -54,13 +50,6 @@ const LegendHeatmap: FC<LegendHeatmapProps> = ({
         <div className="vm-legend-heatmap__value">{minFormat}</div>
         <div className="vm-legend-heatmap__value">{maxFormat}</div>
       </div>
-      {series[1] && (
-        <LegendItem
-          key={series[1]?.label}
-          legend={series[1] as LegendItemType}
-          isHeatmap
-        />
-      )}
     </div>
   );
 };

--- a/app/vmui/packages/vmui/src/components/Chart/Line/Legend/LegendConfigs/LegendConfigs.tsx
+++ b/app/vmui/packages/vmui/src/components/Chart/Line/Legend/LegendConfigs/LegendConfigs.tsx
@@ -1,0 +1,105 @@
+import React, { FC, useMemo } from "preact/compat";
+import Switch from "../../../../Main/Switch/Switch";
+import { LegendDisplayType, useLegendView } from "../hooks/useLegendView";
+import { useHideDuplicateFields } from "../hooks/useHideDuplicateFields";
+import { useShowStats } from "../hooks/useShowStats";
+import TextField from "../../../../Main/TextField/TextField";
+import { useLegendFormat } from "../hooks/useLegendFormat";
+import { WITHOUT_GROUPING } from "../../../../../constants/logs";
+import Select from "../../../../Main/Select/Select";
+import { useLegendGroup } from "../hooks/useLegendGroup";
+import "./style.scss";
+import { MetricResult } from "../../../../../api/types";
+
+type Props = {
+  data: MetricResult[]
+}
+
+const LegendConfigs: FC<Props> = ({ data }) => {
+  const { isTableView, onChange: onChangeView } = useLegendView();
+  const { hideDuplicates, onChange: onChangeDuplicates } = useHideDuplicateFields();
+  const { hideStats, onChange: onChangeStats } = useShowStats();
+  const { format, onChange: onChangeFormat, onApply: onApplyFormat } = useLegendFormat();
+  const { groupByLabel, onChange: onChangeGroup } = useLegendGroup();
+
+  const uniqueFields = useMemo(() => {
+    const fields = data.flatMap(d => Object.keys(d.metric));
+    return Array.from(new Set(fields));
+  }, [data]);
+
+  const handleChangeView = (val: boolean) => {
+    const value = val ? LegendDisplayType.table : LegendDisplayType.lines;
+    onChangeView(value);
+  };
+
+  return (
+    <>
+      <div className="vm-legend-configs-item vm-legend-configs-item_switch">
+        <span className="vm-legend-configs-item__label">Table View</span>
+        <Switch
+          label={isTableView ? "Enabled" : "Disabled"}
+          value={isTableView}
+          onChange={handleChangeView}
+        />
+        <span className="vm-legend-configs-item__info">
+          Switches between table and lines view.
+        </span>
+      </div>
+
+      <div className="vm-legend-configs-item vm-legend-configs-item_switch">
+        <span className="vm-legend-configs-item__label">Common Labels</span>
+        <Switch
+          label={hideDuplicates ? "Hide" : "Show"}
+          value={hideDuplicates}
+          onChange={onChangeDuplicates}
+        />
+        <span className="vm-legend-configs-item__info">
+          Shows or hides labels that are the same for all series.
+        </span>
+      </div>
+
+      <div className="vm-legend-configs-item vm-legend-configs-item_switch">
+        <span className="vm-legend-configs-item__label">Statistics</span>
+        <Switch
+          label={hideStats ? "Hide" : "Show"}
+          value={!hideStats}
+          onChange={onChangeStats}
+        />
+        <span className="vm-legend-configs-item__info">
+          Displays min, median, and max values.
+        </span>
+      </div>
+
+      <div className="vm-legend-configs-item">
+        <TextField
+          label="Custom Legend Format"
+          placeholder={"{{label_name}}"}
+          value={format}
+          onChange={onChangeFormat}
+          onBlur={onApplyFormat}
+          onEnter={onApplyFormat}
+          type="search"
+        />
+        <span className="vm-legend-configs-item__info vm-legend-configs-item__info_input">
+          Customize legend labels with text and &#123;&#123;label_name&#125;&#125; placeholders.
+        </span>
+      </div>
+
+      <div className="vm-legend-configs-item">
+        <Select
+          label="Group Legend By"
+          value={groupByLabel}
+          list={[WITHOUT_GROUPING, ...uniqueFields]}
+          placeholder={WITHOUT_GROUPING}
+          onChange={onChangeGroup}
+          searchable
+        />
+        <span className="vm-legend-configs-item__info">
+          Choose a label to group the legend. By default, legends are grouped by query.
+        </span>
+      </div>
+    </>
+  );
+};
+
+export default LegendConfigs;

--- a/app/vmui/packages/vmui/src/components/Chart/Line/Legend/LegendConfigs/style.scss
+++ b/app/vmui/packages/vmui/src/components/Chart/Line/Legend/LegendConfigs/style.scss
@@ -1,0 +1,26 @@
+@use "src/styles/variables" as *;
+
+.vm-legend-configs {
+  &-item {
+    display: grid;
+    align-items: center;
+    justify-content: stretch;
+    margin-top: calc($padding-global/2);
+
+    &_switch {
+      grid-template-columns: 1fr 100px;
+      margin-top: 0;
+    }
+
+    &__info {
+      margin-top: calc($padding-global/2);
+      font-size: $font-size-small;
+      color: $color-text-secondary;
+      line-height: 130%;
+
+      &_input {
+        margin-top: 0;
+      }
+    }
+  }
+}

--- a/app/vmui/packages/vmui/src/components/Chart/Line/Legend/LegendGroup.tsx
+++ b/app/vmui/packages/vmui/src/components/Chart/Line/Legend/LegendGroup.tsx
@@ -1,0 +1,44 @@
+import React, { FC, useMemo } from "react";
+import { LegendItemType } from "../../../../types";
+import { useLegendView } from "./hooks/useLegendView";
+import LegendLines from "./LegendViews/LegendLines";
+import LegendTable from "./LegendViews/LegendTable";
+import { useHideDuplicateFields } from "./hooks/useHideDuplicateFields";
+
+export type LegendProps = {
+  labels: LegendItemType[];
+  isAnomalyView?: boolean;
+  duplicateFields?: string[];
+  onChange: (item: LegendItemType, metaKey: boolean) => void;
+}
+
+const LegendGroup: FC<LegendProps> = ({ labels, isAnomalyView, onChange }) => {
+  const { isTableView } = useLegendView();
+  const { duplicateFields } = useHideDuplicateFields(labels);
+
+  const sortedLabels = useMemo(() => {
+    return labels.sort((x, y) => (y.median || 0) - (x.median || 0));
+  }, [labels]);
+
+  if (isTableView) {
+    return (
+      <LegendTable
+        labels={sortedLabels}
+        isAnomalyView={isAnomalyView}
+        duplicateFields={duplicateFields}
+        onChange={onChange}
+      />
+    );
+  }
+
+  return (
+    <LegendLines
+      labels={sortedLabels}
+      isAnomalyView={isAnomalyView}
+      duplicateFields={duplicateFields}
+      onChange={onChange}
+    />
+  );
+};
+
+export default LegendGroup;

--- a/app/vmui/packages/vmui/src/components/Chart/Line/Legend/LegendItem/LegendItem.tsx
+++ b/app/vmui/packages/vmui/src/components/Chart/Line/Legend/LegendItem/LegendItem.tsx
@@ -6,36 +6,41 @@ import classNames from "classnames";
 import { getFreeFields } from "./helpers";
 import useCopyToClipboard from "../../../../../hooks/useCopyToClipboard";
 import { STATS_ORDER } from "../../../../../constants/graph";
+import { useShowStats } from "../hooks/useShowStats";
+import { useLegendFormat } from "../hooks/useLegendFormat";
+import { getLabelAlias } from "../../../../../utils/metric";
 
 interface LegendItemProps {
   legend: LegendItemType;
   onChange?: (item: LegendItemType, metaKey: boolean) => void;
-  isHeatmap?: boolean;
   isAnomalyView?: boolean;
+  duplicateFields?: string[];
 }
 
-const LegendItem: FC<LegendItemProps> = ({ legend, onChange, isHeatmap, isAnomalyView }) => {
+const LegendItem: FC<LegendItemProps> = ({ legend, onChange, duplicateFields, isAnomalyView }) => {
   const copyToClipboard = useCopyToClipboard();
+  const { hideStats } = useShowStats();
+
+  const { format } = useLegendFormat();
+  const formattedLabel = getLabelAlias(legend.freeFormFields, format);
 
   const freeFormFields = useMemo(() => {
     const result = getFreeFields(legend);
-    return isHeatmap ? result.filter(f => f.key !== "vmrange") : result;
-  }, [legend, isHeatmap]);
+    return duplicateFields?.length
+      ? result.filter(f => !duplicateFields.includes(f.key))
+      : result;
+  }, [legend, duplicateFields]);
 
   const statsFormatted = legend.statsFormatted;
   const showStats = Object.values(statsFormatted).some(v => v);
-
-  const handleClickFreeField = async (val: string) => {
-    await copyToClipboard(val, `${val} has been copied`);
-  };
 
   const createHandlerClick = (legend: LegendItemType) => (e: MouseEvent<HTMLDivElement>) => {
     onChange && onChange(legend, e.ctrlKey || e.metaKey);
   };
 
-  const createHandlerCopy = (freeField: string) => (e: MouseEvent<HTMLDivElement>) => {
+  const createHandlerCopy = (freeField: string) => async (e: MouseEvent<HTMLDivElement>) => {
     e.stopPropagation();
-    handleClickFreeField(freeField);
+    await copyToClipboard(freeField, `${freeField} has been copied`);
   };
 
   return (
@@ -43,12 +48,11 @@ const LegendItem: FC<LegendItemProps> = ({ legend, onChange, isHeatmap, isAnomal
       className={classNames({
         "vm-legend-item": true,
         "vm-legend-row": true,
-        "vm-legend-item_hide": !legend.checked && !isHeatmap,
-        "vm-legend-item_static": isHeatmap,
+        "vm-legend-item_hide": !legend.checked,
       })}
       onClick={createHandlerClick(legend)}
     >
-      {!isAnomalyView && !isHeatmap && (
+      {!isAnomalyView && (
         <div
           className="vm-legend-item__marker"
           style={{ backgroundColor: legend.color }}
@@ -56,10 +60,12 @@ const LegendItem: FC<LegendItemProps> = ({ legend, onChange, isHeatmap, isAnomal
       )}
       <div className="vm-legend-item-info">
         <span className="vm-legend-item-info__label">
-          {legend.hasAlias ? legend.label : (
+          {legend.hasAlias && legend.label}
+          {!legend.hasAlias && format && formattedLabel}
+          {!legend.hasAlias && !format && (
             <>
               {legend.freeFormFields["__name__"]}
-              {!!freeFormFields.length && <>&#123;</>}
+              {!!freeFormFields.length && <> &#123;</>}
               {freeFormFields.map((f, i) => (
                 <span
                   className="vm-legend-item-info__free-fields"
@@ -75,7 +81,7 @@ const LegendItem: FC<LegendItemProps> = ({ legend, onChange, isHeatmap, isAnomal
           )}
         </span>
       </div>
-      {!isHeatmap && showStats && (
+      {!hideStats && showStats && (
         <div className="vm-legend-item-stats">
           {STATS_ORDER.map((key, i) => (
             <div

--- a/app/vmui/packages/vmui/src/components/Chart/Line/Legend/LegendItem/style.scss
+++ b/app/vmui/packages/vmui/src/components/Chart/Line/Legend/LegendItem/style.scss
@@ -1,5 +1,8 @@
 @use "src/styles/variables" as *;
 
+.vm-legend-item-container {
+}
+
 .vm-legend-item {
   display: grid;
   grid-template-columns: auto auto;
@@ -18,18 +21,7 @@
 
   &_hide {
     text-decoration: line-through;
-    opacity: 0.5;
-  }
-
-  &_static {
-    grid-template-columns: 1fr;
-    margin: 0;
-    padding: 0;
-    cursor: default;
-
-    &:hover {
-      background-color: $color-background-block;
-    }
+    opacity: 0.2;
   }
 
   &__marker {

--- a/app/vmui/packages/vmui/src/components/Chart/Line/Legend/LegendViews/LegendLines.tsx
+++ b/app/vmui/packages/vmui/src/components/Chart/Line/Legend/LegendViews/LegendLines.tsx
@@ -1,0 +1,22 @@
+import React, { FC } from "preact/compat";
+import LegendItem from "../LegendItem/LegendItem";
+import { LegendProps } from "../LegendGroup";
+
+const LegendLines: FC<LegendProps> = ({ labels, isAnomalyView, duplicateFields, onChange }) => {
+
+  return (
+    <div className="vm-legend-item-container">
+      {labels.map((legendItem) =>
+        <LegendItem
+          key={legendItem.label}
+          legend={legendItem}
+          isAnomalyView={isAnomalyView}
+          duplicateFields={duplicateFields}
+          onChange={onChange}
+        />
+      )}
+    </div>
+  );
+};
+
+export default LegendLines;

--- a/app/vmui/packages/vmui/src/components/Chart/Line/Legend/LegendViews/LegendTable.tsx
+++ b/app/vmui/packages/vmui/src/components/Chart/Line/Legend/LegendViews/LegendTable.tsx
@@ -1,0 +1,87 @@
+import React, { FC, useMemo } from "preact/compat";
+import { LegendProps } from "../LegendGroup";
+import "./style.scss";
+import { LegendItemType } from "../../../../../types";
+import { MouseEvent } from "react";
+import classNames from "classnames";
+import get from "lodash.get";
+import { STATS_ORDER } from "../../../../../constants/graph";
+import { useShowStats } from "../hooks/useShowStats";
+
+const statsColumns = STATS_ORDER.map(k => ({
+  key: `statsFormatted.${k}`,
+  title: k
+}));
+
+const LegendTable: FC<LegendProps> = ({ labels, duplicateFields, onChange }) => {
+  const { hideStats } = useShowStats();
+
+  const stats = hideStats ? [] : statsColumns;
+
+  const fields = useMemo(() => {
+    const fields = [...new Set(labels.flatMap(item => Object.keys(item.freeFormFields)))]
+      .map(f => ({ key: `freeFormFields.${f}`, title: f }));
+
+    return duplicateFields?.length
+      ? fields.filter(f => !duplicateFields.includes(f.title))
+      : fields;
+  }, [labels, duplicateFields]);
+
+  const columns = fields.concat(stats);
+
+  const createHandlerClick = (legend: LegendItemType) => (e: MouseEvent<HTMLTableRowElement>) => {
+    onChange && onChange(legend, e.ctrlKey || e.metaKey);
+  };
+
+  return (
+    <div className="vm-legend-table__wrapper">
+      <table className="vm-legend-table">
+        <thead className="vm-legend-table-thead">
+          <tr className="vm-legend-table-row vm-legend-table_thead">
+            <th className="vm-legend-table-col vm-legend-table-col_marker vm-legend-table-col_thead"/>
+            {columns.map((col) => (
+              <th
+                key={col.key}
+                className="vm-legend-table-col vm-legend-table-col_thead"
+              >
+                {col.title}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody className="vm-legend-table-tbody">
+          {labels.map(row => (
+            <tr
+              key={row.label}
+              className={classNames({
+                "vm-legend-table-row": true,
+                "vm-legend-table-row_tbody": true,
+                "vm-legend-table-row_exclude": !row.checked
+              })}
+              onClick={createHandlerClick(row)}
+            >
+              <td className="vm-legend-table-col vm-legend-table-col_marker">
+                <div
+                  className="vm-legend-item__marker"
+                  style={{ backgroundColor: row.color }}
+                />
+              </td>
+              {columns.map((col) => (
+                <td
+                  key={`${col.key}_${row.label}`}
+                  className="vm-legend-table-col"
+                >
+                  <span className="vm-legend-table-col__content">
+                    {get(row, col.key)}
+                  </span>
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+export default LegendTable;

--- a/app/vmui/packages/vmui/src/components/Chart/Line/Legend/LegendViews/style.scss
+++ b/app/vmui/packages/vmui/src/components/Chart/Line/Legend/LegendViews/style.scss
@@ -1,0 +1,64 @@
+@use "src/styles/variables" as *;
+
+.vm-legend-table {
+  table-layout: auto;
+  max-width: 100%;
+  font-size: $font-size-small;
+
+  &__wrapper {
+    width: 100%;
+    max-height: 50vh;
+    overflow: auto;
+  }
+
+  &-row {
+    &_tbody {
+      cursor: pointer;
+      transition: 0.3s ease;
+
+      &:hover {
+        background-color: rgba(0, 0, 0, 0.1);
+      }
+    }
+
+    &_exclude {
+      text-decoration: line-through;
+      opacity: 0.2;
+    }
+  }
+
+  &-col {
+    vertical-align: middle;
+    text-align: left;
+    padding: calc($padding-global / 2);
+    overflow-wrap: anywhere;
+
+    &_thead {
+      position: sticky;
+      top: 0;
+      left: calc(14px + $padding-global);
+      font-weight: bold;
+      z-index: 2;
+      white-space: nowrap;
+      background: $color-background-block;
+    }
+
+    &_marker {
+      position: sticky;
+      left: 0;
+      width: calc(14px + $padding-global);
+      padding: 0 calc($padding-global / 2);
+    }
+
+    &_marker:not(th) {
+      z-index: 1;
+    }
+
+    &__content {
+      display: block;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+  }
+}

--- a/app/vmui/packages/vmui/src/components/Chart/Line/Legend/hooks/useGroupSeries.ts
+++ b/app/vmui/packages/vmui/src/components/Chart/Line/Legend/hooks/useGroupSeries.ts
@@ -1,0 +1,38 @@
+import { useMemo } from "preact/compat";
+import { LegendItemType } from "../../../../../types";
+import { QueryGroup } from "../Legend";
+
+type Props = {
+  labels: LegendItemType[];
+  query: string[];
+  groupByLabel?: string;
+}
+
+export const useGroupSeries = ({ labels, query, groupByLabel }: Props) => {
+  return useMemo(() => {
+    return getGroupSeries(labels, query, groupByLabel);
+  }, [labels, query, groupByLabel]);
+};
+
+const getGroupSeries = (
+  labels: LegendItemType[],
+  query: string[],
+  groupByLabel?: string
+): QueryGroup[] => {
+  const groupMap = new Map<string | number, QueryGroup>();
+
+  for (const label of labels) {
+    const groupKey = groupByLabel
+      ? `${groupByLabel}="${label.freeFormFields[groupByLabel] ?? ""}"`
+      : `${query[label.group - 1]}`;
+
+    if (!groupMap.has(groupKey)) {
+      groupMap.set(groupKey, { group: String(groupKey), items: [] });
+    }
+
+    const groupEntry = groupMap.get(groupKey) as QueryGroup;
+    groupEntry.items.push(label);
+  }
+
+  return Array.from(groupMap.values());
+};

--- a/app/vmui/packages/vmui/src/components/Chart/Line/Legend/hooks/useHideDuplicateFields.ts
+++ b/app/vmui/packages/vmui/src/components/Chart/Line/Legend/hooks/useHideDuplicateFields.ts
@@ -1,0 +1,49 @@
+import { useEffect, useMemo, useState } from "preact/compat";
+import { useSearchParams } from "react-router-dom";
+import { LegendQueryParams } from "../types";
+import { LegendItemType } from "../../../../../types";
+
+const urlKey = LegendQueryParams.hideDuplicates;
+
+export const useHideDuplicateFields = (labels?: LegendItemType[]) => {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const valueFromUrl = searchParams.get(urlKey) === "true";
+  const [hideDuplicates, setHideDuplicates] = useState(valueFromUrl);
+
+  const onChange = (value: boolean) => {
+    if (value) {
+      searchParams.set(urlKey, "true");
+    } else {
+      searchParams.delete(urlKey);
+    }
+
+    setHideDuplicates(value);
+    setSearchParams(searchParams);
+  };
+
+  useEffect(() => {
+    const value = searchParams.get(urlKey) === "true";
+    if (value !== hideDuplicates) {
+      setHideDuplicates(value);
+    }
+  }, [searchParams]);
+
+  const duplicateFields = useMemo(() => {
+    if (!hideDuplicates || !labels?.length || labels?.length < 2) {
+      return [];
+    }
+
+    const allKeys = [...new Set(labels.flatMap(l => Object.keys(l.freeFormFields || {})))];
+
+    return allKeys.filter(key => {
+      const firstValue = labels.find(l => l.freeFormFields[key])?.freeFormFields[key];
+      return labels.every(l => l.freeFormFields[key] === firstValue);
+    });
+  }, [labels, hideDuplicates]);
+
+  return {
+    hideDuplicates,
+    onChange,
+    duplicateFields
+  };
+};

--- a/app/vmui/packages/vmui/src/components/Chart/Line/Legend/hooks/useLegendFormat.ts
+++ b/app/vmui/packages/vmui/src/components/Chart/Line/Legend/hooks/useLegendFormat.ts
@@ -1,0 +1,38 @@
+import { useEffect, useState } from "preact/compat";
+import { useSearchParams } from "react-router-dom";
+import { LegendQueryParams } from "../types";
+
+const urlKey = LegendQueryParams.format;
+
+export const useLegendFormat = () => {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const valueFromUrl = searchParams.get(urlKey) || "";
+  const [format, setFormat] = useState(valueFromUrl);
+
+  const onChange = (value: string) => {
+    setFormat(value);
+  };
+
+  const onApply = () => {
+    if (format) {
+      searchParams.set(urlKey, format);
+    } else {
+      searchParams.delete(urlKey);
+    }
+
+    setSearchParams(searchParams);
+  };
+
+  useEffect(() => {
+    const value = searchParams.get(urlKey);
+    if (value !== format) {
+      setFormat(value || "");
+    }
+  }, [searchParams]);
+
+  return {
+    format,
+    onChange,
+    onApply
+  };
+};

--- a/app/vmui/packages/vmui/src/components/Chart/Line/Legend/hooks/useLegendGroup.ts
+++ b/app/vmui/packages/vmui/src/components/Chart/Line/Legend/hooks/useLegendGroup.ts
@@ -1,0 +1,34 @@
+import { useEffect, useState } from "preact/compat";
+import { useSearchParams } from "react-router-dom";
+import { LegendQueryParams } from "../types";
+import { WITHOUT_GROUPING } from "../../../../../constants/logs";
+
+const urlKey = LegendQueryParams.group;
+
+export const useLegendGroup = () => {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const valueFromUrl = searchParams.get(urlKey) || "";
+  const [groupByLabel, setGroupByLabel] = useState(valueFromUrl);
+
+  const onChange =(value: string) => {
+    if (value && value !== WITHOUT_GROUPING) {
+      searchParams.set(urlKey, value);
+    } else {
+      searchParams.delete(urlKey);
+    }
+    setGroupByLabel(value);
+    setSearchParams(searchParams);
+  };
+
+  useEffect(() => {
+    const value = searchParams.get(urlKey);
+    if (value !== groupByLabel) {
+      setGroupByLabel(value || "");
+    }
+  }, [searchParams]);
+
+  return {
+    groupByLabel,
+    onChange,
+  };
+};

--- a/app/vmui/packages/vmui/src/components/Chart/Line/Legend/hooks/useLegendView.ts
+++ b/app/vmui/packages/vmui/src/components/Chart/Line/Legend/hooks/useLegendView.ts
@@ -1,0 +1,41 @@
+import { useEffect, useState } from "preact/compat";
+import { useSearchParams } from "react-router-dom";
+import { LegendQueryParams } from "../types";
+
+export enum LegendDisplayType {
+  table = "table",
+  lines = "lines"
+}
+
+const urlKey = LegendQueryParams.view;
+
+export const useLegendView = () => {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const valueFromUrl = searchParams.get(urlKey) as LegendDisplayType;
+  const [view, setView] = useState<LegendDisplayType>(valueFromUrl || LegendDisplayType.lines);
+
+  const onChange = (type: LegendDisplayType) => {
+    if (type === LegendDisplayType.table) {
+      searchParams.set(urlKey, type);
+    } else {
+      searchParams.delete(urlKey);
+    }
+
+    setView(type);
+    setSearchParams(searchParams);
+  };
+
+  useEffect(() => {
+    const value = searchParams.get(urlKey);
+    if (value !== view) {
+      setView(value as LegendDisplayType);
+    }
+  }, [searchParams]);
+
+  return {
+    view,
+    isLinesView: view === LegendDisplayType.lines,
+    isTableView: view === LegendDisplayType.table,
+    onChange
+  };
+};

--- a/app/vmui/packages/vmui/src/components/Chart/Line/Legend/hooks/useShowStats.ts
+++ b/app/vmui/packages/vmui/src/components/Chart/Line/Legend/hooks/useShowStats.ts
@@ -1,0 +1,34 @@
+import { useEffect, useState } from "preact/compat";
+import { useSearchParams } from "react-router-dom";
+import { LegendQueryParams } from "../types";
+
+const urlKey = LegendQueryParams.hideStats;
+
+export const useShowStats = () => {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const valueFromUrl = searchParams.get(urlKey) === "true";
+  const [hideStats, setHideStats] = useState(valueFromUrl);
+
+  const onChange = (showName: boolean) => {
+    if (!showName) {
+      searchParams.set(urlKey, "true");
+    } else {
+      searchParams.delete(urlKey);
+    }
+
+    setHideStats(!showName);
+    setSearchParams(searchParams);
+  };
+
+  useEffect(() => {
+    const value = searchParams.get(urlKey) === "true";
+    if (value !== hideStats) {
+      setHideStats(value);
+    }
+  }, [searchParams]);
+
+  return {
+    hideStats,
+    onChange
+  };
+};

--- a/app/vmui/packages/vmui/src/components/Chart/Line/Legend/style.scss
+++ b/app/vmui/packages/vmui/src/components/Chart/Line/Legend/style.scss
@@ -3,8 +3,9 @@
 .vm-legend {
   position: relative;
   display: flex;
-  flex-wrap: wrap;
+  flex-direction: column;
   cursor: default;
+  width: 100%;
 
   &-group {
     min-width: 23%;
@@ -17,13 +18,12 @@
       padding: $padding-small;
       margin-bottom: 1px;
       border-bottom: $border-divider;
+      font-size: $font-size-small;
+      color: $color-text-secondary;
 
-      &__count {
-        font-weight: bold;
-        margin-right: $padding-small;
-      }
-
-      &__query {
+      b {
+        margin-left: $padding-small;
+        color: $color-text;
       }
     }
   }

--- a/app/vmui/packages/vmui/src/components/Chart/Line/Legend/types.ts
+++ b/app/vmui/packages/vmui/src/components/Chart/Line/Legend/types.ts
@@ -1,0 +1,7 @@
+export enum LegendQueryParams {
+  view = "legend_view",
+  hideDuplicates = "legend_hide_duplicates",
+  hideStats = "legend_hide_stats",
+  format = "legend_format",
+  group = "legend_group"
+}

--- a/app/vmui/packages/vmui/src/components/Configurators/GraphSettings/AxesLimitsConfigurator/AxesLimitsConfigurator.tsx
+++ b/app/vmui/packages/vmui/src/components/Configurators/GraphSettings/AxesLimitsConfigurator/AxesLimitsConfigurator.tsx
@@ -41,10 +41,13 @@ const AxesLimitsConfigurator: FC<AxesLimitsConfiguratorProps> = ({ yaxis, setYax
       <Switch
         value={yaxis.limits.enable}
         onChange={toggleEnableLimits}
-        label={`${yaxis.limits.enable ? "Fixed" : "Auto"} limits`}
+        label={yaxis.limits.enable ? "Enabled" : "Disabled"}
         fullWidth={isMobile}
       />
     </div>
+    <span className="vm-legend-configs-item__info">
+      Enables manual setting of min and max values for the y-axis.
+    </span>
     {yaxis.limits.enable && (
       <div className="vm-axes-limits-list">
         {axes.map(axis => (

--- a/app/vmui/packages/vmui/src/components/Configurators/GraphSettings/AxesLimitsConfigurator/style.scss
+++ b/app/vmui/packages/vmui/src/components/Configurators/GraphSettings/AxesLimitsConfigurator/style.scss
@@ -3,8 +3,6 @@
 .vm-axes-limits {
   display: grid;
   align-items: center;
-  gap: $padding-global;
-  max-width: 300px;
 
   &_mobile {
     width: 100%;
@@ -23,8 +21,9 @@
 
     &__inputs {
       display: grid;
-      grid-template-columns: repeat(2, 120px);
+      grid-template-columns: repeat(2, auto);
       gap: $padding-small;
+      margin-top: $padding-global;
     }
   }
 }

--- a/app/vmui/packages/vmui/src/components/Configurators/GraphSettings/GraphSettings.tsx
+++ b/app/vmui/packages/vmui/src/components/Configurators/GraphSettings/GraphSettings.tsx
@@ -3,7 +3,6 @@ import AxesLimitsConfigurator from "./AxesLimitsConfigurator/AxesLimitsConfigura
 import { AxisRange, YaxisState } from "../../../state/graph/reducer";
 import { SettingsIcon } from "../../Main/Icons";
 import Button from "../../Main/Button/Button";
-import Popper from "../../Main/Popper/Popper";
 import "./style.scss";
 import Tooltip from "../../Main/Tooltip/Tooltip";
 import useBoolean from "../../../hooks/useBoolean";
@@ -11,6 +10,8 @@ import LinesConfigurator from "./LinesConfigurator/LinesConfigurator";
 import GraphTypeSwitcher from "./GraphTypeSwitcher/GraphTypeSwitcher";
 import { MetricResult } from "../../../api/types";
 import { isHistogramData } from "../../../utils/metric";
+import LegendConfigs from "../../Chart/Line/Legend/LegendConfigs/LegendConfigs";
+import Modal from "../../Main/Modal/Modal";
 
 const title = "Graph settings";
 
@@ -32,8 +33,8 @@ const GraphSettings: FC<GraphSettingsProps> = ({ data, yaxis, setYaxisLimits, to
   const displayHistogramMode = isHistogramData(data);
 
   const {
-    value: openPopper,
-    toggle: toggleOpen,
+    value: isOpenSettings,
+    setTrue: handleOpen,
     setFalse: handleClose,
   } = useBoolean(false);
 
@@ -44,36 +45,46 @@ const GraphSettings: FC<GraphSettingsProps> = ({ data, yaxis, setYaxisLimits, to
           <Button
             variant="text"
             startIcon={<SettingsIcon/>}
-            onClick={toggleOpen}
+            onClick={handleOpen}
             ariaLabel="settings"
           />
         </div>
       </Tooltip>
-      <Popper
-        open={openPopper}
-        buttonRef={buttonRef}
-        placement="bottom-right"
-        onClose={handleClose}
-        title={title}
-      >
-        <div
-          className="vm-graph-settings-popper"
-          ref={popperRef}
+      {isOpenSettings && (
+        <Modal
+          onClose={handleClose}
+          title={title}
+          className="vm-graph-settings-modal"
         >
-          <div className="vm-graph-settings-popper__body">
-            <AxesLimitsConfigurator
-              yaxis={yaxis}
-              setYaxisLimits={setYaxisLimits}
-              toggleEnableLimits={toggleEnableLimits}
-            />
-            <LinesConfigurator
-              spanGaps={spanGaps.value}
-              onChange={spanGaps.onChange}
-            />
-            {displayHistogramMode && <GraphTypeSwitcher onChange={handleClose}/>}
+          <div
+            className="vm-graph-settings-body"
+            ref={popperRef}
+          >
+            <div className="vm-graph-settings-body-section">
+              <h3 className="vm-graph-settings-body-section__title">Chart Options</h3>
+              <div className="vm-graph-settings-body-section-content">
+                <AxesLimitsConfigurator
+                  yaxis={yaxis}
+                  setYaxisLimits={setYaxisLimits}
+                  toggleEnableLimits={toggleEnableLimits}
+                />
+                <LinesConfigurator
+                  spanGaps={spanGaps.value}
+                  onChange={spanGaps.onChange}
+                />
+                {displayHistogramMode && <GraphTypeSwitcher onChange={handleClose}/>}
+              </div>
+            </div>
+
+            <div className="vm-graph-settings-body-section">
+              <h3 className="vm-graph-settings-body-section__title">Legend Options</h3>
+              <div className="vm-graph-settings-body-section-content">
+                <LegendConfigs data={data}/>
+              </div>
+            </div>
           </div>
-        </div>
-      </Popper>
+        </Modal>
+      )}
     </div>
   );
 };

--- a/app/vmui/packages/vmui/src/components/Configurators/GraphSettings/LinesConfigurator/LinesConfigurator.tsx
+++ b/app/vmui/packages/vmui/src/components/Configurators/GraphSettings/LinesConfigurator/LinesConfigurator.tsx
@@ -19,6 +19,9 @@ const LinesConfigurator: FC<Props> = ({ spanGaps, onChange }) => {
         label={spanGaps ? "Enabled" : "Disabled"}
         fullWidth={isMobile}
       />
+      <span className="vm-legend-configs-item__info">
+        Connects data points by skipping null values instead of creating gaps.
+      </span>
     </div>
   );
 };

--- a/app/vmui/packages/vmui/src/components/Configurators/GraphSettings/style.scss
+++ b/app/vmui/packages/vmui/src/components/Configurators/GraphSettings/style.scss
@@ -5,27 +5,46 @@
   align-items: center;
   gap: $padding-small;
 
-  &-popper {
+  &-modal {
+    .vm-modal-content-body {
+      padding: 0;
+    }
+
+    .vm-modal-content-header {
+      margin-bottom: 0;
+    }
+  }
+
+  &-body {
     display: grid;
-    gap: $padding-global;
-    padding: $padding-small $padding-large $padding-large;
     min-width: 300px;
 
-    &__body {
-      display: grid;
-      gap: $padding-large;
+    &-section {
+      border-bottom: $border-divider;
+
+      &:last-child {
+        border-bottom: none;
+        padding-bottom: $padding-large;
+      }
+
+      &__title {
+        padding: $padding-global;
+        font-weight: bold;
+        background: $color-hover-black;
+      }
+
+      &-content {
+        display: grid;
+        gap: $padding-large;
+        padding: $padding-large;
+      }
     }
   }
 
   &-row {
     display: grid;
-    gap: $padding-small;
-    grid-template-columns: minmax(150px, max-content) 1fr;
-
-    &__label {
-      &:after{
-        content: ":";
-      }
-    }
+    align-items: center;
+    justify-content: stretch;
+    grid-template-columns: 1fr 100px;
   }
 }

--- a/app/vmui/packages/vmui/src/components/Views/GraphView/GraphView.tsx
+++ b/app/vmui/packages/vmui/src/components/Views/GraphView/GraphView.tsx
@@ -266,7 +266,6 @@ const GraphView: FC<GraphViewProps> = ({
       )}
       {isHistogram && showLegend && (
         <LegendHeatmap
-          series={series as SeriesItem[]}
           min={yaxis.limits.range[1][0] || 0}
           max={yaxis.limits.range[1][1] || 0}
           legendValue={legendValue}

--- a/app/vmui/packages/vmui/src/utils/metric.ts
+++ b/app/vmui/packages/vmui/src/utils/metric.ts
@@ -5,7 +5,7 @@ export const getNameForMetric = (result: MetricBase, alias?: string, showQueryNu
   const queryPrefix = showQueryNum ? `[Query ${result.group}] ` : "";
 
   if (alias) {
-    return alias.replace(/\{\{(\w+)}}/g, (_, key) => result.metric[key] || "");
+    return getLabelAlias(result.metric, alias);
   }
 
   const name = `${queryPrefix}${__name__ || ""}`;
@@ -19,6 +19,10 @@ export const getNameForMetric = (result: MetricBase, alias?: string, showQueryNu
     .join(", ");
 
   return `${name}{${fieldsString}}`;
+};
+
+export const getLabelAlias = (fields: { [p: string]: string }, alias: string) => {
+  return alias.replace(/\{\{(\w+)}}/g, (_, key) => fields[key] || "");
 };
 
 export const promValueToNumber = (s: string): number => {


### PR DESCRIPTION
### Describe Your Changes

Legend settings have been added to **Graph Settings**.  

#### **New Features:**  
1. **Table View** – Toggle to display the legend in a table format.  
2. **Hide Common Values** – Option to hide fields with identical values across all series.  
3. **Hide Min/Medium/Max** – Ability to hide min, median, and max values from the legend.  
4. **Custom Label Format** – Set a custom format for series labels (applies only to the legend).  
5. **Group by Label** – Group legend entries based on a selected label.  

<details>  
  <summary>Demo:</summary>
  
  Settings:
  <img src="https://github.com/user-attachments/assets/0a186350-ffab-448e-aed1-e98b5617472e" width="400"/>
  
  Default View:
  ![Group 7](https://github.com/user-attachments/assets/f7a4f62b-d323-47c4-8b28-15589c9506a2)

  Hide Common Labels and Min/Med/Max:
  ![Group 8](https://github.com/user-attachments/assets/1160fe88-f15a-4b63-a1ed-39b7d7ed2ec9)

  With Custom Label Format and Grouping:
  ![Group 9](https://github.com/user-attachments/assets/d46c6061-189d-44a3-9ffc-ad713dcb5fdd)

  Table View:
  ![Group 12](https://github.com/user-attachments/assets/a5f464e1-287d-4413-a15a-4aa4b3071cbb)

  Table View – Hide Common Labels and Min/Med/Max:
  ![Group 11](https://github.com/user-attachments/assets/0c0824fe-1bbb-4796-8332-7210665d6192)

</details>  

---  

Related Issue: #8031 

---

### Checklist

The following checks are **mandatory**:

- [ ] My change adheres [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/contributing/).
