### PR TITLE
vmui/logs: fix incorrect table sorting for numeric

### DIFF
--- a/app/vmui/packages/vmui/src/components/Configurators/QueryEditor/QueryEditorAutocomplete.tsx
+++ b/app/vmui/packages/vmui/src/components/Configurators/QueryEditor/QueryEditorAutocomplete.tsx
@@ -1,7 +1,6 @@
 import React, { FC, useState, useEffect, useMemo, useCallback } from "preact/compat";
 import Autocomplete from "../../Main/Autocomplete/Autocomplete";
 import { useFetchQueryOptions } from "../../../hooks/useFetchQueryOptions";
-import { escapeRegexp, hasUnclosedQuotes } from "../../../utils/regexp";
 import useGetMetricsQL from "../../../hooks/useGetMetricsQL";
 import { QueryContextType } from "../../../types";
 import { AUTOCOMPLETE_LIMITS } from "../../../constants/queryAutocomplete";

--- a/app/vmui/packages/vmui/src/components/Configurators/QueryEditor/autocompleteUtils.ts
+++ b/app/vmui/packages/vmui/src/components/Configurators/QueryEditor/autocompleteUtils.ts
@@ -85,7 +85,7 @@ export function getContext(
   );
   const endOfClosedQuotes =
     !hasUnclosedQuotes(valueBeforeCursor) &&
-    ["`", "'", '"'].some((char) => valueBeforeCursor.endsWith(char));
+    ["`", "'", "\""].some((char) => valueBeforeCursor.endsWith(char));
   if (
     !valueBeforeCursor ||
     endOfClosedBrackets ||

--- a/app/vmui/packages/vmui/src/components/Table/helpers.test.ts
+++ b/app/vmui/packages/vmui/src/components/Table/helpers.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import { descendingComparator } from "./helpers";
+import { getNanoTimestamp } from "../../utils/time"; // используем реальную реализацию
+
+describe("descendingComparator", () => {
+  it("returns 0 for equal numbers", () => {
+    const result = descendingComparator({ value: 42 }, { value: 42 }, "value");
+    expect(result).toBe(0);
+  });
+
+  it("sorts numbers descending", () => {
+    const result = descendingComparator({ value: 100 }, { value: 50 }, "value");
+    expect(result).toBeLessThan(0);
+  });
+
+  it("sorts null below any value", () => {
+    expect(descendingComparator({ value: null }, { value: 10 }, "value")).toBe(1);
+    expect(descendingComparator({ value: 10 }, { value: null }, "value")).toBe(-1);
+    expect(descendingComparator({ value: null }, { value: null }, "value")).toBe(0);
+  });
+
+  it("sorts strings descending", () => {
+    const result = descendingComparator({ name: "zzz" }, { name: "aaa" }, "name");
+    expect(result).toBe(-1);
+  });
+
+  it("sorts numeric strings as numbers when possible", () => {
+    const result = descendingComparator({ value: "200" }, { value: "50" }, "value");
+    expect(result).toBeLessThan(0);
+  });
+
+  it("sorts date strings via getNanoTimestamp", () => {
+    const a = { timestamp: "2024-01-01T00:00:00.200Z" };
+    const b = { timestamp: "2023-01-01T00:00:00.100Z" };
+
+    const nanoA = getNanoTimestamp(a.timestamp);
+    const nanoB = getNanoTimestamp(b.timestamp);
+    expect(nanoA).toBeGreaterThan(nanoB);
+
+    const result = descendingComparator(a, b, "timestamp");
+    expect(result).toBe(-1);
+  });
+
+  it("handles booleans and undefined safely", () => {
+    expect(descendingComparator({ value: true }, { value: false }, "value")).toBe(-1);
+    expect(descendingComparator({ value: undefined }, { value: false }, "value")).toBe(1);
+  });
+});

--- a/app/vmui/packages/vmui/src/components/Table/helpers.ts
+++ b/app/vmui/packages/vmui/src/components/Table/helpers.ts
@@ -6,11 +6,38 @@ const dateColumns = ["date", "timestamp", "time"];
 export function descendingComparator<T>(a: T, b: T, orderBy: keyof T) {
   const valueA = a[orderBy];
   const valueB = b[orderBy];
-  const parsedValueA = dateColumns.includes(String(orderBy)) ? getNanoTimestamp(`${valueA}`) : valueA;
-  const parsedValueB = dateColumns.includes(String(orderBy)) ? getNanoTimestamp(`${valueB}`) : valueB;
 
-  if (parsedValueB < parsedValueA) return -1;
-  if (parsedValueB > parsedValueA) return 1;
+  // null/undefined
+  if (valueA == null && valueB == null) return 0;
+  if (valueA == null) return 1;
+  if (valueB == null) return -1;
+
+  const strA = String(valueA);
+  const strB = String(valueB);
+
+  // Dates
+  const isDate = dateColumns.includes(String(orderBy));
+  if (isDate) {
+    const timeA = getNanoTimestamp(strA);
+    const timeB = getNanoTimestamp(strB);
+
+    if (timeB < timeA) return -1;
+    if (timeB > timeA) return 1;
+    return 0;
+  }
+
+  // Numbers
+  const numA = Number(strA);
+  const numB = Number(strB);
+  const isNumeric = !isNaN(numA) && !isNaN(numB);
+
+  if (isNumeric) {
+    return numB - numA;
+  }
+
+  // Strings
+  if (strB < strA) return -1;
+  if (strB > strA) return 1;
   return 0;
 }
 

--- a/docs/victorialogs/CHANGELOG.md
+++ b/docs/victorialogs/CHANGELOG.md
@@ -20,6 +20,7 @@ according to [these docs](https://docs.victoriametrics.com/victorialogs/quicksta
 
 * BUGFIX: [web UI](https://docs.victoriametrics.com/victorialogs/querying/#web-ui): fix endless group expansion loop bug. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8347).
 * BUGFIX: [web UI](https://docs.victoriametrics.com/victorialogs/querying/#web-ui): respect nanosecond precision when sorting logs. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8346).
+* BUGFIX: [web UI](https://docs.victoriametrics.com/victorialogs/querying/#web-ui): fix incorrect table sorting for numeric columns. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8606).
 
 ## [v1.17.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.17.0-victorialogs)
 


### PR DESCRIPTION
### Describe Your Changes

Fixed table sorting logic and added unit tests for descendingComparator.
Values are now correctly sorted by type: number, date, or string.

Related issue: #8606

### Checklist

The following checks are **mandatory**:

- [ ] My change adheres [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/contributing/).
