### PR TITLE
vmui: fix infinite loader on downsampling page

### DIFF
--- a/app/vmui/packages/vmui/src/pages/DownsamplingFilters/hooks/useDebugDownsamplingFilters.ts
+++ b/app/vmui/packages/vmui/src/pages/DownsamplingFilters/hooks/useDebugDownsamplingFilters.ts
@@ -9,7 +9,7 @@ export const useDebugDownsamplingFilters = () => {
   const { serverUrl } = useAppState();
   const [searchParams, setSearchParams] = useSearchParams();
 
-  const [data, setData] = useState<Map<string, string[]>>(new Map());
+  const [data, setData] = useState<Map<string, string[] | null>>(new Map());
   const [loading, setLoading] = useState(false);
   const [metricsError, setMetricsError] = useState<ErrorTypes | string>();
   const [flagsError, setFlagsError] = useState<ErrorTypes | string>();

--- a/app/vmui/packages/vmui/src/pages/DownsamplingFilters/index.tsx
+++ b/app/vmui/packages/vmui/src/pages/DownsamplingFilters/index.tsx
@@ -7,6 +7,7 @@ import { PlayIcon, WikiIcon } from "../../components/Main/Icons";
 import { useDebugDownsamplingFilters } from "./hooks/useDebugDownsamplingFilters";
 import Spinner from "../../components/Main/Spinner/Spinner";
 import { useSearchParams } from "react-router-dom";
+import classNames from "classnames";
 
 const example = {
   flags: `-downsampling.period={env="dev"}:7d:5m,{env="dev"}:30d:30m
@@ -54,7 +55,14 @@ const DownsamplingFilters: FC = () => {
   for (const [key, value] of data) {
     rows.push(<tr className="vm-table__row">
       <td className="vm-table-cell">{key}</td>
-      <td className="vm-table-cell">{value?.join(" ")}</td>
+      <td
+        className={classNames({
+          "vm-table-cell": true,
+          "vm-table-cell_empty": !value,
+        })}
+      >
+        {value ? value.join(" ") : "No series matched for the given configuration!"}
+      </td>
     </tr>);
   }
   return (

--- a/app/vmui/packages/vmui/src/pages/DownsamplingFilters/index.tsx
+++ b/app/vmui/packages/vmui/src/pages/DownsamplingFilters/index.tsx
@@ -54,7 +54,7 @@ const DownsamplingFilters: FC = () => {
   for (const [key, value] of data) {
     rows.push(<tr className="vm-table__row">
       <td className="vm-table-cell">{key}</td>
-      <td className="vm-table-cell">{value.join(" ")}</td>
+      <td className="vm-table-cell">{value?.join(" ")}</td>
     </tr>);
   }
   return (

--- a/app/vmui/packages/vmui/src/styles/components/table.scss
+++ b/app/vmui/packages/vmui/src/styles/components/table.scss
@@ -94,6 +94,11 @@
       white-space: nowrap;
       width: 100px;
     }
+
+    &_empty {
+      color: $color-text-secondary;
+      font-style: italic;
+    }
   }
 
   &__sort-icon {

--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -40,7 +40,7 @@ See also [LTS releases](https://docs.victoriametrics.com/lts-releases/).
 * BUGFIX: [vmgateway](https://docs.victoriametrics.com/vmgateway): fix data query in [rate limiter](https://docs.victoriametrics.com/vmgateway/#rate-limiter). The bug was introduced in [this commit](https://github.com/VictoriaMetrics/VictoriaMetrics/commit/68bad22fd26d1436ad0236b1f3ced8604c5d851c) starting from [v1.106.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.106.0).
 * BUGFIX: [vmsingle](https://docs.victoriametrics.com/single-server-victoriametrics/) and [vmagent](https://docs.victoriametrics.com/vmagent/): properly escape IPv6 address in [Kubernetes service-discovery](https://docs.victoriametrics.com/sd_configs/#kubernetes_sd_configs) with `role: pod` for containers without exposed ports. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8374).
 * BUGFIX: [vmalert-tool](https://docs.victoriametrics.com/vmalert-tool/): clean up the temporary storage path when process is terminated by SIGTERM or SIGINT. Previously, unclean shut down might affect the next run.
-* BUGFIX: [vmui](https://docs.victoriametrics.com/#vmui): fix an infinite loader on the Downsampling filters debug page that occurred when labels had no matches.
+* BUGFIX: [vmui](https://docs.victoriametrics.com/#vmui): fix an infinite loader on the Downsampling filters debug page that occurred when labels had no matches. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8339).
 
 ## [v1.102.15](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.102.15)
 

--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -40,7 +40,7 @@ See also [LTS releases](https://docs.victoriametrics.com/lts-releases/).
 * BUGFIX: [vmgateway](https://docs.victoriametrics.com/vmgateway): fix data query in [rate limiter](https://docs.victoriametrics.com/vmgateway/#rate-limiter). The bug was introduced in [this commit](https://github.com/VictoriaMetrics/VictoriaMetrics/commit/68bad22fd26d1436ad0236b1f3ced8604c5d851c) starting from [v1.106.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.106.0).
 * BUGFIX: [vmsingle](https://docs.victoriametrics.com/single-server-victoriametrics/) and [vmagent](https://docs.victoriametrics.com/vmagent/): properly escape IPv6 address in [Kubernetes service-discovery](https://docs.victoriametrics.com/sd_configs/#kubernetes_sd_configs) with `role: pod` for containers without exposed ports. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8374).
 * BUGFIX: [vmalert-tool](https://docs.victoriametrics.com/vmalert-tool/): clean up the temporary storage path when process is terminated by SIGTERM or SIGINT. Previously, unclean shut down might affect the next run.
-* BUGFIX: [vmui](https://docs.victoriametrics.com/#vmui): fix an infinite loader on the Downsampling filters debug page that occurred when labels had no matches. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8339).
+* BUGFIX: [vmui](https://docs.victoriametrics.com/#vmui): fix an infinite loader on the [Downsampling filters debug page](https://docs.victoriametrics.com/#vmui) when provided configuration matches no series. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8339).
 
 ## [v1.102.15](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.102.15)
 

--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -40,6 +40,7 @@ See also [LTS releases](https://docs.victoriametrics.com/lts-releases/).
 * BUGFIX: [vmgateway](https://docs.victoriametrics.com/vmgateway): fix data query in [rate limiter](https://docs.victoriametrics.com/vmgateway/#rate-limiter). The bug was introduced in [this commit](https://github.com/VictoriaMetrics/VictoriaMetrics/commit/68bad22fd26d1436ad0236b1f3ced8604c5d851c) starting from [v1.106.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.106.0).
 * BUGFIX: [vmsingle](https://docs.victoriametrics.com/single-server-victoriametrics/) and [vmagent](https://docs.victoriametrics.com/vmagent/): properly escape IPv6 address in [Kubernetes service-discovery](https://docs.victoriametrics.com/sd_configs/#kubernetes_sd_configs) with `role: pod` for containers without exposed ports. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8374).
 * BUGFIX: [vmalert-tool](https://docs.victoriametrics.com/vmalert-tool/): clean up the temporary storage path when process is terminated by SIGTERM or SIGINT. Previously, unclean shut down might affect the next run.
+* BUGFIX: [vmui](https://docs.victoriametrics.com/#vmui): fix an infinite loader on the Downsampling filters debug page that occurred when labels had no matches.
 
 ## [v1.102.15](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.102.15)
 


### PR DESCRIPTION
### Describe Your Changes

This PR fixes an issue where the Downsampling filters debug page would get stuck in an infinite loading state when labels had no matches. Now, the case is properly handled.

Related issue: #8339

### Checklist

The following checks are **mandatory**:

- [x] My change adheres [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/contributing/).
