### PR TITLE
lib/promscrape: support filtering targets via `scrapePool` GET param in `/api/v1/targets` API

### DIFF
--- a/app/vmagent/main.go
+++ b/app/vmagent/main.go
@@ -443,8 +443,10 @@ func requestHandler(w http.ResponseWriter, r *http.Request) bool {
 	case "/prometheus/api/v1/targets", "/api/v1/targets":
 		promscrapeAPIV1TargetsRequests.Inc()
 		w.Header().Set("Content-Type", "application/json")
+		// https://prometheus.io/docs/prometheus/latest/querying/api/#targets
 		state := r.FormValue("state")
-		promscrape.WriteAPIV1Targets(w, state)
+		scrapePool := r.FormValue("scrapePool")
+		promscrape.WriteAPIV1Targets(w, state, scrapePool)
 		return true
 	case "/prometheus/target_response", "/target_response":
 		promscrapeTargetResponseRequests.Inc()

--- a/app/vminsert/main.go
+++ b/app/vminsert/main.go
@@ -320,8 +320,10 @@ func RequestHandler(w http.ResponseWriter, r *http.Request) bool {
 	case "/prometheus/api/v1/targets", "/api/v1/targets":
 		promscrapeAPIV1TargetsRequests.Inc()
 		w.Header().Set("Content-Type", "application/json")
+		// https://prometheus.io/docs/prometheus/latest/querying/api/#targets
 		state := r.FormValue("state")
-		promscrape.WriteAPIV1Targets(w, state)
+		scrapePool := r.FormValue("scrapePool")
+		promscrape.WriteAPIV1Targets(w, state, scrapePool)
 		return true
 	case "/prometheus/target_response", "/target_response":
 		promscrapeTargetResponseRequests.Inc()

--- a/docs/victoriametrics/changelog/CHANGELOG.md
+++ b/docs/victoriametrics/changelog/CHANGELOG.md
@@ -19,6 +19,7 @@ See also [LTS releases](https://docs.victoriametrics.com/lts-releases/).
 ## tip
 
 * FEATURE: [dashboards/single](https://grafana.com/grafana/dashboards/10229), [dashboards/cluster](https://grafana.com/grafana/dashboards/11176): remove panel `Storage full ETA` as it could have showing incorrect predictions and result in user's confusion. See more details in [this PR](https://github.com/VictoriaMetrics/VictoriaMetrics/pull/8492).
+* FEATURE: [vmsingle](https://docs.victoriametrics.com/single-server-victoriametrics/), vmagent](https://docs.victoriametrics.com/vmagent/): support filtering targets via `scrapePool` GET param in `/api/v1/targets` API.
 
 ## [v1.114.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.114.0)
 

--- a/lib/promscrape/targetstatus_test.go
+++ b/lib/promscrape/targetstatus_test.go
@@ -1,0 +1,43 @@
+package promscrape
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/promutil"
+)
+
+func TestWriteActiveTargetsJSON(t *testing.T) {
+	tsm := newTargetStatusMap()
+	tsm.Register(&scrapeWork{
+		Config: &ScrapeWork{
+			jobNameOriginal: "foo",
+			OriginalLabels: promutil.NewLabelsFromMap(map[string]string{
+				"__address__": "host1:80",
+			}),
+		},
+	})
+	tsm.Register(&scrapeWork{
+		Config: &ScrapeWork{
+			jobNameOriginal: "bar",
+			OriginalLabels: promutil.NewLabelsFromMap(map[string]string{
+				"__address__": "host2:80",
+			}),
+		},
+	})
+
+	f := func(scrapePoolFilter, exp string) {
+		t.Helper()
+		b := &bytes.Buffer{}
+		tsm.WriteActiveTargetsJSON(b, scrapePoolFilter)
+		got := b.String()
+		if got != exp {
+			t.Fatalf("unexpected response; \ngot\n %s; \nwant\n %s", got, exp)
+		}
+	}
+
+	f("", `[{"discoveredLabels":{"__address__":"host1:80"},"labels":{},"scrapePool":"foo","scrapeUrl":"","lastError":"","lastScrape":"1970-01-01T01:00:00+01:00","lastScrapeDuration":0,"lastSamplesScraped":0,"health":"down"},{"discoveredLabels":{"__address__":"host2:80"},"labels":{},"scrapePool":"bar","scrapeUrl":"","lastError":"","lastScrape":"1970-01-01T01:00:00+01:00","lastScrapeDuration":0,"lastSamplesScraped":0,"health":"down"}]`)
+	f("foo", `[{"discoveredLabels":{"__address__":"host1:80"},"labels":{},"scrapePool":"foo","scrapeUrl":"","lastError":"","lastScrape":"1970-01-01T01:00:00+01:00","lastScrapeDuration":0,"lastSamplesScraped":0,"health":"down"}]`)
+	f("bar", `[{"discoveredLabels":{"__address__":"host2:80"},"labels":{},"scrapePool":"bar","scrapeUrl":"","lastError":"","lastScrape":"1970-01-01T01:00:00+01:00","lastScrapeDuration":0,"lastSamplesScraped":0,"health":"down"}]`)
+	f("unknown", `[]`)
+}


### PR DESCRIPTION
This improves compatibility with Prometheus `/api/v1/targets` API.
