### PR TITLE
lib/storage: enhance TSDB status response

### DIFF
--- a/app/vmselect/netstorage/netstorage.go
+++ b/app/vmselect/netstorage/netstorage.go
@@ -1301,26 +1301,17 @@ func TSDBStatus(qt *querytracer.Tracer, denyPartialResponse bool, sq *storage.Se
 func mergeTSDBStatuses(statuses []*storage.TSDBStatus, topN int) *storage.TSDBStatus {
 	totalSeries := uint64(0)
 	totalLabelValuePairs := uint64(0)
-	seriesCountByMetricName := make(map[string]storage.TopHeapMetricNameEntry)
+	seriesCountByMetricName := make(map[string]uint64)
 	seriesCountByLabelName := make(map[string]uint64)
 	seriesCountByFocusLabelValue := make(map[string]uint64)
 	seriesCountByLabelValuePair := make(map[string]uint64)
 	labelValueCountByLabelName := make(map[string]uint64)
+	seriesQueryStatsByMetricNames := make(map[string]storage.MetricNamesStatsRecord)
 	for _, st := range statuses {
 		totalSeries += st.TotalSeries
 		totalLabelValuePairs += st.TotalLabelValuePairs
 		for _, e := range st.SeriesCountByMetricName {
-			ne, ok := seriesCountByMetricName[e.Name]
-			if ok {
-				ne.Count += e.Count
-				ne.RequestsCount += e.RequestsCount
-				if e.LastRequestTimestamp > ne.LastRequestTimestamp {
-					ne.LastRequestTimestamp = e.LastRequestTimestamp
-				}
-			} else {
-				ne = e
-			}
-			seriesCountByMetricName[e.Name] = ne
+			seriesCountByMetricName[e.Name] += e.Count
 		}
 		for _, e := range st.SeriesCountByLabelName {
 			seriesCountByLabelName[e.Name] += e.Count
@@ -1338,15 +1329,35 @@ func mergeTSDBStatuses(statuses []*storage.TSDBStatus, topN int) *storage.TSDBSt
 				labelValueCountByLabelName[e.Name] = e.Count
 			}
 		}
+		for _, e := range st.SeriesQueryStatsByMetricName {
+			ne, ok := seriesQueryStatsByMetricNames[e.MetricName]
+			if ok {
+				ne.RequestsCount += e.RequestsCount
+				if e.LastRequestTs > ne.LastRequestTs {
+					ne.LastRequestTs = e.LastRequestTs
+				}
+			} else {
+				ne = e
+			}
+			seriesQueryStatsByMetricNames[e.MetricName] = ne
+		}
+	}
+	// do not apply topN limit
+	// query stats should be joined to SeriesCountByMetricName
+	// at write response
+	seriesQueryStatsTotal := make([]storage.MetricNamesStatsRecord, 0, len(seriesQueryStatsByMetricNames))
+	for _, entry := range seriesQueryStatsByMetricNames {
+		seriesQueryStatsTotal = append(seriesQueryStatsTotal, entry)
 	}
 	return &storage.TSDBStatus{
 		TotalSeries:                  totalSeries,
 		TotalLabelValuePairs:         totalLabelValuePairs,
-		SeriesCountByMetricName:      toTopHeapMetricNameEntries(seriesCountByMetricName, topN),
+		SeriesCountByMetricName:      toTopHeapEntries(seriesCountByMetricName, topN),
 		SeriesCountByLabelName:       toTopHeapEntries(seriesCountByLabelName, topN),
 		SeriesCountByFocusLabelValue: toTopHeapEntries(seriesCountByFocusLabelValue, topN),
 		SeriesCountByLabelValuePair:  toTopHeapEntries(seriesCountByLabelValuePair, topN),
 		LabelValueCountByLabelName:   toTopHeapEntries(labelValueCountByLabelName, topN),
+		SeriesQueryStatsByMetricName: seriesQueryStatsTotal,
 	}
 }
 
@@ -1356,28 +1367,6 @@ func toTopHeapEntries(m map[string]uint64, topN int) []storage.TopHeapEntry {
 		a = append(a, storage.TopHeapEntry{
 			Name:  name,
 			Count: count,
-		})
-	}
-	sort.Slice(a, func(i, j int) bool {
-		if a[i].Count != a[j].Count {
-			return a[i].Count > a[j].Count
-		}
-		return a[i].Name < a[j].Name
-	})
-	if len(a) > topN {
-		a = a[:topN]
-	}
-	return a
-}
-
-func toTopHeapMetricNameEntries(m map[string]storage.TopHeapMetricNameEntry, topN int) []storage.TopHeapMetricNameEntry {
-	a := make([]storage.TopHeapMetricNameEntry, 0, len(m))
-	for _, e := range m {
-		a = append(a, storage.TopHeapMetricNameEntry{
-			Name:                 e.Name,
-			Count:                e.Count,
-			RequestsCount:        e.RequestsCount,
-			LastRequestTimestamp: e.LastRequestTimestamp,
 		})
 	}
 	sort.Slice(a, func(i, j int) bool {
@@ -2845,7 +2834,7 @@ func readTSDBStatus(bc *handshake.BufferedConn) (*storage.TSDBStatus, error) {
 	if err != nil {
 		return nil, fmt.Errorf("cannot read totalLabelValuePairs: %w", err)
 	}
-	seriesCountByMetricName, err := readTopHeapMetricNameEntries(bc)
+	seriesCountByMetricName, err := readTopHeapEntries(bc)
 	if err != nil {
 		return nil, fmt.Errorf("cannot read seriesCountByMetricName: %w", err)
 	}
@@ -2865,6 +2854,10 @@ func readTSDBStatus(bc *handshake.BufferedConn) (*storage.TSDBStatus, error) {
 	if err != nil {
 		return nil, fmt.Errorf("cannot read labelValueCountByLabelName: %w", err)
 	}
+	seriesQueryStatsByMetricName, err := readMetricNamesStatsRecords(bc)
+	if err != nil {
+		return nil, fmt.Errorf("cannot read seriesQueryStatsByMetricName: %w", err)
+	}
 	status := &storage.TSDBStatus{
 		TotalSeries:                  totalSeries,
 		TotalLabelValuePairs:         totalLabelValuePairs,
@@ -2873,6 +2866,7 @@ func readTSDBStatus(bc *handshake.BufferedConn) (*storage.TSDBStatus, error) {
 		SeriesCountByFocusLabelValue: seriesCountByFocusLabelValue,
 		SeriesCountByLabelValuePair:  seriesCountByLabelValuePair,
 		LabelValueCountByLabelName:   labelValueCountByLabelName,
+		SeriesQueryStatsByMetricName: seriesQueryStatsByMetricName,
 	}
 	return status, nil
 }
@@ -2896,40 +2890,6 @@ func readTopHeapEntries(bc *handshake.BufferedConn) ([]storage.TopHeapEntry, err
 		a = append(a, storage.TopHeapEntry{
 			Name:  string(buf),
 			Count: count,
-		})
-	}
-	return a, nil
-}
-
-func readTopHeapMetricNameEntries(bc *handshake.BufferedConn) ([]storage.TopHeapMetricNameEntry, error) {
-	n, err := readUint64(bc)
-	if err != nil {
-		return nil, fmt.Errorf("cannot read the number of topHeapEntries: %w", err)
-	}
-	var a []storage.TopHeapMetricNameEntry
-	var buf []byte
-	for i := uint64(0); i < n; i++ {
-		buf, err = readBytes(buf[:0], bc, maxLabelNameSize)
-		if err != nil {
-			return nil, fmt.Errorf("cannot read metric name: %w", err)
-		}
-		count, err := readUint64(bc)
-		if err != nil {
-			return nil, fmt.Errorf("cannot read series count: %w", err)
-		}
-		requestsCount, err := readUint64(bc)
-		if err != nil {
-			return nil, fmt.Errorf("cannot read requestsCount: %w", err)
-		}
-		lastRequestTimestamp, err := readUint64(bc)
-		if err != nil {
-			return nil, fmt.Errorf("cannot read lastRequestTimestamp: %w", err)
-		}
-		a = append(a, storage.TopHeapMetricNameEntry{
-			Name:                 string(buf),
-			Count:                count,
-			RequestsCount:        requestsCount,
-			LastRequestTimestamp: lastRequestTimestamp,
 		})
 	}
 	return a, nil
@@ -3499,29 +3459,38 @@ func processGetMetricNamesUsageStatsOnConn(bc *handshake.BufferedConn, tt *stora
 	if err != nil {
 		return result, fmt.Errorf("cannot read MaxSizeBytes: %w", err)
 	}
+	records, err := readMetricNamesStatsRecords(bc)
+	if err != nil {
+		return result, fmt.Errorf("cannot read MetricNamesStatsRecord records: %w", err)
+	}
+	result.Records = records
+	return result, nil
+}
+
+func readMetricNamesStatsRecords(bc *handshake.BufferedConn) ([]storage.MetricNamesStatsRecord, error) {
 	n, err := readUint64(bc)
 	if err != nil {
-		return result, fmt.Errorf("cannot read records count: %w", err)
+		return nil, fmt.Errorf("cannot read the number of MetricNamesStatsRecord: %w", err)
 	}
-	result.Records = make([]storage.MetricNamesStatsRecord, n)
+	records := make([]storage.MetricNamesStatsRecord, n)
 	var mnBuff []byte
 	for i := range n {
 		mnBuff, err = readBytes(mnBuff[:0], bc, 256)
 		if err != nil {
-			return result, fmt.Errorf("cannot read record metricName: %w", err)
+			return records, fmt.Errorf("cannot read record metricName: %w", err)
 		}
-		record := &result.Records[i]
+		record := &records[i]
 		record.MetricName = string(mnBuff)
 		record.LastRequestTs, err = readUint64(bc)
 		if err != nil {
-			return result, fmt.Errorf("cannot read record LastRequestTs: %w", err)
+			return records, fmt.Errorf("cannot read record LastRequestTs: %w", err)
 		}
 		record.RequestsCount, err = readUint64(bc)
 		if err != nil {
-			return result, fmt.Errorf("cannot read record RequestCount: %w", err)
+			return records, fmt.Errorf("cannot read record RequestCount: %w", err)
 		}
 	}
-	return result, nil
+	return records, nil
 }
 
 // ResetMetricNamesStats forwards reset tracker state request to the storage nodes

--- a/app/vmselect/netstorage/netstorage.go
+++ b/app/vmselect/netstorage/netstorage.go
@@ -2911,11 +2911,11 @@ func readTopHeapMetricNameEntries(bc *handshake.BufferedConn) ([]storage.TopHeap
 	for i := uint64(0); i < n; i++ {
 		buf, err = readBytes(buf[:0], bc, maxLabelNameSize)
 		if err != nil {
-			return nil, fmt.Errorf("cannot read label name: %w", err)
+			return nil, fmt.Errorf("cannot read metric name: %w", err)
 		}
 		count, err := readUint64(bc)
 		if err != nil {
-			return nil, fmt.Errorf("cannot read label count: %w", err)
+			return nil, fmt.Errorf("cannot read series count: %w", err)
 		}
 		requestsCount, err := readUint64(bc)
 		if err != nil {

--- a/app/vmselect/prometheus/tsdb_status_response.qtpl
+++ b/app/vmselect/prometheus/tsdb_status_response.qtpl
@@ -12,7 +12,7 @@ TSDBStatusResponse generates response for /api/v1/status/tsdb .
 	"data":{
 		"totalSeries": {%dul= status.TotalSeries %},
 		"totalLabelValuePairs": {%dul= status.TotalLabelValuePairs %},
-		"seriesCountByMetricName":{%= tsdbStatusMetricNameEntries(status.SeriesCountByMetricName) %},
+		"seriesCountByMetricName":{%= tsdbStatusMetricNameEntries(status.SeriesCountByMetricName,status.SeriesQueryStatsByMetricName) %},
 		"seriesCountByLabelName":{%= tsdbStatusEntries(status.SeriesCountByLabelName) %},
 		"seriesCountByFocusLabelValue":{%= tsdbStatusEntries(status.SeriesCountByFocusLabelValue) %},
 		"seriesCountByLabelValuePair":{%= tsdbStatusEntries(status.SeriesCountByLabelValuePair) %},
@@ -35,14 +35,27 @@ TSDBStatusResponse generates response for /api/v1/status/tsdb .
 ]
 {% endfunc %}
 
-{% func tsdbStatusMetricNameEntries(a []storage.TopHeapMetricNameEntry) %}
+{% func tsdbStatusMetricNameEntries(a []storage.TopHeapEntry, queryStats []storage.MetricNamesStatsRecord) %}
+{% code
+  queryStatsByMetricName := make(map[string]storage.MetricNamesStatsRecord,len(queryStats))
+  for _, record := range queryStats{
+      queryStatsByMetricName[record.MetricName] = record
+    }
+%}
 [
 	{% for i, e := range a %}
 		{
+      {% code
+      entry, ok := queryStatsByMetricName[e.Name]
+      %}
 			"name":{%q= e.Name %},
+      {% if !ok %}
+			"value":{%d= int(e.Count) %}
+      {% else %}
 			"value":{%d= int(e.Count) %},
-			"requestsCount":{%d= int(e.RequestsCount) %},
-			"lastRequestTimestamp":{%d= int(e.LastRequestTimestamp) %}
+			"requestsCount":{%d= int(entry.RequestsCount) %},
+			"lastRequestTimestamp":{%d= int(entry.LastRequestTs) %}
+      {% endif %}
 		}
 		{% if i+1 < len(a) %},{% endif %}
 	{% endfor %}

--- a/app/vmselect/prometheus/tsdb_status_response.qtpl
+++ b/app/vmselect/prometheus/tsdb_status_response.qtpl
@@ -12,7 +12,7 @@ TSDBStatusResponse generates response for /api/v1/status/tsdb .
 	"data":{
 		"totalSeries": {%dul= status.TotalSeries %},
 		"totalLabelValuePairs": {%dul= status.TotalLabelValuePairs %},
-		"seriesCountByMetricName":{%= tsdbStatusEntries(status.SeriesCountByMetricName) %},
+		"seriesCountByMetricName":{%= tsdbStatusMetricNameEntries(status.SeriesCountByMetricName) %},
 		"seriesCountByLabelName":{%= tsdbStatusEntries(status.SeriesCountByLabelName) %},
 		"seriesCountByFocusLabelValue":{%= tsdbStatusEntries(status.SeriesCountByFocusLabelValue) %},
 		"seriesCountByLabelValuePair":{%= tsdbStatusEntries(status.SeriesCountByLabelValuePair) %},
@@ -34,5 +34,20 @@ TSDBStatusResponse generates response for /api/v1/status/tsdb .
 	{% endfor %}
 ]
 {% endfunc %}
+
+{% func tsdbStatusMetricNameEntries(a []storage.TopHeapMetricNameEntry) %}
+[
+	{% for i, e := range a %}
+		{
+			"name":{%q= e.Name %},
+			"value":{%d= int(e.Count) %},
+			"requestsCount":{%d= int(e.RequestsCount) %},
+			"lastRequestTimestamp":{%d= int(e.LastRequestTimestamp) %}
+		}
+		{% if i+1 < len(a) %},{% endif %}
+	{% endfor %}
+]
+{% endfunc %}
+
 
 {% endstripspace %}

--- a/app/vmselect/prometheus/tsdb_status_response.qtpl.go
+++ b/app/vmselect/prometheus/tsdb_status_response.qtpl.go
@@ -50,7 +50,7 @@ func StreamTSDBStatusResponse(qw422016 *qt422016.Writer, isPartial bool, status 
 //line app/vmselect/prometheus/tsdb_status_response.qtpl:14
 	qw422016.N().S(`,"seriesCountByMetricName":`)
 //line app/vmselect/prometheus/tsdb_status_response.qtpl:15
-	streamtsdbStatusEntries(qw422016, status.SeriesCountByMetricName)
+	streamtsdbStatusMetricNameEntries(qw422016, status.SeriesCountByMetricName)
 //line app/vmselect/prometheus/tsdb_status_response.qtpl:15
 	qw422016.N().S(`,"seriesCountByLabelName":`)
 //line app/vmselect/prometheus/tsdb_status_response.qtpl:16
@@ -158,4 +158,67 @@ func tsdbStatusEntries(a []storage.TopHeapEntry) string {
 //line app/vmselect/prometheus/tsdb_status_response.qtpl:36
 	return qs422016
 //line app/vmselect/prometheus/tsdb_status_response.qtpl:36
+}
+
+//line app/vmselect/prometheus/tsdb_status_response.qtpl:38
+func streamtsdbStatusMetricNameEntries(qw422016 *qt422016.Writer, a []storage.TopHeapMetricNameEntry) {
+//line app/vmselect/prometheus/tsdb_status_response.qtpl:38
+	qw422016.N().S(`[`)
+//line app/vmselect/prometheus/tsdb_status_response.qtpl:40
+	for i, e := range a {
+//line app/vmselect/prometheus/tsdb_status_response.qtpl:40
+		qw422016.N().S(`{"name":`)
+//line app/vmselect/prometheus/tsdb_status_response.qtpl:42
+		qw422016.N().Q(e.Name)
+//line app/vmselect/prometheus/tsdb_status_response.qtpl:42
+		qw422016.N().S(`,"value":`)
+//line app/vmselect/prometheus/tsdb_status_response.qtpl:43
+		qw422016.N().D(int(e.Count))
+//line app/vmselect/prometheus/tsdb_status_response.qtpl:43
+		qw422016.N().S(`,"requestsCount":`)
+//line app/vmselect/prometheus/tsdb_status_response.qtpl:44
+		qw422016.N().D(int(e.RequestsCount))
+//line app/vmselect/prometheus/tsdb_status_response.qtpl:44
+		qw422016.N().S(`,"lastRequestTimestamp":`)
+//line app/vmselect/prometheus/tsdb_status_response.qtpl:45
+		qw422016.N().D(int(e.LastRequestTimestamp))
+//line app/vmselect/prometheus/tsdb_status_response.qtpl:45
+		qw422016.N().S(`}`)
+//line app/vmselect/prometheus/tsdb_status_response.qtpl:47
+		if i+1 < len(a) {
+//line app/vmselect/prometheus/tsdb_status_response.qtpl:47
+			qw422016.N().S(`,`)
+//line app/vmselect/prometheus/tsdb_status_response.qtpl:47
+		}
+//line app/vmselect/prometheus/tsdb_status_response.qtpl:48
+	}
+//line app/vmselect/prometheus/tsdb_status_response.qtpl:48
+	qw422016.N().S(`]`)
+//line app/vmselect/prometheus/tsdb_status_response.qtpl:50
+}
+
+//line app/vmselect/prometheus/tsdb_status_response.qtpl:50
+func writetsdbStatusMetricNameEntries(qq422016 qtio422016.Writer, a []storage.TopHeapMetricNameEntry) {
+//line app/vmselect/prometheus/tsdb_status_response.qtpl:50
+	qw422016 := qt422016.AcquireWriter(qq422016)
+//line app/vmselect/prometheus/tsdb_status_response.qtpl:50
+	streamtsdbStatusMetricNameEntries(qw422016, a)
+//line app/vmselect/prometheus/tsdb_status_response.qtpl:50
+	qt422016.ReleaseWriter(qw422016)
+//line app/vmselect/prometheus/tsdb_status_response.qtpl:50
+}
+
+//line app/vmselect/prometheus/tsdb_status_response.qtpl:50
+func tsdbStatusMetricNameEntries(a []storage.TopHeapMetricNameEntry) string {
+//line app/vmselect/prometheus/tsdb_status_response.qtpl:50
+	qb422016 := qt422016.AcquireByteBuffer()
+//line app/vmselect/prometheus/tsdb_status_response.qtpl:50
+	writetsdbStatusMetricNameEntries(qb422016, a)
+//line app/vmselect/prometheus/tsdb_status_response.qtpl:50
+	qs422016 := string(qb422016.B)
+//line app/vmselect/prometheus/tsdb_status_response.qtpl:50
+	qt422016.ReleaseByteBuffer(qb422016)
+//line app/vmselect/prometheus/tsdb_status_response.qtpl:50
+	return qs422016
+//line app/vmselect/prometheus/tsdb_status_response.qtpl:50
 }

--- a/app/vmselect/prometheus/tsdb_status_response.qtpl.go
+++ b/app/vmselect/prometheus/tsdb_status_response.qtpl.go
@@ -50,7 +50,7 @@ func StreamTSDBStatusResponse(qw422016 *qt422016.Writer, isPartial bool, status 
 //line app/vmselect/prometheus/tsdb_status_response.qtpl:14
 	qw422016.N().S(`,"seriesCountByMetricName":`)
 //line app/vmselect/prometheus/tsdb_status_response.qtpl:15
-	streamtsdbStatusMetricNameEntries(qw422016, status.SeriesCountByMetricName)
+	streamtsdbStatusMetricNameEntries(qw422016, status.SeriesCountByMetricName, status.SeriesQueryStatsByMetricName)
 //line app/vmselect/prometheus/tsdb_status_response.qtpl:15
 	qw422016.N().S(`,"seriesCountByLabelName":`)
 //line app/vmselect/prometheus/tsdb_status_response.qtpl:16
@@ -161,64 +161,87 @@ func tsdbStatusEntries(a []storage.TopHeapEntry) string {
 }
 
 //line app/vmselect/prometheus/tsdb_status_response.qtpl:38
-func streamtsdbStatusMetricNameEntries(qw422016 *qt422016.Writer, a []storage.TopHeapMetricNameEntry) {
-//line app/vmselect/prometheus/tsdb_status_response.qtpl:38
-	qw422016.N().S(`[`)
+func streamtsdbStatusMetricNameEntries(qw422016 *qt422016.Writer, a []storage.TopHeapEntry, queryStats []storage.MetricNamesStatsRecord) {
 //line app/vmselect/prometheus/tsdb_status_response.qtpl:40
-	for i, e := range a {
-//line app/vmselect/prometheus/tsdb_status_response.qtpl:40
-		qw422016.N().S(`{"name":`)
-//line app/vmselect/prometheus/tsdb_status_response.qtpl:42
-		qw422016.N().Q(e.Name)
-//line app/vmselect/prometheus/tsdb_status_response.qtpl:42
-		qw422016.N().S(`,"value":`)
-//line app/vmselect/prometheus/tsdb_status_response.qtpl:43
-		qw422016.N().D(int(e.Count))
-//line app/vmselect/prometheus/tsdb_status_response.qtpl:43
-		qw422016.N().S(`,"requestsCount":`)
-//line app/vmselect/prometheus/tsdb_status_response.qtpl:44
-		qw422016.N().D(int(e.RequestsCount))
-//line app/vmselect/prometheus/tsdb_status_response.qtpl:44
-		qw422016.N().S(`,"lastRequestTimestamp":`)
-//line app/vmselect/prometheus/tsdb_status_response.qtpl:45
-		qw422016.N().D(int(e.LastRequestTimestamp))
-//line app/vmselect/prometheus/tsdb_status_response.qtpl:45
-		qw422016.N().S(`}`)
-//line app/vmselect/prometheus/tsdb_status_response.qtpl:47
-		if i+1 < len(a) {
-//line app/vmselect/prometheus/tsdb_status_response.qtpl:47
-			qw422016.N().S(`,`)
-//line app/vmselect/prometheus/tsdb_status_response.qtpl:47
-		}
-//line app/vmselect/prometheus/tsdb_status_response.qtpl:48
+	queryStatsByMetricName := make(map[string]storage.MetricNamesStatsRecord, len(queryStats))
+	for _, record := range queryStats {
+		queryStatsByMetricName[record.MetricName] = record
 	}
-//line app/vmselect/prometheus/tsdb_status_response.qtpl:48
+
+//line app/vmselect/prometheus/tsdb_status_response.qtpl:44
+	qw422016.N().S(`[`)
+//line app/vmselect/prometheus/tsdb_status_response.qtpl:46
+	for i, e := range a {
+//line app/vmselect/prometheus/tsdb_status_response.qtpl:46
+		qw422016.N().S(`{`)
+//line app/vmselect/prometheus/tsdb_status_response.qtpl:49
+		entry, ok := queryStatsByMetricName[e.Name]
+
+//line app/vmselect/prometheus/tsdb_status_response.qtpl:50
+		qw422016.N().S(`"name":`)
+//line app/vmselect/prometheus/tsdb_status_response.qtpl:51
+		qw422016.N().Q(e.Name)
+//line app/vmselect/prometheus/tsdb_status_response.qtpl:51
+		qw422016.N().S(`,`)
+//line app/vmselect/prometheus/tsdb_status_response.qtpl:52
+		if !ok {
+//line app/vmselect/prometheus/tsdb_status_response.qtpl:52
+			qw422016.N().S(`"value":`)
+//line app/vmselect/prometheus/tsdb_status_response.qtpl:53
+			qw422016.N().D(int(e.Count))
+//line app/vmselect/prometheus/tsdb_status_response.qtpl:54
+		} else {
+//line app/vmselect/prometheus/tsdb_status_response.qtpl:54
+			qw422016.N().S(`"value":`)
+//line app/vmselect/prometheus/tsdb_status_response.qtpl:55
+			qw422016.N().D(int(e.Count))
+//line app/vmselect/prometheus/tsdb_status_response.qtpl:55
+			qw422016.N().S(`,"requestsCount":`)
+//line app/vmselect/prometheus/tsdb_status_response.qtpl:56
+			qw422016.N().D(int(entry.RequestsCount))
+//line app/vmselect/prometheus/tsdb_status_response.qtpl:56
+			qw422016.N().S(`,"lastRequestTimestamp":`)
+//line app/vmselect/prometheus/tsdb_status_response.qtpl:57
+			qw422016.N().D(int(entry.LastRequestTs))
+//line app/vmselect/prometheus/tsdb_status_response.qtpl:58
+		}
+//line app/vmselect/prometheus/tsdb_status_response.qtpl:58
+		qw422016.N().S(`}`)
+//line app/vmselect/prometheus/tsdb_status_response.qtpl:60
+		if i+1 < len(a) {
+//line app/vmselect/prometheus/tsdb_status_response.qtpl:60
+			qw422016.N().S(`,`)
+//line app/vmselect/prometheus/tsdb_status_response.qtpl:60
+		}
+//line app/vmselect/prometheus/tsdb_status_response.qtpl:61
+	}
+//line app/vmselect/prometheus/tsdb_status_response.qtpl:61
 	qw422016.N().S(`]`)
-//line app/vmselect/prometheus/tsdb_status_response.qtpl:50
+//line app/vmselect/prometheus/tsdb_status_response.qtpl:63
 }
 
-//line app/vmselect/prometheus/tsdb_status_response.qtpl:50
-func writetsdbStatusMetricNameEntries(qq422016 qtio422016.Writer, a []storage.TopHeapMetricNameEntry) {
-//line app/vmselect/prometheus/tsdb_status_response.qtpl:50
+//line app/vmselect/prometheus/tsdb_status_response.qtpl:63
+func writetsdbStatusMetricNameEntries(qq422016 qtio422016.Writer, a []storage.TopHeapEntry, queryStats []storage.MetricNamesStatsRecord) {
+//line app/vmselect/prometheus/tsdb_status_response.qtpl:63
 	qw422016 := qt422016.AcquireWriter(qq422016)
-//line app/vmselect/prometheus/tsdb_status_response.qtpl:50
-	streamtsdbStatusMetricNameEntries(qw422016, a)
-//line app/vmselect/prometheus/tsdb_status_response.qtpl:50
+//line app/vmselect/prometheus/tsdb_status_response.qtpl:63
+	streamtsdbStatusMetricNameEntries(qw422016, a, queryStats)
+//line app/vmselect/prometheus/tsdb_status_response.qtpl:63
 	qt422016.ReleaseWriter(qw422016)
-//line app/vmselect/prometheus/tsdb_status_response.qtpl:50
+//line app/vmselect/prometheus/tsdb_status_response.qtpl:63
 }
 
-//line app/vmselect/prometheus/tsdb_status_response.qtpl:50
-func tsdbStatusMetricNameEntries(a []storage.TopHeapMetricNameEntry) string {
-//line app/vmselect/prometheus/tsdb_status_response.qtpl:50
+//line app/vmselect/prometheus/tsdb_status_response.qtpl:63
+func tsdbStatusMetricNameEntries(a []storage.TopHeapEntry, queryStats []storage.MetricNamesStatsRecord) string {
+//line app/vmselect/prometheus/tsdb_status_response.qtpl:63
 	qb422016 := qt422016.AcquireByteBuffer()
-//line app/vmselect/prometheus/tsdb_status_response.qtpl:50
-	writetsdbStatusMetricNameEntries(qb422016, a)
-//line app/vmselect/prometheus/tsdb_status_response.qtpl:50
+//line app/vmselect/prometheus/tsdb_status_response.qtpl:63
+	writetsdbStatusMetricNameEntries(qb422016, a, queryStats)
+//line app/vmselect/prometheus/tsdb_status_response.qtpl:63
 	qs422016 := string(qb422016.B)
-//line app/vmselect/prometheus/tsdb_status_response.qtpl:50
+//line app/vmselect/prometheus/tsdb_status_response.qtpl:63
 	qt422016.ReleaseByteBuffer(qb422016)
-//line app/vmselect/prometheus/tsdb_status_response.qtpl:50
+//line app/vmselect/prometheus/tsdb_status_response.qtpl:63
 	return qs422016
-//line app/vmselect/prometheus/tsdb_status_response.qtpl:50
+//line app/vmselect/prometheus/tsdb_status_response.qtpl:63
 }

--- a/apptest/model.go
+++ b/apptest/model.go
@@ -344,3 +344,53 @@ type SnapshotDeleteResponse struct {
 type SnapshotDeleteAllResponse struct {
 	Status string
 }
+
+// TSDBStatusResponse is an in-memory reprensentation of the json response
+// returned by the /prometheus/api/v1/status/tsdb endpoint.
+type TSDBStatusResponse struct {
+	IsPartial bool
+	Data      TSDBStatusResponseData
+}
+
+// Sort performs sorting of stats entries
+func (tsr *TSDBStatusResponse) Sort() {
+	sortTSDBStatusResponseEntries(tsr.Data.SeriesCountByFocusLabelValue)
+	sortTSDBStatusResponseEntries(tsr.Data.SeriesCountByFocusLabelValue)
+	sortTSDBStatusResponseEntries(tsr.Data.SeriesCountByLabelValuePair)
+	sortTSDBStatusResponseEntries(tsr.Data.LabelValueCountByLabelName)
+}
+
+// TSDBStatusResponseData is a part of TSDBStatusResponse
+type TSDBStatusResponseData struct {
+	TotalSeries                  int
+	TotalLabelValuePairs         int
+	SeriesCountByMetricName      []TSDBStatusResponseMetricNameEntry
+	SeriesCountByLabelName       []TSDBStatusResponseEntry
+	SeriesCountByFocusLabelValue []TSDBStatusResponseEntry
+	SeriesCountByLabelValuePair  []TSDBStatusResponseEntry
+	LabelValueCountByLabelName   []TSDBStatusResponseEntry
+}
+
+// TSDBStatusResponseEntry defines stats entry for TSDBStatusResponseData
+type TSDBStatusResponseEntry struct {
+	Name  string
+	Count int
+}
+
+// TSDBStatusResponseMetricNameEntry defines metric names stats entry for TSDBStatusResponseData
+type TSDBStatusResponseMetricNameEntry struct {
+	Name                 string
+	Count                int
+	RequestsCount        int
+	LastRequestTimestamp int
+}
+
+func sortTSDBStatusResponseEntries(entries []TSDBStatusResponseEntry) {
+	sort.Slice(entries, func(i, j int) bool {
+		left, right := entries[i], entries[j]
+		if left.Count == right.Count {
+			return left.Name < right.Name
+		}
+		return left.Count < right.Count
+	})
+}

--- a/apptest/model.go
+++ b/apptest/model.go
@@ -354,7 +354,7 @@ type TSDBStatusResponse struct {
 
 // Sort performs sorting of stats entries
 func (tsr *TSDBStatusResponse) Sort() {
-	sortTSDBStatusResponseEntries(tsr.Data.SeriesCountByFocusLabelValue)
+	sortTSDBStatusResponseEntries(tsr.Data.SeriesCountByLabelName)
 	sortTSDBStatusResponseEntries(tsr.Data.SeriesCountByFocusLabelValue)
 	sortTSDBStatusResponseEntries(tsr.Data.SeriesCountByLabelValuePair)
 	sortTSDBStatusResponseEntries(tsr.Data.LabelValueCountByLabelName)

--- a/docs/victoriametrics/README.md
+++ b/docs/victoriametrics/README.md
@@ -2410,6 +2410,8 @@ due to [replication](#replication) or [rerouting](https://docs.victoriametrics.c
 
 VictoriaMetrics provides UI on top of `/api/v1/status/tsdb` - see [cardinality explorer docs](#cardinality-explorer).
 
+VictoriaMetrics enhances Prometheus stats with `requestsCount` and `lastRequestTimestamp` for `seriesCountByMetricName`. This stats added if [tracking metric names stats](https://docs.victoriametrics.com/#track-ingested-metrics-usage) is configured.
+
 ## Query tracing
 
 VictoriaMetrics supports query tracing, which can be used for determining bottlenecks during query processing.

--- a/docs/victoriametrics/changelog/CHANGELOG.md
+++ b/docs/victoriametrics/changelog/CHANGELOG.md
@@ -18,10 +18,15 @@ See also [LTS releases](https://docs.victoriametrics.com/lts-releases/).
 
 ## tip
 
+** Update Note 1: Updated the RPC cluster protocol version for the [TSDB status API](https://docs.victoriametrics.com/#tsdb-stats) from `tsdbStatus_v5` to `tsdbStatus_v6`.
+ The TSDB Status API will be temporarily unavailable during the version upgrade process.
+ This update requires both vmselect and vmstorage components to be running version v1.116.0 or higher for full compatibility.
+
 * FEATURE: [vmsingle](https://docs.victoriametrics.com/single-server-victoriametrics/) and `vmselect` in [VictoriaMetrics cluster](https://docs.victoriametrics.com/cluster-victoriametrics/): add command-line flag `-search.logSlowQueryStats`. This flag is available only in VictoriaMetrics [enterprise](https://docs.victoriametrics.com/enterprise/). See the following [docs](https://docs.victoriametrics.com/query-stats) for details.
 * FEATURE: all the VictoriaMetrics components: mask `authKey` value from log messages. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/5973) for details.
 * FEATURE: [vmsingle](https://docs.victoriametrics.com/single-server-victoriametrics/), [vmagent](https://docs.victoriametrics.com/vmagent/): add helpful hints to the unexpected EOF error message in the write concurrency limiter. See [this pull request](https://github.com/VictoriaMetrics/VictoriaMetrics/pull/8704) for details.
 * FEATURE: [vmagent](https://docs.victoriametrics.com/vmagent/): use [VM remote write protocol](https://docs.victoriametrics.com/vmagent/#victoriametrics-remote-write-protocol) by default with automatic downgrade in runtime to Prometheus protocol when needed. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/pull/8462) for details.
+* FEATURE: [Single-node VictoriaMetrics](https://docs.victoriametrics.com/) and [vmstorage](https://docs.victoriametrics.com/cluster-victoriametrics/): add additional metric name stats to TSDB Status API response. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/6145) for details and this [doc](https://docs.victoriametrics.com/#tsdb-stats).
 
 * BUGFIX: [vmagent](https://docs.victoriametrics.com/vmagent/): properly init [enterprise](https://docs.victoriametrics.com/enterprise/) version for `linux/arm` and non-CGO buids. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/6019) for details.
 * BUGFIX: [vmagent](https://docs.victoriametrics.com/vmagent/): remote write client sets correct content encoding header based on actual body content, rather than relying on configuration. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/pull/8650).

--- a/lib/storage/index_db.go
+++ b/lib/storage/index_db.go
@@ -1593,18 +1593,10 @@ func (is *indexSearch) getTSDBStatus(qt *querytracer.Tracer, tfss []*TagFilters,
 	if bytes.HasPrefix(prevLabelValuePair, focusLabelEqualBytes) {
 		thSeriesCountByFocusLabelValue.push(prevLabelValuePair[len(focusLabelEqualBytes):], seriesCountByLabelValuePair)
 	}
-	sortedSeriesByMetricName := thSeriesCountByMetricName.getSortedResult()
-	metricNamesHeapSeries := make([]TopHeapMetricNameEntry, len(sortedSeriesByMetricName))
-	for idx, entry := range sortedSeriesByMetricName {
-		metricNamesHeapSeries[idx] = TopHeapMetricNameEntry{
-			Name:  entry.Name,
-			Count: entry.Count,
-		}
-	}
 	status := &TSDBStatus{
 		TotalSeries:                  totalSeries,
 		TotalLabelValuePairs:         totalLabelValuePairs,
-		SeriesCountByMetricName:      metricNamesHeapSeries,
+		SeriesCountByMetricName:      thSeriesCountByMetricName.getSortedResult(),
 		SeriesCountByLabelName:       thSeriesCountByLabelName.getSortedResult(),
 		SeriesCountByFocusLabelValue: thSeriesCountByFocusLabelValue.getSortedResult(),
 		SeriesCountByLabelValuePair:  thSeriesCountByLabelValuePair.getSortedResult(),
@@ -1619,11 +1611,12 @@ func (is *indexSearch) getTSDBStatus(qt *querytracer.Tracer, tfss []*TagFilters,
 type TSDBStatus struct {
 	TotalSeries                  uint64
 	TotalLabelValuePairs         uint64
-	SeriesCountByMetricName      []TopHeapMetricNameEntry
+	SeriesCountByMetricName      []TopHeapEntry
 	SeriesCountByLabelName       []TopHeapEntry
 	SeriesCountByFocusLabelValue []TopHeapEntry
 	SeriesCountByLabelValuePair  []TopHeapEntry
 	LabelValueCountByLabelName   []TopHeapEntry
+	SeriesQueryStatsByMetricName []MetricNamesStatsRecord
 }
 
 func (status *TSDBStatus) hasEntries() bool {
@@ -1705,14 +1698,6 @@ func (th *topHeap) Push(_ any) {
 
 func (th *topHeap) Pop() any {
 	panic(fmt.Errorf("BUG: Pop shouldn't be called"))
-}
-
-// TopHeapMetricNameEntry represents an entry from `top heap` used in stats for series metric names.
-type TopHeapMetricNameEntry struct {
-	Name                 string
-	Count                uint64
-	RequestsCount        uint64
-	LastRequestTimestamp uint64
 }
 
 // searchMetricName appends metric name for the given metricID to dst

--- a/lib/storage/index_db_test.go
+++ b/lib/storage/index_db_test.go
@@ -1959,7 +1959,7 @@ func TestSearchTSIDWithTimeRange(t *testing.T) {
 	if !status.hasEntries() {
 		t.Fatalf("expecting non-empty TSDB status")
 	}
-	expectedSeriesCountByMetricName := []TopHeapEntry{
+	expectedSeriesCountByMetricName := []TopHeapMetricNameEntry{
 		{
 			Name:  "testMetric",
 			Count: 1000,
@@ -2073,7 +2073,7 @@ func TestSearchTSIDWithTimeRange(t *testing.T) {
 	if !status.hasEntries() {
 		t.Fatalf("expecting non-empty TSDB status")
 	}
-	expectedSeriesCountByMetricName = []TopHeapEntry{
+	expectedSeriesCountByMetricName = []TopHeapMetricNameEntry{
 		{
 			Name:  "testMetric",
 			Count: 1000,
@@ -2099,7 +2099,7 @@ func TestSearchTSIDWithTimeRange(t *testing.T) {
 	if !status.hasEntries() {
 		t.Fatalf("expecting non-empty TSDB status")
 	}
-	expectedSeriesCountByMetricName = []TopHeapEntry{
+	expectedSeriesCountByMetricName = []TopHeapMetricNameEntry{
 		{
 			Name:  "testMetric",
 			Count: 5000,
@@ -2154,7 +2154,7 @@ func TestSearchTSIDWithTimeRange(t *testing.T) {
 	if !status.hasEntries() {
 		t.Fatalf("expecting non-empty TSDB status")
 	}
-	expectedSeriesCountByMetricName = []TopHeapEntry{
+	expectedSeriesCountByMetricName = []TopHeapMetricNameEntry{
 		{
 			Name:  "testMetric",
 			Count: 3,
@@ -2180,7 +2180,7 @@ func TestSearchTSIDWithTimeRange(t *testing.T) {
 	if !status.hasEntries() {
 		t.Fatalf("expecting non-empty TSDB status")
 	}
-	expectedSeriesCountByMetricName = []TopHeapEntry{
+	expectedSeriesCountByMetricName = []TopHeapMetricNameEntry{
 		{
 			Name:  "testMetric",
 			Count: 15,

--- a/lib/storage/index_db_test.go
+++ b/lib/storage/index_db_test.go
@@ -1959,7 +1959,7 @@ func TestSearchTSIDWithTimeRange(t *testing.T) {
 	if !status.hasEntries() {
 		t.Fatalf("expecting non-empty TSDB status")
 	}
-	expectedSeriesCountByMetricName := []TopHeapMetricNameEntry{
+	expectedSeriesCountByMetricName := []TopHeapEntry{
 		{
 			Name:  "testMetric",
 			Count: 1000,
@@ -2073,7 +2073,7 @@ func TestSearchTSIDWithTimeRange(t *testing.T) {
 	if !status.hasEntries() {
 		t.Fatalf("expecting non-empty TSDB status")
 	}
-	expectedSeriesCountByMetricName = []TopHeapMetricNameEntry{
+	expectedSeriesCountByMetricName = []TopHeapEntry{
 		{
 			Name:  "testMetric",
 			Count: 1000,
@@ -2099,7 +2099,7 @@ func TestSearchTSIDWithTimeRange(t *testing.T) {
 	if !status.hasEntries() {
 		t.Fatalf("expecting non-empty TSDB status")
 	}
-	expectedSeriesCountByMetricName = []TopHeapMetricNameEntry{
+	expectedSeriesCountByMetricName = []TopHeapEntry{
 		{
 			Name:  "testMetric",
 			Count: 5000,
@@ -2154,7 +2154,7 @@ func TestSearchTSIDWithTimeRange(t *testing.T) {
 	if !status.hasEntries() {
 		t.Fatalf("expecting non-empty TSDB status")
 	}
-	expectedSeriesCountByMetricName = []TopHeapMetricNameEntry{
+	expectedSeriesCountByMetricName = []TopHeapEntry{
 		{
 			Name:  "testMetric",
 			Count: 3,
@@ -2180,7 +2180,7 @@ func TestSearchTSIDWithTimeRange(t *testing.T) {
 	if !status.hasEntries() {
 		t.Fatalf("expecting non-empty TSDB status")
 	}
-	expectedSeriesCountByMetricName = []TopHeapMetricNameEntry{
+	expectedSeriesCountByMetricName = []TopHeapEntry{
 		{
 			Name:  "testMetric",
 			Count: 15,

--- a/lib/storage/metricnamestats/tracker.go
+++ b/lib/storage/metricnamestats/tracker.go
@@ -391,8 +391,8 @@ func (mt *Tracker) GetStatsForTenant(accountID, projectID uint32, limit, le int,
 	return result
 }
 
-// WriteStatsToForNames writes stats records for the given metric names into provided dst
-func (mt *Tracker) WriteStatsToForNames(dst []StatRecord, accountID, projectID uint32, metricNames []string) {
+// WriteStatsForNamesTo writes stats records for the given metric names into provided dst
+func (mt *Tracker) WriteStatsForNamesTo(dst []StatRecord, accountID, projectID uint32, metricNames []string) {
 	if mt == nil {
 		return
 	}

--- a/lib/storage/metricnamestats/tracker.go
+++ b/lib/storage/metricnamestats/tracker.go
@@ -391,16 +391,14 @@ func (mt *Tracker) GetStatsForTenant(accountID, projectID uint32, limit, le int,
 	return result
 }
 
-// WriteStatsForNamesTo writes stats records for the given metric names into provided dst
-func (mt *Tracker) WriteStatsForNamesTo(dst []StatRecord, accountID, projectID uint32, metricNames []string) {
+// GetStatRecordsForNames returns stats records for the given metric names and tenant
+func (mt *Tracker) GetStatRecordsForNames(accountID, projectID uint32, metricNames []string) []StatRecord {
 	if mt == nil {
-		return
-	}
-	if len(dst) != len(metricNames) {
-		logger.Fatalf("BUG: provided StatRecord len=%d must match metricName=%d", len(dst), len(metricNames))
+		return nil
 	}
 	mt.mu.RLock()
-	for idx, mn := range metricNames {
+	records := make([]StatRecord, 0, len(metricNames))
+	for _, mn := range metricNames {
 		sk := statKey{
 			accountID:  accountID,
 			projectID:  projectID,
@@ -410,12 +408,14 @@ func (mt *Tracker) WriteStatsForNamesTo(dst []StatRecord, accountID, projectID u
 		if !ok {
 			continue
 		}
-		dst[idx] = StatRecord{
+		records = append(records, StatRecord{
+			MetricName:    mn,
 			RequestsCount: si.requestsCount.Load(),
 			LastRequestTs: si.lastRequestTs.Load(),
-		}
+		})
 	}
 	mt.mu.RUnlock()
+	return records
 }
 
 // GetStats returns stats response for the tracked metrics

--- a/lib/storage/metricnamestats/tracker.go
+++ b/lib/storage/metricnamestats/tracker.go
@@ -391,7 +391,7 @@ func (mt *Tracker) GetStatsForTenant(accountID, projectID uint32, limit, le int,
 	return result
 }
 
-// WriteStatsToForNames writees stats records for the given metric names into provided buffer
+// WriteStatsToForNames writes stats records for the given metric names into provided dst
 func (mt *Tracker) WriteStatsToForNames(dst []StatRecord, accountID, projectID uint32, metricNames []string) {
 	if mt == nil {
 		return

--- a/lib/storage/storage.go
+++ b/lib/storage/storage.go
@@ -1791,7 +1791,7 @@ func (s *Storage) GetTSDBStatus(qt *querytracer.Tracer, accountID, projectID uin
 			names[idx] = mns.Name
 		}
 		stats := make([]metricnamestats.StatRecord, len(names))
-		s.metricsTracker.WriteStatsToForNames(stats, accountID, projectID, names)
+		s.metricsTracker.WriteStatsForNamesTo(stats, accountID, projectID, names)
 		for idx, stat := range stats {
 			entry := &res.SeriesCountByMetricName[idx]
 			entry.RequestsCount = stat.RequestsCount

--- a/lib/storage/storage.go
+++ b/lib/storage/storage.go
@@ -1785,18 +1785,12 @@ func (s *Storage) GetTSDBStatus(qt *querytracer.Tracer, accountID, projectID uin
 		return nil, err
 	}
 	if s.metricsTracker != nil && len(res.SeriesCountByMetricName) > 0 {
-		// join query stats for given top metric names
+		// for performance reason always check if metricsTracker is configured
 		names := make([]string, len(res.SeriesCountByMetricName))
 		for idx, mns := range res.SeriesCountByMetricName {
 			names[idx] = mns.Name
 		}
-		stats := make([]metricnamestats.StatRecord, len(names))
-		s.metricsTracker.WriteStatsForNamesTo(stats, accountID, projectID, names)
-		for idx, stat := range stats {
-			entry := &res.SeriesCountByMetricName[idx]
-			entry.RequestsCount = stat.RequestsCount
-			entry.LastRequestTimestamp = stat.LastRequestTs
-		}
+		res.SeriesQueryStatsByMetricName = s.metricsTracker.GetStatRecordsForNames(accountID, projectID, names)
 	}
 	return res, nil
 }

--- a/lib/vmselectapi/server.go
+++ b/lib/vmselectapi/server.go
@@ -957,7 +957,7 @@ func writeTSDBStatus(ctx *vmselectRequestCtx, status *storage.TSDBStatus) error 
 	if err := ctx.writeUint64(status.TotalLabelValuePairs); err != nil {
 		return fmt.Errorf("cannot write totalLabelValuePairs to vmselect: %w", err)
 	}
-	if err := writeTopHeapMetricNamesEntries(ctx, status.SeriesCountByMetricName); err != nil {
+	if err := writeTopHeapEntries(ctx, status.SeriesCountByMetricName); err != nil {
 		return fmt.Errorf("cannot write seriesCountByMetricName to vmselect: %w", err)
 	}
 	if err := writeTopHeapEntries(ctx, status.SeriesCountByLabelName); err != nil {
@@ -972,6 +972,9 @@ func writeTSDBStatus(ctx *vmselectRequestCtx, status *storage.TSDBStatus) error 
 	if err := writeTopHeapEntries(ctx, status.LabelValueCountByLabelName); err != nil {
 		return fmt.Errorf("cannot write labelValueCountByLabelName to vmselect: %w", err)
 	}
+	if err := writeMetricNameStatRecords(ctx, status.SeriesQueryStatsByMetricName); err != nil {
+		return fmt.Errorf("cannot write SeriesMetricNamesStats: %w", err)
+	}
 	return nil
 }
 
@@ -985,27 +988,6 @@ func writeTopHeapEntries(ctx *vmselectRequestCtx, a []storage.TopHeapEntry) erro
 		}
 		if err := ctx.writeUint64(e.Count); err != nil {
 			return fmt.Errorf("cannot write topHeapEntry count: %w", err)
-		}
-	}
-	return nil
-}
-
-func writeTopHeapMetricNamesEntries(ctx *vmselectRequestCtx, a []storage.TopHeapMetricNameEntry) error {
-	if err := ctx.writeUint64(uint64(len(a))); err != nil {
-		return fmt.Errorf("cannot write TopHeapMetricNameEntry size: %w", err)
-	}
-	for _, e := range a {
-		if err := ctx.writeString(e.Name); err != nil {
-			return fmt.Errorf("cannot write TopHeapMetricNameEntry name: %w", err)
-		}
-		if err := ctx.writeUint64(e.Count); err != nil {
-			return fmt.Errorf("cannot write TopHeapMetricNameEntry count: %w", err)
-		}
-		if err := ctx.writeUint64(e.RequestsCount); err != nil {
-			return fmt.Errorf("cannot write TopHeapMetricNameEntry requestsCount: %w", err)
-		}
-		if err := ctx.writeUint64(e.LastRequestTimestamp); err != nil {
-			return fmt.Errorf("cannot write TopHeapMetricNameEntry lastRequestTimestamp: %w", err)
 		}
 	}
 	return nil
@@ -1158,10 +1140,17 @@ func (s *Server) processMetricNamesUsageStats(ctx *vmselectRequestCtx) error {
 	if err := ctx.writeUint64(result.MaxSizeBytes); err != nil {
 		return fmt.Errorf("cannot write MaxSizeBytes: %w", err)
 	}
-	if err := ctx.writeUint64(uint64(len(result.Records))); err != nil {
-		return fmt.Errorf("cannot write records count: %w", err)
+	if err := writeMetricNameStatRecords(ctx, result.Records); err != nil {
+		return fmt.Errorf("cannot write Records: %w", err)
 	}
-	for _, r := range result.Records {
+	return nil
+}
+
+func writeMetricNameStatRecords(ctx *vmselectRequestCtx, records []storage.MetricNamesStatsRecord) error {
+	if err := ctx.writeUint64(uint64(len(records))); err != nil {
+		return fmt.Errorf("cannot write MetricNamesStatsRecord size: %w", err)
+	}
+	for _, r := range records {
 		if err := ctx.writeString(r.MetricName); err != nil {
 			return fmt.Errorf("cannot write MetricName=%q record: %w", r.MetricName, err)
 		}

--- a/lib/vmselectapi/server.go
+++ b/lib/vmselectapi/server.go
@@ -578,7 +578,7 @@ func (s *Server) processRPC(ctx *vmselectRequestCtx, rpcName string) error {
 		return s.processLabelNames(ctx)
 	case "seriesCount_v4":
 		return s.processSeriesCount(ctx)
-	case "tsdbStatus_v5":
+	case "tsdbStatus_v6":
 		return s.processTSDBStatus(ctx)
 	case "deleteSeries_v5":
 		return s.processDeleteSeries(ctx)
@@ -957,7 +957,7 @@ func writeTSDBStatus(ctx *vmselectRequestCtx, status *storage.TSDBStatus) error 
 	if err := ctx.writeUint64(status.TotalLabelValuePairs); err != nil {
 		return fmt.Errorf("cannot write totalLabelValuePairs to vmselect: %w", err)
 	}
-	if err := writeTopHeapEntries(ctx, status.SeriesCountByMetricName); err != nil {
+	if err := writeTopHeapMetricNamesEntries(ctx, status.SeriesCountByMetricName); err != nil {
 		return fmt.Errorf("cannot write seriesCountByMetricName to vmselect: %w", err)
 	}
 	if err := writeTopHeapEntries(ctx, status.SeriesCountByLabelName); err != nil {
@@ -985,6 +985,27 @@ func writeTopHeapEntries(ctx *vmselectRequestCtx, a []storage.TopHeapEntry) erro
 		}
 		if err := ctx.writeUint64(e.Count); err != nil {
 			return fmt.Errorf("cannot write topHeapEntry count: %w", err)
+		}
+	}
+	return nil
+}
+
+func writeTopHeapMetricNamesEntries(ctx *vmselectRequestCtx, a []storage.TopHeapMetricNameEntry) error {
+	if err := ctx.writeUint64(uint64(len(a))); err != nil {
+		return fmt.Errorf("cannot write TopHeapMetricNameEntry size: %w", err)
+	}
+	for _, e := range a {
+		if err := ctx.writeString(e.Name); err != nil {
+			return fmt.Errorf("cannot write TopHeapMetricNameEntry name: %w", err)
+		}
+		if err := ctx.writeUint64(e.Count); err != nil {
+			return fmt.Errorf("cannot write TopHeapMetricNameEntry count: %w", err)
+		}
+		if err := ctx.writeUint64(e.RequestsCount); err != nil {
+			return fmt.Errorf("cannot write TopHeapMetricNameEntry requestsCount: %w", err)
+		}
+		if err := ctx.writeUint64(e.LastRequestTimestamp); err != nil {
+			return fmt.Errorf("cannot write TopHeapMetricNameEntry lastRequestTimestamp: %w", err)
 		}
 	}
 	return nil


### PR DESCRIPTION
 This commit adds new fields - `requestsCount` and `lastRequestTimestamp` to series count be metric names stats.
It allows to display an additional stats at explore cardinality page. Stats will only be added if `storage.trackMetricNameStats` flag is set.

 This change requires an update to RPC protocol in order to properly
marshal data.

 In addition, this commit adds integration tests to TSDB stats API.

Related issue:
https://github.com/VictoriaMetrics/VictoriaMetrics/issues/6145

### Describe Your Changes

Please provide a brief description of the changes you made. Be as specific as possible to help others understand the purpose and impact of your modifications.

### Checklist

The following checks are **mandatory**:

- [ ] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/contributing/).
