### PR TITLE
lib/metricnamestats: add new matchNames stats query filter

### DIFF
--- a/app/vmselect/clusternative/vmselect.go
+++ b/app/vmselect/clusternative/vmselect.go
@@ -117,9 +117,9 @@ func (api *vmstorageAPI) ResetMetricNamesUsageStats(qt *querytracer.Tracer, dead
 	return netstorage.ResetMetricNamesStats(qt, dl)
 }
 
-func (api *vmstorageAPI) GetMetricNamesUsageStats(qt *querytracer.Tracer, sq storage.MetricNamesStatsQuery, deadline uint64) (storage.MetricNamesStatsResponse, error) {
+func (api *vmstorageAPI) GetMetricNamesUsageStats(qt *querytracer.Tracer, statsQuery storage.MetricNamesStatsQuery, deadline uint64) (storage.MetricNamesStatsResponse, error) {
 	dl := searchutil.DeadlineFromTimestamp(deadline)
-	return netstorage.GetMetricNamesStats(qt, sq, dl)
+	return netstorage.GetMetricNamesStats(qt, statsQuery, dl)
 }
 
 // blockIterator implements vmselectapi.BlockIterator

--- a/app/vmselect/clusternative/vmselect.go
+++ b/app/vmselect/clusternative/vmselect.go
@@ -117,9 +117,9 @@ func (api *vmstorageAPI) ResetMetricNamesUsageStats(qt *querytracer.Tracer, dead
 	return netstorage.ResetMetricNamesStats(qt, dl)
 }
 
-func (api *vmstorageAPI) GetMetricNamesUsageStats(qt *querytracer.Tracer, tt *storage.TenantToken, le, limit int, matchPattern string, deadline uint64) (storage.MetricNamesStatsResponse, error) {
+func (api *vmstorageAPI) GetMetricNamesUsageStats(qt *querytracer.Tracer, sq storage.MetricNamesStatsQuery, deadline uint64) (storage.MetricNamesStatsResponse, error) {
 	dl := searchutil.DeadlineFromTimestamp(deadline)
-	return netstorage.GetMetricNamesStats(qt, tt, le, limit, matchPattern, dl)
+	return netstorage.GetMetricNamesStats(qt, sq, dl)
 }
 
 // blockIterator implements vmselectapi.BlockIterator

--- a/app/vmselect/netstorage/netstorage.go
+++ b/app/vmselect/netstorage/netstorage.go
@@ -3382,8 +3382,6 @@ func (sn *storageNode) processGetMetricNamesStats(qt *querytracer.Tracer, sq sto
 	return result, nil
 }
 
-const maxStatsQuerySize = 1024 * 1024
-
 func processGetMetricNamesUsageStatsOnConn(bc *handshake.BufferedConn, sq storage.MetricNamesStatsQuery) (storage.MetricNamesStatsResponse, error) {
 	var result storage.MetricNamesStatsResponse
 

--- a/app/vmselect/stats/stats.go
+++ b/app/vmselect/stats/stats.go
@@ -45,7 +45,18 @@ func MetricNamesStatsHandler(startTime time.Time, at *auth.Token, qt *querytrace
 			ProjectID: at.ProjectID,
 		}
 	}
-	stats, err := netstorage.GetMetricNamesStats(qt, tt, limit, le, matchPattern, deadline)
+	matchNames := r.Form["match_names"]
+	sq := storage.MetricNamesStatsQuery{
+		TenantToken:  tt,
+		Limit:        limit,
+		Le:           le,
+		MatchNames:   matchNames,
+		MatchPattern: matchPattern,
+	}
+	if limit > 0 && len(matchNames) > limit {
+		return fmt.Errorf("match_names len=%d cannot exceed limit=%d", len(matchNames), limit)
+	}
+	stats, err := netstorage.GetMetricNamesStats(qt, sq, deadline)
 	if err != nil {
 		return err
 	}

--- a/app/vmselect/stats/stats.go
+++ b/app/vmselect/stats/stats.go
@@ -46,7 +46,7 @@ func MetricNamesStatsHandler(startTime time.Time, at *auth.Token, qt *querytrace
 		}
 	}
 	matchNames := r.Form["match_names"]
-	sq := storage.MetricNamesStatsQuery{
+	statsQuery := storage.MetricNamesStatsQuery{
 		TenantToken:  tt,
 		Limit:        limit,
 		Le:           le,
@@ -56,7 +56,7 @@ func MetricNamesStatsHandler(startTime time.Time, at *auth.Token, qt *querytrace
 	if limit > 0 && len(matchNames) > limit {
 		return fmt.Errorf("match_names len=%d cannot exceed limit=%d", len(matchNames), limit)
 	}
-	stats, err := netstorage.GetMetricNamesStats(qt, sq, deadline)
+	stats, err := netstorage.GetMetricNamesStats(qt, statsQuery, deadline)
 	if err != nil {
 		return err
 	}

--- a/app/vmstorage/servers/vmselect.go
+++ b/app/vmstorage/servers/vmselect.go
@@ -195,8 +195,8 @@ func (api *vmstorageAPI) RegisterMetricNames(qt *querytracer.Tracer, mrs []stora
 	return nil
 }
 
-func (api *vmstorageAPI) GetMetricNamesUsageStats(qt *querytracer.Tracer, sq storage.MetricNamesStatsQuery, _ uint64) (storage.MetricNamesStatsResponse, error) {
-	return api.s.GetMetricNamesStats(qt, sq), nil
+func (api *vmstorageAPI) GetMetricNamesUsageStats(qt *querytracer.Tracer, statsQuery storage.MetricNamesStatsQuery, _ uint64) (storage.MetricNamesStatsResponse, error) {
+	return api.s.GetMetricNamesStats(qt, statsQuery), nil
 }
 
 func (api *vmstorageAPI) ResetMetricNamesUsageStats(qt *querytracer.Tracer, _ uint64) error {

--- a/app/vmstorage/servers/vmselect.go
+++ b/app/vmstorage/servers/vmselect.go
@@ -195,8 +195,8 @@ func (api *vmstorageAPI) RegisterMetricNames(qt *querytracer.Tracer, mrs []stora
 	return nil
 }
 
-func (api *vmstorageAPI) GetMetricNamesUsageStats(qt *querytracer.Tracer, tt *storage.TenantToken, limit, le int, matchPattern string, _ uint64) (storage.MetricNamesStatsResponse, error) {
-	return api.s.GetMetricNamesStats(qt, tt, limit, le, matchPattern), nil
+func (api *vmstorageAPI) GetMetricNamesUsageStats(qt *querytracer.Tracer, sq storage.MetricNamesStatsQuery, _ uint64) (storage.MetricNamesStatsResponse, error) {
+	return api.s.GetMetricNamesStats(qt, sq), nil
 }
 
 func (api *vmstorageAPI) ResetMetricNamesUsageStats(qt *querytracer.Tracer, _ uint64) error {

--- a/apptest/vmselect.go
+++ b/apptest/vmselect.go
@@ -139,13 +139,16 @@ func (app *Vmselect) DeleteSeries(t *testing.T, matchQuery string, opts QueryOpt
 // and returns the statistics response for given params.
 //
 // See https://docs.victoriametrics.com/#Trackingestedmetricsusage
-func (app *Vmselect) MetricNamesStats(t *testing.T, limit, le, matchPattern string, opts QueryOpts) MetricNamesStatsResponse {
+func (app *Vmselect) MetricNamesStats(t *testing.T, limit, le, matchPattern string, matchNames []string, opts QueryOpts) MetricNamesStatsResponse {
 	t.Helper()
 
 	values := opts.asURLValues()
 	values.Add("limit", limit)
 	values.Add("le", le)
 	values.Add("match_pattern", matchPattern)
+	for _, mn := range matchNames {
+		values.Add("match_names", mn)
+	}
 	queryURL := fmt.Sprintf("http://%s/select/%s/prometheus/api/v1/status/metric_names_stats", app.httpListenAddr, opts.getTenant())
 
 	res, statusCode := app.cli.PostForm(t, queryURL, values)

--- a/docs/victoriametrics/README.md
+++ b/docs/victoriametrics/README.md
@@ -483,6 +483,7 @@ To get metric names usage statistics, use the `/prometheus/api/v1/status/metric_
 * `limit` - integer value to limit the number of metric names in response. By default, API returns 1000 records.
 * `le` -  `less than or equal`, is an integer threshold for filtering metric names by their usage count in queries. For example, with `?le=1` API returns metric names that were queried <=1 times.
 * `match_pattern` - a substring pattern to match metric names. For example, `?match_pattern=vm_` will match any metric names with `vm_` pattern, like `vm_http_requests`, `max_vm_memory_available`. It doesn't support regex syntax.
+* `match_names` - a list of metric names to query. If this param is defined, `le` and `match_pattern` options will be ignored.
 
  The API endpoint returns the following `JSON` response:
 

--- a/docs/victoriametrics/changelog/CHANGELOG.md
+++ b/docs/victoriametrics/changelog/CHANGELOG.md
@@ -18,9 +18,12 @@ See also [LTS releases](https://docs.victoriametrics.com/lts-releases/).
 
 ## tip
 
+** update note 1: change vmselect to vmstorage cluster RPC method from `metricNamesUsageStats_v1` to `metricNamesUsageStats_v2`
+
 * FEATURE: all the VictoriaMetrics components: mask `authKey` value from log messages. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/5973) for details.
 * FEATURE: [vmsingle](https://docs.victoriametrics.com/single-server-victoriametrics/), [vmagent](https://docs.victoriametrics.com/vmagent/): add helpful hints to the unexpected EOF error message in the write concurrency limiter. See [this pull request](https://github.com/VictoriaMetrics/VictoriaMetrics/pull/8704) for details.
 * FEATURE: [vmagent](https://docs.victoriametrics.com/vmagent/): use [VM remote write protocol](https://docs.victoriametrics.com/vmagent/#victoriametrics-remote-write-protocol) by default with automatic downgrade in runtime to Prometheus protocol when needed. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/pull/8462) for details.
+* FEATURE: [vmsingle](https://docs.victoriametrics.com/single-server-victoriametrics/) and `vmstorage` in [VictoriaMetrics cluster](https://docs.victoriametrics.com/cluster-victoriametrics/): enhance  - `/api/v1/status/metric_names_stats` [API](https://docs.victoriametrics.com/keyconcepts/#structure-of-a-metric) with `match_names` query param. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/6145) for details and related [docs](https://docs.victoriametrics.com/#track-ingested-metrics-usage)
 
 * BUGFIX: [vmagent](https://docs.victoriametrics.com/vmagent/): properly init [enterprise](https://docs.victoriametrics.com/enterprise/) version for `linux/arm` and non-CGO buids. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/6019) for details.
 * BUGFIX: [vmagent](https://docs.victoriametrics.com/vmagent/): remote write client sets correct content encoding header based on actual body content, rather than relying on configuration. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/pull/8650).

--- a/lib/storage/metricnamestats/tracker.go
+++ b/lib/storage/metricnamestats/tracker.go
@@ -394,7 +394,7 @@ func (mt *Tracker) GetStatsForTenant(accountID, projectID uint32, limit, le int,
 // GetStatsForNamesMultitenant returns stats for metric names
 // ignores accountID and projectID
 //
-// SingleNode version must use GetStatsForNamesTenant with 0 account nad project IDs
+// SingleNode version must use GetStatsForNamesTenant with 0 account and project IDs
 func (mt *Tracker) GetStatsForNamesMultitenant(names []string) StatsResult {
 	var result StatsResult
 

--- a/lib/storage/metricnamestats/tracker.go
+++ b/lib/storage/metricnamestats/tracker.go
@@ -391,6 +391,71 @@ func (mt *Tracker) GetStatsForTenant(accountID, projectID uint32, limit, le int,
 	return result
 }
 
+// GetStatsForNamesMultitenant returns stats for metric names
+// ignores accountID and projectID
+//
+// SingleNode version must use GetStatsForNamesTenant with 0 account nad project IDs
+func (mt *Tracker) GetStatsForNamesMultitenant(names []string) StatsResult {
+	var result StatsResult
+
+	result.CollectedSinceTs = mt.creationTs.Load()
+	result.TotalRecords = mt.currentItemsCount.Load()
+	result.MaxSizeBytes = mt.maxSizeBytes
+	result.CurrentSizeBytes = mt.currentSizeBytes.Load()
+
+	mt.mu.RLock()
+	for sk, si := range mt.store {
+		for _, mn := range names {
+			if mn == sk.metricName {
+				result.Records = append(result.Records, StatRecord{
+					MetricName:    sk.metricName,
+					RequestsCount: si.requestsCount.Load(),
+					LastRequestTs: si.lastRequestTs.Load(),
+				})
+				break
+			}
+		}
+	}
+	mt.mu.RUnlock()
+
+	result.sort()
+	result.DeduplicateMergeRecords()
+	return result
+}
+
+// GetStatsForNamesTenant returns stats for given accountID and projectID
+func (mt *Tracker) GetStatsForNamesTenant(accountID, projectID uint32, names []string) StatsResult {
+	var result StatsResult
+
+	result.CollectedSinceTs = mt.creationTs.Load()
+	result.TotalRecords = mt.currentItemsCount.Load()
+	result.MaxSizeBytes = mt.maxSizeBytes
+	result.CurrentSizeBytes = mt.currentSizeBytes.Load()
+
+	mt.mu.RLock()
+	for _, mn := range names {
+		sk := statKey{
+			accountID:  accountID,
+			projectID:  projectID,
+			metricName: mn,
+		}
+		si, ok := mt.store[sk]
+		if !ok {
+			continue
+		}
+		result.Records = append(result.Records, StatRecord{
+			MetricName:    sk.metricName,
+			RequestsCount: si.requestsCount.Load(),
+			LastRequestTs: si.lastRequestTs.Load(),
+		})
+	}
+
+	mt.mu.RUnlock()
+
+	result.sort()
+	return result
+}
+
 // GetStats returns stats response for the tracked metrics
 //
 // DeduplicateMergeRecords must be called at cluster version on returned result.

--- a/lib/storage/storage.go
+++ b/lib/storage/storage.go
@@ -3134,22 +3134,22 @@ type MetricNamesStatsQuery struct {
 }
 
 // GetMetricNamesStats returns metric names usage stats for given Query params
-func (s *Storage) GetMetricNamesStats(_ *querytracer.Tracer, sq MetricNamesStatsQuery) MetricNamesStatsResponse {
+func (s *Storage) GetMetricNamesStats(_ *querytracer.Tracer, statsQuery MetricNamesStatsQuery) MetricNamesStatsResponse {
 
-	if sq.TenantToken != nil {
-		tt := sq.TenantToken
-		if len(sq.MatchNames) > 0 {
-			return s.metricsTracker.GetStatsForNamesTenant(tt.AccountID, tt.ProjectID, sq.MatchNames)
+	if statsQuery.TenantToken != nil {
+		tt := statsQuery.TenantToken
+		if len(statsQuery.MatchNames) > 0 {
+			return s.metricsTracker.GetStatsForNamesTenant(tt.AccountID, tt.ProjectID, statsQuery.MatchNames)
 		}
 
-		return s.metricsTracker.GetStatsForTenant(tt.AccountID, tt.ProjectID, sq.Limit, sq.Le, sq.MatchPattern)
+		return s.metricsTracker.GetStatsForTenant(tt.AccountID, tt.ProjectID, statsQuery.Limit, statsQuery.Le, statsQuery.MatchPattern)
 	}
 
 	var res MetricNamesStatsResponse
-	if len(sq.MatchNames) > 0 {
-		return s.metricsTracker.GetStatsForNamesMultitenant(sq.MatchNames)
+	if len(statsQuery.MatchNames) > 0 {
+		return s.metricsTracker.GetStatsForNamesMultitenant(statsQuery.MatchNames)
 	}
-	res = s.metricsTracker.GetStats(sq.Limit, sq.Le, sq.MatchPattern)
+	res = s.metricsTracker.GetStats(statsQuery.Limit, statsQuery.Le, statsQuery.MatchPattern)
 	res.DeduplicateMergeRecords()
 	return res
 }

--- a/lib/storage/storage_test.go
+++ b/lib/storage/storage_test.go
@@ -3471,10 +3471,10 @@ func TestStorageMetricTracker(t *testing.T) {
 
 	var sr Search
 	// check stats for metrics with 0 requests count
-	sq := MetricNamesStatsQuery{
+	statsQuery := MetricNamesStatsQuery{
 		Limit: 10_000,
 	}
-	mus := s.GetMetricNamesStats(nil, sq)
+	mus := s.GetMetricNamesStats(nil, statsQuery)
 	if len(mus.Records) != int(numRows) {
 		t.Fatalf("unexpected Stats records count=%d, want %d records", len(mus.Records), numRows)
 	}
@@ -3490,12 +3490,12 @@ func TestStorageMetricTracker(t *testing.T) {
 	}
 	sr.MustClose()
 
-	mus = s.GetMetricNamesStats(nil, sq)
+	mus = s.GetMetricNamesStats(nil, statsQuery)
 	if len(mus.Records) != 0 {
 		t.Fatalf("unexpected Stats records count=%d; want 0 records", len(mus.Records))
 	}
-	sq.Le = 1
-	mus = s.GetMetricNamesStats(nil, sq)
+	statsQuery.Le = 1
+	mus = s.GetMetricNamesStats(nil, statsQuery)
 	if len(mus.Records) != int(numRows) {
 		t.Fatalf("unexpected Stats records count=%d, want %d records", len(mus.Records), numRows)
 	}

--- a/lib/storage/storage_test.go
+++ b/lib/storage/storage_test.go
@@ -3471,7 +3471,10 @@ func TestStorageMetricTracker(t *testing.T) {
 
 	var sr Search
 	// check stats for metrics with 0 requests count
-	mus := s.GetMetricNamesStats(nil, nil, 10_000, 0, "")
+	sq := MetricNamesStatsQuery{
+		Limit: 10_000,
+	}
+	mus := s.GetMetricNamesStats(nil, sq)
 	if len(mus.Records) != int(numRows) {
 		t.Fatalf("unexpected Stats records count=%d, want %d records", len(mus.Records), numRows)
 	}
@@ -3487,11 +3490,12 @@ func TestStorageMetricTracker(t *testing.T) {
 	}
 	sr.MustClose()
 
-	mus = s.GetMetricNamesStats(nil, nil, 10_000, 0, "")
+	mus = s.GetMetricNamesStats(nil, sq)
 	if len(mus.Records) != 0 {
 		t.Fatalf("unexpected Stats records count=%d; want 0 records", len(mus.Records))
 	}
-	mus = s.GetMetricNamesStats(nil, nil, 10_000, 1, "")
+	sq.Le = 1
+	mus = s.GetMetricNamesStats(nil, sq)
 	if len(mus.Records) != int(numRows) {
 		t.Fatalf("unexpected Stats records count=%d, want %d records", len(mus.Records), numRows)
 	}

--- a/lib/vmselectapi/api.go
+++ b/lib/vmselectapi/api.go
@@ -40,7 +40,7 @@ type API interface {
 	Tenants(qt *querytracer.Tracer, tr storage.TimeRange, deadline uint64) ([]string, error)
 
 	// GetMetricNamesUsageStats returns statistics for metric names
-	GetMetricNamesUsageStats(qt *querytracer.Tracer, tt *storage.TenantToken, limit, le int, matchPattern string, deadline uint64) (storage.MetricNamesStatsResponse, error)
+	GetMetricNamesUsageStats(qt *querytracer.Tracer, sq storage.MetricNamesStatsQuery, deadline uint64) (storage.MetricNamesStatsResponse, error)
 
 	// ResetMetricNamesUsageStats resets internal state of metric names tracker
 	ResetMetricNamesUsageStats(qt *querytracer.Tracer, deadline uint64) error

--- a/lib/vmselectapi/server.go
+++ b/lib/vmselectapi/server.go
@@ -1072,8 +1072,8 @@ func (s *Server) processMetricNamesUsageStats(ctx *vmselectRequestCtx) error {
 	if err := ctx.readDataBufBytes(maxMetricNamesStatsQueryJSONSize); err != nil {
 		return fmt.Errorf("cannot read matchPattern: %w", err)
 	}
-	var sq storage.MetricNamesStatsQuery
-	if err := json.Unmarshal(ctx.dataBuf, &sq); err != nil {
+	var statsQuery storage.MetricNamesStatsQuery
+	if err := json.Unmarshal(ctx.dataBuf, &statsQuery); err != nil {
 		return fmt.Errorf("cannot parse MetricNamesStatsQuery: %w", err)
 	}
 
@@ -1082,7 +1082,7 @@ func (s *Server) processMetricNamesUsageStats(ctx *vmselectRequestCtx) error {
 	}
 	defer s.endConcurrentRequest()
 
-	result, err := s.api.GetMetricNamesUsageStats(ctx.qt, sq, ctx.deadline)
+	result, err := s.api.GetMetricNamesUsageStats(ctx.qt, statsQuery, ctx.deadline)
 	if err != nil {
 		return ctx.writeErrorMessage(err)
 	}


### PR DESCRIPTION
 Introduce new query filter option matchNames for metricnamestats query Requests.
It allows to fetch stats for exact metric names. Which is useful for Explore Cardinality page. It's also allows 3rd party tool to check if application metrics are used for query requests.

 This commit adds the following changes:
* replaces MetricNamesUsageStats inline func query args with dedicated struct.
* bumps cluster RPC metricNamesUsageStats_v1 to metricNamesUsageStats_v2 in order to properly encode new RequestQuery params
* adds new methods for MetricNameTracker

Related issue:
https://github.com/VictoriaMetrics/VictoriaMetrics/issues/6145