### PR TITLE
metricsql: support auto-format (prettify) for expressions that use quoted metric or label names

### DIFF
--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -32,6 +32,7 @@ See also [LTS releases](https://docs.victoriametrics.com/lts-releases/).
 * FEATURE: [vmui](https://docs.victoriametrics.com/#vmui): improve numbers formatting for better readability on the `Explore Cardinality` page. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8318).
 * FEATURE: [vmui](https://docs.victoriametrics.com/#vmui): print full error messages for failed queries on the `Explore Cardinality` page. Before, only response status code was printed. 
 * FEATURE: [vmui](https://docs.victoriametrics.com/#vmui): move values representing changes relative to the previous day to a separate column for easier sorting on the `Explore Cardinality` page.
+* FEATURE: [MetricsQL](https://docs.victoriametrics.com/metricsql/): support auto-format (prettify) for expressions that use quoted metric or label names. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/7703) for details.
 
 * BUGFIX: all the VictoriaMetrics components: properly override basic authorization for API endpoints protected with `authKey`. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/7345#issuecomment-2662595807) for details.
 * BUGFIX: [vmalert](https://docs.victoriametrics.com/vmalert/): fix polluted alert messages when multiple Alertmanager instances are configured with `alert_relabel_configs`. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8040), and thanks to @evkuzin for [the pull request](https://github.com/VictoriaMetrics/VictoriaMetrics/pull/8258).

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/VictoriaMetrics/easyproto v0.1.4
 	github.com/VictoriaMetrics/fastcache v1.12.2
 	github.com/VictoriaMetrics/metrics v1.35.2
-	github.com/VictoriaMetrics/metricsql v0.83.0
+	github.com/VictoriaMetrics/metricsql v0.83.1
 	github.com/aws/aws-sdk-go-v2 v1.36.1
 	github.com/aws/aws-sdk-go-v2/config v1.29.6
 	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.17.61

--- a/go.sum
+++ b/go.sum
@@ -45,6 +45,8 @@ github.com/VictoriaMetrics/metrics v1.35.2 h1:Bj6L6ExfnakZKYPpi7mGUnkJP4NGQz2v5w
 github.com/VictoriaMetrics/metrics v1.35.2/go.mod h1:r7hveu6xMdUACXvB8TYdAj8WEsKzWB0EkpJN+RDtOf8=
 github.com/VictoriaMetrics/metricsql v0.83.0 h1:3460jZ97XWD+595jpPdtVTVoKJflbxqBgeCbzPCiSgU=
 github.com/VictoriaMetrics/metricsql v0.83.0/go.mod h1:1g4hdCwlbJZ851PU9VN65xy9Rdlzupo6fx3SNZ8Z64U=
+github.com/VictoriaMetrics/metricsql v0.83.1 h1:+eHBVsYJvOPw8oy25gh1VT7OnT+jtfHb31eGvfYNEkY=
+github.com/VictoriaMetrics/metricsql v0.83.1/go.mod h1:1g4hdCwlbJZ851PU9VN65xy9Rdlzupo6fx3SNZ8Z64U=
 github.com/VividCortex/ewma v1.2.0 h1:f58SaIzcDXrSy3kWaHNvuJgJ3Nmz59Zji6XoJR/q1ow=
 github.com/VividCortex/ewma v1.2.0/go.mod h1:nz4BbCtbLyFDeC9SUHbtcT5644juEuWfUAUnGx7j5l4=
 github.com/alecthomas/units v0.0.0-20240927000941-0f3dac36c52b h1:mimo19zliBX/vSQ6PWWSL9lK8qwHozUj03+zLoEB8O0=

--- a/vendor/github.com/VictoriaMetrics/metricsql/lexer.go
+++ b/vendor/github.com/VictoriaMetrics/metricsql/lexer.go
@@ -399,6 +399,29 @@ func unescapeIdent(s string) string {
 	}
 }
 
+func hasEscapedChars(s string) bool {
+	i := 0
+	for i < len(s) {
+		r, size := utf8.DecodeRuneInString(s[i:])
+		if i == 0 && !isFirstIdentChar(r) || i > 0 && !isIdentChar(r) {
+			return true
+		}
+		i += size
+	}
+	return false
+}
+
+func appendQuotedIdent(dst []byte, s string) []byte {
+	dst = utf8.AppendRune(dst, '"')
+	for i := 0; i < len(s); {
+		r, size := utf8.DecodeRuneInString(s[i:])
+		dst = utf8.AppendRune(dst, r)
+		i += size
+	}
+	dst = utf8.AppendRune(dst, '"')
+	return dst
+}
+
 func appendEscapedIdent(dst []byte, s string) []byte {
 	i := 0
 	for i < len(s) {
@@ -411,6 +434,13 @@ func appendEscapedIdent(dst []byte, s string) []byte {
 		i += size
 	}
 	return dst
+}
+
+func ifEscapedCharsAppendQuotedIdent(dst []byte, s string) []byte {
+	if hasEscapedChars(s) {
+		return appendQuotedIdent(dst, s)
+	}
+	return appendEscapedIdent(dst, s)
 }
 
 func (lex *lexer) Prev() {

--- a/vendor/github.com/VictoriaMetrics/metricsql/prettifier.go
+++ b/vendor/github.com/VictoriaMetrics/metricsql/prettifier.go
@@ -160,13 +160,21 @@ func appendPrettifiedExpr(dst []byte, e Expr, indent int, needParens bool) []byt
 		lfss := t.labelFilterss
 		offset := 0
 		metricName := getMetricNameFromLabelFilterss(lfss)
+		metricNamehasEscapedChars := hasEscapedChars(metricName)
+
 		if metricName != "" {
 			offset = 1
 		}
 		dst = appendIndent(dst, indent)
-		dst = appendEscapedIdent(dst, metricName)
+		if !metricNamehasEscapedChars {
+			dst = appendEscapedIdent(dst, metricName)
+		}
 		if !isOnlyMetricNameInLabelFilterss(lfss) {
 			dst = append(dst, "{\n"...)
+			if metricNamehasEscapedChars {
+				dst = ifEscapedCharsAppendQuotedIdent(dst, metricName)
+				dst = append(dst, ',', ' ', '\n')
+			}
 			for i, lfs := range lfss {
 				lfs = lfs[offset:]
 				if len(lfs) == 0 {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -119,7 +119,7 @@ github.com/VictoriaMetrics/fastcache
 # github.com/VictoriaMetrics/metrics v1.35.2
 ## explicit; go 1.17
 github.com/VictoriaMetrics/metrics
-# github.com/VictoriaMetrics/metricsql v0.83.0
+# github.com/VictoriaMetrics/metricsql v0.83.1
 ## explicit; go 1.13
 github.com/VictoriaMetrics/metricsql
 github.com/VictoriaMetrics/metricsql/binaryop


### PR DESCRIPTION
See https://github.com/VictoriaMetrics/VictoriaMetrics/issues/7703
