### PR TITLE
add utf(and dots) escaping support to make /federate compatible with prometheus3

### DIFF
--- a/app/vmselect/prometheus/escape.go
+++ b/app/vmselect/prometheus/escape.go
@@ -1,0 +1,104 @@
+package prometheus
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/logger"
+)
+
+/*
+	See https://github.com/VictoriaMetrics/VictoriaMetrics/pull/8352#issuecomment-2682078886
+	original https://github.com/VictoriaMetrics/VictoriaMetrics/blob/10abdf34ab082a61f40fd7df24a9df165f4f8b59/vendor/github.com/prometheus/common/model/metric.go#L63
+*/
+
+type EscapingScheme int
+
+const (
+	// NoEscaping indicates that a name will not be escaped. Unescaped names that
+	// do not conform to the legacy validity check will use a new exposition
+	// format syntax that will be officially standardized in future versions.
+	NoEscaping EscapingScheme = iota
+
+	// UnderscoreEscaping replaces all legacy-invalid characters with underscores.
+	UnderscoreEscaping
+)
+
+const (
+	// EscapingKey is the key in an Accept or Content-Type header that defines how
+	// metric and label names that do not conform to the legacy character
+	// requirements should be escaped when being scraped by a legacy prometheus
+	// system. If a system does not explicitly pass an escaping parameter in the
+	// Accept header, the default NameEscapingScheme will be used.
+	EscapingKey = "escaping"
+
+	// AllowUTF8 Possible values for Escaping Key:
+	AllowUTF8 = "allow-utf-8" // No escaping required.
+)
+
+func ParseEscapingScheme(header http.Header) EscapingScheme {
+	acceptValue := header.Get("Accept")
+	if len(acceptValue) == 0 {
+		return UnderscoreEscaping
+	}
+
+	parts := strings.Split(acceptValue, ";")
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		kv := strings.SplitN(part, "=", 2)
+		if len(kv) == 2 {
+			key := strings.TrimSpace(kv[0])
+			value := strings.TrimSpace(kv[1])
+			if key == EscapingKey {
+				if value == AllowUTF8 {
+					return NoEscaping
+				}
+				return UnderscoreEscaping
+			}
+		}
+	}
+
+	return UnderscoreEscaping
+}
+
+func isValidLegacyRune(b rune, i int) bool {
+	return (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') || b == '_' || b == ':' || (b >= '0' && b <= '9' && i > 0)
+}
+
+func IsValidLegacyMetricName(n string) bool {
+	if len(n) == 0 {
+		return false
+	}
+	for i, b := range n {
+		if !isValidLegacyRune(b, i) {
+			return false
+		}
+	}
+	return true
+}
+
+func EscapeName(name string, scheme EscapingScheme) string {
+	if len(name) == 0 {
+		return name
+	}
+	var escaped strings.Builder
+	switch scheme {
+	case NoEscaping:
+		return name
+	case UnderscoreEscaping:
+		if IsValidLegacyMetricName(name) {
+			return name
+		}
+		for i, b := range name {
+			if isValidLegacyRune(b, i) {
+				escaped.WriteRune(b)
+			} else {
+				escaped.WriteRune('_')
+			}
+		}
+		return escaped.String()
+	default:
+		logger.Panicf("BUG: invalid escaping scheme %d", scheme)
+		return ""
+	}
+}

--- a/app/vmselect/prometheus/federate.qtpl
+++ b/app/vmselect/prometheus/federate.qtpl
@@ -2,7 +2,6 @@
 	"math"
 	"unsafe"
 
-	"github.com/prometheus/common/model"
 	"github.com/VictoriaMetrics/VictoriaMetrics/app/vmselect/netstorage"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/storage"
 ) %}
@@ -11,7 +10,7 @@
 
 // Federate writes rs in /federate format.
 // See https://prometheus.io/docs/prometheus/latest/federation/
-{% func Federate(rs *netstorage.Result, escapingScheme model.EscapingScheme) %}
+{% func Federate(rs *netstorage.Result, escapingScheme EscapingScheme) %}
 	{% code
 		values := rs.Values
 		timestamps := rs.Timestamps
@@ -33,8 +32,8 @@
 	{%dl= timestamps[len(timestamps)-1] %}{% newline %}
 {% endfunc %}
 
-{% func prometheusFederateMetricName(mn *storage.MetricName, escapingScheme model.EscapingScheme)  %}
-    {% if escapingScheme == model.NoEscaping %}
+{% func prometheusFederateMetricName(mn *storage.MetricName, escapingScheme EscapingScheme)  %}
+    {% if escapingScheme == NoEscaping %}
         {% if len(mn.Tags) > 0 %}
             {
                 {% code tags := mn.Tags %}
@@ -54,17 +53,17 @@
     {% endif %}
 {% endfunc %}
 
-{% func escapePrometheusKey(name []byte, escapingScheme model.EscapingScheme) %}
+{% func escapePrometheusKey(name []byte, escapingScheme EscapingScheme) %}
     {% code str := unsafe.String(unsafe.SliceData(name), len(name)) %}
-    {% code escapedStr := model.EscapeName(str, escapingScheme) %}
-    {% if !model.IsValidLegacyMetricName(escapedStr) %}
+    {% code escapedStr := EscapeName(str, escapingScheme) %}
+    {% if !IsValidLegacyMetricName(escapedStr) %}
         "{%s= escapedStr %}"
     {% else %}
         {%s= escapedStr %}
     {% endif %}
 {% endfunc %}
 
-{% func fillTags(tags []storage.Tag, escapingScheme model.EscapingScheme) %}
+{% func fillTags(tags []storage.Tag, escapingScheme EscapingScheme) %}
     {% for i := range tags %}
         {% code tag := &tags[i] %}
         ,{%= escapePrometheusKey(tag.Key, escapingScheme) %}={%= escapePrometheusLabel(tag.Value) %}

--- a/app/vmselect/prometheus/federate.qtpl
+++ b/app/vmselect/prometheus/federate.qtpl
@@ -1,14 +1,17 @@
 {% import (
 	"math"
+	"unsafe"
 
+    "github.com/prometheus/common/model"
 	"github.com/VictoriaMetrics/VictoriaMetrics/app/vmselect/netstorage"
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/storage"
 ) %}
 
 {% stripspace %}
 
 // Federate writes rs in /federate format.
 // See https://prometheus.io/docs/prometheus/latest/federation/
-{% func Federate(rs *netstorage.Result) %}
+{% func Federate(rs *netstorage.Result, escapingScheme model.EscapingScheme) %}
 	{% code
 		values := rs.Values
 		timestamps := rs.Timestamps
@@ -25,9 +28,47 @@
 		{% endcomment %}
 		{% return %}
 	{% endif %}
-	{%= prometheusMetricName(&rs.MetricName) %}{% space %}
+	{%= prometheusFederateMetricName(&rs.MetricName, escapingScheme) %}{% space %}
 	{%f= lastValue %}{% space %}
 	{%dl= timestamps[len(timestamps)-1] %}{% newline %}
+{% endfunc %}
+
+{% func prometheusFederateMetricName(mn *storage.MetricName, escapingScheme model.EscapingScheme)  %}
+    {% if escapingScheme == model.NoEscaping %}
+        {% if len(mn.Tags) > 0 %}
+            {
+                {% code tags := mn.Tags %}
+                {%= escapePrometheusKey(mn.MetricGroup, escapingScheme) %}
+                {%s= fillTags(tags, escapingScheme) %}
+            }
+	    {% endif %}
+    {% else %}
+        {%= escapePrometheusKey(mn.MetricGroup, escapingScheme) %}
+        {% if len(mn.Tags) > 0 %}
+            {
+                {% code tags := mn.Tags %}
+                {%= escapePrometheusKey(tags[0].Key, escapingScheme) %}={%= escapePrometheusLabel(tags[0].Value) %}
+                {%s= fillTags(tags[1:], escapingScheme) %}
+            }
+        {% endif %}
+    {% endif %}
+{% endfunc %}
+
+{% func escapePrometheusKey(name []byte, escapingScheme model.EscapingScheme) %}
+    {% code str := unsafe.String(unsafe.SliceData(name), len(name)) %}
+    {% code escapedStr := model.EscapeName(str, escapingScheme) %}
+    {% if !model.IsValidLegacyMetricName(escapedStr) %}
+        "{%s= escapedStr %}"
+    {% else %}
+        {%s= escapedStr %}
+    {% endif %}
+{% endfunc %}
+
+{% func fillTags(tags []storage.Tag, escapingScheme model.EscapingScheme) %}
+    {% for i := range tags %}
+        {% code tag := &tags[i] %}
+        ,{%= escapePrometheusKey(tag.Key, escapingScheme) %}={%= escapePrometheusLabel(tag.Value) %}
+    {% endfor %}
 {% endfunc %}
 
 {% endstripspace %}

--- a/app/vmselect/prometheus/federate.qtpl
+++ b/app/vmselect/prometheus/federate.qtpl
@@ -2,7 +2,7 @@
 	"math"
 	"unsafe"
 
-    "github.com/prometheus/common/model"
+	"github.com/prometheus/common/model"
 	"github.com/VictoriaMetrics/VictoriaMetrics/app/vmselect/netstorage"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/storage"
 ) %}

--- a/app/vmselect/prometheus/federate.qtpl.go
+++ b/app/vmselect/prometheus/federate.qtpl.go
@@ -11,253 +11,252 @@ import (
 
 	"github.com/VictoriaMetrics/VictoriaMetrics/app/vmselect/netstorage"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/storage"
-	"github.com/prometheus/common/model"
 )
 
 // Federate writes rs in /federate format.// See https://prometheus.io/docs/prometheus/latest/federation/
 
-//line app/vmselect/prometheus/federate.qtpl:14
+//line app/vmselect/prometheus/federate.qtpl:13
 import (
 	qtio422016 "io"
 
 	qt422016 "github.com/valyala/quicktemplate"
 )
 
-//line app/vmselect/prometheus/federate.qtpl:14
+//line app/vmselect/prometheus/federate.qtpl:13
 var (
 	_ = qtio422016.Copy
 	_ = qt422016.AcquireByteBuffer
 )
 
-//line app/vmselect/prometheus/federate.qtpl:14
-func StreamFederate(qw422016 *qt422016.Writer, rs *netstorage.Result, escapingScheme model.EscapingScheme) {
-//line app/vmselect/prometheus/federate.qtpl:16
+//line app/vmselect/prometheus/federate.qtpl:13
+func StreamFederate(qw422016 *qt422016.Writer, rs *netstorage.Result, escapingScheme EscapingScheme) {
+//line app/vmselect/prometheus/federate.qtpl:15
 	values := rs.Values
 	timestamps := rs.Timestamps
 
-//line app/vmselect/prometheus/federate.qtpl:19
+//line app/vmselect/prometheus/federate.qtpl:18
 	if len(timestamps) == 0 || len(values) == 0 {
-//line app/vmselect/prometheus/federate.qtpl:19
+//line app/vmselect/prometheus/federate.qtpl:18
 		return
-//line app/vmselect/prometheus/federate.qtpl:19
+//line app/vmselect/prometheus/federate.qtpl:18
 	}
-//line app/vmselect/prometheus/federate.qtpl:21
+//line app/vmselect/prometheus/federate.qtpl:20
 	lastValue := values[len(values)-1]
 
-//line app/vmselect/prometheus/federate.qtpl:23
+//line app/vmselect/prometheus/federate.qtpl:22
 	if math.IsNaN(lastValue) {
-//line app/vmselect/prometheus/federate.qtpl:29
+//line app/vmselect/prometheus/federate.qtpl:28
 		return
-//line app/vmselect/prometheus/federate.qtpl:30
+//line app/vmselect/prometheus/federate.qtpl:29
 	}
-//line app/vmselect/prometheus/federate.qtpl:31
+//line app/vmselect/prometheus/federate.qtpl:30
 	streamprometheusFederateMetricName(qw422016, &rs.MetricName, escapingScheme)
+//line app/vmselect/prometheus/federate.qtpl:30
+	qw422016.N().S(` `)
+//line app/vmselect/prometheus/federate.qtpl:31
+	qw422016.N().F(lastValue)
 //line app/vmselect/prometheus/federate.qtpl:31
 	qw422016.N().S(` `)
 //line app/vmselect/prometheus/federate.qtpl:32
-	qw422016.N().F(lastValue)
-//line app/vmselect/prometheus/federate.qtpl:32
-	qw422016.N().S(` `)
-//line app/vmselect/prometheus/federate.qtpl:33
 	qw422016.N().DL(timestamps[len(timestamps)-1])
-//line app/vmselect/prometheus/federate.qtpl:33
+//line app/vmselect/prometheus/federate.qtpl:32
 	qw422016.N().S(`
 `)
-//line app/vmselect/prometheus/federate.qtpl:34
+//line app/vmselect/prometheus/federate.qtpl:33
 }
 
-//line app/vmselect/prometheus/federate.qtpl:34
-func WriteFederate(qq422016 qtio422016.Writer, rs *netstorage.Result, escapingScheme model.EscapingScheme) {
-//line app/vmselect/prometheus/federate.qtpl:34
+//line app/vmselect/prometheus/federate.qtpl:33
+func WriteFederate(qq422016 qtio422016.Writer, rs *netstorage.Result, escapingScheme EscapingScheme) {
+//line app/vmselect/prometheus/federate.qtpl:33
 	qw422016 := qt422016.AcquireWriter(qq422016)
-//line app/vmselect/prometheus/federate.qtpl:34
+//line app/vmselect/prometheus/federate.qtpl:33
 	StreamFederate(qw422016, rs, escapingScheme)
-//line app/vmselect/prometheus/federate.qtpl:34
+//line app/vmselect/prometheus/federate.qtpl:33
 	qt422016.ReleaseWriter(qw422016)
-//line app/vmselect/prometheus/federate.qtpl:34
+//line app/vmselect/prometheus/federate.qtpl:33
 }
 
-//line app/vmselect/prometheus/federate.qtpl:34
-func Federate(rs *netstorage.Result, escapingScheme model.EscapingScheme) string {
-//line app/vmselect/prometheus/federate.qtpl:34
+//line app/vmselect/prometheus/federate.qtpl:33
+func Federate(rs *netstorage.Result, escapingScheme EscapingScheme) string {
+//line app/vmselect/prometheus/federate.qtpl:33
 	qb422016 := qt422016.AcquireByteBuffer()
-//line app/vmselect/prometheus/federate.qtpl:34
+//line app/vmselect/prometheus/federate.qtpl:33
 	WriteFederate(qb422016, rs, escapingScheme)
-//line app/vmselect/prometheus/federate.qtpl:34
+//line app/vmselect/prometheus/federate.qtpl:33
 	qs422016 := string(qb422016.B)
-//line app/vmselect/prometheus/federate.qtpl:34
+//line app/vmselect/prometheus/federate.qtpl:33
 	qt422016.ReleaseByteBuffer(qb422016)
-//line app/vmselect/prometheus/federate.qtpl:34
+//line app/vmselect/prometheus/federate.qtpl:33
 	return qs422016
-//line app/vmselect/prometheus/federate.qtpl:34
+//line app/vmselect/prometheus/federate.qtpl:33
 }
 
+//line app/vmselect/prometheus/federate.qtpl:35
+func streamprometheusFederateMetricName(qw422016 *qt422016.Writer, mn *storage.MetricName, escapingScheme EscapingScheme) {
 //line app/vmselect/prometheus/federate.qtpl:36
-func streamprometheusFederateMetricName(qw422016 *qt422016.Writer, mn *storage.MetricName, escapingScheme model.EscapingScheme) {
+	if escapingScheme == NoEscaping {
 //line app/vmselect/prometheus/federate.qtpl:37
-	if escapingScheme == model.NoEscaping {
-//line app/vmselect/prometheus/federate.qtpl:38
 		if len(mn.Tags) > 0 {
-//line app/vmselect/prometheus/federate.qtpl:38
+//line app/vmselect/prometheus/federate.qtpl:37
 			qw422016.N().S(`{`)
+//line app/vmselect/prometheus/federate.qtpl:39
+			tags := mn.Tags
+
 //line app/vmselect/prometheus/federate.qtpl:40
-			tags := mn.Tags
-
-//line app/vmselect/prometheus/federate.qtpl:41
 			streamescapePrometheusKey(qw422016, mn.MetricGroup, escapingScheme)
-//line app/vmselect/prometheus/federate.qtpl:42
+//line app/vmselect/prometheus/federate.qtpl:41
 			qw422016.N().S(fillTags(tags, escapingScheme))
-//line app/vmselect/prometheus/federate.qtpl:42
+//line app/vmselect/prometheus/federate.qtpl:41
 			qw422016.N().S(`}`)
-//line app/vmselect/prometheus/federate.qtpl:44
+//line app/vmselect/prometheus/federate.qtpl:43
 		}
-//line app/vmselect/prometheus/federate.qtpl:45
+//line app/vmselect/prometheus/federate.qtpl:44
 	} else {
-//line app/vmselect/prometheus/federate.qtpl:46
+//line app/vmselect/prometheus/federate.qtpl:45
 		streamescapePrometheusKey(qw422016, mn.MetricGroup, escapingScheme)
-//line app/vmselect/prometheus/federate.qtpl:47
+//line app/vmselect/prometheus/federate.qtpl:46
 		if len(mn.Tags) > 0 {
-//line app/vmselect/prometheus/federate.qtpl:47
+//line app/vmselect/prometheus/federate.qtpl:46
 			qw422016.N().S(`{`)
-//line app/vmselect/prometheus/federate.qtpl:49
+//line app/vmselect/prometheus/federate.qtpl:48
 			tags := mn.Tags
 
-//line app/vmselect/prometheus/federate.qtpl:50
+//line app/vmselect/prometheus/federate.qtpl:49
 			streamescapePrometheusKey(qw422016, tags[0].Key, escapingScheme)
-//line app/vmselect/prometheus/federate.qtpl:50
+//line app/vmselect/prometheus/federate.qtpl:49
 			qw422016.N().S(`=`)
-//line app/vmselect/prometheus/federate.qtpl:50
+//line app/vmselect/prometheus/federate.qtpl:49
 			streamescapePrometheusLabel(qw422016, tags[0].Value)
-//line app/vmselect/prometheus/federate.qtpl:51
+//line app/vmselect/prometheus/federate.qtpl:50
 			qw422016.N().S(fillTags(tags[1:], escapingScheme))
-//line app/vmselect/prometheus/federate.qtpl:51
+//line app/vmselect/prometheus/federate.qtpl:50
 			qw422016.N().S(`}`)
-//line app/vmselect/prometheus/federate.qtpl:53
+//line app/vmselect/prometheus/federate.qtpl:52
 		}
-//line app/vmselect/prometheus/federate.qtpl:54
+//line app/vmselect/prometheus/federate.qtpl:53
 	}
-//line app/vmselect/prometheus/federate.qtpl:55
+//line app/vmselect/prometheus/federate.qtpl:54
 }
 
-//line app/vmselect/prometheus/federate.qtpl:55
-func writeprometheusFederateMetricName(qq422016 qtio422016.Writer, mn *storage.MetricName, escapingScheme model.EscapingScheme) {
-//line app/vmselect/prometheus/federate.qtpl:55
+//line app/vmselect/prometheus/federate.qtpl:54
+func writeprometheusFederateMetricName(qq422016 qtio422016.Writer, mn *storage.MetricName, escapingScheme EscapingScheme) {
+//line app/vmselect/prometheus/federate.qtpl:54
 	qw422016 := qt422016.AcquireWriter(qq422016)
-//line app/vmselect/prometheus/federate.qtpl:55
+//line app/vmselect/prometheus/federate.qtpl:54
 	streamprometheusFederateMetricName(qw422016, mn, escapingScheme)
-//line app/vmselect/prometheus/federate.qtpl:55
+//line app/vmselect/prometheus/federate.qtpl:54
 	qt422016.ReleaseWriter(qw422016)
-//line app/vmselect/prometheus/federate.qtpl:55
+//line app/vmselect/prometheus/federate.qtpl:54
 }
 
-//line app/vmselect/prometheus/federate.qtpl:55
-func prometheusFederateMetricName(mn *storage.MetricName, escapingScheme model.EscapingScheme) string {
-//line app/vmselect/prometheus/federate.qtpl:55
+//line app/vmselect/prometheus/federate.qtpl:54
+func prometheusFederateMetricName(mn *storage.MetricName, escapingScheme EscapingScheme) string {
+//line app/vmselect/prometheus/federate.qtpl:54
 	qb422016 := qt422016.AcquireByteBuffer()
-//line app/vmselect/prometheus/federate.qtpl:55
+//line app/vmselect/prometheus/federate.qtpl:54
 	writeprometheusFederateMetricName(qb422016, mn, escapingScheme)
-//line app/vmselect/prometheus/federate.qtpl:55
+//line app/vmselect/prometheus/federate.qtpl:54
 	qs422016 := string(qb422016.B)
-//line app/vmselect/prometheus/federate.qtpl:55
+//line app/vmselect/prometheus/federate.qtpl:54
 	qt422016.ReleaseByteBuffer(qb422016)
-//line app/vmselect/prometheus/federate.qtpl:55
+//line app/vmselect/prometheus/federate.qtpl:54
 	return qs422016
-//line app/vmselect/prometheus/federate.qtpl:55
+//line app/vmselect/prometheus/federate.qtpl:54
 }
 
+//line app/vmselect/prometheus/federate.qtpl:56
+func streamescapePrometheusKey(qw422016 *qt422016.Writer, name []byte, escapingScheme EscapingScheme) {
 //line app/vmselect/prometheus/federate.qtpl:57
-func streamescapePrometheusKey(qw422016 *qt422016.Writer, name []byte, escapingScheme model.EscapingScheme) {
-//line app/vmselect/prometheus/federate.qtpl:58
 	str := unsafe.String(unsafe.SliceData(name), len(name))
 
+//line app/vmselect/prometheus/federate.qtpl:58
+	escapedStr := EscapeName(str, escapingScheme)
+
 //line app/vmselect/prometheus/federate.qtpl:59
-	escapedStr := model.EscapeName(str, escapingScheme)
-
-//line app/vmselect/prometheus/federate.qtpl:60
-	if !model.IsValidLegacyMetricName(escapedStr) {
-//line app/vmselect/prometheus/federate.qtpl:60
+	if !IsValidLegacyMetricName(escapedStr) {
+//line app/vmselect/prometheus/federate.qtpl:59
 		qw422016.N().S(`"`)
-//line app/vmselect/prometheus/federate.qtpl:61
+//line app/vmselect/prometheus/federate.qtpl:60
 		qw422016.N().S(escapedStr)
-//line app/vmselect/prometheus/federate.qtpl:61
+//line app/vmselect/prometheus/federate.qtpl:60
 		qw422016.N().S(`"`)
-//line app/vmselect/prometheus/federate.qtpl:62
+//line app/vmselect/prometheus/federate.qtpl:61
 	} else {
-//line app/vmselect/prometheus/federate.qtpl:63
+//line app/vmselect/prometheus/federate.qtpl:62
 		qw422016.N().S(escapedStr)
-//line app/vmselect/prometheus/federate.qtpl:64
+//line app/vmselect/prometheus/federate.qtpl:63
 	}
-//line app/vmselect/prometheus/federate.qtpl:65
+//line app/vmselect/prometheus/federate.qtpl:64
 }
 
-//line app/vmselect/prometheus/federate.qtpl:65
-func writeescapePrometheusKey(qq422016 qtio422016.Writer, name []byte, escapingScheme model.EscapingScheme) {
-//line app/vmselect/prometheus/federate.qtpl:65
+//line app/vmselect/prometheus/federate.qtpl:64
+func writeescapePrometheusKey(qq422016 qtio422016.Writer, name []byte, escapingScheme EscapingScheme) {
+//line app/vmselect/prometheus/federate.qtpl:64
 	qw422016 := qt422016.AcquireWriter(qq422016)
-//line app/vmselect/prometheus/federate.qtpl:65
+//line app/vmselect/prometheus/federate.qtpl:64
 	streamescapePrometheusKey(qw422016, name, escapingScheme)
-//line app/vmselect/prometheus/federate.qtpl:65
+//line app/vmselect/prometheus/federate.qtpl:64
 	qt422016.ReleaseWriter(qw422016)
-//line app/vmselect/prometheus/federate.qtpl:65
+//line app/vmselect/prometheus/federate.qtpl:64
 }
 
-//line app/vmselect/prometheus/federate.qtpl:65
-func escapePrometheusKey(name []byte, escapingScheme model.EscapingScheme) string {
-//line app/vmselect/prometheus/federate.qtpl:65
+//line app/vmselect/prometheus/federate.qtpl:64
+func escapePrometheusKey(name []byte, escapingScheme EscapingScheme) string {
+//line app/vmselect/prometheus/federate.qtpl:64
 	qb422016 := qt422016.AcquireByteBuffer()
-//line app/vmselect/prometheus/federate.qtpl:65
+//line app/vmselect/prometheus/federate.qtpl:64
 	writeescapePrometheusKey(qb422016, name, escapingScheme)
-//line app/vmselect/prometheus/federate.qtpl:65
+//line app/vmselect/prometheus/federate.qtpl:64
 	qs422016 := string(qb422016.B)
-//line app/vmselect/prometheus/federate.qtpl:65
+//line app/vmselect/prometheus/federate.qtpl:64
 	qt422016.ReleaseByteBuffer(qb422016)
-//line app/vmselect/prometheus/federate.qtpl:65
+//line app/vmselect/prometheus/federate.qtpl:64
 	return qs422016
-//line app/vmselect/prometheus/federate.qtpl:65
+//line app/vmselect/prometheus/federate.qtpl:64
 }
 
+//line app/vmselect/prometheus/federate.qtpl:66
+func streamfillTags(qw422016 *qt422016.Writer, tags []storage.Tag, escapingScheme EscapingScheme) {
 //line app/vmselect/prometheus/federate.qtpl:67
-func streamfillTags(qw422016 *qt422016.Writer, tags []storage.Tag, escapingScheme model.EscapingScheme) {
-//line app/vmselect/prometheus/federate.qtpl:68
 	for i := range tags {
-//line app/vmselect/prometheus/federate.qtpl:69
+//line app/vmselect/prometheus/federate.qtpl:68
 		tag := &tags[i]
 
-//line app/vmselect/prometheus/federate.qtpl:69
+//line app/vmselect/prometheus/federate.qtpl:68
 		qw422016.N().S(`,`)
-//line app/vmselect/prometheus/federate.qtpl:70
+//line app/vmselect/prometheus/federate.qtpl:69
 		streamescapePrometheusKey(qw422016, tag.Key, escapingScheme)
-//line app/vmselect/prometheus/federate.qtpl:70
+//line app/vmselect/prometheus/federate.qtpl:69
 		qw422016.N().S(`=`)
-//line app/vmselect/prometheus/federate.qtpl:70
+//line app/vmselect/prometheus/federate.qtpl:69
 		streamescapePrometheusLabel(qw422016, tag.Value)
-//line app/vmselect/prometheus/federate.qtpl:71
+//line app/vmselect/prometheus/federate.qtpl:70
 	}
-//line app/vmselect/prometheus/federate.qtpl:72
+//line app/vmselect/prometheus/federate.qtpl:71
 }
 
-//line app/vmselect/prometheus/federate.qtpl:72
-func writefillTags(qq422016 qtio422016.Writer, tags []storage.Tag, escapingScheme model.EscapingScheme) {
-//line app/vmselect/prometheus/federate.qtpl:72
+//line app/vmselect/prometheus/federate.qtpl:71
+func writefillTags(qq422016 qtio422016.Writer, tags []storage.Tag, escapingScheme EscapingScheme) {
+//line app/vmselect/prometheus/federate.qtpl:71
 	qw422016 := qt422016.AcquireWriter(qq422016)
-//line app/vmselect/prometheus/federate.qtpl:72
+//line app/vmselect/prometheus/federate.qtpl:71
 	streamfillTags(qw422016, tags, escapingScheme)
-//line app/vmselect/prometheus/federate.qtpl:72
+//line app/vmselect/prometheus/federate.qtpl:71
 	qt422016.ReleaseWriter(qw422016)
-//line app/vmselect/prometheus/federate.qtpl:72
+//line app/vmselect/prometheus/federate.qtpl:71
 }
 
-//line app/vmselect/prometheus/federate.qtpl:72
-func fillTags(tags []storage.Tag, escapingScheme model.EscapingScheme) string {
-//line app/vmselect/prometheus/federate.qtpl:72
+//line app/vmselect/prometheus/federate.qtpl:71
+func fillTags(tags []storage.Tag, escapingScheme EscapingScheme) string {
+//line app/vmselect/prometheus/federate.qtpl:71
 	qb422016 := qt422016.AcquireByteBuffer()
-//line app/vmselect/prometheus/federate.qtpl:72
+//line app/vmselect/prometheus/federate.qtpl:71
 	writefillTags(qb422016, tags, escapingScheme)
-//line app/vmselect/prometheus/federate.qtpl:72
+//line app/vmselect/prometheus/federate.qtpl:71
 	qs422016 := string(qb422016.B)
-//line app/vmselect/prometheus/federate.qtpl:72
+//line app/vmselect/prometheus/federate.qtpl:71
 	qt422016.ReleaseByteBuffer(qb422016)
-//line app/vmselect/prometheus/federate.qtpl:72
+//line app/vmselect/prometheus/federate.qtpl:71
 	return qs422016
-//line app/vmselect/prometheus/federate.qtpl:72
+//line app/vmselect/prometheus/federate.qtpl:71
 }

--- a/app/vmselect/prometheus/federate_test.go
+++ b/app/vmselect/prometheus/federate_test.go
@@ -5,18 +5,19 @@ import (
 
 	"github.com/VictoriaMetrics/VictoriaMetrics/app/vmselect/netstorage"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/storage"
+	"github.com/prometheus/common/model"
 )
 
 func TestFederate(t *testing.T) {
-	f := func(rs *netstorage.Result, expectedResult string) {
+	f := func(rs *netstorage.Result, expectedResult string, scheme model.EscapingScheme) {
 		t.Helper()
-		result := Federate(rs)
+		result := Federate(rs, scheme)
 		if result != expectedResult {
 			t.Fatalf("unexpected result; got\n%s\nwant\n%s", result, expectedResult)
 		}
 	}
 
-	f(&netstorage.Result{}, ``)
+	f(&netstorage.Result{}, ``, model.UnderscoreEscaping)
 
 	f(&netstorage.Result{
 		MetricName: storage.MetricName{
@@ -39,5 +40,121 @@ func TestFederate(t *testing.T) {
 		},
 		Values:     []float64{1.23},
 		Timestamps: []int64{123},
-	}, `foo{a="b",qqq="\\",abc="a<b\"\\c"} 1.23 123`+"\n")
+	}, `foo{a="b",qqq="\\",abc="a<b\"\\c"} 1.23 123`+"\n", model.UnderscoreEscaping)
+
+	f(&netstorage.Result{
+		MetricName: storage.MetricName{
+			MetricGroup: []byte("f.o.o"),
+			Tags: []storage.Tag{
+				{
+					Key:   []byte("a"),
+					Value: []byte("b"),
+				},
+				{
+					Key:   []byte("q.q.q"),
+					Value: []byte("\\"),
+				},
+				{
+					Key: []byte("abc"),
+					// Verify that < isn't encoded. See https://github.com/VictoriaMetrics/VictoriaMetrics/issues/5431
+					Value: []byte("a<b\"\\c"),
+				},
+			},
+		},
+		Values:     []float64{1.23},
+		Timestamps: []int64{123},
+	}, `f_o_o{a="b",q_q_q="\\",abc="a<b\"\\c"} 1.23 123`+"\n", model.UnderscoreEscaping)
+
+	f(&netstorage.Result{
+		MetricName: storage.MetricName{
+			MetricGroup: []byte("f.o.o"),
+			Tags: []storage.Tag{
+				{
+					Key:   []byte("a"),
+					Value: []byte("b"),
+				},
+				{
+					Key:   []byte("q.q.q"),
+					Value: []byte("\\"),
+				},
+				{
+					Key: []byte("abc"),
+					// Verify that < isn't encoded. See https://github.com/VictoriaMetrics/VictoriaMetrics/issues/5431
+					Value: []byte("a<b\"\\c"),
+				},
+			},
+		},
+		Values:     []float64{1.23},
+		Timestamps: []int64{123},
+	}, `{"f.o.o",a="b","q.q.q"="\\",abc="a<b\"\\c"} 1.23 123`+"\n", model.NoEscaping)
+
+	f(&netstorage.Result{
+		MetricName: storage.MetricName{
+			MetricGroup: []byte("f.ö.o"),
+			Tags: []storage.Tag{
+				{
+					Key:   []byte("a"),
+					Value: []byte("b"),
+				},
+				{
+					Key:   []byte("q.ö.q"),
+					Value: []byte("\\"),
+				},
+				{
+					Key: []byte("abc"),
+					// Verify that < isn't encoded. See https://github.com/VictoriaMetrics/VictoriaMetrics/issues/5431
+					Value: []byte("a<b\"\\c"),
+				},
+			},
+		},
+		Values:     []float64{1.23},
+		Timestamps: []int64{123},
+	}, `{"f.ö.o",a="b","q.ö.q"="\\",abc="a<b\"\\c"} 1.23 123`+"\n", model.NoEscaping)
+
+	f(&netstorage.Result{
+		MetricName: storage.MetricName{
+			MetricGroup: []byte("f.ö.o"),
+			Tags: []storage.Tag{
+				{
+					Key:   []byte("a"),
+					Value: []byte("b"),
+				},
+				{
+					Key:   []byte("q.ö.q"),
+					Value: []byte("\\"),
+				},
+				{
+					Key: []byte("abc"),
+					// Verify that < isn't encoded. See https://github.com/VictoriaMetrics/VictoriaMetrics/issues/5431
+					Value: []byte("a<b\"\\c"),
+				},
+			},
+		},
+		Values:     []float64{1.23},
+		Timestamps: []int64{123},
+	}, `f_dot____dot_o{a="b",q_dot____dot_q="\\",abc="a<b\"\\c"} 1.23 123`+"\n", model.DotsEscaping)
+
+	f(&netstorage.Result{
+		MetricName: storage.MetricName{
+			MetricGroup: []byte("f.ö.o"),
+			Tags: []storage.Tag{
+				{
+					Key:   []byte("a"),
+					Value: []byte("b"),
+				},
+				{
+					Key:   []byte("q.ö.q"),
+					Value: []byte("\\"),
+				},
+				{
+					Key: []byte("abc"),
+					// Verify that < isn't encoded. See https://github.com/VictoriaMetrics/VictoriaMetrics/issues/5431
+					Value: []byte("a<b\"\\c"),
+				},
+			},
+		},
+		Values:     []float64{1.23},
+		Timestamps: []int64{123},
+	}, `U__f_2e__f6__2e_o{a="b",U__q_2e__f6__2e_q="\\",abc="a<b\"\\c"} 1.23 123`+"\n", model.ValueEncodingEscaping)
+
 }

--- a/app/vmselect/prometheus/federate_test.go
+++ b/app/vmselect/prometheus/federate_test.go
@@ -5,11 +5,10 @@ import (
 
 	"github.com/VictoriaMetrics/VictoriaMetrics/app/vmselect/netstorage"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/storage"
-	"github.com/prometheus/common/model"
 )
 
 func TestFederate(t *testing.T) {
-	f := func(rs *netstorage.Result, expectedResult string, scheme model.EscapingScheme) {
+	f := func(rs *netstorage.Result, expectedResult string, scheme EscapingScheme) {
 		t.Helper()
 		result := Federate(rs, scheme)
 		if result != expectedResult {
@@ -17,7 +16,7 @@ func TestFederate(t *testing.T) {
 		}
 	}
 
-	f(&netstorage.Result{}, ``, model.UnderscoreEscaping)
+	f(&netstorage.Result{}, ``, UnderscoreEscaping)
 
 	f(&netstorage.Result{
 		MetricName: storage.MetricName{
@@ -40,7 +39,7 @@ func TestFederate(t *testing.T) {
 		},
 		Values:     []float64{1.23},
 		Timestamps: []int64{123},
-	}, `foo{a="b",qqq="\\",abc="a<b\"\\c"} 1.23 123`+"\n", model.UnderscoreEscaping)
+	}, `foo{a="b",qqq="\\",abc="a<b\"\\c"} 1.23 123`+"\n", UnderscoreEscaping)
 
 	f(&netstorage.Result{
 		MetricName: storage.MetricName{
@@ -63,7 +62,7 @@ func TestFederate(t *testing.T) {
 		},
 		Values:     []float64{1.23},
 		Timestamps: []int64{123},
-	}, `f_o_o{a="b",q_q_q="\\",abc="a<b\"\\c"} 1.23 123`+"\n", model.UnderscoreEscaping)
+	}, `f_o_o{a="b",q_q_q="\\",abc="a<b\"\\c"} 1.23 123`+"\n", UnderscoreEscaping)
 
 	f(&netstorage.Result{
 		MetricName: storage.MetricName{
@@ -86,7 +85,7 @@ func TestFederate(t *testing.T) {
 		},
 		Values:     []float64{1.23},
 		Timestamps: []int64{123},
-	}, `{"f.o.o",a="b","q.q.q"="\\",abc="a<b\"\\c"} 1.23 123`+"\n", model.NoEscaping)
+	}, `{"f.o.o",a="b","q.q.q"="\\",abc="a<b\"\\c"} 1.23 123`+"\n", NoEscaping)
 
 	f(&netstorage.Result{
 		MetricName: storage.MetricName{
@@ -109,52 +108,5 @@ func TestFederate(t *testing.T) {
 		},
 		Values:     []float64{1.23},
 		Timestamps: []int64{123},
-	}, `{"f.ö.o",a="b","q.ö.q"="\\",abc="a<b\"\\c"} 1.23 123`+"\n", model.NoEscaping)
-
-	f(&netstorage.Result{
-		MetricName: storage.MetricName{
-			MetricGroup: []byte("f.ö.o"),
-			Tags: []storage.Tag{
-				{
-					Key:   []byte("a"),
-					Value: []byte("b"),
-				},
-				{
-					Key:   []byte("q.ö.q"),
-					Value: []byte("\\"),
-				},
-				{
-					Key: []byte("abc"),
-					// Verify that < isn't encoded. See https://github.com/VictoriaMetrics/VictoriaMetrics/issues/5431
-					Value: []byte("a<b\"\\c"),
-				},
-			},
-		},
-		Values:     []float64{1.23},
-		Timestamps: []int64{123},
-	}, `f_dot____dot_o{a="b",q_dot____dot_q="\\",abc="a<b\"\\c"} 1.23 123`+"\n", model.DotsEscaping)
-
-	f(&netstorage.Result{
-		MetricName: storage.MetricName{
-			MetricGroup: []byte("f.ö.o"),
-			Tags: []storage.Tag{
-				{
-					Key:   []byte("a"),
-					Value: []byte("b"),
-				},
-				{
-					Key:   []byte("q.ö.q"),
-					Value: []byte("\\"),
-				},
-				{
-					Key: []byte("abc"),
-					// Verify that < isn't encoded. See https://github.com/VictoriaMetrics/VictoriaMetrics/issues/5431
-					Value: []byte("a<b\"\\c"),
-				},
-			},
-		},
-		Values:     []float64{1.23},
-		Timestamps: []int64{123},
-	}, `U__f_2e__f6__2e_o{a="b",U__q_2e__f6__2e_q="\\",abc="a<b\"\\c"} 1.23 123`+"\n", model.ValueEncodingEscaping)
-
+	}, `{"f.ö.o",a="b","q.ö.q"="\\",abc="a<b\"\\c"} 1.23 123`+"\n", NoEscaping)
 }

--- a/app/vmselect/prometheus/federate_timing_test.go
+++ b/app/vmselect/prometheus/federate_timing_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/VictoriaMetrics/VictoriaMetrics/app/vmselect/netstorage"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/storage"
-	"github.com/prometheus/common/model"
 )
 
 func BenchmarkFederate(b *testing.B) {
@@ -33,7 +32,7 @@ func BenchmarkFederate(b *testing.B) {
 		var bb bytes.Buffer
 		for pb.Next() {
 			bb.Reset()
-			WriteFederate(&bb, rs, model.NoEscaping)
+			WriteFederate(&bb, rs, NoEscaping)
 		}
 	})
 }

--- a/app/vmselect/prometheus/federate_timing_test.go
+++ b/app/vmselect/prometheus/federate_timing_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/VictoriaMetrics/VictoriaMetrics/app/vmselect/netstorage"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/storage"
+	"github.com/prometheus/common/model"
 )
 
 func BenchmarkFederate(b *testing.B) {
@@ -32,7 +33,7 @@ func BenchmarkFederate(b *testing.B) {
 		var bb bytes.Buffer
 		for pb.Next() {
 			bb.Reset()
-			WriteFederate(&bb, rs)
+			WriteFederate(&bb, rs, model.NoEscaping)
 		}
 	})
 }

--- a/app/vmselect/prometheus/prometheus.go
+++ b/app/vmselect/prometheus/prometheus.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/VictoriaMetrics/metrics"
 	"github.com/VictoriaMetrics/metricsql"
+	"github.com/prometheus/common/expfmt"
 	"github.com/valyala/fastjson/fastfloat"
 
 	"github.com/VictoriaMetrics/VictoriaMetrics/app/vmselect/netstorage"
@@ -111,6 +112,9 @@ func PrettifyQuery(w http.ResponseWriter, r *http.Request) {
 func FederateHandler(startTime time.Time, w http.ResponseWriter, r *http.Request) error {
 	defer federateDuration.UpdateDuration(startTime)
 
+	format := expfmt.Negotiate(r.Header)
+	escapingScheme := format.ToEscapingScheme()
+
 	cp, err := getCommonParams(r, startTime, true)
 	if err != nil {
 		return err
@@ -140,7 +144,7 @@ func FederateHandler(startTime time.Time, w http.ResponseWriter, r *http.Request
 			return err
 		}
 		bb := sw.getBuffer(workerID)
-		WriteFederate(bb, rs)
+		WriteFederate(bb, rs, escapingScheme)
 		return sw.maybeFlushBuffer(bb)
 	})
 	if err == nil {

--- a/app/vmselect/prometheus/prometheus.go
+++ b/app/vmselect/prometheus/prometheus.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/VictoriaMetrics/metrics"
 	"github.com/VictoriaMetrics/metricsql"
-	"github.com/prometheus/common/expfmt"
 	"github.com/valyala/fastjson/fastfloat"
 
 	"github.com/VictoriaMetrics/VictoriaMetrics/app/vmselect/netstorage"
@@ -112,8 +111,7 @@ func PrettifyQuery(w http.ResponseWriter, r *http.Request) {
 func FederateHandler(startTime time.Time, w http.ResponseWriter, r *http.Request) error {
 	defer federateDuration.UpdateDuration(startTime)
 
-	format := expfmt.Negotiate(r.Header)
-	escapingScheme := format.ToEscapingScheme()
+	escapingScheme := ParseEscapingScheme(r.Header)
 
 	cp, err := getCommonParams(r, startTime, true)
 	if err != nil {


### PR DESCRIPTION
### Describe Your Changes

add support for UTF-8 (and dots) escaping in /federate API as implemented in Prometheus v3 ([reference](https://prometheus.io/docs/guides/utf8/#scrape-content-negotiation-for-utf-8-escaping))
add tests to verify escaping behavior based on different escaping types


issue is [here](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8321)
### Checklist

The following checks are **mandatory**:

- [ ] My change adheres [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/contributing/).
