### PR TITLE
add CLI flags to allow specifying additional listen addresses for vlinsert handlers

### DIFF
--- a/docs/VictoriaLogs/CHANGELOG.md
+++ b/docs/VictoriaLogs/CHANGELOG.md
@@ -16,6 +16,8 @@ according to [these docs](https://docs.victoriametrics.com/victorialogs/quicksta
 
 ## tip
 
+* FEATURE: [data ingestion](https://docs.victoriametrics.com/victorialogs/data-ingestion/): add new flags `-insert.httpListenAddr` and `-insert.useProxyProtocol` to specify additional listen addresses for data ingestion. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8404).
+
 * BUGFIX: [web UI](https://docs.victoriametrics.com/victorialogs/querying/#web-ui): fix endless group expansion loop bug. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8347).
 
 ## [v1.17.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.17.0-victorialogs)

--- a/docs/VictoriaLogs/README.md
+++ b/docs/VictoriaLogs/README.md
@@ -409,6 +409,14 @@ Pass `-help` to VictoriaLogs in order to see the list of supported command-line 
     	Supports the following optional suffixes for size values: KB, MB, GB, TB, KiB, MiB, GiB, TiB (default 262144)
   -insert.maxQueueDuration duration
     	The maximum duration to wait in the queue when -maxConcurrentInserts concurrent insert requests are executed (default 1m0s)
+  -insert.httpListenAddr array
+    	TCP address to listen on for /insert/* handlers in addition to those provided with -httpListenAddr . See also -insert.httpListenAddr.useProxyProtocol
+    	Supports an array of values separated by comma or specified via multiple flags.
+    	Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
+  -insert.httpListenAddr.useProxyProtocol array
+    	Whether to use proxy protocol for connections accepted at the given -insert.httpListenAddr . See https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt .
+    	Supports array of values separated by comma or specified via multiple flags.
+    	Empty values are set to false.
   -internStringCacheExpireDuration duration
     	The expiry duration for caches for interned strings. See https://en.wikipedia.org/wiki/String_interning . See also -internStringMaxLen and -internStringDisableCache (default 6m0s)
   -internStringDisableCache


### PR DESCRIPTION
### Describe Your Changes

A solution for https://github.com/VictoriaMetrics/VictoriaLogs/issues/223
It would allow specifying extra listen addresses for the vlinsert handlers, so that data ingestion could happen on an IP network without exposing the query API.

### Checklist

The following checks are **mandatory**:

- [x] My change adheres [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/contributing/).
