### PR TITLE
vmui/logs: fix endless group expansion loop bug

### DIFF
--- a/app/vmui/packages/vmui/src/components/Main/Accordion/Accordion.tsx
+++ b/app/vmui/packages/vmui/src/components/Main/Accordion/Accordion.tsx
@@ -23,12 +23,13 @@ const Accordion: FC<AccordionProps> = ({
     if (selection && selection.toString()) {
       return; // If the text is selected, cancel the execution of toggle.
     }
-    setIsOpen(prev => !prev);
-  };
 
-  useEffect(() => {
-    onChange && onChange(isOpen);
-  }, [isOpen]);
+    setIsOpen((prev) => {
+      const newState = !prev;
+      onChange && onChange(newState);
+      return newState;
+    });
+  };
 
   useEffect(() => {
     setIsOpen(defaultExpanded);

--- a/docs/VictoriaLogs/CHANGELOG.md
+++ b/docs/VictoriaLogs/CHANGELOG.md
@@ -16,6 +16,8 @@ according to [these docs](https://docs.victoriametrics.com/victorialogs/quicksta
 
 ## tip
 
+* BUGFIX: [web UI](https://docs.victoriametrics.com/victorialogs/querying/#web-ui): fix endless group expansion loop bug. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8347).
+
 ## [v1.17.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.17.0-victorialogs)
 
 Released at 2025-03-16


### PR DESCRIPTION
### Describe Your Changes

Fix endless group expansion loop.
Related issue: #8347

### Checklist

The following checks are **mandatory**:

- [ ] My change adheres [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/contributing/).
