### PR TITLE
lib/metricnamestats: add new matchNames stats query filter

### DIFF
--- a/app/vmselect/netstorage/netstorage.go
+++ b/app/vmselect/netstorage/netstorage.go
@@ -1369,10 +1369,11 @@ func applyGraphiteRegexpFilter(filter string, ss []string) ([]string, error) {
 const maxFastAllocBlockSize = 32 * 1024
 
 // GetMetricNamesStats returns statistic for timeseries metric names usage.
-func GetMetricNamesStats(qt *querytracer.Tracer, limit, le int, matchPattern string) (storage.MetricNamesStatsResponse, error) {
-	qt = qt.NewChild("get metric names usage statistics with limit: %d, less or equal to: %d, match pattern=%q", limit, le, matchPattern)
+func GetMetricNamesStats(qt *querytracer.Tracer, statsQuery storage.MetricNamesStatsQuery) (storage.MetricNamesStatsResponse, error) {
+	qt = qt.NewChild("get metric names usage statistics with limit: %d, less or equal to: %d, match pattern=%q,match_names_len=%d",
+		statsQuery.Limit, statsQuery.Le, statsQuery.MatchPattern, len(statsQuery.MatchNames))
 	defer qt.Done()
-	return vmstorage.GetMetricNamesStats(qt, limit, le, matchPattern)
+	return vmstorage.GetMetricNamesStats(qt, statsQuery)
 }
 
 // ResetMetricNamesStats resets state of metric names usage

--- a/app/vmstorage/main.go
+++ b/app/vmstorage/main.go
@@ -200,9 +200,9 @@ func DeleteSeries(qt *querytracer.Tracer, tfss []*storage.TagFilters, maxMetrics
 }
 
 // GetMetricNamesStats returns metric names usage stats with give limit and lte predicate
-func GetMetricNamesStats(qt *querytracer.Tracer, limit, le int, matchPattern string) (storage.MetricNamesStatsResponse, error) {
+func GetMetricNamesStats(qt *querytracer.Tracer, statsQuery storage.MetricNamesStatsQuery) (storage.MetricNamesStatsResponse, error) {
 	WG.Add(1)
-	r := Storage.GetMetricNamesStats(qt, limit, le, matchPattern)
+	r := Storage.GetMetricNamesStats(qt, statsQuery)
 	WG.Done()
 	return r, nil
 }

--- a/docs/victoriametrics/README.md
+++ b/docs/victoriametrics/README.md
@@ -483,6 +483,7 @@ To get metric names usage statistics, use the `/prometheus/api/v1/status/metric_
 * `limit` - integer value to limit the number of metric names in response. By default, API returns 1000 records.
 * `le` -  `less than or equal`, is an integer threshold for filtering metric names by their usage count in queries. For example, with `?le=1` API returns metric names that were queried <=1 times.
 * `match_pattern` - a substring pattern to match metric names. For example, `?match_pattern=vm_` will match any metric names with `vm_` pattern, like `vm_http_requests`, `max_vm_memory_available`. It doesn't support regex syntax.
+* `match_names` - a list of metric names to query. If this param is defined, `le` and `match_pattern` options will be ignored.
 
  The API endpoint returns the following `JSON` response:
 

--- a/docs/victoriametrics/changelog/CHANGELOG.md
+++ b/docs/victoriametrics/changelog/CHANGELOG.md
@@ -18,9 +18,12 @@ See also [LTS releases](https://docs.victoriametrics.com/lts-releases/).
 
 ## tip
 
+** update note 1: change vmselect to vmstorage cluster RPC method from `metricNamesUsageStats_v1` to `metricNamesUsageStats_v2`
+
 * FEATURE: all the VictoriaMetrics components: mask `authKey` value from log messages. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/5973) for details.
 * FEATURE: [vmsingle](https://docs.victoriametrics.com/single-server-victoriametrics/), [vmagent](https://docs.victoriametrics.com/vmagent/): add helpful hints to the unexpected EOF error message in the write concurrency limiter. See [this pull request](https://github.com/VictoriaMetrics/VictoriaMetrics/pull/8704) for details.
 * FEATURE: [vmagent](https://docs.victoriametrics.com/vmagent/): use [VM remote write protocol](https://docs.victoriametrics.com/vmagent/#victoriametrics-remote-write-protocol) by default with automatic downgrade in runtime to Prometheus protocol when needed. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/pull/8462) for details.
+* FEATURE: [vmsingle](https://docs.victoriametrics.com/single-server-victoriametrics/) and `vmstorage` in [VictoriaMetrics cluster](https://docs.victoriametrics.com/cluster-victoriametrics/): enhance  - `/api/v1/status/metric_names_stats` [API](https://docs.victoriametrics.com/keyconcepts/#structure-of-a-metric) with `match_names` query param. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/6145) for details and related [docs](https://docs.victoriametrics.com/#track-ingested-metrics-usage)
 
 * BUGFIX: [vmagent](https://docs.victoriametrics.com/vmagent/): properly init [enterprise](https://docs.victoriametrics.com/enterprise/) version for `linux/arm` and non-CGO buids. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/6019) for details.
 * BUGFIX: [vmagent](https://docs.victoriametrics.com/vmagent/): remote write client sets correct content encoding header based on actual body content, rather than relying on configuration. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/pull/8650).

--- a/lib/storage/storage.go
+++ b/lib/storage/storage.go
@@ -2957,9 +2957,21 @@ func (s *Storage) wasMetricIDMissingBefore(metricID uint64) bool {
 // MetricNamesStatsResponse contains metric names usage stats API response
 type MetricNamesStatsResponse = metricnamestats.StatsResult
 
-// GetMetricNamesStats returns metric names usage stats with given limit and le predicate
-func (s *Storage) GetMetricNamesStats(_ *querytracer.Tracer, limit, le int, matchPattern string) MetricNamesStatsResponse {
-	return s.metricsTracker.GetStats(limit, le, matchPattern)
+// MetricNamesStatsQuery represents query params for Stats requests
+
+type MetricNamesStatsQuery struct {
+	Limit        int
+	Le           int
+	MatchPattern string
+	MatchNames   []string
+}
+
+// GetMetricNamesStats returns metric names usage stats for given Query params
+func (s *Storage) GetMetricNamesStats(_ *querytracer.Tracer, statsQuery MetricNamesStatsQuery) MetricNamesStatsResponse {
+	if len(statsQuery.MatchNames) > 0 {
+		return s.metricsTracker.GetStatsForNamesTenant(0, 0, statsQuery.MatchNames)
+	}
+	return s.metricsTracker.GetStats(statsQuery.Limit, statsQuery.Le, statsQuery.MatchPattern)
 }
 
 // ResetMetricNamesStats resets state for metric names usage tracker

--- a/lib/storage/storage_test.go
+++ b/lib/storage/storage_test.go
@@ -3262,9 +3262,11 @@ func TestStorageMetricTracker(t *testing.T) {
 		MinTimestamp: minTimestamp,
 		MaxTimestamp: maxTimestamp,
 	}
-
+	statsQuery := MetricNamesStatsQuery{
+		Limit: 10_000,
+	}
 	// check stats for metrics with 0 requests count
-	mus := s.GetMetricNamesStats(nil, 10_000, 0, "")
+	mus := s.GetMetricNamesStats(nil, statsQuery)
 	if len(mus.Records) != int(numRows) {
 		t.Fatalf("unexpected Stats records count=%d, want %d records", len(mus.Records), numRows)
 	}
@@ -3280,11 +3282,12 @@ func TestStorageMetricTracker(t *testing.T) {
 	}
 	sr.MustClose()
 
-	mus = s.GetMetricNamesStats(nil, 10_000, 0, "")
+	mus = s.GetMetricNamesStats(nil, statsQuery)
 	if len(mus.Records) != 0 {
 		t.Fatalf("unexpected Stats records count=%d; want 0 records", len(mus.Records))
 	}
-	mus = s.GetMetricNamesStats(nil, 10_000, 1, "")
+	statsQuery.Le = 1
+	mus = s.GetMetricNamesStats(nil, statsQuery)
 	if len(mus.Records) != int(numRows) {
 		t.Fatalf("unexpected Stats records count=%d, want %d records", len(mus.Records), numRows)
 	}


### PR DESCRIPTION
 Introduce new query filter option matchNames for metricnamestats query Requests.
It allows to fetch stats for exact metric names. Which is useful for Explore Cardinality page. It's also allows 3rd party tool to check if application metrics are used for query requests.

 This commit adds the following changes:
* replaces MetricNamesUsageStats inline func query args with dedicated struct.
* bumps cluster RPC metricNamesUsageStats_v1 to metricNamesUsageStats_v2 in order to properly encode new RequestQuery params
* adds new methods for MetricNameTracker

Related issue:
https://github.com/VictoriaMetrics/VictoriaMetrics/issues/6145

### Describe Your Changes

Please provide a brief description of the changes you made. Be as specific as possible to help others understand the purpose and impact of your modifications.

### Checklist

The following checks are **mandatory**:

- [ ] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/contributing/).
