### PR TITLE
dashboards: take indexdb storage in to account in Storage full ETA

### DIFF
--- a/dashboards/victoriametrics-cluster.json
+++ b/dashboards/victoriametrics-cluster.json
@@ -5276,7 +5276,7 @@
                 "uid": "$ds"
               },
               "editorMode": "code",
-              "expr": "min((vm_free_disk_space_bytes{job=~\"$job_storage\", instance=~\"$instance\"} - vm_free_disk_space_limit_bytes{job=~\"$job_storage\", instance=~\"$instance\"}) \n/ \nignoring(path) (\n    rate(vm_rows_added_to_storage_total{job=~\"$job_storage\", instance=~\"$instance\"}[1d])\n    * scalar(\n            sum(vm_data_size_bytes{job=~\"$job_storage\", instance=~\"$instance\", type!~\"indexdb.*\"})\n            / \n            sum(vm_rows{job=~\"$job_storage\", instance=~\"$instance\", type!~\"indexdb.*\"})\n            )\n))",
+              "expr": "min((vm_free_disk_space_bytes{job=~\"$job_storage\", instance=~\"$instance\"} - vm_free_disk_space_limit_bytes{job=~\"$job_storage\", instance=~\"$instance\"}) \n/ \nignoring(path) (\n    rate(vm_rows_added_to_storage_total{job=~\"$job_storage\", instance=~\"$instance\"}[1d])\n    * scalar(\n            sum(vm_data_size_bytes{job=~\"$job_storage\", instance=~\"$instance\", type!~\".*inmemory\"})\n            / \n            sum(vm_rows{job=~\"$job_storage\", instance=~\"$instance\", type!~\".*inmemory\"})\n            )\n))",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,

--- a/dashboards/victoriametrics.json
+++ b/dashboards/victoriametrics.json
@@ -4600,7 +4600,7 @@
                 "uid": "$ds"
               },
               "editorMode": "code",
-              "expr": "(vm_free_disk_space_bytes{job=~\"$job\", instance=~\"$instance\"}-vm_free_disk_space_limit_bytes{job=~\"$job\", instance=~\"$instance\"}) \n/ ignoring(path) (\n  rate(vm_rows_added_to_storage_total{job=~\"$job\", instance=~\"$instance\"}[1d]) \n  * scalar(\n    sum(vm_data_size_bytes{job=~\"$job\", instance=~\"$instance\", type!~\"indexdb.*\"}) \n    / sum(vm_rows{job=~\"$job\", instance=~\"$instance\", type!~\"indexdb.*\"})\n    )\n  )",
+              "expr": "(vm_free_disk_space_bytes{job=~\"$job\", instance=~\"$instance\"}-vm_free_disk_space_limit_bytes{job=~\"$job\", instance=~\"$instance\"}) \n/ ignoring(path) (\n  rate(vm_rows_added_to_storage_total{job=~\"$job\", instance=~\"$instance\"}[1d]) \n  * scalar(\n    sum(vm_data_size_bytes{job=~\"$job\", instance=~\"$instance\", type!~\".*inmemory\"}) \n    / sum(vm_rows{job=~\"$job\", instance=~\"$instance\", type!~\".*inmemory\"})\n    )\n  )",
               "format": "time_series",
               "hide": false,
               "interval": "",


### PR DESCRIPTION
### Describe Your Changes

https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8491

Attempting to improve the accuracy of `Storage full ETA` panel in Victoria Metrics dashboards, by including the `indexdb` file storage and excluding `inmem` in `vm_data_size_bytes` and `vm_rows` metrics in the query. `indexdb` storage can be a large contributor to disk space and in such case, also the estimation is inaccurate, when excluded.

The linked issue documents the findings more thoroughly. I might need help verifying the solution works also when there's no particularily high churn rate.

### Checklist

- [x] My change adheres [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/contributing/).
