### PR TITLE
deployment/docker/make: publish images to multiple repos

### DIFF
--- a/deployment/docker/Makefile
+++ b/deployment/docker/Makefile
@@ -1,5 +1,6 @@
 # All these commands must run from repository root.
 
+DOCKER_REGISTRIES ?= docker.io quay.io
 DOCKER_NAMESPACE ?= victoriametrics
 
 ROOT_IMAGE ?= alpine:3.21.3
@@ -92,8 +93,10 @@ publish-via-docker:
 		--label "org.opencontainers.image.vendor=VictoriaMetrics" \
 		--label "org.opencontainers.image.version=$(PKG_TAG)" \
 		--label "org.opencontainers.image.created=$(shell date -u +"%Y-%m-%dT%H:%M:%SZ")" \
-		--tag $(DOCKER_NAMESPACE)/$(APP_NAME):$(PKG_TAG)$(RACE) \
-		--tag $(DOCKER_NAMESPACE)/$(APP_NAME):$(LATEST_TAG)$(RACE) \
+		$(foreach registry,$(DOCKER_REGISTRIES),\
+		--tag $(registry)/$(DOCKER_NAMESPACE)/$(APP_NAME):$(PKG_TAG)$(RACE) \
+		--tag $(registry)/$(DOCKER_NAMESPACE)/$(APP_NAME):$(LATEST_TAG)$(RACE) \
+		) \
 		-o type=image \
 		--provenance=false \
 		-f app/$(APP_NAME)/multiarch/Dockerfile \
@@ -110,8 +113,10 @@ publish-via-docker:
 		--label "org.opencontainers.image.vendor=VictoriaMetrics" \
 		--label "org.opencontainers.image.version=$(PKG_TAG)" \
 		--label "org.opencontainers.image.created=$(shell date -u +"%Y-%m-%dT%H:%M:%SZ")" \
-		--tag $(DOCKER_NAMESPACE)/$(APP_NAME):$(PKG_TAG)$(RACE)-scratch \
-		--tag $(DOCKER_NAMESPACE)/$(APP_NAME):$(LATEST_TAG)$(RACE)-scratch \
+		$(foreach registry,$(DOCKER_REGISTRIES),\
+		--tag $(registry)/$(DOCKER_NAMESPACE)/$(APP_NAME):$(PKG_TAG)$(RACE)-scratch \
+		--tag $(registry)/$(DOCKER_NAMESPACE)/$(APP_NAME):$(LATEST_TAG)$(RACE)-scratch \
+		) \
 		-o type=image \
 		--provenance=false \
 		-f app/$(APP_NAME)/multiarch/Dockerfile \


### PR DESCRIPTION


### Describe Your Changes

Updated `publish-via-docker` task to push images to multiple registries as defined by `DOCKER_REGISTRIES`. By default, publish pushes images to both docker.io and quay.io. It is possible to choose a single repo by overriding `DOCKER_REGISTRIES`, for example: `DOCKER_REGISTRIES=quay.io make publish-victoria-logs`

Note that `package-via-docker` task is not using multiple registries as there is usually little sense in building same image with different tags for local use.

See: https://github.com/VictoriaMetrics/VictoriaMetrics/issues/4116
### Checklist

The following checks are **mandatory**:

- [x] My change adheres [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/contributing/).
