### PR TITLE
doc: [guide] update k8s vmsingle vmcluster helm and operator guide

### DIFF
--- a/docs/guides/getting-started-with-vm-operator/README.md
+++ b/docs/guides/getting-started-with-vm-operator/README.md
@@ -28,7 +28,7 @@ The expected output is:
 
 ```sh
 NAME: vmoperator
-LAST DEPLOYED: Thu Sep 30 17:30:30 2021
+LAST DEPLOYED: Fri Mar 21 12:01:52 2025
 NAMESPACE: default
 STATUS: deployed
 REVISION: 1
@@ -38,7 +38,7 @@ victoria-metrics-operator has been installed. Check its status by running:
   kubectl --namespace default get pods -l "app.kubernetes.io/instance=vmoperator"
 
 Get more information on https://github.com/VictoriaMetrics/helm-charts/tree/master/charts/victoria-metrics-operator.
-See "Getting started guide for VM Operator" on https://docs.victoriametrics.com/guides/getting-started-with-vm-operator.html.
+See "Getting started guide for VM Operator" on https://docs.victoriametrics.com/guides/getting-started-with-vm-operator
 ```
 
 Run the following command to check that VM Operator is up and running:

--- a/docs/guides/k8s-monitoring-via-vm-cluster/README.md
+++ b/docs/guides/k8s-monitoring-via-vm-cluster/README.md
@@ -38,14 +38,19 @@ helm search repo vm/
 The expected output is:
 
 ```text
-NAME                         	CHART VERSION	APP VERSION	DESCRIPTION                                       
-vm/victoria-metrics-agent    	0.7.20       	v1.62.0    	Victoria Metrics Agent - collects metrics from ...
-vm/victoria-metrics-alert    	0.3.34       	v1.62.0    	Victoria Metrics Alert - executes a list of giv...
-vm/victoria-metrics-auth     	0.2.23       	1.62.0     	Victoria Metrics Auth - is a simple auth proxy ...
-vm/victoria-metrics-cluster  	0.8.32       	1.62.0     	Victoria Metrics Cluster version - high-perform...
-vm/victoria-metrics-k8s-stack	0.2.9        	1.16.0     	Kubernetes monitoring on VictoriaMetrics stack....
-vm/victoria-metrics-operator 	0.1.17       	0.16.0     	Victoria Metrics Operator                         
-vm/victoria-metrics-single   	0.7.5        	1.62.0     	Victoria Metrics Single version - high-performa...
+NAME                           	CHART VERSION	APP VERSION	DESCRIPTION                                       
+vm/victoria-logs-single        	0.9.3        	v1.16.0    	Victoria Logs Single version - high-performance...
+vm/victoria-metrics-agent      	0.17.2       	v1.113.0   	Victoria Metrics Agent - collects metrics from ...
+vm/victoria-metrics-alert      	0.15.0       	v1.113.0   	Victoria Metrics Alert - executes a list of giv...
+vm/victoria-metrics-anomaly    	1.9.0        	v1.21.0    	Victoria Metrics Anomaly Detection - a service ...
+vm/victoria-metrics-auth       	0.10.0       	v1.113.0   	Victoria Metrics Auth - is a simple auth proxy ...
+vm/victoria-metrics-cluster    	0.19.2       	v1.113.0   	Victoria Metrics Cluster version - high-perform...
+vm/victoria-metrics-common     	0.0.42       	           	Victoria Metrics Common - contains shared templ...
+vm/victoria-metrics-distributed	0.9.0        	v1.113.0   	A Helm chart for Running VMCluster on Multiple ...
+vm/victoria-metrics-gateway    	0.8.0        	v1.113.0   	Victoria Metrics Gateway - Auth & Rate-Limittin...
+vm/victoria-metrics-k8s-stack  	0.39.0       	v1.113.0   	Kubernetes monitoring on VictoriaMetrics stack....
+vm/victoria-metrics-operator   	0.43.0       	v0.54.1    	Victoria Metrics Operator                         
+vm/victoria-metrics-single     	0.15.1       	v1.113.0   	Victoria Metrics Single version - high-performa...
 ```
 
 ## 2. Install VictoriaMetrics Cluster from the Helm chart
@@ -80,7 +85,7 @@ As a result of this command you will see the following output:
 
 ```text
 NAME: vmcluster
-LAST DEPLOYED: Thu Jul  1 09:41:57 2021
+LAST DEPLOYED: Fri Mar 21 11:55:50 2025
 NAMESPACE: default
 STATUS: deployed
 REVISION: 1
@@ -89,10 +94,10 @@ NOTES:
 Write API:
 
 The Victoria Metrics write api can be accessed via port 8480 with the following DNS name from within your cluster:
-vmcluster-victoria-metrics-cluster-vminsert.default.svc.cluster.local
+vmcluster-victoria-metrics-cluster-vminsert.default.svc.cluster.local.
 
 Get the Victoria Metrics insert service URL by running these commands in the same shell:
-  export POD_NAME=$(kubectl get pods --namespace default -l "app=vminsert" -o jsonpath="{.items[0].metadata.name}")
+  export POD_NAME=$(kubectl get pods --namespace default -l "app=" -o jsonpath="{.items[0].metadata.name}")
   kubectl --namespace default port-forward $POD_NAME 8480
 
 You need to update your Prometheus configuration file and add the following lines to it:
@@ -102,33 +107,30 @@ prometheus.yml
     remote_write:
       - url: "http://<insert-service>/insert/0/prometheus/"
 
-
-
 for example -  inside the Kubernetes cluster:
 
     remote_write:
-      - url: "http://vmcluster-victoria-metrics-cluster-vminsert.default.svc.cluster.local:8480/insert/0/prometheus/"
+      - url: http://vmcluster-victoria-metrics-cluster-vminsert.default.svc.cluster.local.:8480/insert/0/prometheus/
 Read API:
 
 The VictoriaMetrics read api can be accessed via port 8481 with the following DNS name from within your cluster:
-vmcluster-victoria-metrics-cluster-vmselect.default.svc.cluster.local
+vmcluster-victoria-metrics-cluster-vmselect.default.svc.cluster.local.
 
 Get the VictoriaMetrics select service URL by running these commands in the same shell:
-  export POD_NAME=$(kubectl get pods --namespace default -l "app=vmselect" -o jsonpath="{.items[0].metadata.name}")
+  export POD_NAME=$(kubectl get pods --namespace default -l "app=" -o jsonpath="{.items[0].metadata.name}")
   kubectl --namespace default port-forward $POD_NAME 8481
 
-You will need to specify select service URL in your Grafana:
- NOTE: you need to use Prometheus Data Source
+You need to specify select service URL into your Grafana:
+ NOTE: you need to use the Prometheus Data Source
 
-Input this URL field in Grafana
+Input this URL field into Grafana
 
     http://<select-service>/select/0/prometheus/
 
 
 for example - inside the Kubernetes cluster:
 
-    http://vmcluster-victoria-metrics-cluster-vmselect.default.svc.cluster.local:8481/select/0/prometheus/"
-
+    http://vmcluster-victoria-metrics-cluster-vmselect.default.svc.cluster.local.:8481/select/0/prometheus/
 ```
 
 For us it’s important to remember the url for the datasource (copy lines from the output).
@@ -165,7 +167,7 @@ Here is full file content `guide-vmcluster-vmagent-values.yaml`
 
 ```yaml
 remoteWrite:
-   - url: http://vmcluster-victoria-metrics-cluster-vminsert.default.svc.cluster.local:8480/insert/0/prometheus/
+  - url: http://vmcluster-victoria-metrics-cluster-vminsert.default.svc.cluster.local:8480/insert/0/prometheus/
 
 config:
   global:

--- a/docs/guides/k8s-monitoring-via-vm-single/README.md
+++ b/docs/guides/k8s-monitoring-via-vm-single/README.md
@@ -40,14 +40,19 @@ helm search repo vm/
 The expected output is:
 
 ```text
-NAME                         	CHART VERSION	APP VERSION	DESCRIPTION                                       
-vm/victoria-metrics-agent    	0.7.20       	v1.62.0    	Victoria Metrics Agent - collects metrics from ...
-vm/victoria-metrics-alert    	0.3.34       	v1.62.0    	Victoria Metrics Alert - executes a list of giv...
-vm/victoria-metrics-auth     	0.2.23       	1.62.0     	Victoria Metrics Auth - is a simple auth proxy ...
-vm/victoria-metrics-cluster  	0.8.32       	1.62.0     	Victoria Metrics Cluster version - high-perform...
-vm/victoria-metrics-k8s-stack	0.2.9        	1.16.0     	Kubernetes monitoring on VictoriaMetrics stack....
-vm/victoria-metrics-operator 	0.1.17       	0.16.0     	Victoria Metrics Operator                         
-vm/victoria-metrics-single   	0.7.5        	1.62.0     	Victoria Metrics Single version - high-performa...
+NAME                           	CHART VERSION	APP VERSION	DESCRIPTION                                       
+vm/victoria-logs-single        	0.9.3        	v1.16.0    	Victoria Logs Single version - high-performance...
+vm/victoria-metrics-agent      	0.17.2       	v1.113.0   	Victoria Metrics Agent - collects metrics from ...
+vm/victoria-metrics-alert      	0.15.0       	v1.113.0   	Victoria Metrics Alert - executes a list of giv...
+vm/victoria-metrics-anomaly    	1.9.0        	v1.21.0    	Victoria Metrics Anomaly Detection - a service ...
+vm/victoria-metrics-auth       	0.10.0       	v1.113.0   	Victoria Metrics Auth - is a simple auth proxy ...
+vm/victoria-metrics-cluster    	0.19.2       	v1.113.0   	Victoria Metrics Cluster version - high-perform...
+vm/victoria-metrics-common     	0.0.42       	           	Victoria Metrics Common - contains shared templ...
+vm/victoria-metrics-distributed	0.9.0        	v1.113.0   	A Helm chart for Running VMCluster on Multiple ...
+vm/victoria-metrics-gateway    	0.8.0        	v1.113.0   	Victoria Metrics Gateway - Auth & Rate-Limittin...
+vm/victoria-metrics-k8s-stack  	0.39.0       	v1.113.0   	Kubernetes monitoring on VictoriaMetrics stack....
+vm/victoria-metrics-operator   	0.43.0       	v0.54.1    	Victoria Metrics Operator                         
+vm/victoria-metrics-single     	0.15.1       	v1.113.0   	Victoria Metrics Single version - high-performa...
 ```
 
 
@@ -84,9 +89,9 @@ server:
           relabel_configs:
             - source_labels:
                 [
-                    __meta_kubernetes_namespace,
-                    __meta_kubernetes_service_name,
-                    __meta_kubernetes_endpoint_port_name,
+                  __meta_kubernetes_namespace,
+                  __meta_kubernetes_service_name,
+                  __meta_kubernetes_endpoint_port_name,
                 ]
               action: keep
               regex: default;kubernetes;https
@@ -143,36 +148,39 @@ server:
               regex: '^/system\.slice/(.+)\.service$'
               target_label: systemd_service_name
               replacement: '${1}'
-
 ```
 
 
 * By running `helm install vmsingle vm/victoria-metrics-single` we install [VictoriaMetrics Single](https://docs.victoriametrics.com/single-server-victoriametrics/) to default [namespace](https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/) inside your cluster
 * By adding `scrape: enabled: true` we add and enable autodiscovery scraping from kubernetes cluster to [VictoriaMetrics Single](https://docs.victoriametrics.com/single-server-victoriametrics/)
-* On line 166 from [https://docs.victoriametrics.com/guides/examples/guide-vmsingle-values.yaml](https://docs.victoriametrics.com/guides/examples/guide-vmsingle-values.yaml) we added `metric_relabel_configs` section that will help us to show Kubernetes metrics on Grafana dashboard.
+* On line 67 from [https://docs.victoriametrics.com/guides/examples/guide-vmsingle-values.yaml](https://docs.victoriametrics.com/guides/examples/guide-vmsingle-values.yaml) we added `metric_relabel_configs` section that will help us to show Kubernetes metrics on Grafana dashboard.
 
 
 As a result of the command you will see the following output:
 
 ```text
-NAME: victoria-metrics
-LAST DEPLOYED: Fri Jun 25 12:06:13 2021
+NAME: vmsingle
+LAST DEPLOYED: Fri Mar 21 11:50:39 2025
 NAMESPACE: default
 STATUS: deployed
 REVISION: 1
 TEST SUITE: None
 NOTES:
 The VictoriaMetrics write api can be accessed via port 8428 on the following DNS name from within your cluster:
-    vmsingle-victoria-metrics-single-server.default.svc.cluster.local
-
+    vmsingle-victoria-metrics-single-server.default.svc.cluster.local.
 
 Metrics Ingestion:
   Get the Victoria Metrics service URL by running these commands in the same shell:
-    export POD_NAME=$(kubectl get pods --namespace default -l "app=server" -o jsonpath="{.items[0].metadata.name}")
+    export POD_NAME=$(kubectl get pods --namespace default -l "app=" -o jsonpath="{.items[0].metadata.name}")
     kubectl --namespace default port-forward $POD_NAME 8428
 
-  Write url inside the kubernetes cluster:
-    http://vmsingle-victoria-metrics-single-server.default.svc.cluster.local:8428/api/v1/write
+  Write URL inside the kubernetes cluster:
+    http://vmsingle-victoria-metrics-single-server.default.svc.cluster.local.:8428/<protocol-specific-write-endpoint>
+
+  All supported write endpoints can be found at https://docs.victoriametrics.com/single-server-victoriametrics/#how-to-import-time-series-data
+
+  E.g: for Prometheus:
+    http://vmsingle-victoria-metrics-single-server.default.svc.cluster.local.:8428/api/v1/write
 
 Metrics Scrape:
   Pull-based scrapes are enabled
@@ -181,15 +189,14 @@ Metrics Scrape:
 
   The target’s information is accessible via api:
     Inside cluster:
-      http://vmsingle-victoria-metrics-single-server.default.svc.cluster.local:8428/targets
+      http://vmsingle-victoria-metrics-single-server.default.svc.cluster.local.:8428/targets
     Outside cluster:
       You need to port-forward service (see instructions above) and call
       http://<service-host-port>/targets
 
 Read Data:
-  The following url can be used as the datasource url in Grafana::
-    http://vmsingle-victoria-metrics-single-server.default.svc.cluster.local:8428
-
+  The following URL can be used as the datasource URL in Grafana::
+    http://vmsingle-victoria-metrics-single-server.default.svc.cluster.local.:8428
 ```
 
 For us it’s important to remember the url for the datasource (copy lines from output).


### PR DESCRIPTION
### Describe Your Changes

This pull request update some wording for the k8s guide here:
- [Kubernetes monitoring via VictoriaMetrics Single](https://docs.victoriametrics.com/guides/k8s-monitoring-via-vm-single)
- [Kubernetes monitoring with VictoriaMetrics Cluster](https://docs.victoriametrics.com/guides/k8s-monitoring-via-vm-cluster)
- [Getting started with VM Operator, ](https://docs.victoriametrics.com/guides/getting-started-with-vm-operator)

The change is based on executing the commands in guide and check the output diff.

### Checklist

The following checks are **mandatory**:

- [x] My change adheres [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/contributing/).
