### PR TITLE
app/vmui: fix mobile layout on the VictoriaLogs page, fix width of groups and table settings modal

### DIFF
--- a/app/vmui/packages/vmui/src/components/LogsConfigurators/GroupLogsConfigurators/style.scss
+++ b/app/vmui/packages/vmui/src/components/LogsConfigurators/GroupLogsConfigurators/style.scss
@@ -4,7 +4,7 @@
   display: grid;
   gap: calc($padding-large * 2);
   padding: $padding-global 0;
-  width: 600px;
+  max-width: 600px;
 
   &-item {
     display: grid;

--- a/app/vmui/packages/vmui/src/components/Table/TableSettings/style.scss
+++ b/app/vmui/packages/vmui/src/components/Table/TableSettings/style.scss
@@ -37,6 +37,10 @@
         overflow: auto;
         margin-bottom: $padding-global;
 
+        @media(max-width: 500px) {
+          width: 100vw;
+        }
+
         &__item {
           width: 100%;
           font-size: $font-size;

--- a/app/vmui/packages/vmui/src/layouts/Header/style.scss
+++ b/app/vmui/packages/vmui/src/layouts/Header/style.scss
@@ -58,8 +58,8 @@
     }
 
     &_mobile {
-      max-width: 65px;
-      min-width: 65px;
+      max-width: 75px;
+      min-width: 75px;
       margin: 0 auto;
     }
   }

--- a/app/vmui/packages/vmui/src/pages/ExploreLogs/ExploreLogsBody/ExploreLogsBody.tsx
+++ b/app/vmui/packages/vmui/src/pages/ExploreLogs/ExploreLogsBody/ExploreLogsBody.tsx
@@ -84,7 +84,12 @@ const ExploreLogsBody: FC<ExploreLogBodyProps> = ({ data, isLoading }) => {
           "vm-explore-logs-body-header_mobile": isMobile,
         })}
       >
-        <div className="vm-section-header__tabs">
+        <div
+          className={classNames({
+            "vm-section-header__tabs": true,
+            "vm-explore-logs-body-header__tabs_mobile": isMobile,
+          })}
+        >
           <Tabs
             activeItem={String(activeTab)}
             items={tabs}

--- a/app/vmui/packages/vmui/src/pages/ExploreLogs/ExploreLogsBody/style.scss
+++ b/app/vmui/packages/vmui/src/pages/ExploreLogs/ExploreLogsBody/style.scss
@@ -8,12 +8,15 @@
 
     &_mobile {
       margin: -$padding-global 0-$padding-global 0;
+      display: block;
+      border-bottom: none;
     }
 
     &__settings {
       display: flex;
       align-items: center;
       gap: $padding-small;
+      justify-content: flex-end;
     }
 
     &__table-settings {
@@ -27,6 +30,12 @@
       padding-right: $padding-large;
       color: $color-text-secondary;
       font-size: $font-size-small;
+    }
+
+    &__tabs {
+      &_mobile {
+        border-bottom: var(--border-divider);
+      }
     }
   }
 
@@ -50,6 +59,7 @@
 
     &_mobile {
       width: calc(100vw - ($padding-global * 2) - var(--scrollbar-width));
+      padding-top: $padding-large;
     }
 
     .vm-table {

--- a/app/vmui/packages/vmui/src/pages/ExploreLogs/GroupLogs/GroupLogs.tsx
+++ b/app/vmui/packages/vmui/src/pages/ExploreLogs/GroupLogs/GroupLogs.tsx
@@ -18,6 +18,7 @@ import SelectLimit from "../../../components/Main/Pagination/SelectLimit/SelectL
 import { usePaginateGroups } from "../hooks/usePaginateGroups";
 import { GroupLogsType } from "../../../types";
 import { getNanoTimestamp } from "../../../utils/time";
+import useDeviceDetect from "../../../hooks/useDeviceDetect";
 import DownloadLogsButton from "../DownloadLogsButton/DownloadLogsButton";
 
 interface Props {
@@ -26,6 +27,7 @@ interface Props {
 }
 
 const GroupLogs: FC<Props> = ({ logs, settingsRef }) => {
+  const { isMobile } = useDeviceDetect();
   const [searchParams, setSearchParams] = useSearchParams();
 
   const [page, setPage] = useState(1);
@@ -95,7 +97,7 @@ const GroupLogs: FC<Props> = ({ logs, settingsRef }) => {
   };
 
   useEffect(() => {
-    setExpandGroups(new Array(groupData.length).fill(true));
+    setExpandGroups(new Array(groupData.length).fill(!isMobile));
   }, [groupData]);
 
   useEffect(() => {

--- a/docs/victorialogs/CHANGELOG.md
+++ b/docs/victorialogs/CHANGELOG.md
@@ -30,6 +30,7 @@ Released at 2025-04-10
 
 * BUGFIX: [web UI](https://docs.victoriametrics.com/victorialogs/querying/#web-ui): fix endless group expansion loop bug. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8347).
 * BUGFIX: [web UI](https://docs.victoriametrics.com/victorialogs/querying/#web-ui): respect nanosecond precision when sorting logs. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8346).
+* BUGFIX: [web UI](https://docs.victoriametrics.com/victorialogs/querying/#web-ui): fix mobile layout on the VictoriaLogs page, fix width of groups and table settings modal.
 
 ## [v1.17.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.17.0-victorialogs)
 

--- a/docs/victorialogs/CHANGELOG.md
+++ b/docs/victorialogs/CHANGELOG.md
@@ -17,6 +17,7 @@ according to [these docs](https://docs.victoriametrics.com/victorialogs/quicksta
 ## tip
 
 * FEATURE: [web UI](https://docs.victoriametrics.com/victorialogs/querying/#web-ui): add button for downloading displayed logs. It supports downloading in the following formats: csv, json. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8604).
+* FEATURE: [web UI](https://docs.victoriametrics.com/victorialogs/querying/#web-ui): optimize vmui for mobile layout to use space more efficiently.
 
 ## [v1.18.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.18.0-victorialogs)
 
@@ -30,7 +31,6 @@ Released at 2025-04-10
 
 * BUGFIX: [web UI](https://docs.victoriametrics.com/victorialogs/querying/#web-ui): fix endless group expansion loop bug. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8347).
 * BUGFIX: [web UI](https://docs.victoriametrics.com/victorialogs/querying/#web-ui): respect nanosecond precision when sorting logs. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8346).
-* BUGFIX: [web UI](https://docs.victoriametrics.com/victorialogs/querying/#web-ui): fix mobile layout on the VictoriaLogs page, fix width of groups and table settings modal.
 
 ## [v1.17.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.17.0-victorialogs)
 


### PR DESCRIPTION
### Describe Your Changes
 - Fix mobile layout on the VictoriaLogs page
<img width="361" alt="image" src="https://github.com/user-attachments/assets/2e09b999-34d5-4059-ba09-95a21b3e8ab3" />
<img width="353" alt="image" src="https://github.com/user-attachments/assets/b9048d41-5972-4290-988f-e9b0a0472b99" />
 
- Fix width of groups settings modal
<img width="372" alt="image" src="https://github.com/user-attachments/assets/e1cb1902-dc93-4bfd-8b32-eaf0d8e54253" />
<img width="352" alt="image" src="https://github.com/user-attachments/assets/a7c7000f-2c4a-41d9-a3c1-a515fd077b9b" />

- Fix width of table settings modal
<img width="361" alt="image" src="https://github.com/user-attachments/assets/12921936-6824-47e9-aff8-d0bb4de2e7f7" />
<img width="352" alt="image" src="https://github.com/user-attachments/assets/77c857ee-85f4-4992-8113-4e252b40f1a6" />

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/contributing/).
