### PR TITLE
vmagent: revert doc change for on-disk persistence and move new content to another section

### DIFF
--- a/app/vmagent/remotewrite/remotewrite.go
+++ b/app/vmagent/remotewrite/remotewrite.go
@@ -89,9 +89,9 @@ var (
 
 	disableOnDiskQueue = flagutil.NewArrayBool("remoteWrite.disableOnDiskQueue", "Whether to disable storing pending data to -remoteWrite.tmpDataPath "+
 		"when the remote storage system at the corresponding -remoteWrite.url cannot keep up with the data ingestion rate. "+
-		"See https://docs.victoriametrics.com/vmagent#on-disk-persistence-and-how-to-disable-it . See also -remoteWrite.dropSamplesOnOverload")
+		"See https://docs.victoriametrics.com/vmagent#disabling-on-disk-persistence . See also -remoteWrite.dropSamplesOnOverload")
 	dropSamplesOnOverload = flag.Bool("remoteWrite.dropSamplesOnOverload", false, "Whether to drop samples when -remoteWrite.disableOnDiskQueue is set and if the samples "+
-		"cannot be pushed into the configured -remoteWrite.url systems in a timely manner. See https://docs.victoriametrics.com/vmagent#on-disk-persistence-and-how-to-disable-it")
+		"cannot be pushed into the configured -remoteWrite.url systems in a timely manner. See https://docs.victoriametrics.com/vmagent#disabling-on-disk-persistence")
 )
 
 var (

--- a/docs/vmagent.md
+++ b/docs/vmagent.md
@@ -1029,6 +1029,7 @@ scrape_configs:
   proxy_headers:
   - "Proxy-Auth: top-secret"
 ```
+
 ## On-disk persistence
 
 By default `vmagent` stores pending data, which cannot be sent to the configured remote storage systems in a timely manner, in the folder set

--- a/docs/vmagent.md
+++ b/docs/vmagent.md
@@ -1029,8 +1029,7 @@ scrape_configs:
   proxy_headers:
   - "Proxy-Auth: top-secret"
 ```
-
-## On-disk persistence and how to disable it
+## On-disk persistence
 
 By default `vmagent` stores pending data, which cannot be sent to the configured remote storage systems in a timely manner, in the folder set
 by `-remoteWrite.tmpDataPath` command-line flag. By default `vmagent` writes all the pending data to this folder until this data is sent to the configured
@@ -1048,21 +1047,23 @@ The folder structure of persistence data is as follows. Each remote write URL co
 
 It's generated based on the following information:
 1. The **sequence order** of this remote write URL in the remote write configuration, starting from **1**.
-2. The **hash result** of the remote write URL itself, excluding query parameters and fragments. 
+2. The **hash result** of the remote write URL itself, excluding query parameters and fragments.
 
-For the following remote write configs:
+For the remote write configs:
 ```
 -remoteWrite.url=http://example-1:8428/prometheus/api/v1/write?foo=bar#baz
 -remoteWrite.url=http://user:pass@example-2:8428/prometheus/api/v1/write?qux=quux#quuz
 ```
 
-vmagent will generate persistent queue folders:
+vmagent will generate the following persistent queue folders:
 ```bash
 # 1_<hash(http://example-1:8428/prometheus/api/v1/write)>, query parameters foo=bar and fragment baz are removed.
 1_BA6E4303DCFA0D45
 # 2_<hash(http://user:pass@example-2:8428/prometheus/api/v1/write)>, query parameters qux=quux and fragment quuz are removed.
 2_0AAFDF53E314A72A
 ```
+
+## Disabling On-disk persistence
 
 There are cases when it is better disabling on-disk persistence for pending data at `vmagent` side:
 
@@ -2173,11 +2174,11 @@ See the docs at https://docs.victoriametrics.com/vmagent/ .
      Supports an array of values separated by comma or specified via multiple flags.
      Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
   -remoteWrite.disableOnDiskQueue array
-     Whether to disable storing pending data to -remoteWrite.tmpDataPath when the remote storage system at the corresponding -remoteWrite.url cannot keep up with the data ingestion rate. See https://docs.victoriametrics.com/vmagent#on-disk-persistence-and-how-to-disable-it . See also -remoteWrite.dropSamplesOnOverload
+     Whether to disable storing pending data to -remoteWrite.tmpDataPath when the remote storage system at the corresponding -remoteWrite.url cannot keep up with the data ingestion rate. See https://docs.victoriametrics.com/vmagent#disabling-on-disk-persistence . See also -remoteWrite.dropSamplesOnOverload
      Supports array of values separated by comma or specified via multiple flags.
      Empty values are set to false.
   -remoteWrite.dropSamplesOnOverload
-     Whether to drop samples when -remoteWrite.disableOnDiskQueue is set and if the samples cannot be pushed into the configured -remoteWrite.url systems in a timely manner. See https://docs.victoriametrics.com/vmagent#on-disk-persistence-and-how-to-disable-it
+     Whether to drop samples when -remoteWrite.disableOnDiskQueue is set and if the samples cannot be pushed into the configured -remoteWrite.url systems in a timely manner. See https://docs.victoriametrics.com/vmagent#disabling-on-disk-persistence
   -remoteWrite.flushInterval duration
      Interval for flushing the data to remote storage. This option takes effect only when less than 10K data points per second are pushed to -remoteWrite.url (default 1s)
   -remoteWrite.forcePromProto array


### PR DESCRIPTION
### Describe Your Changes

revert doc change in https://github.com/VictoriaMetrics/VictoriaMetrics/commit/815bad3687a2207ce267ec81099b4e20e9a91cbb and move new content to another section.

### Checklist

The following checks are **mandatory**:

- [x] My change adheres [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/contributing/).
