### PR TITLE
make: fix `make package` for vmalert-tool

### DIFF
--- a/app/vmalert-tool/deployment/Dockerfile
+++ b/app/vmalert-tool/deployment/Dockerfile
@@ -1,0 +1,8 @@
+ARG base_image=non-existing
+FROM $base_image
+
+EXPOSE 8880
+
+ENTRYPOINT ["/vmalert-tool-prod"]
+ARG src_binary=non-existing
+COPY $src_binary ./vmalert-tool-prod


### PR DESCRIPTION
### Describe Your Changes

`make package` relies on presence of `APP_NAME/deployment/Dockerfile` which was missing for vmalert-tool.

### Checklist

The following checks are **mandatory**:

- [x] My change adheres [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/contributing/).
