### PR TITLE
app/vlselect/logsql: allow returning first n matches for seamless pagination

### DIFF
--- a/app/vlselect/logsql/logsql.go
+++ b/app/vlselect/logsql/logsql.go
@@ -875,7 +875,13 @@ func ProcessQueryRequest(ctx context.Context, w http.ResponseWriter, r *http.Req
 
 	if limit > 0 {
 		if q.CanReturnLastNResults() {
-			rows, err := getLastNQueryResults(ctx, tenantIDs, q, limit)
+			var rows []row
+			var err error
+			if httputils.GetBool(r, "firstmatches") {
+				rows, err = getFirstNQueryResults(ctx, tenantIDs, q, limit)
+			} else {
+				rows, err = getLastNQueryResults(ctx, tenantIDs, q, limit)
+			}
 			if err != nil {
 				httpserver.Errorf(w, r, "%s", err)
 				return
@@ -919,6 +925,74 @@ var blockResultPool bytesutil.ByteBufferPool
 type row struct {
 	timestamp int64
 	fields    []logstorage.Field
+}
+
+func getFirstNQueryResults(ctx context.Context, tenantIDs []logstorage.TenantID, q *logstorage.Query, limit int) ([]row, error) {
+	limitUpper := 2 * limit
+	q.AddPipeLimit(uint64(limitUpper))
+
+	rows, err := getQueryResultsWithLimit(ctx, tenantIDs, q, limitUpper)
+	if err != nil {
+		return nil, err
+	}
+	if len(rows) < limitUpper {
+		// Fast path - the requested time range contains up to limitUpper rows.
+		rows = getFirstNRows(rows, limit)
+		return rows, nil
+	}
+
+	start, end := q.GetFilterTimeRange()
+	d := end/2 - start/2
+	end -= d
+
+	qOrig := q
+	for {
+		timestamp := qOrig.GetTimestamp()
+		q = qOrig.CloneWithTimeFilter(timestamp, start, end)
+		rows, err := getQueryResultsWithLimit(ctx, tenantIDs, q, limitUpper)
+		if err != nil {
+			return nil, err
+		}
+
+		if d == 0 || start >= end {
+			// The [start ... end] time range equals one nanosecond.
+			// Just return up to limit rows.
+			if len(rows) > limit {
+				rows = rows[:limit]
+			}
+			return rows, nil
+		}
+
+		dLastBit := d & 1
+		d /= 2
+
+		if len(rows) >= limitUpper {
+			// The number of found rows on the [start ... end] time range exceeds limitUpper,
+			// so reduce the time range to [start+d ... end].
+			end -= d
+			continue
+		}
+		if len(rows) >= limit {
+			// The number of found rows is in the range [limit ... limitUpper).
+			// This means that found rows contains the needed limit rows with the biggest timestamps.
+			rows = getFirstNRows(rows, limit)
+			return rows, nil
+		}
+
+		// The number of found rows on [start ... end] time range is below the limit.
+		// This means the time range doesn't cover the needed logs, so it must be extended.
+
+		if len(rows) == 0 {
+			// The [start ... end] time range doesn't contain any rows, so change it to [end ... end+d).
+			start = end + 1
+			end += d + dLastBit
+			continue
+		}
+
+		// The number of found rows on [start ... end] time range is bigger than 0 but smaller than limit.
+		// Increase the time range to [start ... end+n].
+		end += d + dLastBit
+	}
 }
 
 func getLastNQueryResults(ctx context.Context, tenantIDs []logstorage.TenantID, q *logstorage.Query, limit int) ([]row, error) {
@@ -988,6 +1062,16 @@ func getLastNQueryResults(ctx context.Context, tenantIDs []logstorage.TenantID, 
 		// Increase the time range to [start-d ... end].
 		start -= d + dLastBit
 	}
+}
+
+func getFirstNRows(rows []row, limit int) []row {
+	sort.Slice(rows, func(i, j int) bool {
+		return rows[i].timestamp < rows[j].timestamp
+	})
+	if len(rows) > limit {
+		rows = rows[:limit]
+	}
+	return rows
 }
 
 func getLastNRows(rows []row, limit int) []row {

--- a/docs/VictoriaLogs/querying/README.md
+++ b/docs/VictoriaLogs/querying/README.md
@@ -56,6 +56,10 @@ By default the `/select/logsql/query` returns all the log entries matching the g
   ```sh
   curl http://localhost:9428/select/logsql/query -d 'query=error' -d 'limit=10'
   ```
+  In addition to returning the most recently added log entries, the `firstmatches=true` query arg can be passed to return the first matching log entries instead:
+  ```sh
+  cccurl http://localhost:9428/select/logsql/query -d 'query=error' -d 'limit=10' -d 'firstmatches=true'
+  ```
 - By adding [`limit` pipe](https://docs.victoriametrics.com/victorialogs/logsql/#limit-pipe) to the query. For example, the following command returns up to 10 **random** log entries
   with the `error` [word](https://docs.victoriametrics.com/victorialogs/logsql/#word) in the [`_msg` field](https://docs.victoriametrics.com/victorialogs/keyconcepts/#message-field):
   ```sh


### PR DESCRIPTION
### Describe Your Changes

VictoriaLogs currently only allows retrieving the last n matches within a given time window based on the `limit=n` query argument which allows seamless backwards pagination through logs.
In order to allow seamless forward pagination, an additional argument `firstmatches=true` has been added in this change which makes VictoriaLogs return the first n matches within the given time window instead.

In order to implement this feature, code from the `getLastNQueryResults` and `getLastNRows` functions have been re-used to implement similar, slightly modified `getFirstNQueryResults` and `getFirstNRows` functions.

This would also address the issues described in https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8127 and https://github.com/VictoriaMetrics/VictoriaMetrics/issues/7701 by allowing a combination of `end=<time>` to paginate backwards (existing behavior) or `start=<time>`+`firstmatches=true` to paginate forwards (new behavior).

### Checklist

The following checks are **mandatory**:

- [x] My change adheres [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/contributing/).
