### PR TITLE
docs: update /VictoriaLogs path in hugo to /victorialogs

### DIFF
--- a/docs/victorialogs/CHANGELOG.md
+++ b/docs/victorialogs/CHANGELOG.md
@@ -8,7 +8,7 @@ menu:
     weight: 7
     title: CHANGELOG
 aliases:
-- /VictoriaLogs/CHANGELOG.html
+- /victorialogs/CHANGELOG.html
 ---
 
 The following `tip` changes can be tested by building VictoriaLogs from the latest commit of [VictoriaMetrics](https://github.com/VictoriaMetrics/VictoriaMetrics/) repository

--- a/docs/victorialogs/FAQ.md
+++ b/docs/victorialogs/FAQ.md
@@ -8,8 +8,8 @@ menu:
     weight: 6
     title: FAQ
 aliases:
-- /VictoriaLogs/FAQ.html
-- /VictoriaLogs/faq.html
+- /victorialogs/FAQ.html
+- /victorialogs/faq.html
 ---
 
 ## Is VictoriaLogs ready for production use?

--- a/docs/victorialogs/LogsQL.md
+++ b/docs/victorialogs/LogsQL.md
@@ -6,7 +6,7 @@ menu:
     parent: "victorialogs"
     weight: 5
 aliases:
-- /VictoriaLogs/LogsQL.html
+- /victorialogs/LogsQL.html
 ---
 LogsQL is a simple yet powerful query language for [VictoriaLogs](https://docs.victoriametrics.com/victorialogs/).
 See [examples](https://docs.victoriametrics.com/victorialogs/logsql-examples/), [LogsQL tutorial](#logsql-tutorial)

--- a/docs/victorialogs/QuickStart.md
+++ b/docs/victorialogs/QuickStart.md
@@ -8,7 +8,7 @@ menu:
     weight: 1
     title: Quick Start
 aliases:
-- /VictoriaLogs/QuickStart.html
+- /victorialogs/QuickStart.html
 - /victorialogs/quick-start.html
 - /victorialogs/quick-start/
 ---

--- a/docs/victorialogs/Roadmap.md
+++ b/docs/victorialogs/Roadmap.md
@@ -8,7 +8,7 @@ menu:
     weight: 8
     title: Roadmap
 aliases:
-- /VictoriaLogs/Roadmap.html
+- /victorialogs/Roadmap.html
 ---
 The following functionality is available in [VictoriaLogs](https://docs.victoriametrics.com/victorialogs/):
 

--- a/docs/victorialogs/_index.md
+++ b/docs/victorialogs/_index.md
@@ -7,7 +7,7 @@ menu:
     identifier: victorialogs
     pageRef: /victorialogs/
 aliases:
-- /VictoriaLogs/
-- /VictoriaLogs/index.html
+- /victorialogs/
+- /victorialogs/index.html
 ---
 {{% content "README.md" %}}

--- a/docs/victorialogs/data-ingestion/DataDogAgent.md
+++ b/docs/victorialogs/data-ingestion/DataDogAgent.md
@@ -8,7 +8,7 @@ menu:
     weight: 5
 url: /victorialogs/data-ingestion/datadog-agent/
 aliases:
-  - /VictoriaLogs/data-ingestion/DataDogAgent.html
+  - /victorialogs/data-ingestion/DataDogAgent.html
 ---
 
 Datadog Agent doesn't support custom path prefix, so for this reason it's required to use [VMAuth](https://docs.victoriametrics.com/vmauth/) or any other
@@ -34,7 +34,7 @@ unauthorized_user:
       url_prefix: `<victoria-metrics-base-url>`/datadog/
 ```
 
-To start ingesting logs from DataDog agent please specify a custom URL instead of default one for sending collected logs to [VictoriaLogs](https://docs.victoriametrics.com/VictoriaLogs/):
+To start ingesting logs from DataDog agent please specify a custom URL instead of default one for sending collected logs to [VictoriaLogs](https://docs.victoriametrics.com/victorialogs/):
 
 ```yaml
 logs_enabled: true

--- a/docs/victorialogs/data-ingestion/Filebeat.md
+++ b/docs/victorialogs/data-ingestion/Filebeat.md
@@ -7,7 +7,6 @@ menu:
     parent: "victorialogs-data-ingestion"
     weight: 1
 aliases:
-  - /VictoriaLogs/data-ingestion/Filebeat.html
   - /victorialogs/data-ingestion/Filebeat.html
   - /victorialogs/data-ingestion/filebeat.html
 ---

--- a/docs/victorialogs/data-ingestion/Fluentbit.md
+++ b/docs/victorialogs/data-ingestion/Fluentbit.md
@@ -7,7 +7,6 @@ menu:
     parent: "victorialogs-data-ingestion"
     weight: 2
 aliases:
-  - /VictoriaLogs/data-ingestion/Fluentbit.html
   - /victorialogs/data-ingestion/fluentbit.html
   - /victorialogs/data-ingestion/Fluentbit.html
 ---

--- a/docs/victorialogs/data-ingestion/Fluentd.md
+++ b/docs/victorialogs/data-ingestion/Fluentd.md
@@ -7,7 +7,6 @@ menu:
     parent: "victorialogs-data-ingestion"
     weight: 2
 aliases:
-  - /VictoriaLogs/data-ingestion/Fluentd.html
   - /victorialogs/data-ingestion/fluentd.html
   - /victorialogs/data-ingestion/Fluentd.html
 ---

--- a/docs/victorialogs/data-ingestion/Journald.md
+++ b/docs/victorialogs/data-ingestion/Journald.md
@@ -7,7 +7,7 @@ menu:
     parent: "victorialogs-data-ingestion"
     weight: 10
 aliases:
-  - /VictoriaLogs/data-ingestion/Journald.html
+  - /victorialogs/data-ingestion/Journald.html
 ---
 On a client site which should already have journald please install additionally [systemd-journal-upload](https://www.freedesktop.org/software/systemd/man/latest/systemd-journal-upload.service.html) and edit `/etc/systemd/journal-upload.conf` and set `URL` to VictoriaLogs endpoint:
 

--- a/docs/victorialogs/data-ingestion/Logstash.md
+++ b/docs/victorialogs/data-ingestion/Logstash.md
@@ -7,7 +7,6 @@ menu:
     parent: "victorialogs-data-ingestion"
     weight: 3
 aliases:
-  - /VictoriaLogs/data-ingestion/Logstash.html
   - /victorialogs/data-ingestion/logstash.html
   - /victorialogs/data-ingestion/Logstash.html
 ---

--- a/docs/victorialogs/data-ingestion/Promtail.md
+++ b/docs/victorialogs/data-ingestion/Promtail.md
@@ -7,7 +7,6 @@ menu:
     parent: "victorialogs-data-ingestion"
     weight: 4
 aliases:
-  - /VictoriaLogs/data-ingestion/Promtail.html
   - /victorialogs/data-ingestion/Promtail.html
   - /victorialogs/data-ingestion/promtail.html
 ---

--- a/docs/victorialogs/data-ingestion/README.md
+++ b/docs/victorialogs/data-ingestion/README.md
@@ -337,5 +337,5 @@ Here is the list of log collectors and their ingestion formats supported by Vict
 | [Telegraf](https://docs.victoriametrics.com/victorialogs/data-ingestion/telegraf/) | [Yes](https://github.com/influxdata/telegraf/tree/master/plugins/outputs/elasticsearch) | [Yes](https://github.com/influxdata/telegraf/tree/master/plugins/outputs/http) | [Yes](https://github.com/influxdata/telegraf/tree/master/plugins/outputs/loki) | [Yes](https://github.com/influxdata/telegraf/blob/master/plugins/outputs/syslog) | Yes | No | No |
 | [Fluentd](https://docs.victoriametrics.com/victorialogs/data-ingestion/fluentd/) | [Yes](https://github.com/uken/fluent-plugin-elasticsearch) | [Yes](https://docs.fluentd.org/output/http) | [Yes](https://grafana.com/docs/loki/latest/send-data/fluentd/) | [Yes](https://github.com/fluent-plugins-nursery/fluent-plugin-remote_syslog) | No | No | No |
 | [Journald](https://docs.victoriametrics.com/victorialogs/data-ingestion/journald/) | No | No | No | No | No | Yes | No |
-| [DataDog Agent](https://docs.victoriametrics.com/VictoriaLogs/data-ingestion/datadog-agent) | No | No | No | No | No | No | Yes |
+| [DataDog Agent](https://docs.victoriametrics.com/victorialogs/data-ingestion/datadog-agent) | No | No | No | No | No | No | Yes |
 

--- a/docs/victorialogs/data-ingestion/Telegraf.md
+++ b/docs/victorialogs/data-ingestion/Telegraf.md
@@ -7,7 +7,7 @@ menu:
     parent: "victorialogs-data-ingestion"
     weight: 5
 aliases:
-  - /VictoriaLogs/data-ingestion/Telegraf.html
+  - /victorialogs/data-ingestion/Telegraf.html
 ---
 VictoriaLogs supports given below Telegraf outputs:
 - [Elasticsearch](#elasticsearch)

--- a/docs/victorialogs/data-ingestion/Vector.md
+++ b/docs/victorialogs/data-ingestion/Vector.md
@@ -7,7 +7,6 @@ menu:
     parent: "victorialogs-data-ingestion"
     weight: 20
 aliases:
-  - /VictoriaLogs/data-ingestion/Vector.html
   - /victorialogs/data-ingestion/Vector.html
   - /victorialogs/data-ingestion/vector.html
 ---

--- a/docs/victorialogs/data-ingestion/_index.md
+++ b/docs/victorialogs/data-ingestion/_index.md
@@ -7,7 +7,7 @@ menu:
     parent: "victorialogs"
     weight: 3
 aliases:
-  - /VictoriaLogs/data-ingestion/
-  - /VictoriaLogs/data-ingestion/index.html
+  - /victorialogs/data-ingestion/
+  - /victorialogs/data-ingestion/index.html
 ---
 {{% content "README.md" %}}

--- a/docs/victorialogs/data-ingestion/opentelemetry.md
+++ b/docs/victorialogs/data-ingestion/opentelemetry.md
@@ -7,7 +7,7 @@ menu:
     parent: "victorialogs-data-ingestion"
     weight: 4
 aliases:
-  - /VictoriaLogs/data-ingestion/OpenTelemetry.html
+  - /victorialogs/data-ingestion/OpenTelemetry.html
 ---
 VictoriaLogs supports both client open-telemetry [SDK](https://opentelemetry.io/docs/languages/) and [collector](https://opentelemetry.io/docs/collector/).
 
@@ -38,7 +38,7 @@ logExporter, err := otlploghttp.New(ctx,
 
 VictoriaLogs supports other HTTP headers - see the list [here](https://docs.victoriametrics.com/victorialogs/data-ingestion/#http-headers).
 
-The ingested log entries can be queried according to [these docs](https://docs.victoriametrics.com/VictoriaLogs/querying/).
+The ingested log entries can be queried according to [these docs](https://docs.victoriametrics.com/victorialogs/querying/).
 
 ## Collector configuration
 

--- a/docs/victorialogs/keyConcepts.md
+++ b/docs/victorialogs/keyConcepts.md
@@ -8,7 +8,7 @@ menu:
     weight: 2
     title: Key concepts
 aliases:
-- /VictoriaLogs/keyConcepts.html
+- /victorialogs/keyConcepts.html
 ---
 ## Data model
 

--- a/docs/victorialogs/querying/_index.md
+++ b/docs/victorialogs/querying/_index.md
@@ -7,7 +7,7 @@ menu:
     parent: "victorialogs"
     weight: 4
 aliases:
-  - /VictoriaLogs/querying/
-  - /VictoriaLogs/querying/index.html
+  - /victorialogs/querying/
+  - /victorialogs/querying/index.html
 ---
 {{% content "README.md" %}}

--- a/docs/victorialogs/vmalert.md
+++ b/docs/victorialogs/vmalert.md
@@ -7,7 +7,7 @@ menu:
     weight: 10
     identifier: "victorialogs-vmalert"
 aliases:
-- /VictoriaLogs/vmalert.html
+- /victorialogs/vmalert.html
 ---
 
 [vmalert](https://docs.victoriametrics.com/vmalert/){{% available_from "v1.106.0" %}} integrates with VictoriaLogs {{% available_from "v0.36.0" "logs" %}} via stats APIs [`/select/logsql/stats_query`](https://docs.victoriametrics.com/victorialogs/querying/#querying-log-stats)


### PR DESCRIPTION
### Describe Your Changes

replace /VictoriaLogs aliases to /victorialogs as generated directories are anyway renamed to victorialogs before deployment

need to merge this PR immediately after https://github.com/VictoriaMetrics/vmdocs/pull/116

### Checklist

The following checks are **mandatory**:

- [ ] My change adheres [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/contributing/).
