### PR TITLE
app/vmselect/promql: extract delta factor to a command-line flag

### DIFF
--- a/app/vmselect/promql/rollup.go
+++ b/app/vmselect/promql/rollup.go
@@ -21,6 +21,12 @@ var minStalenessInterval = flag.Duration("search.minStalenessInterval", 0, "The 
 	"This flag could be useful for removing gaps on graphs generated from time series with irregular intervals between samples. "+
 	"See also '-search.maxStalenessInterval'")
 
+var deltaTolerationFactor = flag.Int("search.deltaTolerationFactor", 10, "The factor between the first value and the first delta used to infer the previous missing value. "+
+	"This flag could be useful for adjusting the calculation of the missing previous value in delta() and increase() functions . "+
+	"A negative value forces the assumption of a missing value of zero. "+
+	"A value of zero assumes the missing value is equal to the first recorded value. "+
+	"Higher values allow for greater toleration in assuming the counter starts at 0.")
+
 var rollupFuncs = map[string]newRollupFunc{
 	"absent_over_time":        newRollupFuncOneArg(rollupAbsent),
 	"aggr_over_time":          newRollupFuncTwoArgs(rollupFake),
@@ -1864,7 +1870,7 @@ func rollupDelta(rfa *rollupFuncArg) float64 {
 		} else if !math.IsNaN(rfa.realNextValue) {
 			d = rfa.realNextValue - values[0]
 		}
-		if math.Abs(values[0]) < 10*(math.Abs(d)+1) {
+		if math.Abs(values[0]) < float64(*deltaTolerationFactor)*(math.Abs(d)+1) {
 			prevValue = 0
 		} else {
 			prevValue = values[0]

--- a/docs/Cluster-VictoriaMetrics.md
+++ b/docs/Cluster-VictoriaMetrics.md
@@ -1556,6 +1556,8 @@ Below is the output for `/path/to/vmselect -help`:
      Supports an array of `key:value` entries separated by comma or specified via multiple flags.
   -search.cacheTimestampOffset duration
      The maximum duration since the current time for response data, which is always queried from the original raw data, without using the response cache. Increase this value if you see gaps in responses due to time synchronization issues between VictoriaMetrics and data sources (default 5m0s)
+  -search.deltaTolerationFactor int
+    	The factor between the first value and the first delta used to infer the previous missing value. This flag could be useful for adjusting the calculation of the missing previous value in delta() and increase() functions . A negative value forces the assumption of a missing value of zero. A value of zero assumes the missing value is equal to the first recorded value. Higher values allow for greater toleration in assuming the counter starts at 0. (default 10)
   -search.denyPartialResponse
      Whether to deny partial responses if a part of -storageNode instances fail to perform queries; this trades availability over consistency; see also -search.maxQueryDuration
   -search.disableCache

--- a/docs/README.md
+++ b/docs/README.md
@@ -3220,6 +3220,8 @@ Pass `-help` to VictoriaMetrics in order to see the list of supported command-li
      The offset for performing indexdb rotation. If set to 0, then the indexdb rotation is performed at 4am UTC time per each -retentionPeriod. If set to 2h, then the indexdb rotation is performed at 4am EET time (the timezone with +2h offset)
   -search.cacheTimestampOffset duration
      The maximum duration since the current time for response data, which is always queried from the original raw data, without using the response cache. Increase this value if you see gaps in responses due to time synchronization issues between VictoriaMetrics and data sources. See also -search.disableAutoCacheReset (default 5m0s)
+  -search.deltaTolerationFactor int
+    	The factor between the first value and the first delta used to infer the previous missing value. This flag could be useful for adjusting the calculation of the missing previous value in delta() and increase() functions . A negative value forces the assumption of a missing value of zero. A value of zero assumes the missing value is equal to the first recorded value. Higher values allow for greater toleration in assuming the counter starts at 0. (default 10)
   -search.disableAutoCacheReset
      Whether to disable automatic response cache reset if a sample with timestamp outside -search.cacheTimestampOffset is inserted into VictoriaMetrics
   -search.disableCache


### PR DESCRIPTION
### Describe Your Changes

Added the flag "-search.deltaTolerationFactor" to configure the relation between the first point and the first delta to consider a zero-starting counter in increase()/delta() functions.

Currently this factor is fixed to 10.

```
P0 / ((P1-P2) +1) < factor
```
- true: We assume that the recent started counter at zero
- false: We assume that the recent started counter starts at the first recorded value.

### Checklist

The following checks are **mandatory**:

- [x] My change adheres [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/contributing/).
