### PR TITLE
app/vmui/logs: fix zoom behavior on VictoriaLogs chart

### DIFF
--- a/app/vmui/packages/vmui/src/components/Chart/BarHitsChart/BarHitsChart.tsx
+++ b/app/vmui/packages/vmui/src/components/Chart/BarHitsChart/BarHitsChart.tsx
@@ -83,18 +83,36 @@ const BarHitsChart: FC<Props> = ({ logHits, data: _data, period, setPeriod, onAp
 
   useEffect(() => {
     if (!uPlotInst) return;
+
+    const oldSeriesMap = new Map(uPlotInst.series.map(s => [s.label, s]));
+
+    const syncedSeries = series.map(s => {
+      const old = oldSeriesMap.get(s.label);
+      return old ? { ...s, show: old.show } : s;
+    });
+
     delSeries(uPlotInst);
-    addSeries(uPlotInst, series, true);
-    setBand(uPlotInst, series);
+    addSeries(uPlotInst, syncedSeries, true);
+    setBand(uPlotInst, syncedSeries);
     uPlotInst.redraw();
-  }, [series]);
+  }, [series, uPlotInst]);
+
+
+  useEffect(() => {
+    if (!uPlotInst) return;
+    uPlotInst.delBand();
+    bands.forEach(band => {
+      uPlotInst.addBand(band);
+    });
+    uPlotInst.redraw();
+  }, [bands]);
 
   useEffect(() => {
     if (!uPlotRef.current) return;
     const uplot = new uPlot(options, data, uPlotRef.current);
     setUPlotInst(uplot);
     return () => uplot.destroy();
-  }, [uPlotRef.current, options]);
+  }, [uPlotRef.current]);
 
   useEffect(() => {
     if (!uPlotInst) return;

--- a/app/vmui/packages/vmui/src/components/Chart/BarHitsChart/BarHitsChart.tsx
+++ b/app/vmui/packages/vmui/src/components/Chart/BarHitsChart/BarHitsChart.tsx
@@ -1,23 +1,13 @@
-import React, { FC, useCallback, useMemo, useRef, useState } from "preact/compat";
+import React, { FC, useState } from "preact/compat";
 import "./style.scss";
 import "uplot/dist/uPlot.min.css";
-import useElementSize from "../../../hooks/useElementSize";
-import uPlot, { AlignedData } from "uplot";
-import { useEffect } from "react";
-import useBarHitsOptions, { getLabelFromLogHit } from "./hooks/useBarHitsOptions";
-import BarHitsTooltip from "./BarHitsTooltip/BarHitsTooltip";
+import { AlignedData } from "uplot";
 import { TimeParams } from "../../../types";
-import usePlotScale from "../../../hooks/uplot/usePlotScale";
-import useReadyChart from "../../../hooks/uplot/useReadyChart";
-import useZoomChart from "../../../hooks/uplot/useZoomChart";
 import classNames from "classnames";
-import { LegendLogHits, LogHits } from "../../../api/types";
-import { addSeries, delSeries, setBand } from "../../../utils/uplot";
+import { LogHits } from "../../../api/types";
 import { GraphOptions, GRAPH_STYLES } from "./types";
 import BarHitsOptions from "./BarHitsOptions/BarHitsOptions";
-import stack from "../../../utils/uplot/stack";
-import BarHitsLegend from "./BarHitsLegend/BarHitsLegend";
-import { calculateTotalHits, sortLogHits } from "../../../utils/logs";
+import BarHitsPlot from "./BarHitsPlot/BarHitsPlot";
 
 interface Props {
   logHits: LogHits[];
@@ -27,9 +17,6 @@ interface Props {
   onApplyFilter: (value: string) => void;
 }
 const BarHitsChart: FC<Props> = ({ logHits, data: _data, period, setPeriod, onApplyFilter }) => {
-  const [containerRef, containerSize] = useElementSize();
-  const uPlotRef = useRef<HTMLDivElement>(null);
-  const [uPlotInst, setUPlotInst] = useState<uPlot>();
   const [graphOptions, setGraphOptions] = useState<GraphOptions>({
     graphStyle: GRAPH_STYLES.LINE_STEPPED,
     stacked: false,
@@ -37,100 +24,6 @@ const BarHitsChart: FC<Props> = ({ logHits, data: _data, period, setPeriod, onAp
     hideChart: false,
   });
 
-  const { xRange, setPlotScale } = usePlotScale({ period, setPeriod });
-  const { onReadyChart, isPanning } = useReadyChart(setPlotScale);
-  useZoomChart({ uPlotInst, xRange, setPlotScale });
-
-  const isEmptyData = useMemo(() => _data.every(d => d.length === 0), [_data]);
-
-  const { data, bands } = useMemo(() => {
-    return graphOptions.stacked ? stack(_data, () => false) : { data: _data, bands: [] };
-  }, [graphOptions, _data]);
-
-  const { options, series, focusDataIdx } = useBarHitsOptions({
-    data,
-    logHits,
-    bands,
-    xRange,
-    containerSize,
-    onReadyChart,
-    setPlotScale,
-    graphOptions
-  });
-
-  const prepareLegend = useCallback((hits: LogHits[], totalHits: number): LegendLogHits[] => {
-    return hits.map((hit) => {
-      const label = getLabelFromLogHit(hit);
-
-      const legendItem: LegendLogHits = {
-        label,
-        isOther: hit._isOther,
-        fields: hit.fields,
-        total: hit.total || 0,
-        totalHits,
-        stroke: series.find((s) => s.label === label)?.stroke,
-      };
-
-      return legendItem;
-    }).sort(sortLogHits("total"));
-  }, [series]);
-
-
-  const legendDetails: LegendLogHits[] = useMemo(() => {
-    const totalHits = calculateTotalHits(logHits);
-    return prepareLegend(logHits, totalHits);
-  }, [logHits, prepareLegend]);
-
-  useEffect(() => {
-    if (!uPlotInst) return;
-
-    const oldSeriesMap = new Map(uPlotInst.series.map(s => [s.label, s]));
-
-    const syncedSeries = series.map(s => {
-      const old = oldSeriesMap.get(s.label);
-      return old ? { ...s, show: old.show } : s;
-    });
-
-    delSeries(uPlotInst);
-    addSeries(uPlotInst, syncedSeries, true);
-    setBand(uPlotInst, syncedSeries);
-    uPlotInst.redraw();
-  }, [series, uPlotInst]);
-
-
-  useEffect(() => {
-    if (!uPlotInst) return;
-    uPlotInst.delBand();
-    bands.forEach(band => {
-      uPlotInst.addBand(band);
-    });
-    uPlotInst.redraw();
-  }, [bands]);
-
-  useEffect(() => {
-    if (!uPlotRef.current) return;
-    const uplot = new uPlot(options, data, uPlotRef.current);
-    setUPlotInst(uplot);
-    return () => uplot.destroy();
-  }, [uPlotRef.current]);
-
-  useEffect(() => {
-    if (!uPlotInst) return;
-    uPlotInst.scales.x.range = () => [xRange.min, xRange.max];
-    uPlotInst.redraw();
-  }, [xRange]);
-
-  useEffect(() => {
-    if (!uPlotInst) return;
-    uPlotInst.setSize(containerSize);
-    uPlotInst.redraw();
-  }, [containerSize]);
-
-  useEffect(() => {
-    if (!uPlotInst) return;
-    uPlotInst.setData(data);
-    uPlotInst.redraw();
-  }, [data]);
 
   return (
     <div
@@ -140,32 +33,16 @@ const BarHitsChart: FC<Props> = ({ logHits, data: _data, period, setPeriod, onAp
       })}
     >
       {!graphOptions.hideChart && (
-        <div
-          className={classNames({
-            "vm-bar-hits-chart": true,
-            "vm-bar-hits-chart_panning": isPanning
-          })}
-          ref={containerRef}
-        >
-          <div
-            className="vm-line-chart__u-plot"
-            ref={uPlotRef}
-          />
-          <BarHitsTooltip
-            uPlotInst={uPlotInst}
-            data={_data}
-            focusDataIdx={focusDataIdx}
-          />
-        </div>
-      )}
-      <BarHitsOptions onChange={setGraphOptions}/>
-      {uPlotInst && !isEmptyData && !graphOptions.hideChart && (
-        <BarHitsLegend
-          uPlotInst={uPlotInst}
+        <BarHitsPlot
+          logHits={logHits}
+          data={_data}
+          period={period}
+          setPeriod={setPeriod}
           onApplyFilter={onApplyFilter}
-          legendDetails={legendDetails}
+          graphOptions={graphOptions}
         />
       )}
+      <BarHitsOptions onChange={setGraphOptions}/>
     </div>
   );
 };

--- a/app/vmui/packages/vmui/src/components/Chart/BarHitsChart/BarHitsLegend/BarHitsLegend.tsx
+++ b/app/vmui/packages/vmui/src/components/Chart/BarHitsChart/BarHitsLegend/BarHitsLegend.tsx
@@ -25,7 +25,12 @@ const BarHitsLegend: FC<Props> = ({ uPlotInst, legendDetails, onApplyFilter }) =
   };
 
   useEffect(() => {
-    setSeries(getSeries());
+    if (!uPlotInst.hooks.draw) {
+      uPlotInst.hooks.draw = [];
+    }
+    uPlotInst.hooks.draw.push(() => {
+      setSeries(getSeries());
+    });
   }, [uPlotInst]);
 
   return (

--- a/app/vmui/packages/vmui/src/components/Chart/BarHitsChart/BarHitsLegend/BarHitsLegend.tsx
+++ b/app/vmui/packages/vmui/src/components/Chart/BarHitsChart/BarHitsLegend/BarHitsLegend.tsx
@@ -21,7 +21,6 @@ const BarHitsLegend: FC<Props> = ({ uPlotInst, legendDetails, onApplyFilter }) =
 
   const handleRedrawGraph = () => {
     uPlotInst.redraw();
-    setSeries(getSeries());
   };
 
   useEffect(() => {

--- a/app/vmui/packages/vmui/src/components/Chart/BarHitsChart/BarHitsPlot/BarHitsPlot.tsx
+++ b/app/vmui/packages/vmui/src/components/Chart/BarHitsChart/BarHitsPlot/BarHitsPlot.tsx
@@ -1,0 +1,153 @@
+import React, { FC, useCallback } from "preact/compat";
+import useElementSize from "../../../../hooks/useElementSize";
+import { useEffect, useMemo, useRef, useState } from "react";
+import uPlot, { AlignedData, Series } from "uplot";
+import { GraphOptions } from "../types";
+import usePlotScale from "../../../../hooks/uplot/usePlotScale";
+import useReadyChart from "../../../../hooks/uplot/useReadyChart";
+import useZoomChart from "../../../../hooks/uplot/useZoomChart";
+import stack from "../../../../utils/uplot/stack";
+import useBarHitsOptions, { getLabelFromLogHit } from "../hooks/useBarHitsOptions";
+import { LegendLogHits, LogHits } from "../../../../api/types";
+import { addSeries, delSeries, setBand } from "../../../../utils/uplot";
+import classNames from "classnames";
+import BarHitsTooltip from "../BarHitsTooltip/BarHitsTooltip";
+import { TimeParams } from "../../../../types";
+import BarHitsLegend from "../BarHitsLegend/BarHitsLegend";
+import { calculateTotalHits, sortLogHits } from "../../../../utils/logs";
+
+interface Props {
+  logHits: LogHits[];
+  data: AlignedData;
+  period: TimeParams;
+  setPeriod: ({ from, to }: { from: Date, to: Date }) => void;
+  onApplyFilter: (value: string) => void;
+  graphOptions: GraphOptions;
+}
+
+const BarHitsPlot: FC<Props> = ({ graphOptions, logHits, data: _data, period, setPeriod, onApplyFilter }: Props) => {
+  const [containerRef, containerSize] = useElementSize();
+  const uPlotRef = useRef<HTMLDivElement>(null);
+  const [uPlotInst, setUPlotInst] = useState<uPlot>();
+
+  const { xRange, setPlotScale } = usePlotScale({ period, setPeriod });
+  const { onReadyChart, isPanning } = useReadyChart(setPlotScale);
+  useZoomChart({ uPlotInst, xRange, setPlotScale });
+
+  const { data, bands } = useMemo(() => {
+    return graphOptions.stacked ? stack(_data, () => false) : { data: _data, bands: [] };
+  }, [graphOptions, _data]);
+
+  const { options, series, focusDataIdx } = useBarHitsOptions({
+    data,
+    logHits,
+    bands,
+    xRange,
+    containerSize,
+    onReadyChart,
+    setPlotScale,
+    graphOptions
+  });
+
+  const prepareLegend = useCallback((hits: LogHits[], totalHits: number): LegendLogHits[] => {
+    return hits.map((hit) => {
+      const label = getLabelFromLogHit(hit);
+
+      const legendItem: LegendLogHits = {
+        label,
+        isOther: hit._isOther,
+        fields: hit.fields,
+        total: hit.total || 0,
+        totalHits,
+        stroke: series.find((s) => s.label === label)?.stroke,
+      };
+
+      return legendItem;
+    }).sort(sortLogHits("total"));
+  }, [series]);
+
+
+  const legendDetails: LegendLogHits[] = useMemo(() => {
+    const totalHits = calculateTotalHits(logHits);
+    return prepareLegend(logHits, totalHits);
+  }, [logHits, prepareLegend]);
+
+  useEffect(() => {
+    if (!uPlotInst) return;
+
+    const oldSeriesMap = new Map(uPlotInst.series.map(s => [s.label, s]));
+
+    const syncedSeries = series.map(s => {
+      const old = oldSeriesMap.get(s.label);
+      return old ? { ...s, show: old.show } : s;
+    });
+
+    delSeries(uPlotInst);
+    addSeries(uPlotInst, syncedSeries, true);
+    setBand(uPlotInst, syncedSeries);
+    uPlotInst.redraw();
+  }, [series, uPlotInst]);
+
+  useEffect(() => {
+    if (!uPlotInst) return;
+    uPlotInst.delBand();
+    bands.forEach(band => {
+      uPlotInst.addBand(band);
+    });
+    uPlotInst.redraw();
+  }, [bands]);
+
+  useEffect(() => {
+    if (!uPlotRef.current) return;
+    const uplot = new uPlot(options, data, uPlotRef.current);
+    setUPlotInst(uplot);
+    return () => uplot.destroy();
+  }, [uPlotRef.current]);
+
+  useEffect(() => {
+    if (!uPlotInst) return;
+    uPlotInst.scales.x.range = () => [xRange.min, xRange.max];
+    uPlotInst.redraw();
+  }, [xRange]);
+
+  useEffect(() => {
+    if (!uPlotInst) return;
+    uPlotInst.setSize(containerSize);
+    uPlotInst.redraw();
+  }, [containerSize]);
+
+  useEffect(() => {
+    if (!uPlotInst) return;
+    uPlotInst.setData(data);
+    uPlotInst.redraw();
+  }, [data]);
+
+  return (
+    <>
+      <div
+        className={classNames({
+          "vm-bar-hits-chart": true,
+          "vm-bar-hits-chart_panning": isPanning
+        })}
+        ref={containerRef}
+      >
+        <div
+          className="vm-line-chart__u-plot"
+          ref={uPlotRef}
+        />
+        <BarHitsTooltip
+          uPlotInst={uPlotInst}
+          data={_data}
+          focusDataIdx={focusDataIdx}
+        />
+      </div>
+      {uPlotInst && <BarHitsLegend
+        uPlotInst={uPlotInst}
+        onApplyFilter={onApplyFilter}
+        legendDetails={legendDetails}
+      />}
+    </>
+  );
+};
+
+export default BarHitsPlot;

--- a/app/vmui/packages/vmui/src/components/Chart/BarHitsChart/hooks/useBarHitsOptions.ts
+++ b/app/vmui/packages/vmui/src/components/Chart/BarHitsChart/hooks/useBarHitsOptions.ts
@@ -71,25 +71,34 @@ const useBarHitsOptions = ({
   };
 
   const series: Series[] = useMemo(() => {
-    let colorN = 0;
+    let visibleColorIndex = 0;
+
     return data.map((_d, i) => {
-      if (i === 0) return {}; // 0 index is xAxis(timestamps)
-      const target = logHits?.[i - 1];
-      const label = getLabelFromLogHit(target);
-      const color = getCssVariable(target?._isOther ? "color-log-hits-bar-0" : seriesColors[colorN]);
-      if (!target?._isOther) colorN++;
+      if (i === 0) return {}; // x-axis
+
+      const logHit = logHits?.[i - 1];
+      const label = getLabelFromLogHit(logHit);
+
+      const isOther = logHit?._isOther;
+      const colorVar = isOther
+        ? "color-log-hits-bar-0"
+        : seriesColors[visibleColorIndex++];
+
+      const color = getCssVariable(colorVar);
+
       return {
         label,
         width: strokeWidth[graphOptions.graphStyle],
         spanGaps: true,
+        show: true,
         stroke: color,
-        fill: graphOptions.fill ? color + (target?._isOther ? "" : "80") : "",
+        fill: graphOptions.fill && !isOther ? `${color}80` : graphOptions.fill ? color : "",
         paths: getSeriesPaths(graphOptions.graphStyle),
       };
     });
   }, [isDarkTheme, data, graphOptions]);
 
-  const options: Options = useMemo(() => ({
+  const options: Options = {
     series,
     bands,
     width: containerSize.width || (window.innerWidth / 2),
@@ -121,7 +130,7 @@ const useBarHitsOptions = ({
     legend: { show: false },
     axes: getAxes([{}, { scale: "y" }]),
     tzDate: ts => dayjs(formatDateForNativeInput(dateFromSeconds(ts))).local().toDate(),
-  }), [isDarkTheme, series, bands]);
+  };
 
   return {
     options,

--- a/docs/victorialogs/CHANGELOG.md
+++ b/docs/victorialogs/CHANGELOG.md
@@ -58,6 +58,7 @@ Released at 2025-04-10
 
 * BUGFIX: [web UI](https://docs.victoriametrics.com/victorialogs/querying/#web-ui): fix endless group expansion loop bug. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8347).
 * BUGFIX: [web UI](https://docs.victoriametrics.com/victorialogs/querying/#web-ui): respect nanosecond precision when sorting logs. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8346).
+* BUGFIX: [web UI](https://docs.victoriametrics.com/victorialogs/querying/#web-ui): preserve zoom selection in the logs chart when auto-refresh is enabled. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8557).
 
 ## [v1.17.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.17.0-victorialogs)
 

--- a/docs/victorialogs/CHANGELOG.md
+++ b/docs/victorialogs/CHANGELOG.md
@@ -23,6 +23,8 @@ according to [these docs](https://docs.victoriametrics.com/victorialogs/quicksta
 
 * BUGFIX: [web UI](https://docs.victoriametrics.com/victorialogs/querying/#web-ui): fix the Group tab to display raw JSON when `_msg` is missing. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8205).
 * BUGFIX: [web UI](https://docs.victoriametrics.com/victorialogs/querying/#web-ui): fix display of `Query history` icon in mobile view. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8788).
+* BUGFIX: [web UI](https://docs.victoriametrics.com/victorialogs/querying/#web-ui): fix zoom behavior on logs chart. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8558).
+* BUGFIX: [web UI](https://docs.victoriametrics.com/victorialogs/querying/#web-ui): preserve zoom selection in the logs chart when auto-refresh is enabled. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8557).
 
 ## [v1.20.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.20.0-victorialogs)
 
@@ -58,7 +60,6 @@ Released at 2025-04-10
 
 * BUGFIX: [web UI](https://docs.victoriametrics.com/victorialogs/querying/#web-ui): fix endless group expansion loop bug. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8347).
 * BUGFIX: [web UI](https://docs.victoriametrics.com/victorialogs/querying/#web-ui): respect nanosecond precision when sorting logs. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8346).
-* BUGFIX: [web UI](https://docs.victoriametrics.com/victorialogs/querying/#web-ui): preserve zoom selection in the logs chart when auto-refresh is enabled. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8557).
 
 ## [v1.17.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.17.0-victorialogs)
 


### PR DESCRIPTION
### Describe Your Changes

Related issue: #8557, #8558 

Fix zoom behavior on VictoriaLogs chart. The problem was that after zooming, the chart was recreated and the cursor position on the graph was lost, so further zooming occurred relative to the zero position. So to fix this problem:
 - removed unnecessary dependencies from useEffect to avoid recreating the chart;
 - moved the chart with the legend to a separate component to optimize the code when the graph is hidden;
 - also this PR contains changes from [this PR](https://github.com/VictoriaMetrics/VictoriaMetrics/pull/8718), which preserve zoom selection on autorefresh 

### Checklist

The following checks are **mandatory**:

- [ ] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/contributing/).
