### PR TITLE
lib/backup/s3: properly set ProfileName

### DIFF
--- a/docs/victoriametrics/changelog/CHANGELOG.md
+++ b/docs/victoriametrics/changelog/CHANGELOG.md
@@ -18,6 +18,8 @@ See also [LTS releases](https://docs.victoriametrics.com/lts-releases/).
 
 ## tip
 
+* BUGFIX: [vmbackup](https://docs.victoriametrics.com/vmbackup/) and [vmbackupmanager](https://docs.victoriametrics.com/vmbackupmanager/): properly configure s3 client with if `configFilePath` is set. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8668) for details.
+
 ## [v1.115.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.115.0)
 
 Released at 2025-04-04

--- a/lib/backup/s3remote/s3.go
+++ b/lib/backup/s3remote/s3.go
@@ -98,7 +98,6 @@ func (fs *FS) Init() error {
 		fs.Dir += "/"
 	}
 	configOpts := []func(*config.LoadOptions) error{
-		config.WithSharedConfigProfile(fs.ProfileName),
 		config.WithDefaultRegion("us-east-1"),
 		config.WithRetryer(func() aws.Retryer {
 			return retry.NewStandard(func(o *retry.StandardOptions) {
@@ -113,6 +112,9 @@ func (fs *FS) Init() error {
 		}),
 	}
 
+	if len(fs.ProfileName) > 0 {
+		configOpts = append(configOpts, config.WithSharedConfigProfile(fs.ProfileName))
+	}
 	if len(fs.ConfigFilePath) > 0 {
 		configOpts = append(configOpts, config.WithSharedConfigFiles([]string{
 			fs.ConfigFilePath,


### PR DESCRIPTION
Previously, if ProfileName is set to empty value (as default). AWS s3 lib ignored any profile config defined with `-configProfilePath`.

 This commit correctly configure client options and set profile name only if it's set to non-empty value.

Related issue:
https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8668
