### PR TITLE
lib/promutils: move time-related funcs from `promutils` to `timeutil`

### DIFF
--- a/app/vlogsgenerator/main.go
+++ b/app/vlogsgenerator/main.go
@@ -18,7 +18,7 @@ import (
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/buildinfo"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/envflag"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/logger"
-	"github.com/VictoriaMetrics/VictoriaMetrics/lib/promutils"
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/timeutil"
 )
 
 var (
@@ -306,7 +306,7 @@ type timeFlag struct {
 }
 
 func (tf *timeFlag) Set(s string) error {
-	msec, err := promutils.ParseTimeMsec(s)
+	msec, err := timeutil.ParseTimeMsec(s)
 	if err != nil {
 		return fmt.Errorf("cannot parse time from %q: %w", s, err)
 	}

--- a/app/vlselect/logsql/logsql.go
+++ b/app/vlselect/logsql/logsql.go
@@ -22,7 +22,7 @@ import (
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/httputils"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/logger"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/logstorage"
-	"github.com/VictoriaMetrics/VictoriaMetrics/lib/promutils"
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/timeutil"
 )
 
 // ProcessFacetsRequest handles /select/logsql/facets request.
@@ -116,7 +116,7 @@ func ProcessHitsRequest(ctx context.Context, w http.ResponseWriter, r *http.Requ
 	if stepStr == "" {
 		stepStr = "1d"
 	}
-	step, err := promutils.ParseDuration(stepStr)
+	step, err := timeutil.ParseDuration(stepStr)
 	if err != nil {
 		httpserver.Errorf(w, r, "cannot parse 'step' arg: %s", err)
 		return
@@ -131,7 +131,7 @@ func ProcessHitsRequest(ctx context.Context, w http.ResponseWriter, r *http.Requ
 	if offsetStr == "" {
 		offsetStr = "0s"
 	}
-	offset, err := promutils.ParseDuration(offsetStr)
+	offset, err := timeutil.ParseDuration(offsetStr)
 	if err != nil {
 		httpserver.Errorf(w, r, "cannot parse 'offset' arg: %s", err)
 		return
@@ -665,7 +665,7 @@ func ProcessStatsQueryRangeRequest(ctx context.Context, w http.ResponseWriter, r
 	if stepStr == "" {
 		stepStr = "1d"
 	}
-	step, err := promutils.ParseDuration(stepStr)
+	step, err := timeutil.ParseDuration(stepStr)
 	if err != nil {
 		err = fmt.Errorf("cannot parse 'step' arg: %s", err)
 		httpserver.SendPrometheusError(w, r, err)
@@ -1122,7 +1122,7 @@ func getTimeNsec(r *http.Request, argName string) (int64, bool, error) {
 		return 0, false, nil
 	}
 	currentTimestamp := time.Now().UnixNano()
-	nsecs, err := promutils.ParseTimeAt(s, currentTimestamp)
+	nsecs, err := timeutil.ParseTimeAt(s, currentTimestamp)
 	if err != nil {
 		return 0, false, fmt.Errorf("cannot parse %s=%s: %w", argName, s, err)
 	}

--- a/app/vmalert/templates/template.go
+++ b/app/vmalert/templates/template.go
@@ -33,7 +33,7 @@ import (
 
 	"github.com/VictoriaMetrics/VictoriaMetrics/app/vmalert/datasource"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/formatutil"
-	"github.com/VictoriaMetrics/VictoriaMetrics/lib/promutils"
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/timeutil"
 )
 
 // go template execution fails when it's tree is empty
@@ -259,7 +259,7 @@ func templateFuncs() textTpl.FuncMap {
 
 		// parseDuration parses a duration string such as "1h" into the number of seconds it represents
 		"parseDuration": func(s string) (float64, error) {
-			d, err := promutils.ParseDuration(s)
+			d, err := timeutil.ParseDuration(s)
 			if err != nil {
 				return 0, err
 			}
@@ -268,7 +268,7 @@ func templateFuncs() textTpl.FuncMap {
 
 		// same with parseDuration but returns a time.Duration
 		"parseDurationTime": func(s string) (time.Duration, error) {
-			d, err := promutils.ParseDuration(s)
+			d, err := timeutil.ParseDuration(s)
 			if err != nil {
 				return 0, err
 			}

--- a/app/vmctl/utils/time.go
+++ b/app/vmctl/utils/time.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/VictoriaMetrics/VictoriaMetrics/lib/promutils"
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/timeutil"
 )
 
 const (
@@ -16,7 +16,7 @@ const (
 // ParseTime parses time in s string and returns time.Time object
 // if parse correctly or error if not
 func ParseTime(s string) (time.Time, error) {
-	msecs, err := promutils.ParseTimeMsec(s)
+	msecs, err := timeutil.ParseTimeMsec(s)
 	if err != nil {
 		return time.Time{}, fmt.Errorf("cannot parse %s: %w", s, err)
 	}

--- a/lib/httputils/duration.go
+++ b/lib/httputils/duration.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/VictoriaMetrics/VictoriaMetrics/lib/promutils"
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/timeutil"
 )
 
 // GetDuration returns duration in milliseconds from the given argKey query arg.
@@ -21,7 +21,7 @@ func GetDuration(r *http.Request, argKey string, defaultValue int64) (int64, err
 	secs, err := strconv.ParseFloat(argValue, 64)
 	if err != nil {
 		// Try parsing string format
-		d, err := promutils.ParseDuration(argValue)
+		d, err := timeutil.ParseDuration(argValue)
 		if err != nil {
 			return 0, fmt.Errorf("cannot parse %q=%q: %w", argKey, argValue, err)
 		}

--- a/lib/httputils/time.go
+++ b/lib/httputils/time.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/VictoriaMetrics/VictoriaMetrics/lib/promutils"
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/timeutil"
 )
 
 // GetTime returns time in milliseconds from the given argKey query arg.
@@ -28,7 +28,7 @@ func GetTime(r *http.Request, argKey string, defaultMs int64) (int64, error) {
 		return maxTimeMsecs, nil
 	}
 	// Parse argValue
-	msecs, err := promutils.ParseTimeMsec(argValue)
+	msecs, err := timeutil.ParseTimeMsec(argValue)
 	if err != nil {
 		return 0, fmt.Errorf("cannot parse %s=%s: %w", argKey, argValue, err)
 	}

--- a/lib/logstorage/parser.go
+++ b/lib/logstorage/parser.go
@@ -11,8 +11,8 @@ import (
 	"unicode/utf8"
 
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/logger"
-	"github.com/VictoriaMetrics/VictoriaMetrics/lib/promutils"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/regexutil"
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/timeutil"
 )
 
 type lexer struct {
@@ -2890,7 +2890,7 @@ func parseTime(lex *lexer) (int64, string, error) {
 	if err != nil {
 		return 0, "", err
 	}
-	nsecs, err := promutils.ParseTimeAt(s, lex.currentTimestamp)
+	nsecs, err := timeutil.ParseTimeAt(s, lex.currentTimestamp)
 	if err != nil {
 		return 0, "", err
 	}

--- a/lib/promscrape/config.go
+++ b/lib/promscrape/config.go
@@ -48,6 +48,7 @@ import (
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/promscrape/discovery/yandexcloud"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/promutils"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/proxy"
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/timeutil"
 )
 
 var (
@@ -1220,7 +1221,7 @@ func (swc *scrapeWorkConfig) getScrapeWork(target string, extraLabels, metaLabel
 	// Read __scrape_interval__ and __scrape_timeout__ from labels.
 	scrapeInterval := swc.scrapeInterval
 	if s := labels.Get("__scrape_interval__"); len(s) > 0 {
-		d, err := promutils.ParseDuration(s)
+		d, err := timeutil.ParseDuration(s)
 		if err != nil {
 			return nil, fmt.Errorf("cannot parse __scrape_interval__=%q: %w", s, err)
 		}
@@ -1228,7 +1229,7 @@ func (swc *scrapeWorkConfig) getScrapeWork(target string, extraLabels, metaLabel
 	}
 	scrapeTimeout := swc.scrapeTimeout
 	if s := labels.Get("__scrape_timeout__"); len(s) > 0 {
-		d, err := promutils.ParseDuration(s)
+		d, err := timeutil.ParseDuration(s)
 		if err != nil {
 			return nil, fmt.Errorf("cannot parse __scrape_timeout__=%q: %w", s, err)
 		}

--- a/lib/promutils/duration.go
+++ b/lib/promutils/duration.go
@@ -44,12 +44,3 @@ func (pd *Duration) Duration() time.Duration {
 	}
 	return pd.D
 }
-
-// ParseDuration parses duration string in Prometheus format
-func ParseDuration(s string) (time.Duration, error) {
-	ms, err := metricsql.DurationValue(s, 0)
-	if err != nil {
-		return 0, err
-	}
-	return time.Duration(ms) * time.Millisecond, nil
-}

--- a/lib/promutils/duration_test.go
+++ b/lib/promutils/duration_test.go
@@ -3,13 +3,15 @@ package promutils
 import (
 	"testing"
 	"time"
+
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/timeutil"
 )
 
 func TestDuration(t *testing.T) {
-	if _, err := ParseDuration("foobar"); err == nil {
+	if _, err := timeutil.ParseDuration("foobar"); err == nil {
 		t.Fatalf("expecting error for invalid duration")
 	}
-	dNative, err := ParseDuration("1w")
+	dNative, err := timeutil.ParseDuration("1w")
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}

--- a/lib/storage/part_header.go
+++ b/lib/storage/part_header.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/fs"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/logger"
-	"github.com/VictoriaMetrics/VictoriaMetrics/lib/promutils"
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/timeutil"
 )
 
 // partHeader represents part header.
@@ -58,7 +58,7 @@ func (ph *partHeader) readMinDedupInterval(partPath string) error {
 		}
 		return fmt.Errorf("cannot read %q: %w", filePath, err)
 	}
-	dedupInterval, err := promutils.ParseDuration(string(data))
+	dedupInterval, err := timeutil.ParseDuration(string(data))
 	if err != nil {
 		return fmt.Errorf("cannot parse minimum dedup interval %q at %q: %w", data, filePath, err)
 	}

--- a/lib/timeutil/duration.go
+++ b/lib/timeutil/duration.go
@@ -1,0 +1,16 @@
+package timeutil
+
+import (
+	"time"
+
+	"github.com/VictoriaMetrics/metricsql"
+)
+
+// ParseDuration parses duration string in Prometheus format
+func ParseDuration(s string) (time.Duration, error) {
+	ms, err := metricsql.DurationValue(s, 0)
+	if err != nil {
+		return 0, err
+	}
+	return time.Duration(ms) * time.Millisecond, nil
+}

--- a/lib/timeutil/time.go
+++ b/lib/timeutil/time.go
@@ -1,4 +1,4 @@
-package promutils
+package timeutil
 
 import (
 	"fmt"
@@ -6,8 +6,6 @@ import (
 	"strconv"
 	"strings"
 	"time"
-
-	"github.com/VictoriaMetrics/VictoriaMetrics/lib/timeutil"
 )
 
 // ParseTimeMsec parses time s in different formats.
@@ -64,7 +62,7 @@ func ParseTimeAt(s string, currentTimestamp int64) (int64, error) {
 			s = sOrig[:len(sOrig)-6]
 		} else {
 			if !strings.HasSuffix(s, "Z") {
-				tzOffset = -timeutil.GetLocalTimezoneOffsetNsecs()
+				tzOffset = -GetLocalTimezoneOffsetNsecs()
 			} else {
 				s = s[:len(s)-1]
 			}

--- a/lib/timeutil/time_test.go
+++ b/lib/timeutil/time_test.go
@@ -1,4 +1,4 @@
-package promutils
+package timeutil
 
 import (
 	"testing"


### PR DESCRIPTION
Since funcs `ParseDuration` and `ParseTimeMsec` are used in vlogs, vmalert, victoriametrics and other components, importing promutils only for this reason makes them to export irrelevant `vm_rows_invalid_total{type="prometheus"}` metric.

This change removes `vm_rows_invalid_total{type="prometheus"}` metric from /metrics page for these components.

### Describe Your Changes

Please provide a brief description of the changes you made. Be as specific as possible to help others understand the purpose and impact of your modifications.

### Checklist

The following checks are **mandatory**:

- [ ] My change adheres [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/contributing/).
