### PR TITLE
vmui: update default step calculation for instant queries

### DIFF
--- a/app/vmui/packages/vmui/src/components/Configurators/StepConfigurator/StepConfigurator.tsx
+++ b/app/vmui/packages/vmui/src/components/Configurators/StepConfigurator/StepConfigurator.tsx
@@ -15,6 +15,7 @@ import useDeviceDetect from "../../../hooks/useDeviceDetect";
 import classNames from "classnames";
 import useBoolean from "../../../hooks/useBoolean";
 import { useCustomPanelState } from "../../../state/customPanel/CustomPanelStateContext";
+import Hyperlink from "../../Main/Hyperlink/Hyperlink";
 
 const StepConfigurator: FC = () => {
   const appModeEnable = getAppModeEnable();
@@ -29,10 +30,13 @@ const StepConfigurator: FC = () => {
 
   const defaultStep = useMemo(() => {
     return getStepFromDuration(end - start, isHistogram, displayType);
-  }, [step, isHistogram, displayType]);
+  }, [end, start, isHistogram, displayType]);
+  const prevDefaultStep = usePrevious(defaultStep);
 
   const [customStep, setCustomStep] = useState(value || defaultStep);
   const [error, setError] = useState("");
+
+  const isAutoStep = value === defaultStep;
 
   const {
     value: openOptions,
@@ -103,11 +107,11 @@ const StepConfigurator: FC = () => {
 
   useEffect(() => {
     const dur = end - start;
-    if (dur === prevDuration || !prevDuration) return;
+    if (dur === prevDuration || !prevDuration || value !== prevDefaultStep) return;
     if (defaultStep) {
       handleApply(defaultStep);
     }
-  }, [end, start, prevDuration, defaultStep]);
+  }, [prevDuration, defaultStep]);
 
   useEffect(() => {
     if (step === value || step === defaultStep) handleApply(defaultStep);
@@ -131,17 +135,15 @@ const StepConfigurator: FC = () => {
           <span className="vm-mobile-option__arrow"><ArrowDownIcon/></span>
         </div>
       ) : (
-        <Tooltip title="Query resolution step width">
-          <Button
-            className={appModeEnable ? "" : "vm-header-button"}
-            variant="contained"
-            color="primary"
-            startIcon={<TimelineIcon/>}
-            onClick={toggleOpenOptions}
-          >
-            STEP {customStep}
-          </Button>
-        </Tooltip>
+        <Button
+          className={appModeEnable ? "" : "vm-header-button"}
+          variant="contained"
+          color="primary"
+          startIcon={<TimelineIcon/>}
+          onClick={toggleOpenOptions}
+        >
+            Step: {isAutoStep ? `auto (${customStep})` : customStep}
+        </Button>
       )}
       <Popper
         open={openOptions}
@@ -166,7 +168,7 @@ const StepConfigurator: FC = () => {
             onFocus={handleFocus}
             onBlur={handleApply}
             endIcon={(
-              <Tooltip title={`Set default step value: ${defaultStep}`}>
+              <Tooltip title={`Reset to auto step (${defaultStep})`}>
                 <Button
                   size="small"
                   variant="text"
@@ -179,25 +181,23 @@ const StepConfigurator: FC = () => {
             )}
           />
           <div className="vm-step-control-popper-info">
-            <code>step</code> - the <a
-              className="vm-link vm-link_colored"
-              href="https://prometheus.io/docs/prometheus/latest/querying/basics/#time-durations"
-              target="_blank"
-              rel="noreferrer"
-            >
-            interval
-            </a>
-            between datapoints, which must be returned from the range query.
-            The <code>query</code> is executed at
-            <code>start</code>, <code>start+step</code>, <code>start+2*step</code>, …, <code>end</code> timestamps.
-            <a
-              className="vm-link vm-link_colored"
-              href="https://docs.victoriametrics.com/keyConcepts.html#range-query"
-              target="_blank"
-              rel="help noreferrer"
-            >
-              Read more about Range query
-            </a>
+            <p>
+              <code>step</code> - the <Hyperlink
+                href="https://prometheus.io/docs/prometheus/latest/querying/basics/#time-durations"
+                text="interval"
+              /> between datapoints, which must be returned from the range query.
+              The <code>query</code> is executed
+              at <code>start</code>, <code>start+step</code>, <code>start+2*step</code>, …, <code>end</code> timestamps.
+            </p>
+            <p>
+              Read more about <Hyperlink
+                href="https://docs.victoriametrics.com/keyConcepts.html#range-query"
+                text="Range"
+              /> and <Hyperlink
+                href="https://docs.victoriametrics.com/keyconcepts/#instant-query"
+                text="Instant"
+              /> queries.
+            </p>
           </div>
         </div>
       </Popper>

--- a/app/vmui/packages/vmui/src/components/Configurators/StepConfigurator/StepConfigurator.tsx
+++ b/app/vmui/packages/vmui/src/components/Configurators/StepConfigurator/StepConfigurator.tsx
@@ -14,6 +14,7 @@ import Popper from "../../Main/Popper/Popper";
 import useDeviceDetect from "../../../hooks/useDeviceDetect";
 import classNames from "classnames";
 import useBoolean from "../../../hooks/useBoolean";
+import { useCustomPanelState } from "../../../state/customPanel/CustomPanelStateContext";
 
 const StepConfigurator: FC = () => {
   const appModeEnable = getAppModeEnable();
@@ -22,12 +23,13 @@ const StepConfigurator: FC = () => {
   const { customStep: value, isHistogram } = useGraphState();
   const { period: { step, end, start } } = useTimeState();
   const graphDispatch = useGraphDispatch();
+  const { displayType } = useCustomPanelState();
 
   const prevDuration = usePrevious(end - start);
 
   const defaultStep = useMemo(() => {
-    return getStepFromDuration(end - start, isHistogram);
-  }, [step, isHistogram]);
+    return getStepFromDuration(end - start, isHistogram, displayType);
+  }, [step, isHistogram, displayType]);
 
   const [customStep, setCustomStep] = useState(value || defaultStep);
   const [error, setError] = useState("");
@@ -109,7 +111,7 @@ const StepConfigurator: FC = () => {
 
   useEffect(() => {
     if (step === value || step === defaultStep) handleApply(defaultStep);
-  }, [isHistogram]);
+  }, [isHistogram, displayType]);
 
   return (
     <div

--- a/app/vmui/packages/vmui/src/components/Configurators/StepConfigurator/style.scss
+++ b/app/vmui/packages/vmui/src/components/Configurators/StepConfigurator/style.scss
@@ -12,7 +12,6 @@
     display: grid;
     gap: $padding-small;
     max-width: 300px;
-    max-height: 208px;
     overflow: auto;
     padding: $padding-global;
     font-size: $font-size;
@@ -31,13 +30,11 @@
       font-size: $font-size-small;
       line-height: 1.8;
 
-      a {
-        margin: 0 0.4em;
-      }
-
       code {
-        padding: 0.2em 0.4em;
-        margin: 0 0.2em;
+        padding: .2em .4em;
+        margin: 0;
+        font-size: 85%;
+        white-space: break-spaces;
         background-color: $color-hover-black;
         border-radius: 6px;
       }

--- a/app/vmui/packages/vmui/src/hooks/useFetchQuery.ts
+++ b/app/vmui/packages/vmui/src/hooks/useFetchQuery.ts
@@ -76,8 +76,8 @@ export const useFetchQuery = ({
 
   const defaultStep = useMemo(() => {
     const { end, start } = period;
-    return getStepFromDuration(end - start, isHistogramState);
-  }, [period, isHistogramState]);
+    return getStepFromDuration(end - start, isHistogramState, displayType);
+  }, [period, isHistogramState, displayType]);
 
   const fetchData = async ({
     fetchUrl,

--- a/app/vmui/packages/vmui/src/utils/time.ts
+++ b/app/vmui/packages/vmui/src/utils/time.ts
@@ -1,4 +1,4 @@
-import { RelativeTimeOption, TimeParams, TimePeriod, Timezone } from "../types";
+import { DisplayType, RelativeTimeOption, TimeParams, TimePeriod, Timezone } from "../types";
 import dayjs, { UnitTypeShort } from "dayjs";
 import { getQueryStringValue } from "./query-string";
 import { DATE_ISO_FORMAT } from "../constants/date";
@@ -88,7 +88,10 @@ export const getSecondsFromDuration = (dur: string) => {
   return dayjs.duration(durObject).asSeconds();
 };
 
-export const getStepFromDuration = (dur: number, histogram?: boolean): string => {
+const instantQueryViews = [DisplayType.table, DisplayType.code];
+export const getStepFromDuration = (dur: number, histogram?: boolean, displayType?: DisplayType): string => {
+  if (displayType && instantQueryViews.includes(displayType)) return roundStep(dur);
+
   const size = histogram ? MAX_ITEMS_PER_HISTOGRAM : MAX_ITEMS_PER_CHART;
   return roundStep(dur / size);
 };

--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -30,6 +30,7 @@ Released at 2025-02-10
 
 * FEATURE: [Single-node VictoriaMetrics](https://docs.victoriametrics.com/) and [vmstorage](https://docs.victoriametrics.com/cluster-victoriametrics/): improve startup times when opening a storage with the [retention](https://docs.victoriametrics.com/#retention) exceeding a few months.
 * FEATURE: [vmui](https://docs.victoriametrics.com/#vmui): add the ability to switch the heatmap to a line chart. Now, vmui would suggest to switch to line graph display if heatmap can't be properly rendered. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8057).
+* FEATURE: [vmui](https://docs.victoriametrics.com/#vmui): automatically calculate `step` as `end - start` by default when switching to Table or JSON view in instant queries. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8240).
 * FEATURE: [vmauth](https://docs.victoriametrics.com/vmauth/): add `-httpInternalListenAddr` cmd-line flag to serve internal HTTP routes `/metrics`, `/flags`, etc. It allows properly route requests to backends with the same service routes as vmauth. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/6468) and [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/7345) for details.
 * FEATURE: expose `/-/healthy` and `/-/ready` endpoints as Prometheus does on vmselect endpoints, thus achieving full Prometheus compatibility for external dependencies.
 

--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -20,8 +20,8 @@ See also [LTS releases](https://docs.victoriametrics.com/lts-releases/).
 
 * SECURITY: upgrade Go builder from Go1.23.5 to Go1.23.6. See the list of issues addressed in [Go1.23.6](https://github.com/golang/go/issues?q=milestone%3AGo1.23.6+label%3ACherryPickApproved).
 
-* FEATURE: [vmui](https://docs.victoriametrics.com/#vmui): automatically calculate `step` as `end - start` by default when switching to Table or JSON view in instant queries. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8240).
-* FEATURE: [vmui](https://docs.victoriametrics.com/#vmui): preserve the user-defined `step` value when changing the time range. See [this comment](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8240#issuecomment-2647674065).
+* FEATURE: [vmui](https://docs.victoriametrics.com/#vmui): look back for recent data for longer time intervals when switching to Table or JSON view. The look back window depends on the `step` setting, which is now set as `end - start` (30m) by default. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8240).
+* FEATURE: [vmui](https://docs.victoriametrics.com/#vmui): preserve user-defined `step` setting when changing the time interval of displayed query. See [this comment](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8240#issuecomment-2647674065).
 
 * BUGFIX: [vmalert](https://docs.victoriametrics.com/vmalert/): fix polluted alert messages when multiple Alertmanager instances are configured with `alert_relabel_configs`. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8040), and thanks to @evkuzin for [the pull request](https://github.com/VictoriaMetrics/VictoriaMetrics/pull/8258).
 

--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -20,6 +20,8 @@ See also [LTS releases](https://docs.victoriametrics.com/lts-releases/).
 
 * SECURITY: upgrade Go builder from Go1.23.5 to Go1.23.6. See the list of issues addressed in [Go1.23.6](https://github.com/golang/go/issues?q=milestone%3AGo1.23.6+label%3ACherryPickApproved).
 
+* FEATURE: [vmui](https://docs.victoriametrics.com/#vmui): automatically calculate `step` as `end - start` by default when switching to Table or JSON view in instant queries. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8240).
+
 * BUGFIX: [vmalert](https://docs.victoriametrics.com/vmalert/): fix polluted alert messages when multiple Alertmanager instances are configured with `alert_relabel_configs`. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8040), and thanks to @evkuzin for [the pull request](https://github.com/VictoriaMetrics/VictoriaMetrics/pull/8258).
 
 ## [v1.111.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.111.0)
@@ -30,7 +32,6 @@ Released at 2025-02-10
 
 * FEATURE: [Single-node VictoriaMetrics](https://docs.victoriametrics.com/) and [vmstorage](https://docs.victoriametrics.com/cluster-victoriametrics/): improve startup times when opening a storage with the [retention](https://docs.victoriametrics.com/#retention) exceeding a few months.
 * FEATURE: [vmui](https://docs.victoriametrics.com/#vmui): add the ability to switch the heatmap to a line chart. Now, vmui would suggest to switch to line graph display if heatmap can't be properly rendered. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8057).
-* FEATURE: [vmui](https://docs.victoriametrics.com/#vmui): automatically calculate `step` as `end - start` by default when switching to Table or JSON view in instant queries. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8240).
 * FEATURE: [vmauth](https://docs.victoriametrics.com/vmauth/): add `-httpInternalListenAddr` cmd-line flag to serve internal HTTP routes `/metrics`, `/flags`, etc. It allows properly route requests to backends with the same service routes as vmauth. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/6468) and [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/7345) for details.
 * FEATURE: expose `/-/healthy` and `/-/ready` endpoints as Prometheus does on vmselect endpoints, thus achieving full Prometheus compatibility for external dependencies.
 

--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -21,6 +21,7 @@ See also [LTS releases](https://docs.victoriametrics.com/lts-releases/).
 * SECURITY: upgrade Go builder from Go1.23.5 to Go1.23.6. See the list of issues addressed in [Go1.23.6](https://github.com/golang/go/issues?q=milestone%3AGo1.23.6+label%3ACherryPickApproved).
 
 * FEATURE: [vmui](https://docs.victoriametrics.com/#vmui): automatically calculate `step` as `end - start` by default when switching to Table or JSON view in instant queries. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8240).
+* FEATURE: [vmui](https://docs.victoriametrics.com/#vmui): preserve the user-defined `step` value when changing the time range. See [this comment](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8240#issuecomment-2647674065).
 
 * BUGFIX: [vmalert](https://docs.victoriametrics.com/vmalert/): fix polluted alert messages when multiple Alertmanager instances are configured with `alert_relabel_configs`. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8040), and thanks to @evkuzin for [the pull request](https://github.com/VictoriaMetrics/VictoriaMetrics/pull/8258).
 


### PR DESCRIPTION
### Describe Your Changes

Updated default `step` calculation for `Table` and `JSON` views.

- When switching to the `Table` or `JSON` view, the default step is now automatically set to `end - start`, where `end` and `start` correspond to the selected time range.
- If the user has manually set a step value, it will remain unchanged when switching views or changing the time range.
- The UI now explicitly indicates when the step is automatically calculated. 

<details> <summary>Demo</summary>

https://github.com/user-attachments/assets/2540de24-36ed-4764-a047-1c6b48a80ed4

</details>

**Note:** These views use the [`/api/v1/query`](https://docs.victoriametrics.com/keyconcepts/#instant-query) endpoint for instant queries.  

Related issue: #8240


### Checklist

The following checks are **mandatory**:

- [x] My change adheres [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/contributing/).
