### PR TITLE
lib/prompbmarshal: move MustParsePromMetrics to protoparser/prometheus

### DIFF
--- a/app/vmagent/remotewrite/remotewrite_test.go
+++ b/app/vmagent/remotewrite/remotewrite_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/prompbmarshal"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/promrelabel"
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/protoparser/prometheus"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/streamaggr"
 	"github.com/VictoriaMetrics/metrics"
 )
@@ -94,7 +95,7 @@ func TestRemoteWriteContext_TryPush_ImmutableTimeseries(t *testing.T) {
 		}
 
 		offsetMsecs := time.Now().UnixMilli()
-		inputTss := prompbmarshal.MustParsePromMetrics(input, offsetMsecs)
+		inputTss := prometheus.MustParsePromMetrics(input, offsetMsecs)
 		expectedTss := make([]prompbmarshal.TimeSeries, len(inputTss))
 
 		// copy inputTss to make sure it is not mutated during TryPush call

--- a/lib/prompbmarshal/util.go
+++ b/lib/prompbmarshal/util.go
@@ -3,7 +3,6 @@ package prompbmarshal
 import (
 	"fmt"
 
-	"github.com/VictoriaMetrics/VictoriaMetrics/lib/protoparser/prometheus"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/slicesutil"
 )
 
@@ -28,44 +27,4 @@ func (wr *WriteRequest) Reset() {
 func ResetTimeSeries(tss []TimeSeries) []TimeSeries {
 	clear(tss)
 	return tss[:0]
-}
-
-// MustParsePromMetrics parses metrics in Prometheus text exposition format from s and returns them.
-//
-// Metrics must be delimited with newlines.
-//
-// offsetMsecs is added to every timestamp in parsed metrics.
-//
-// This function is for testing purposes only. Do not use it in non-test code.
-func MustParsePromMetrics(s string, offsetMsecs int64) []TimeSeries {
-	var rows prometheus.Rows
-	errLogger := func(s string) {
-		panic(fmt.Errorf("unexpected error when parsing Prometheus metrics: %s", s))
-	}
-	rows.UnmarshalWithErrLogger(s, errLogger)
-	tss := make([]TimeSeries, 0, len(rows.Rows))
-	samples := make([]Sample, 0, len(rows.Rows))
-	for _, row := range rows.Rows {
-		labels := make([]Label, 0, len(row.Tags)+1)
-		labels = append(labels, Label{
-			Name:  "__name__",
-			Value: row.Metric,
-		})
-		for _, tag := range row.Tags {
-			labels = append(labels, Label{
-				Name:  tag.Key,
-				Value: tag.Value,
-			})
-		}
-		samples = append(samples, Sample{
-			Value:     row.Value,
-			Timestamp: row.Timestamp + offsetMsecs,
-		})
-		ts := TimeSeries{
-			Labels:  labels,
-			Samples: samples[len(samples)-1:],
-		}
-		tss = append(tss, ts)
-	}
-	return tss
 }

--- a/lib/promscrape/scrapework_test.go
+++ b/lib/promscrape/scrapework_test.go
@@ -775,7 +775,7 @@ func parsePromRow(data string) *parser.Row {
 }
 
 func parseData(data string) []prompbmarshal.TimeSeries {
-	return prompbmarshal.MustParsePromMetrics(data, 0)
+	return parser.MustParsePromMetrics(data, 0)
 }
 
 func expectEqualTimeseries(tss, tssExpected []prompbmarshal.TimeSeries) error {

--- a/lib/protoparser/prometheus/util.go
+++ b/lib/protoparser/prometheus/util.go
@@ -1,0 +1,47 @@
+package prometheus
+
+import (
+	"fmt"
+
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/prompbmarshal"
+)
+
+// MustParsePromMetrics parses metrics in Prometheus text exposition format from s and returns them.
+//
+// Metrics must be delimited with newlines.
+//
+// offsetMsecs is added to every timestamp in parsed metrics.
+//
+// This function is for testing purposes only. Do not use it in non-test code.
+func MustParsePromMetrics(s string, offsetMsecs int64) []prompbmarshal.TimeSeries {
+	var rows Rows
+	errLogger := func(s string) {
+		panic(fmt.Errorf("unexpected error when parsing Prometheus metrics: %s", s))
+	}
+	rows.UnmarshalWithErrLogger(s, errLogger)
+	tss := make([]prompbmarshal.TimeSeries, 0, len(rows.Rows))
+	samples := make([]prompbmarshal.Sample, 0, len(rows.Rows))
+	for _, row := range rows.Rows {
+		labels := make([]prompbmarshal.Label, 0, len(row.Tags)+1)
+		labels = append(labels, prompbmarshal.Label{
+			Name:  "__name__",
+			Value: row.Metric,
+		})
+		for _, tag := range row.Tags {
+			labels = append(labels, prompbmarshal.Label{
+				Name:  tag.Key,
+				Value: tag.Value,
+			})
+		}
+		samples = append(samples, prompbmarshal.Sample{
+			Value:     row.Value,
+			Timestamp: row.Timestamp + offsetMsecs,
+		})
+		ts := prompbmarshal.TimeSeries{
+			Labels:  labels,
+			Samples: samples[len(samples)-1:],
+		}
+		tss = append(tss, ts)
+	}
+	return tss
+}

--- a/lib/streamaggr/deduplicator_test.go
+++ b/lib/streamaggr/deduplicator_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/prompbmarshal"
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/protoparser/prometheus"
 )
 
 func TestDeduplicator(t *testing.T) {
@@ -18,7 +19,7 @@ func TestDeduplicator(t *testing.T) {
 	}
 
 	offsetMsecs := time.Now().Add(time.Minute).UnixMilli()
-	tss := prompbmarshal.MustParsePromMetrics(`
+	tss := prometheus.MustParsePromMetrics(`
 foo{instance="x",job="aaa",pod="sdfd-dfdfdfs",node="aosijjewrerfd",namespace="asdff",container="ohohffd"} 123
 bar{instance="x",job="aaa",pod="sdfd-dfdfdfs",node="aosijjewrerfd",namespace="asdff",container="ohohffd"} 34.54
 x 8943 1

--- a/lib/streamaggr/streamaggr_test.go
+++ b/lib/streamaggr/streamaggr_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/prompbmarshal"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/promrelabel"
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/protoparser/prometheus"
 )
 
 func TestAggregatorsFailure(t *testing.T) {
@@ -278,7 +279,7 @@ func TestAggregatorsSuccess(t *testing.T) {
 
 		// Push the inputMetrics to Aggregators
 		offsetMsecs := time.Now().Add(15 * time.Second).UnixMilli()
-		tssInput := prompbmarshal.MustParsePromMetrics(inputMetrics, offsetMsecs)
+		tssInput := prometheus.MustParsePromMetrics(inputMetrics, offsetMsecs)
 		matchIdxs := a.Push(tssInput, nil)
 		a.MustStop()
 
@@ -1010,7 +1011,7 @@ func TestAggregatorsWithDedupInterval(t *testing.T) {
 
 		// Push the inputMetrics to Aggregators
 		offsetMsecs := time.Now().Add(15 * time.Second).UnixMilli()
-		tssInput := prompbmarshal.MustParsePromMetrics(inputMetrics, offsetMsecs)
+		tssInput := prometheus.MustParsePromMetrics(inputMetrics, offsetMsecs)
 		matchIdxs := a.Push(tssInput, nil)
 		a.MustStop()
 

--- a/lib/streamaggr/streamaggr_timing_test.go
+++ b/lib/streamaggr/streamaggr_timing_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/prompbmarshal"
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/protoparser/prometheus"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/stringsutil"
 )
 
@@ -87,7 +88,7 @@ func newBenchSeries(seriesCount int) []prompbmarshal.TimeSeries {
 	}
 	metrics := strings.Join(a, "\n")
 	offsetMsecs := time.Now().UnixMilli()
-	return prompbmarshal.MustParsePromMetrics(metrics, offsetMsecs)
+	return prometheus.MustParsePromMetrics(metrics, offsetMsecs)
 }
 
 const seriesCount = 10_000


### PR DESCRIPTION
`MustParsePromMetrics` imports `lib/protoparser/prometheus`, and this package exposes the following metrics:
```
vm_protoparser_rows_read_total{type="promscrape"}
vm_rows_invalid_total{type="prometheus"}
```

It means every package that uses `lib/prompbmarshal` will start exposing these metrics. For example, vlogs imports `lib/protoparser/common` which uses `lib/prompbmarshal.Label`. And only because of this vlogs starts exposing unrelated prometheus metrics on /metrics page.

Moving `MustParsePromMetrics` to `lib/protoparser/prometheus` seems like the leas intrusive change.


-----------

Depends on another change https://github.com/VictoriaMetrics/VictoriaMetrics/pull/8403
