### PR TITLE
app/vmctl: propagate context to avoid data races

### DIFF
--- a/app/vmctl/main.go
+++ b/app/vmctl/main.go
@@ -97,7 +97,7 @@ func main() {
 					}
 
 					otsdbProcessor := newOtsdbProcessor(otsdbClient, importer, c.Int(otsdbConcurrency), c.Bool(globalVerbose))
-					return otsdbProcessor.run()
+					return otsdbProcessor.run(ctx)
 				},
 			},
 			{
@@ -158,7 +158,7 @@ func main() {
 						c.Bool(influxSkipDatabaseLabel),
 						c.Bool(influxPrometheusMode),
 						c.Bool(globalVerbose))
-					return processor.run()
+					return processor.run(ctx)
 				},
 			},
 			{
@@ -261,7 +261,7 @@ func main() {
 						cc:        c.Int(promConcurrency),
 						isVerbose: c.Bool(globalVerbose),
 					}
-					return pp.run()
+					return pp.run(ctx)
 				},
 			},
 			{

--- a/app/vmctl/prometheus_test.go
+++ b/app/vmctl/prometheus_test.go
@@ -160,7 +160,7 @@ func TestPrometheusProcessorRun(t *testing.T) {
 				go tt.fields.closer(importer)
 			}
 
-			if err := pp.run(); (err != nil) != tt.wantErr {
+			if err := pp.run(context.Background()); (err != nil) != tt.wantErr {
 				t.Fatalf("run() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/app/vmctl/remoteread.go
+++ b/app/vmctl/remoteread.go
@@ -112,7 +112,7 @@ func (rrp *remoteReadProcessor) run(ctx context.Context) error {
 
 func (rrp *remoteReadProcessor) do(ctx context.Context, filter *remoteread.Filter) error {
 	return rrp.src.Read(ctx, filter, func(series *vm.TimeSeries) error {
-		if err := rrp.dst.Input(series); err != nil {
+		if err := rrp.dst.Input(ctx, series); err != nil {
 			return fmt.Errorf(
 				"failed to read data for time range start: %d, end: %d, %s",
 				filter.StartTimestampMs, filter.EndTimestampMs, err)

--- a/app/vmctl/vm/vm.go
+++ b/app/vmctl/vm/vm.go
@@ -69,7 +69,6 @@ type Importer struct {
 	user       string
 	password   string
 
-	close  chan struct{}
 	input  chan *TimeSeries
 	errors chan *ImportError
 
@@ -143,7 +142,6 @@ func NewImporter(ctx context.Context, cfg Config) (*Importer, error) {
 		user:       cfg.User,
 		password:   cfg.Password,
 		rl:         limiter.NewLimiter(cfg.RateLimit),
-		close:      make(chan struct{}),
 		input:      make(chan *TimeSeries, cfg.Concurrency*4),
 		errors:     make(chan *ImportError, cfg.Concurrency),
 		backoff:    cfg.Backoff,
@@ -207,7 +205,6 @@ func (im *Importer) Input(ctx context.Context, ts *TimeSeries) error {
 // and waits until they are finished
 func (im *Importer) Close() {
 	im.once.Do(func() {
-		close(im.close)
 		close(im.input)
 		im.wg.Wait()
 		close(im.errors)


### PR DESCRIPTION
### Describe Your Changes

Propagated context to correctly stop the process on graceful shutdown to avoid data races and correctly send last metrics to the data source

The discussion of context usage was started in the [PR](https://github.com/VictoriaMetrics/VictoriaMetrics/pull/7863)

### Checklist

The following checks are **mandatory**:

- [x] My change adheres [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/contributing/).
