### PR TITLE
lib/storage: refactoring introduce OpenOptions

### DIFF
--- a/app/vmstorage/main.go
+++ b/app/vmstorage/main.go
@@ -110,7 +110,13 @@ func Init(resetCacheIfNeeded func(mrs []storage.MetricRow)) {
 	logger.Infof("opening storage at %q with -retentionPeriod=%s", *DataPath, retentionPeriod)
 	startTime := time.Now()
 	WG = syncwg.WaitGroup{}
-	strg := storage.MustOpenStorage(*DataPath, retentionPeriod.Duration(), *maxHourlySeries, *maxDailySeries)
+
+	opts := storage.OpenOptions{
+		Retention:       retentionPeriod.Duration(),
+		MaxHourlySeries: *maxHourlySeries,
+		MaxDailySeries:  *maxDailySeries,
+	}
+	strg := storage.MustOpenStorage(*DataPath, opts)
 	Storage = strg
 	initStaleSnapshotsRemover(strg)
 

--- a/lib/storage/index_db_test.go
+++ b/lib/storage/index_db_test.go
@@ -71,7 +71,7 @@ func TestTagFiltersToMetricIDsCache(t *testing.T) {
 		path := t.Name()
 		defer fs.MustRemoveAll(path)
 
-		s := MustOpenStorage(path, 0, 0, 0)
+		s := MustOpenStorage(path, OpenOptions{})
 		defer s.MustClose()
 
 		idb := s.idb()
@@ -95,7 +95,7 @@ func TestTagFiltersToMetricIDsCache(t *testing.T) {
 func TestTagFiltersToMetricIDsCache_EmptyMetricIDList(t *testing.T) {
 	path := t.Name()
 	defer fs.MustRemoveAll(path)
-	s := MustOpenStorage(path, 0, 0, 0)
+	s := MustOpenStorage(path, OpenOptions{})
 	defer s.MustClose()
 	idb := s.idb()
 
@@ -581,7 +581,7 @@ func TestIndexDB(t *testing.T) {
 
 	t.Run("serial", func(t *testing.T) {
 		const path = "TestIndexDB-serial"
-		s := MustOpenStorage(path, retentionMax, 0, 0)
+		s := MustOpenStorage(path, OpenOptions{})
 
 		db := s.idb()
 		mns, tsids, err := testIndexDBGetOrCreateTSIDByName(db, metricGroups)
@@ -594,7 +594,7 @@ func TestIndexDB(t *testing.T) {
 
 		// Re-open the storage and verify it works as expected.
 		s.MustClose()
-		s = MustOpenStorage(path, retentionMax, 0, 0)
+		s = MustOpenStorage(path, OpenOptions{})
 
 		db = s.idb()
 		if err := testIndexDBCheckTSIDByName(db, mns, tsids, false); err != nil {
@@ -607,7 +607,7 @@ func TestIndexDB(t *testing.T) {
 
 	t.Run("concurrent", func(t *testing.T) {
 		const path = "TestIndexDB-concurrent"
-		s := MustOpenStorage(path, retentionMax, 0, 0)
+		s := MustOpenStorage(path, OpenOptions{})
 		db := s.idb()
 
 		ch := make(chan error, 3)
@@ -1502,7 +1502,12 @@ func TestMatchTagFilters(t *testing.T) {
 func TestIndexDBRepopulateAfterRotation(t *testing.T) {
 	r := rand.New(rand.NewSource(1))
 	path := "TestIndexRepopulateAfterRotation"
-	s := MustOpenStorage(path, retention31Days, 1e5, 1e5)
+	opts := OpenOptions{
+		Retention:       retention31Days,
+		MaxHourlySeries: 1e5,
+		MaxDailySeries:  1e5,
+	}
+	s := MustOpenStorage(path, opts)
 
 	db := s.idb()
 	if db.generation == 0 {
@@ -1585,7 +1590,7 @@ func TestIndexDBRepopulateAfterRotation(t *testing.T) {
 
 func TestSearchTSIDWithTimeRange(t *testing.T) {
 	const path = "TestSearchTSIDWithTimeRange"
-	s := MustOpenStorage(path, retentionMax, 0, 0)
+	s := MustOpenStorage(path, OpenOptions{})
 	db := s.idb()
 
 	is := db.getIndexSearch(noDeadline)
@@ -2105,7 +2110,7 @@ func stopTestStorage(s *Storage) {
 func TestSearchContainsTimeRange(t *testing.T) {
 	path := t.Name()
 	os.RemoveAll(path)
-	s := MustOpenStorage(path, retentionMax, 0, 0)
+	s := MustOpenStorage(path, OpenOptions{})
 	db := s.idb()
 
 	is := db.getIndexSearch(noDeadline)

--- a/lib/storage/index_db_timing_test.go
+++ b/lib/storage/index_db_timing_test.go
@@ -41,7 +41,7 @@ func BenchmarkRegexpFilterMismatch(b *testing.B) {
 
 func BenchmarkIndexDBAddTSIDs(b *testing.B) {
 	const path = "BenchmarkIndexDBAddTSIDs"
-	s := MustOpenStorage(path, retentionMax, 0, 0)
+	s := MustOpenStorage(path, OpenOptions{})
 	db := s.idb()
 
 	const recordsPerLoop = 1e3
@@ -95,7 +95,7 @@ func BenchmarkHeadPostingForMatchers(b *testing.B) {
 	// This benchmark is equivalent to https://github.com/prometheus/prometheus/blob/23c0299d85bfeb5d9b59e994861553a25ca578e5/tsdb/head_bench_test.go#L52
 	// See https://www.robustperception.io/evaluating-performance-and-correctness for more details.
 	const path = "BenchmarkHeadPostingForMatchers"
-	s := MustOpenStorage(path, retentionMax, 0, 0)
+	s := MustOpenStorage(path, OpenOptions{})
 	db := s.idb()
 
 	// Fill the db with data as in https://github.com/prometheus/prometheus/blob/23c0299d85bfeb5d9b59e994861553a25ca578e5/tsdb/head_bench_test.go#L66
@@ -262,7 +262,7 @@ func BenchmarkHeadPostingForMatchers(b *testing.B) {
 
 func BenchmarkIndexDBGetTSIDs(b *testing.B) {
 	const path = "BenchmarkIndexDBGetTSIDs"
-	s := MustOpenStorage(path, retentionMax, 0, 0)
+	s := MustOpenStorage(path, OpenOptions{})
 	db := s.idb()
 
 	const recordsPerLoop = 1000

--- a/lib/storage/search_test.go
+++ b/lib/storage/search_test.go
@@ -72,7 +72,7 @@ func TestSearchQueryMarshalUnmarshal(t *testing.T) {
 
 func TestSearch(t *testing.T) {
 	path := "TestSearch"
-	st := MustOpenStorage(path, 0, 0, 0)
+	st := MustOpenStorage(path, OpenOptions{})
 	defer func() {
 		st.MustClose()
 		if err := os.RemoveAll(path); err != nil {
@@ -113,7 +113,7 @@ func TestSearch(t *testing.T) {
 
 	// Re-open the storage in order to flush all the pending cached data.
 	st.MustClose()
-	st = MustOpenStorage(path, 0, 0, 0)
+	st = MustOpenStorage(path, OpenOptions{})
 
 	// Run search.
 	tr := TimeRange{

--- a/lib/storage/storage_timing_test.go
+++ b/lib/storage/storage_timing_test.go
@@ -17,7 +17,7 @@ func BenchmarkStorageAddRows(b *testing.B) {
 
 func benchmarkStorageAddRows(b *testing.B, rowsPerBatch int) {
 	path := fmt.Sprintf("BenchmarkStorageAddRows_%d", rowsPerBatch)
-	s := MustOpenStorage(path, 0, 0, 0)
+	s := MustOpenStorage(path, OpenOptions{})
 	defer func() {
 		s.MustClose()
 		if err := os.RemoveAll(path); err != nil {


### PR DESCRIPTION
MustOpenStorage function may accept variadic number of optional arguments. This commit combines optional args into dedicated OpenOptions struct. It reduces complexity of adding new optional args.

 Related PR:
https://github.com/VictoriaMetrics/VictoriaMetrics/pull/8118

### Describe Your Changes

Please provide a brief description of the changes you made. Be as specific as possible to help others understand the purpose and impact of your modifications.

### Checklist

The following checks are **mandatory**:

- [ ] My change adheres [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/contributing/).
