### PR TITLE
vmagent: Sliding Window-Based Cleanup for LabelsCompressor

### DIFF
--- a/lib/promutils/labelscompressor.go
+++ b/lib/promutils/labelscompressor.go
@@ -284,8 +284,10 @@ func (lm *labelsMap) cleanup(labelToIdx *sync.Map) {
 		// TODO: test sync.MAP reduce memory on delete.
 		labelToIdx.Delete(lm.mutable[i])
 	}
-	pReadOnly.idxToLabels = append(pReadOnly.idxToLabels[:0], pReadOnly.idxToLabels[:diff]...)
-	pReadOnly.offset += diff
+	newReadOnlyLabelsMap := &readOnlyLabelsMap{}
+	newReadOnlyLabelsMap.idxToLabels = append(newReadOnlyLabelsMap.idxToLabels, pReadOnly.idxToLabels[:diff]...)
+	newReadOnlyLabelsMap.offset += diff
+	lm.readOnly.Store(newReadOnlyLabelsMap)
 
 	lm.cleanupScheduled.Store(false)
 	lm.mutableLock.Unlock()

--- a/lib/promutils/labelscompressor.go
+++ b/lib/promutils/labelscompressor.go
@@ -283,6 +283,7 @@ func (lm *labelsMap) cleanup(labelToIdx *sync.Map) {
 	for i := uint64(0); i < diff; i++ {
 		// TODO: test sync.MAP reduce memory on delete.
 		labelToIdx.Delete(lm.mutable[i])
+		delete(lm.mutable, i)
 	}
 	newReadOnlyLabelsMap := &readOnlyLabelsMap{}
 	newReadOnlyLabelsMap.idxToLabels = append(newReadOnlyLabelsMap.idxToLabels, pReadOnly.idxToLabels[:diff]...)


### PR DESCRIPTION
### Describe Your Changes

Fixes https://github.com/VictoriaMetrics/VictoriaMetrics/issues/7146

This is an early PoC aimed at gathering feedback and securing general approval before further investment. Many aspects still need to be addressed and validated through experiments.

I propose a sliding window approach to control `LabelsCompressor` size. This strategy introduces three distinct "time"-based windows to balance memory consumptions, compress\decompress performance, and the cleanup cost.

* Compression Reuse Window (The smallest):
  * Defines which idx values can be reused during compression.
  * If an idx falls within this window, the existing behavior is maintained—reusing or creating cached entries.
  * If an idx is outside this window, it is ignored, and a new record is created.

* Decompression Window (Larger than the compression one)
  * Controls which idx values can still be decompressed.
  * If an idx falls within this window, it returns the label.
  * If an idx is outside this window, it should never happen if window sizes are big enough.

* Cleanup Window
  * It grows backward and emptied once reaches the cleanup threshold.
  * The labels\idx are permanently removed. 
  * The cleanup updates offset and shift readOnly map.

![label-compressor-cleanup](https://github.com/user-attachments/assets/9879bde4-0423-4c3d-8012-c0adf69492f3)


Advantages
    * The approach avoids additional locks, maintaining existing performance characteristics.
    * The lm.readOnly slice growth is controlled, ensuring idx values remain near zero through an offset mechanism.
    * Cleanup is computationally cheap since we do not maintain any additional cleanup-related states and remove stuff in batches.
    * Should not introduce additional costs for low churn metrics. 

Potential Trade-offs
* Aggregate functions might produce incorrect results if an idx is rotated by the first window.
* The cleanup process may introduce a temporary "stop-the-world" effect, but this should be infrequent and negligible in most setups.

Since this is an early-stage proposal, further testing and validation are required to refine the approach. Feedback is highly appreciated.

### Checklist

The following checks are **mandatory**:

- [x] My change adheres [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/contributing/).
