### PR TITLE
vmui/logs: implement nanosecond log sorting

### DIFF
--- a/app/vmui/packages/vmui/src/components/Table/helpers.ts
+++ b/app/vmui/packages/vmui/src/components/Table/helpers.ts
@@ -1,19 +1,16 @@
 import { Order } from "../../pages/CardinalityPanel/Table/types";
-import dayjs from "dayjs";
+import { getNanoTimestamp } from "../../utils/time";
 
 const dateColumns = ["date", "timestamp", "time"];
 
 export function descendingComparator<T>(a: T, b: T, orderBy: keyof T) {
   const valueA = a[orderBy];
   const valueB = b[orderBy];
-  const parsedValueA = dateColumns.includes(String(orderBy)) ? dayjs(`${valueA}`).unix() : valueA;
-  const parsedValueB = dateColumns.includes(String(orderBy)) ? dayjs(`${valueB}`).unix() : valueB;
-  if (parsedValueB < parsedValueA) {
-    return -1;
-  }
-  if (parsedValueB > parsedValueA) {
-    return 1;
-  }
+  const parsedValueA = dateColumns.includes(String(orderBy)) ? getNanoTimestamp(`${valueA}`) : valueA;
+  const parsedValueB = dateColumns.includes(String(orderBy)) ? getNanoTimestamp(`${valueB}`) : valueB;
+
+  if (parsedValueB < parsedValueA) return -1;
+  if (parsedValueB > parsedValueA) return 1;
   return 0;
 }
 

--- a/app/vmui/packages/vmui/src/pages/ExploreLogs/GroupLogs/GroupLogs.tsx
+++ b/app/vmui/packages/vmui/src/pages/ExploreLogs/GroupLogs/GroupLogs.tsx
@@ -17,6 +17,7 @@ import Pagination from "../../../components/Main/Pagination/Pagination";
 import SelectLimit from "../../../components/Main/Pagination/SelectLimit/SelectLimit";
 import { usePaginateGroups } from "../hooks/usePaginateGroups";
 import { GroupLogsType } from "../../../types";
+import { getNanoTimestamp } from "../../../utils/time";
 
 interface Props {
   logs: Logs[];
@@ -42,8 +43,17 @@ const GroupLogs: FC<Props> = ({ logs, settingsRef }) => {
     return groupByMultipleKeys(logs, [groupBy]).map((item) => {
       const streamValue = item.values[0]?.[groupBy] || "";
       const pairs = getStreamPairs(streamValue);
+
       // values sorting by time
-      const values = item.values.sort((a, b) => new Date(b._time).getTime() - new Date(a._time).getTime());
+      const values = item.values.sort((a, b) => {
+        const aTimestamp = getNanoTimestamp(a._time);
+        const bTimestamp = getNanoTimestamp(b._time);
+
+        if (aTimestamp > bTimestamp) return 1;
+        if (aTimestamp < bTimestamp) return -1;
+        return 0;
+      });
+
       return {
         keys: item.keys,
         keysString: item.keys.join(""),

--- a/app/vmui/packages/vmui/src/utils/time.ts
+++ b/app/vmui/packages/vmui/src/utils/time.ts
@@ -250,3 +250,33 @@ export const getBrowserTimezone = () => {
     region: isValid ? timezone : "UTC",
   };
 };
+
+export const getNanoTimestamp = (dateStr: string): bigint => {
+  if (!dateStr) return 0n;
+
+  // Get the millisecond timestamp using dayjs
+  const baseMs = dayjs(dateStr).valueOf(); // milliseconds
+
+  // If the date string doesn't contain a fractional part, return the timestamp in nanoseconds directly
+  if (!dateStr.includes(".")) {
+    return BigInt(baseMs) * 1000000n;
+  }
+
+  // Extract the fractional part between the decimal point and the "Z" character
+  const match = dateStr.match(/\.(\d+)Z/);
+  if (!match) {
+    return BigInt(baseMs) * 1000000n;
+  }
+
+  let fraction = match[1];
+  // Pad with trailing zeros to represent nanoseconds if necessary
+  fraction = fraction.padEnd(9, "0");
+
+  // The first 3 digits are already included in baseMs,
+  // the remaining 6 digits represent additional nanoseconds
+  const extraNano = parseInt(fraction.slice(3), 10);
+
+  // Return the full timestamp in nanoseconds as a BigInt
+  return BigInt(baseMs) * 1000000n + BigInt(extraNano);
+};
+

--- a/docs/VictoriaLogs/CHANGELOG.md
+++ b/docs/VictoriaLogs/CHANGELOG.md
@@ -16,6 +16,8 @@ according to [these docs](https://docs.victoriametrics.com/victorialogs/quicksta
 
 ## tip
 
+* FEATURE: [web UI](https://docs.victoriametrics.com/victorialogs/querying/#web-ui): implement nanosecond precision in log sorting to accurately order entries. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8346).
+
 ## [v1.17.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.17.0-victorialogs)
 
 Released at 2025-03-16


### PR DESCRIPTION
### Describe Your Changes

This PR adds nanosecond precision to log sorting, ensuring accurate ordering of entries with sub-millisecond differences.

Related issue:  #8346

### Checklist

The following checks are **mandatory**:

- [ ] My change adheres [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/contributing/).
