### PR TITLE
Vmselect returns inconsistent results in multitenant mode if a subquery for one tenant fails

### DIFF
--- a/app/vmselect/netstorage/netstorage.go
+++ b/app/vmselect/netstorage/netstorage.go
@@ -1888,11 +1888,9 @@ func processBlocks(qt *querytracer.Tracer, sns []*storageNode, denyPartialRespon
 	}
 	// Send the query to all the storage nodes in parallel.
 	snr := startStorageNodesRequest(qt, sns, denyPartialResponse, func(qt *querytracer.Tracer, workerID uint, sn *storageNode) any {
-		// Use a separate variable for each goroutine
-		var err error
 		res := execSearchQuery(qt, sq, func(qt *querytracer.Tracer, rd []byte, _ storage.TenantToken) any {
 			sn.searchRequests.Inc()
-			err = sn.processSearchQuery(qt, rd, f, workerID, deadline)
+			err := sn.processSearchQuery(qt, rd, f, workerID, deadline)
 			if err != nil {
 				sn.searchErrors.Inc()
 				err = fmt.Errorf("cannot perform search on vmstorage %s: %w", sn.connPool.Addr(), err)
@@ -1909,7 +1907,7 @@ func processBlocks(qt *querytracer.Tracer, sns []*storageNode, denyPartialRespon
 			}
 		}
 
-		return &err
+		return nil
 	})
 
 	// Collect results.


### PR DESCRIPTION

### Describe Your Changes

In the original implementation, a single variable err was declared outside the closure:

```
	snr := startStorageNodesRequest(qt, sns, denyPartialResponse, func(qt *querytracer.Tracer, workerID uint, sn *storageNode) any {
		// Use a separate variable for each goroutine
		var err error
		res := execSearchQuery(qt, sq, func(qt *querytracer.Tracer, rd []byte, _ storage.TenantToken) any {
			sn.searchRequests.Inc()
			err = sn.processSearchQuery(qt, rd, f, workerID, deadline)
			if err != nil {
				sn.searchErrors.Inc()
				err = fmt.Errorf("cannot perform search on vmstorage %s: %w", sn.connPool.Addr(), err)
				return &err
			}

			return &err
		})
```

As a result, all returned errors referenced the same memory address (&err). 
`execSearchQuery` iterates through tenants sequentially (`sq.TenantTokens`), if an error occurs for one tenant (like `cannot select more than -search.maxSamplesPerQuery=N samples`) but the next tenant query succeeds, the previous tenant's error is overwritten, causing the error state to be lost.

Related issue: https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8461

### Checklist

The following checks are **mandatory**:

- [ ] My change adheres [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/contributing/).
