### PR TITLE
fixed docker compose setups silent collision

### DIFF
--- a/deployment/docker/Makefile
+++ b/deployment/docker/Makefile
@@ -15,6 +15,7 @@ DOCKER_RUN ?= $(DOCKER) run
 DOCKER_BUILD ?= $(DOCKER) build
 DOCKER_COMPOSE ?= $(DOCKER) compose
 DOCKER_IMAGE_LS ?= $(DOCKER) image ls --format '{{.Repository}}:{{.Tag}}'
+DOCKER_CTX ?= deployment/docker
 
 package-base:
 	($(DOCKER_IMAGE_LS) | grep -q '$(BASE_IMAGE)$$') \
@@ -209,31 +210,51 @@ remove-docker-images:
 	docker image ls --format '{{.ID}}' | xargs docker image rm -f
 
 docker-single-up:
-	$(DOCKER_COMPOSE) -f deployment/docker/docker-compose.yml up -d
+	COMPOSE_PROJECT_NAME=vmsingle \
+	COMPOSE_FILE=$(DOCKER_CTX)/compose.yml \
+	$(DOCKER_COMPOSE) up -d
 
 docker-single-down:
-	$(DOCKER_COMPOSE) -f deployment/docker/docker-compose.yml down -v
+	COMPOSE_PROJECT_NAME=vmsingle \
+	COMPOSE_FILE=$(DOCKER_CTX)/compose.yml \
+	$(DOCKER_COMPOSE) down -v
 
 docker-single-vm-datasource-up:
-	$(DOCKER_COMPOSE) -f deployment/docker/docker-compose.yml -f deployment/docker/vm-datasource/docker-compose.yml up -d
+	COMPOSE_PROJECT_NAME=vmsingle \
+	COMPOSE_FILE=$(DOCKER_CTX)/compose.yml:$(DOCKER_CTX)/vm-datasource/compose.yml \
+	$(DOCKER_COMPOSE) up -d
 
 docker-single-vm-datasource-down:
-	$(DOCKER_COMPOSE) -f deployment/docker/docker-compose.yml -f deployment/docker/vm-datasource/docker-compose.yml down -v
+	COMPOSE_PROJECT_NAME=vmsingle \
+	COMPOSE_FILE=$(DOCKER_CTX)/compose.yml:$(DOCKER_CTX)/vm-datasource/compose.yml \
+	$(DOCKER_COMPOSE) down -v
 
 docker-cluster-up:
-	$(DOCKER_COMPOSE) -f deployment/docker/docker-compose-cluster.yml up -d
+	COMPOSE_PROJECT_NAME=vmcluster \
+	COMPOSE_FILE=$(DOCKER_CTX)/compose-cluster.yml \
+	$(DOCKER_COMPOSE) up -d
 
 docker-cluster-down:
-	$(DOCKER_COMPOSE) -f deployment/docker/docker-compose-cluster.yml down -v
+	COMPOSE_PROJECT_NAME=vmcluster \
+        COMPOSE_FILE=$(DOCKER_CTX)/compose-cluster.yml \
+	$(DOCKER_COMPOSE) down -v
 
 docker-cluster-vm-datasource-up:
-	$(DOCKER_COMPOSE) -f deployment/docker/docker-compose-cluster.yml -f deployment/docker/vm-datasource/docker-compose-cluster.yml up -d
+	COMPOSE_PROJECT_NAME=vmcluster \
+        COMPOSE_FILE=$(DOCKER_CTX)/compose-cluster.yml:$(DOCKER_CTX)/vm-datasource/compose-cluster.yml \
+	$(DOCKER_COMPOSE) up -d
 
 docker-cluster-vm-datasource-down:
-	$(DOCKER_COMPOSE) -f deployment/docker/docker-compose-cluster.yml -f deployment/docker/vm-datasource/docker-compose-cluster.yml down -v
+	COMPOSE_PROJECT_NAME=vmcluster \
+        COMPOSE_FILE=$(DOCKER_CTX)/compose-cluster.yml:$(DOCKER_CTX)/vm-datasource/compose-cluster.yml \
+	$(DOCKER_COMPOSE) down -v
 
 docker-victorialogs-up:
-	$(DOCKER_COMPOSE) -f deployment/docker/docker-compose-victorialogs.yml up -d
+	COMPOSE_PROJECT_NAME=victorialogs \
+	COMPOSE_FILE=$(DOCKER_CTX)/compose-victorialogs.yml \
+	$(DOCKER_COMPOSE) up -d
 
 docker-victorialogs-down:
-	$(DOCKER_COMPOSE) -f deployment/docker/docker-compose-victorialogs.yml down -v
+	COMPOSE_PROJECT_NAME=victorialogs \
+        COMPOSE_FILE=$(DOCKER_CTX)/compose-victorialogs.yml \
+	$(DOCKER_COMPOSE) down -v

--- a/deployment/docker/compose-cluster.yml
+++ b/deployment/docker/compose-cluster.yml
@@ -3,7 +3,6 @@ services:
   #  It scrapes targets defined in --promscrape.config
   #  And forward them to --remoteWrite.url
   vmagent:
-    container_name: vmagent
     image: victoriametrics/vmagent:v1.113.0
     depends_on:
       - "vminsert"
@@ -19,7 +18,6 @@ services:
 
   # Grafana instance configured with VictoriaMetrics as datasource
   grafana:
-    container_name: grafana
     image: grafana/grafana:11.5.0
     depends_on:
       - "vmauth"
@@ -38,7 +36,6 @@ services:
   # vmstorage shards. Each shard receives 1/N of all metrics sent to vminserts,
   # where N is number of vmstorages (2 in this case).
   vmstorage-1:
-    container_name: vmstorage-1
     image: victoriametrics/vmstorage:v1.113.0-cluster
     ports:
       - 8482
@@ -50,7 +47,6 @@ services:
       - "--storageDataPath=/storage"
     restart: always
   vmstorage-2:
-    container_name: vmstorage-2
     image: victoriametrics/vmstorage:v1.113.0-cluster
     ports:
       - 8482
@@ -65,7 +61,6 @@ services:
   # vminsert is ingestion frontend. It receives metrics pushed by vmagent,
   # pre-process them and distributes across configured vmstorage shards.
   vminsert:
-    container_name: vminsert
     image: victoriametrics/vminsert:v1.113.0-cluster
     depends_on:
       - "vmstorage-1"
@@ -80,7 +75,6 @@ services:
   # vmselect is a query fronted. It serves read queries in MetricsQL or PromQL.
   # vmselect collects results from configured `--storageNode` shards.
   vmselect-1:
-    container_name: vmselect-1
     image: victoriametrics/vmselect:v1.113.0-cluster
     depends_on:
       - "vmstorage-1"
@@ -93,7 +87,6 @@ services:
       - 8481
     restart: always
   vmselect-2:
-    container_name: vmselect-2
     image: victoriametrics/vmselect:v1.113.0-cluster
     depends_on:
       - "vmstorage-1"
@@ -111,7 +104,6 @@ services:
   # read requests from Grafana, vmui, vmalert among vmselects.
   # It can be used as an authentication proxy.
   vmauth:
-    container_name: vmauth
     image: victoriametrics/vmauth:v1.113.0
     depends_on:
       - "vmselect-1"
@@ -126,7 +118,6 @@ services:
 
   # vmalert executes alerting and recording rules
   vmalert:
-    container_name: vmalert
     image: victoriametrics/vmalert:v1.113.0
     depends_on:
       - "vmauth"
@@ -151,7 +142,6 @@ services:
   # alertmanager receives alerting notifications from vmalert
   # and distributes them according to --config.file.
   alertmanager:
-    container_name: alertmanager
     image: prom/alertmanager:v0.28.0
     volumes:
       - ./alertmanager.yml:/config/alertmanager.yml

--- a/deployment/docker/compose-victorialogs.yml
+++ b/deployment/docker/compose-victorialogs.yml
@@ -1,7 +1,6 @@
 services:
   # Grafana instance configured with VictoriaLogs as datasource
   grafana:
-    container_name: grafana
     image: grafana/grafana:11.5.0
     depends_on:
       - "victoriametrics"
@@ -17,8 +16,6 @@ services:
       - ./../../dashboards/victorialogs.json:/var/lib/grafana/dashboards/vl.json
     environment:
       - "GF_INSTALL_PLUGINS=victoriametrics-logs-datasource"
-    networks:
-      - vm_net
     restart: always
 
   # vector is logs collector. It collects logs according to vector.yaml
@@ -37,13 +34,10 @@ services:
     ports:
       - "8686:8686"
     user: root
-    networks:
-      - vm_net
 
   #  VictoriaLogs instance, a single process responsible for
   #  storing logs and serving read queries.
   victorialogs:
-    container_name: victorialogs
     image: victoriametrics/victoria-logs:v1.15.0-victorialogs
     command:
       - "--storageDataPath=/vlogs"
@@ -52,13 +46,10 @@ services:
       - vldata:/vlogs
     ports:
       - "9428:9428"
-    networks:
-      - vm_net
 
   # VictoriaMetrics instance, a single process responsible for
   # scraping, storing metrics and serve read requests.
   victoriametrics:
-    container_name: victoriametrics
     image: victoriametrics/victoria-metrics:v1.113.0
     ports:
       - 8428:8428
@@ -69,15 +60,12 @@ services:
       - "--storageDataPath=/storage"
       - "--httpListenAddr=:8428"
       - "--promscrape.config=/etc/prometheus/prometheus.yml"
-    networks:
-      - vm_net
     restart: always
 
   # vmauth is a router and balancer for HTTP requests.
   # It proxies query requests from vmalert to either VictoriaMetrics or VictoriaLogs,
   # depending on the requested path.
   vmauth:
-    container_name: vmauth
     image: victoriametrics/vmauth:v1.113.0
     depends_on:
       - "victoriametrics"
@@ -88,13 +76,10 @@ services:
       - "--auth.config=/etc/auth.yml"
     ports:
       - 8427:8427
-    networks:
-      - vm_net
     restart: always
 
   # vmalert executes alerting and recording rules according to given rule type.
   vmalert:
-    container_name: vmalert
     image: victoriametrics/vmalert:v1.113.0
     depends_on:
       - "vmauth"
@@ -118,14 +103,11 @@ services:
       - "--rule=/etc/alerts/*.yml"
       # display source of alerts in grafana
       - "--external.url=http://127.0.0.1:3000" #grafana outside container
-    networks:
-      - vm_net
     restart: always
 
   # alertmanager receives alerting notifications from vmalert
   # and distributes them according to --config.file.
   alertmanager:
-    container_name: alertmanager
     image: prom/alertmanager:v0.28.0
     volumes:
       - ./alertmanager.yml:/config/alertmanager.yml
@@ -133,13 +115,9 @@ services:
       - "--config.file=/config/alertmanager.yml"
     ports:
       - 9093:9093
-    networks:
-      - vm_net
     restart: always
 
 volumes:
   vmdata: {}
   vldata: {}
   grafanadata: {}
-networks:
-  vm_net:

--- a/deployment/docker/compose.yml
+++ b/deployment/docker/compose.yml
@@ -3,7 +3,6 @@ services:
   #  It scrapes targets defined in --promscrape.config
   #  And forward them to --remoteWrite.url
   vmagent:
-    container_name: vmagent
     image: victoriametrics/vmagent:v1.113.0
     depends_on:
       - "victoriametrics"
@@ -19,7 +18,6 @@ services:
   # VictoriaMetrics instance, a single process responsible for
   # storing metrics and serve read requests.
   victoriametrics:
-    container_name: victoriametrics
     image: victoriametrics/victoria-metrics:v1.113.0
     ports:
       - 8428:8428
@@ -41,7 +39,6 @@ services:
 
   # Grafana instance configured with VictoriaMetrics as datasource
   grafana:
-    container_name: grafana
     image: grafana/grafana:11.5.0
     depends_on:
       - "victoriametrics"
@@ -58,7 +55,6 @@ services:
 
   # vmalert executes alerting and recording rules
   vmalert:
-    container_name: vmalert
     image: victoriametrics/vmalert:v1.113.0
     depends_on:
       - "victoriametrics"
@@ -84,7 +80,6 @@ services:
   # alertmanager receives alerting notifications from vmalert
   # and distributes them according to --config.file.
   alertmanager:
-    container_name: alertmanager
     image: prom/alertmanager:v0.28.0
     volumes:
       - ./alertmanager.yml:/config/alertmanager.yml

--- a/deployment/docker/vm-datasource/compose-cluster.yml
+++ b/deployment/docker/vm-datasource/compose-cluster.yml
@@ -1,6 +1,5 @@
 services:
   grafana:
-    container_name: grafana
     image: grafana/grafana:11.5.0
     depends_on:
       - "vmauth"

--- a/deployment/docker/vm-datasource/compose.yml
+++ b/deployment/docker/vm-datasource/compose.yml
@@ -1,6 +1,5 @@
 services:
   grafana:
-    container_name: grafana
     image: grafana/grafana:11.5.0
     depends_on:
       - "victoriametrics"
@@ -15,6 +14,4 @@ services:
       - ./../../dashboards/vm/vmalert.json:/var/lib/grafana/dashboards/vmalert.json
     environment:
       - GF_INSTALL_PLUGINS=victoriametrics-metrics-datasource
-    networks:
-      - vm_net
     restart: always

--- a/deployment/docker/vmanomaly/vmanomaly-integration/compose.yml
+++ b/deployment/docker/vmanomaly/vmanomaly-integration/compose.yml
@@ -1,6 +1,5 @@
 services:
   vmagent:
-    container_name: vmagent
     image: victoriametrics/vmagent:v1.113.0
     depends_on:
       - "victoriametrics"
@@ -12,12 +11,9 @@ services:
     command:
       - "--promscrape.config=/etc/prometheus/prometheus.yml"
       - "--remoteWrite.url=http://victoriametrics:8428/api/v1/write"
-    networks:
-      - vm_net
     restart: always
 
   victoriametrics:
-    container_name: victoriametrics
     image: victoriametrics/victoria-metrics:v1.113.0
     ports:
       - 8428:8428
@@ -28,12 +24,9 @@ services:
       - "--httpListenAddr=:8428"
       - "--vmalert.proxyURL=http://vmalert:8880"
       - "-search.disableCache=1" # for guide only, do not use in production
-    networks:
-      - vm_net
     restart: always
 
   grafana:
-    container_name: grafana
     image: grafana/grafana-oss:10.2.1
     depends_on:
       - "victoriametrics"
@@ -44,12 +37,9 @@ services:
       - ./provisioning/datasources:/etc/grafana/provisioning/datasources
       - ./provisioning/dashboards:/etc/grafana/provisioning/dashboards
       - ./vmanomaly_guide_dashboard.json:/var/lib/grafana/dashboards/vmanomaly_guide_dashboard.json
-    networks:
-      - vm_net
     restart: always
 
   vmalert:
-    container_name: vmalert
     image: victoriametrics/vmalert:v1.113.0
     depends_on:
       - "victoriametrics"
@@ -67,18 +57,13 @@ services:
       - "--external.url=http://127.0.0.1:3000" #grafana outside container
       # when copypaste the line be aware of '$$' for escaping in '$expr'
       - '--external.alert.source=explore?orgId=1&left=["now-1h","now","VictoriaMetrics",{"expr": },{"mode":"Metrics"},{"ui":[true,true,true,"none"]}]'
-    networks:
-      - vm_net
     restart: always
   vmanomaly:
-    container_name: vmanomaly
     image: victoriametrics/vmanomaly:v1.20.0
     depends_on:
       - "victoriametrics"
     ports:
       - "8490:8490"
-    networks:
-      - vm_net
     restart: always
     volumes:
       - ./vmanomaly_config.yml:/config.yaml
@@ -88,7 +73,6 @@ services:
       - "/config.yaml"
       - "--licenseFile=/license"
   alertmanager:
-    container_name: alertmanager
     image: prom/alertmanager:v0.28.0
     volumes:
       - ./alertmanager.yml:/config/alertmanager.yml
@@ -96,23 +80,16 @@ services:
       - "--config.file=/config/alertmanager.yml"
     ports:
       - 9093:9093
-    networks:
-      - vm_net
     restart: always
 
   node-exporter:
     image: quay.io/prometheus/node-exporter:v1.7.0
-    container_name: node-exporter
     ports:
       - 9100:9100
     pid: host
     restart: unless-stopped
-    networks:
-      - vm_net
 
 volumes:
   vmagentdata-guide-vmanomaly-vmalert: {}
   vmdata-guide-vmanomaly-vmalert: {}
   grafanadata-guide-vmanomaly-vmalert: {}
-networks:
-  vm_net:

--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -18,7 +18,10 @@ See also [LTS releases](https://docs.victoriametrics.com/lts-releases/).
 
 ## tip
 
+**Update note 1: Update compose files at [deployment/docker](https://github.com/VictoriaMetrics/VictoriaMetrics/tree/master/deployment/docker) to prevent silent collision issues. Consider recreating existing environments if you rely on any of `make docker-*-up` targets**
+
 * BUGFIX: [stream aggregation](https://docs.victoriametrics.com/stream-aggregation): fix panic on `rate` output. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8469).
+* BUGFIX: Remove `container_name` and `networks` from compose files at deployment/docker, run conflicting compose files with project name to prevent silent collision-related issues. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8459).
 
 ## [v1.113.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.113.0)
 


### PR DESCRIPTION
### Describe Your Changes

fixes https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8459

currently all compose setups, that are defined in compose files at deployment/docker, override each other as they share the same project name, which leads to same volume names and have explicitly defined `container_name`. it can lead to issues like #8459. 

This PR adds project name for each compose setup and removes `container_name` to generate containers with names, that are prefixed with a project name. This will help to see an error immediately. Additionally each setup can have port numbers, which are not overlapping to be able to run multiple setups concurrently

### Checklist

The following checks are **mandatory**:

- [ ] My change adheres [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/contributing/).
