### PR TITLE
docs: remove VictoriaMetrics prefix from anomaly detection menu items titles

### DIFF
--- a/docs/anomaly-detection/QuickStart.md
+++ b/docs/anomaly-detection/QuickStart.md
@@ -1,9 +1,10 @@
 ---
 weight: 1
-title: VictoriaMetrics Anomaly Detection Quick Start
+title: Quick Start
 menu:
   docs:
     parent: "anomaly-detection"
+    identifier: "vmanomaly-quick-start"
     weight: 1
     title: Quick Start
 aliases:

--- a/docs/anomaly-detection/_index.md
+++ b/docs/anomaly-detection/_index.md
@@ -1,5 +1,5 @@
 ---
-title: VictoriaMetrics Anomaly Detection
+title: Anomaly Detection
 weight: 50
 menu:
   docs:


### PR DESCRIPTION
### Describe Your Changes

Removed VictoriaMetrics prefix from anomaly detection menu items

### Checklist

The following checks are **mandatory**:

- [ ] My change adheres [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/contributing/).
