### PR TITLE
lib/{storage,mergeset}: Make sure all parts have recCount == 1 when c…

### DIFF
--- a/lib/mergeset/table.go
+++ b/lib/mergeset/table.go
@@ -529,6 +529,9 @@ func (tb *Table) MustClose() {
 	tb.partsLock.Unlock()
 
 	for _, pw := range fileParts {
+		if n := pw.refCount.Load(); n != 1 {
+			logger.Panicf("BUG: unexpected refCount=%d when closing the indexdb part %q; probably there are pending searches", n, pw.p.path)
+		}
 		pw.decRef()
 	}
 }

--- a/lib/mergeset/table_test.go
+++ b/lib/mergeset/table_test.go
@@ -163,6 +163,7 @@ func TestTableCreateSnapshotAt(t *testing.T) {
 			t.Fatalf("unexpected item found for key=%q in snapshot2; got %q", key, ts2.Item)
 		}
 	}
+	ts.MustClose()
 	ts1.MustClose()
 	ts2.MustClose()
 

--- a/lib/storage/partition.go
+++ b/lib/storage/partition.go
@@ -927,9 +927,15 @@ func (pt *partition) MustClose() {
 	pt.partsLock.Unlock()
 
 	for _, pw := range smallParts {
+		if n := pw.refCount.Load(); n != 1 {
+			logger.Panicf("BUG: unexpected refCount=%d when closing the small part %q; probably there are pending searches", n, pw.p.path)
+		}
 		pw.decRef()
 	}
 	for _, pw := range bigParts {
+		if n := pw.refCount.Load(); n != 1 {
+			logger.Panicf("BUG: unexpected refCount=%d when closing the big part %q; probably there are pending searches", n, pw.p.path)
+		}
 		pw.decRef()
 	}
 }


### PR DESCRIPTION
…losing data partitions and index table

This check is already present in storage.Table. Also adding it to storage.Partition and mergeset.Table.

### Checklist

The following checks are **mandatory**:

- [x] My change adheres [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/contributing/).
