### PR TITLE
lib/httpserver: properly check basic authorization

### DIFF
--- a/apptest/tests/vmauth_routing_test.go
+++ b/apptest/tests/vmauth_routing_test.go
@@ -185,9 +185,9 @@ func TestSingleVMAuthHTTPServerAuthKeys(t *testing.T) {
 	tc := apptest.NewTestCase(t)
 	defer tc.Stop()
 
-	var unauthorizedRequestsCount int
+	var authorizedRequestsCount int
 	backend := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
-		unauthorizedRequestsCount++
+		authorizedRequestsCount++
 	}))
 	defer backend.Close()
 
@@ -233,10 +233,10 @@ unauthorized_user:
 			t.Fatalf("unexpected http response code: %d, want: %d, response text: %s", resp.StatusCode, expectCode, responseText)
 		}
 	}
-	assertBackendsRequestsCount := func(expectUnauthorized int) {
+	assertBackendsRequestsCount := func(expectAuthorized int) {
 		t.Helper()
-		if expectUnauthorized != unauthorizedRequestsCount {
-			t.Fatalf("expected to have %d unauthorized proxied requests, got: %d", expectUnauthorized, unauthorizedRequestsCount)
+		if expectAuthorized != authorizedRequestsCount {
+			t.Fatalf("expected to have %d authorized proxied requests, got: %d", expectAuthorized, authorizedRequestsCount)
 		}
 	}
 

--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -23,6 +23,7 @@ See also [LTS releases](https://docs.victoriametrics.com/lts-releases/).
 * FEATURE: [vmui](https://docs.victoriametrics.com/#vmui): look back for recent data for longer time intervals when switching to Table or JSON view. The look back window depends on the `step` setting, which is now set as `end - start` (30m) by default. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8240).
 * FEATURE: [vmui](https://docs.victoriametrics.com/#vmui): preserve user-defined `step` setting when changing the time interval of displayed query. See [this comment](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8240#issuecomment-2647674065).
 
+* BUGFIX: all the VictoriaMetrics components: properly override basic authorization for API endpoints protected with `authKey`. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/7345#issuecomment-2662595807) for details.
 * BUGFIX: [vmalert](https://docs.victoriametrics.com/vmalert/): fix polluted alert messages when multiple Alertmanager instances are configured with `alert_relabel_configs`. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8040), and thanks to @evkuzin for [the pull request](https://github.com/VictoriaMetrics/VictoriaMetrics/pull/8258).
 * BUGFIX: `vminsert` in [VictoriaMetrics cluster](https://docs.victoriametrics.com/cluster-victoriametrics/) and `vmstorage` in [VictoriaMetrics cluster](https://docs.victoriametrics.com/cluster-victoriametrics/): properly return parsing error for data ingestion.
 

--- a/lib/httpserver/httpserver.go
+++ b/lib/httpserver/httpserver.go
@@ -386,9 +386,6 @@ func handlerWrapper(w http.ResponseWriter, r *http.Request, rh RequestHandler) {
 }
 
 func builtinRoutesHandler(s *server, r *http.Request, w http.ResponseWriter, rh RequestHandler) bool {
-	if !isProtectedByAuthFlag(r.URL.Path) && !CheckBasicAuth(w, r) {
-		return true
-	}
 
 	h := w.Header()
 


### PR DESCRIPTION
Commit 68791f9ccc21548d27f1cf04d0b3270be4146b82 introduced regression. It performed basicAuth check before built-in routes. It made impossible to bypass basic authorization with `authKey` param.

 This commit fixeds that issue and removes unneeded check. It also adds integration tests for this case.

 Related issue:
https://github.com/VictoriaMetrics/VictoriaMetrics/issues/7345

### Describe Your Changes

Please provide a brief description of the changes you made. Be as specific as possible to help others understand the purpose and impact of your modifications.

### Checklist

The following checks are **mandatory**:

- [ ] My change adheres [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/contributing/).
