### PR TITLE
deployment/docker: update Go builder from go1.23.6 to go1.24

### DIFF
--- a/app/vmui/Dockerfile-web
+++ b/app/vmui/Dockerfile-web
@@ -1,4 +1,4 @@
-FROM golang:1.23.6 AS build-web-stage
+FROM golang:1.24 AS build-web-stage
 COPY build /build
 
 WORKDIR /build

--- a/deployment/docker/Makefile
+++ b/deployment/docker/Makefile
@@ -6,7 +6,7 @@ ROOT_IMAGE ?= alpine:3.21.3
 ROOT_IMAGE_SCRATCH ?= scratch
 CERTS_IMAGE := alpine:3.21.3
 
-GO_BUILDER_IMAGE := golang:1.23.6-alpine
+GO_BUILDER_IMAGE := golang:1.24-alpine
 BUILDER_IMAGE := local/builder:2.0.0-$(shell echo $(GO_BUILDER_IMAGE) | tr :/ __)-1
 BASE_IMAGE := local/base:1.1.4-$(shell echo $(ROOT_IMAGE) | tr :/ __)-$(shell echo $(CERTS_IMAGE) | tr :/ __)
 DOCKER ?= docker

--- a/deployment/logs-benchmark/docker-compose-elk.yml
+++ b/deployment/logs-benchmark/docker-compose-elk.yml
@@ -18,7 +18,7 @@ services:
       - vlogs
 
   generator:
-    image: golang:1.23.6-alpine
+    image: golang:1.24-alpine
     restart: always
     working_dir: /go/src/app
     volumes:

--- a/deployment/logs-benchmark/docker-compose-loki.yml
+++ b/deployment/logs-benchmark/docker-compose-loki.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   generator:
-    image: golang:1.23.6-alpine
+    image: golang:1.24-alpine
     restart: always
     working_dir: /go/src/app
     volumes:

--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -18,6 +18,8 @@ See also [LTS releases](https://docs.victoriametrics.com/lts-releases/).
 
 ## tip
 
+* SECURITY: upgrade Go builder from Go1.23.6 to Go1.24. See the list of issues addressed in [Go1.24](https://github.com/golang/go/issues?q=milestone%3AGo1.24).
+
 * FEATURE: [alerts](https://github.com/VictoriaMetrics/VictoriaMetrics/blob/master/deployment/docker/rules/alerts-vmalert.yml): add alerting rule `TooHighQueryLoad` to notify user when VictoriaMetrics or vmselect weren't able to serve requests in timely manner during last 15min.
 * FEATURE: [dashboards/single](https://grafana.com/grafana/dashboards/10229) and [dashboards/cluster](https://grafana.com/grafana/dashboards/11176): add panel `Deduplication rate` that shows how many samples are [deduplicated](https://docs.victoriametrics.com/#deduplication) during merges or read queries by VictoriaMetrics components.
 * FEATURE: [dashboards/single](https://grafana.com/grafana/dashboards/10229) and [dashboards/cluster](https://grafana.com/grafana/dashboards/11176): add panel `Number of snapshots` that shows the max number of [snapshots](https://docs.victoriametrics.com/#how-to-work-with-snapshots) across vmstorage nodes. This panel should help in disk usage [troubleshooting](https://docs.victoriametrics.com/#snapshot-troubleshooting).

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/VictoriaMetrics/VictoriaMetrics
 
-go 1.23.6
+go 1.24
 
 // This is needed in order to avoid vmbackup and vmrestore binary size increase by 20MB
 // See https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8008


### PR DESCRIPTION
### Describe Your Changes

Bump to go1.24. I wanted to give it a try go1.24 performance with vmagent, and here is some benchmarks that we did test on our ~50 staging clusters: (10:30 - 11:00 rollout window, no errors observed on logs)

Prod-ready build tag was: `heads-go1.24-0-gfdfd3fd80-dirty-d5335eb1`

![Screenshot 2025-02-24 at 22 06 07](https://github.com/user-attachments/assets/d1591db5-c438-42bc-b2b1-d9a09accb1b2)

![Screenshot 2025-02-24 at 22 06 20](https://github.com/user-attachments/assets/eac0be0f-0bdd-4c02-8149-68c7dd2760fa)

Go Runtime metrics: (Total average)

![Screenshot 2025-02-24 at 22 08 41](https://github.com/user-attachments/assets/ce369190-5b8f-494b-9cc7-4953b5a0e02f)

![Screenshot 2025-02-24 at 22 10 21](https://github.com/user-attachments/assets/cab1b04c-04a9-4920-bce2-a699da8a0771)

I don't familiar with internal benchmark so it'd be also great to compare using those benchmarks.

### Checklist

The following checks are **mandatory**:

- [X] My change adheres [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/contributing/).
