### PR TITLE
lib/promrelabel/debug: make metric name easier to distinguish from labels

### DIFF
--- a/lib/promrelabel/debug.qtpl
+++ b/lib/promrelabel/debug.qtpl
@@ -185,7 +185,7 @@ function submitRelabelDebugForm(e) {
                 {% else %}
                         {%s metricName %}
                 {% endif %}
-                {% if len(labelsList) == 0 %}{% return %}{% endif %}
+                {% if len(labelsList) == 0 %}{}{% return %}{% endif %}
         {% endif %}
 {
         {% for i, label := range labelsList %}
@@ -201,7 +201,7 @@ function submitRelabelDebugForm(e) {
 
 {% func mustFormatLabels(s string) %}
         {% code labels := promutil.MustNewLabelsFromString(s) %}
-        {%= labelsWithHighlight(labels, nil, "") %}
+        {%= labelsWithHighlight(labels, map[string]struct{}{"__name__": {}}, "") %}
 {% endfunc %}
 
 {% endstripspace %}

--- a/lib/promrelabel/debug.qtpl.go
+++ b/lib/promrelabel/debug.qtpl.go
@@ -465,6 +465,8 @@ func streamlabelsWithHighlight(qw422016 *qt422016.Writer, labels *promutil.Label
 //line lib/promrelabel/debug.qtpl:188
 		if len(labelsList) == 0 {
 //line lib/promrelabel/debug.qtpl:188
+			qw422016.N().S(`{}`)
+//line lib/promrelabel/debug.qtpl:188
 			return
 //line lib/promrelabel/debug.qtpl:188
 		}
@@ -547,7 +549,7 @@ func streammustFormatLabels(qw422016 *qt422016.Writer, s string) {
 	labels := promutil.MustNewLabelsFromString(s)
 
 //line lib/promrelabel/debug.qtpl:204
-	streamlabelsWithHighlight(qw422016, labels, nil, "")
+	streamlabelsWithHighlight(qw422016, labels, map[string]struct{}{"__name__": {}}, "")
 //line lib/promrelabel/debug.qtpl:205
 }
 


### PR DESCRIPTION
### Describe Your Changes

Previously, users could get confused in cases when metric name which is valid for MetricsQL but not valid for Prom was used in relabeling debug. See #8584 for example.

This adds highlight to a metric name and prints empty labels set in order to explicitly show metric name and set of labels.

<details>
<summary>Before</summary>

![image](https://github.com/user-attachments/assets/33cfcd6b-dcde-4c43-a88d-28d368d16d77)

</details>


<details>
<summary>After</summary>

![image](https://github.com/user-attachments/assets/d4e7c997-d51e-4302-9950-8cdf36cf0ab3)

</details>


### Checklist

The following checks are **mandatory**:

- [x] My change adheres [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/contributing/).
