### PR TITLE
lib/promscrape: calculate shard hash for original labels

### DIFF
--- a/lib/promscrape/discovery/kubernetes/common_types.go
+++ b/lib/promscrape/discovery/kubernetes/common_types.go
@@ -8,7 +8,7 @@ import (
 
 // ObjectMeta represents ObjectMeta from k8s API.
 //
-// See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#objectmeta-v1-meta
+// See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#objectmeta-v1-meta
 type ObjectMeta struct {
 	Name            string
 	Namespace       string
@@ -23,7 +23,7 @@ func (om *ObjectMeta) key() string {
 }
 
 // ListMeta is a Kubernetes list metadata
-// https://v1-17.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#listmeta-v1-meta
+// https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#listmeta-v1-meta
 type ListMeta struct {
 	ResourceVersion string
 }
@@ -64,7 +64,7 @@ func appendThreeStrings(dst []byte, a, b, c string) []byte {
 
 // OwnerReference represents OwnerReferense from k8s API.
 //
-// See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#ownerreference-v1-meta
+// See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#ownerreference-v1-meta
 type OwnerReference struct {
 	Name       string
 	Controller bool
@@ -73,7 +73,7 @@ type OwnerReference struct {
 
 // DaemonEndpoint represents DaemonEndpoint from k8s API.
 //
-// See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#daemonendpoint-v1-core
+// See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#daemonendpoint-v1-core
 type DaemonEndpoint struct {
 	Port int
 }

--- a/lib/promscrape/discovery/kubernetes/endpoints.go
+++ b/lib/promscrape/discovery/kubernetes/endpoints.go
@@ -37,7 +37,7 @@ func parseEndpoints(data []byte) (object, error) {
 
 // EndpointsList implements k8s endpoints list.
 //
-// See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#endpointslist-v1-core
+// See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#endpointslist-v1-core
 type EndpointsList struct {
 	Metadata ListMeta
 	Items    []*Endpoints
@@ -45,7 +45,7 @@ type EndpointsList struct {
 
 // Endpoints implements k8s endpoints.
 //
-// See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#endpoints-v1-core
+// See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#endpoints-v1-core
 type Endpoints struct {
 	Metadata ObjectMeta
 	Subsets  []EndpointSubset
@@ -53,7 +53,7 @@ type Endpoints struct {
 
 // EndpointSubset implements k8s endpoint subset.
 //
-// See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#endpointsubset-v1-core
+// See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#endpointsubset-v1-core
 type EndpointSubset struct {
 	Addresses         []EndpointAddress
 	NotReadyAddresses []EndpointAddress
@@ -62,7 +62,7 @@ type EndpointSubset struct {
 
 // EndpointAddress implements k8s endpoint address.
 //
-// See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#endpointaddress-v1-core
+// See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#endpointaddress-v1-core
 type EndpointAddress struct {
 	Hostname  string
 	IP        string
@@ -72,7 +72,7 @@ type EndpointAddress struct {
 
 // ObjectReference implements k8s object reference.
 //
-// See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#objectreference-v1-core
+// See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#objectreference-v1-core
 type ObjectReference struct {
 	Kind      string
 	Name      string
@@ -81,7 +81,7 @@ type ObjectReference struct {
 
 // EndpointPort implements k8s endpoint port.
 //
-// See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#endpointport-v1-discovery-k8s-io
+// See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#endpointport-v1-discovery-k8s-io
 type EndpointPort struct {
 	AppProtocol string
 	Name        string

--- a/lib/promscrape/discovery/kubernetes/endpointslice.go
+++ b/lib/promscrape/discovery/kubernetes/endpointslice.go
@@ -187,7 +187,7 @@ func getEndpointSliceLabels(eps *EndpointSlice, addr string, ea Endpoint, epp En
 
 // EndpointSliceList - implements kubernetes endpoint slice list object, that groups service endpoints slices.
 //
-// See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#endpointslicelist-v1-discovery-k8s-io
+// See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#endpointslicelist-v1-discovery-k8s-io
 type EndpointSliceList struct {
 	Metadata ListMeta
 	Items    []*EndpointSlice
@@ -195,7 +195,7 @@ type EndpointSliceList struct {
 
 // EndpointSlice - implements kubernetes endpoint slice.
 //
-// See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#endpointslice-v1-discovery-k8s-io
+// See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#endpointslice-v1-discovery-k8s-io
 type EndpointSlice struct {
 	Metadata    ObjectMeta
 	Endpoints   []Endpoint
@@ -205,7 +205,7 @@ type EndpointSlice struct {
 
 // Endpoint implements kubernetes object endpoint for endpoint slice.
 //
-// See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#endpoint-v1-discovery-k8s-io
+// See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#endpoint-v1-discovery-k8s-io
 type Endpoint struct {
 	Addresses  []string
 	Conditions EndpointConditions
@@ -216,7 +216,7 @@ type Endpoint struct {
 
 // EndpointConditions implements kubernetes endpoint condition.
 //
-// See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#endpointconditions-v1-discovery-k8s-io
+// See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#endpointconditions-v1-discovery-k8s-io
 type EndpointConditions struct {
 	Ready bool
 }

--- a/lib/promscrape/discovery/kubernetes/ingress.go
+++ b/lib/promscrape/discovery/kubernetes/ingress.go
@@ -36,7 +36,7 @@ func parseIngress(data []byte) (object, error) {
 
 // IngressList represents ingress list in k8s.
 //
-// See https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#ingresslist-v1-networking-k8s-io
+// See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#ingresslist-v1-networking-k8s-io
 type IngressList struct {
 	Metadata ListMeta
 	Items    []*Ingress
@@ -44,7 +44,7 @@ type IngressList struct {
 
 // Ingress represents ingress in k8s.
 //
-// See https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#ingress-v1-networking-k8s-io
+// See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#ingress-v1-networking-k8s-io
 type Ingress struct {
 	Metadata ObjectMeta
 	Spec     IngressSpec
@@ -52,7 +52,7 @@ type Ingress struct {
 
 // IngressSpec represents ingress spec in k8s.
 //
-// See https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#ingressspec-v1-networking-k8s-io
+// See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#ingressspec-v1-networking-k8s-io
 type IngressSpec struct {
 	TLS              []IngressTLS `json:"tls"`
 	Rules            []IngressRule
@@ -61,14 +61,14 @@ type IngressSpec struct {
 
 // IngressTLS represents ingress TLS spec in k8s.
 //
-// See https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#ingresstls-v1-networking-k8s-io
+// See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#ingresstls-v1-networking-k8s-io
 type IngressTLS struct {
 	Hosts []string
 }
 
 // IngressRule represents ingress rule in k8s.
 //
-// See https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#ingressrule-v1-networking-k8s-io
+// See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#ingressrule-v1-networking-k8s-io
 type IngressRule struct {
 	Host string
 	HTTP HTTPIngressRuleValue `json:"http"`
@@ -76,14 +76,14 @@ type IngressRule struct {
 
 // HTTPIngressRuleValue represents HTTP ingress rule value in k8s.
 //
-// See https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#httpingressrulevalue-v1-networking-k8s-io
+// See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#httpingressrulevalue-v1-networking-k8s-io
 type HTTPIngressRuleValue struct {
 	Paths []HTTPIngressPath
 }
 
 // HTTPIngressPath represents HTTP ingress path in k8s.
 //
-// See https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#httpingresspath-v1-networking-k8s-io
+// See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#httpingresspath-v1-networking-k8s-io
 type HTTPIngressPath struct {
 	Path string
 }

--- a/lib/promscrape/discovery/kubernetes/node.go
+++ b/lib/promscrape/discovery/kubernetes/node.go
@@ -37,7 +37,7 @@ func parseNode(data []byte) (object, error) {
 
 // NodeList represents NodeList from k8s API.
 //
-// See https://kubernetes.io/docs/reference/kubernetes-api/cluster-resources/node-v1/#NodeList
+// See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#nodelist-v1-core
 type NodeList struct {
 	Metadata ListMeta
 	Items    []*Node
@@ -45,7 +45,7 @@ type NodeList struct {
 
 // Node represents Node from k8s API.
 //
-// See https://kubernetes.io/docs/reference/kubernetes-api/cluster-resources/node-v1/
+// See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#node-v1-core
 type Node struct {
 	Metadata ObjectMeta
 	Status   NodeStatus
@@ -54,7 +54,7 @@ type Node struct {
 
 // NodeStatus represents NodeStatus from k8s API.
 //
-// See https://kubernetes.io/docs/reference/kubernetes-api/cluster-resources/node-v1/#NodeStatus
+// See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#nodestatus-v1-core
 type NodeStatus struct {
 	Addresses       []NodeAddress
 	DaemonEndpoints NodeDaemonEndpoints
@@ -62,14 +62,14 @@ type NodeStatus struct {
 
 // NodeSpec represents NodeSpec from k8s API.
 //
-// See https://kubernetes.io/docs/reference/kubernetes-api/cluster-resources/node-v1/#NodeSpec
+// See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#nodespec-v1-core
 type NodeSpec struct {
 	ProviderID string
 }
 
 // NodeAddress represents NodeAddress from k8s API.
 //
-// See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#nodeaddress-v1-core
+// See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#nodeaddress-v1-core
 type NodeAddress struct {
 	Type    string
 	Address string
@@ -77,7 +77,7 @@ type NodeAddress struct {
 
 // NodeDaemonEndpoints represents NodeDaemonEndpoints from k8s API.
 //
-// See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#nodedaemonendpoints-v1-core
+// See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#nodedaemonendpoints-v1-core
 type NodeDaemonEndpoints struct {
 	KubeletEndpoint DaemonEndpoint
 }

--- a/lib/promscrape/discovery/kubernetes/pod.go
+++ b/lib/promscrape/discovery/kubernetes/pod.go
@@ -38,7 +38,7 @@ func parsePod(data []byte) (object, error) {
 
 // PodList implements k8s pod list.
 //
-// See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#podlist-v1-core
+// See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#podlist-v1-core
 type PodList struct {
 	Metadata ListMeta
 	Items    []*Pod
@@ -46,7 +46,7 @@ type PodList struct {
 
 // Pod implements k8s pod.
 //
-// See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#pod-v1-core
+// See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#pod-v1-core
 type Pod struct {
 	Metadata ObjectMeta
 	Spec     PodSpec
@@ -55,7 +55,7 @@ type Pod struct {
 
 // PodSpec implements k8s pod spec.
 //
-// See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#podspec-v1-core
+// See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#podspec-v1-core
 type PodSpec struct {
 	NodeName       string
 	Containers     []Container
@@ -64,7 +64,7 @@ type PodSpec struct {
 
 // Container implements k8s container.
 //
-// See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#container-v1-core
+// See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#container-v1-core
 type Container struct {
 	Name          string
 	Image         string
@@ -81,7 +81,7 @@ type ContainerPort struct {
 
 // PodStatus implements k8s pod status.
 //
-// See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#podstatus-v1-core
+// See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#podstatus-v1-core
 type PodStatus struct {
 	Phase                 string
 	PodIP                 string
@@ -93,7 +93,7 @@ type PodStatus struct {
 
 // PodCondition implements k8s pod condition.
 //
-// See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#podcondition-v1-core
+// See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#podcondition-v1-core
 type PodCondition struct {
 	Type   string
 	Status string
@@ -101,7 +101,7 @@ type PodCondition struct {
 
 // ContainerStatus implements k8s container status.
 //
-// See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#containerstatus-v1-core
+// See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#containerstatus-v1-core
 type ContainerStatus struct {
 	Name        string
 	ContainerID string
@@ -110,14 +110,14 @@ type ContainerStatus struct {
 
 // ContainerState implements k8s container state.
 //
-// See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#containerstatus-v1-core
+// See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#containerstatus-v1-core
 type ContainerState struct {
 	Terminated *ContainerStateTerminated
 }
 
 // ContainerStateTerminated implements k8s terminated container state.
 //
-// See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#containerstatus-v1-core
+// See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#containerstatus-v1-core
 type ContainerStateTerminated struct {
 	ExitCode int
 }

--- a/lib/promscrape/discovery/kubernetes/service.go
+++ b/lib/promscrape/discovery/kubernetes/service.go
@@ -37,7 +37,7 @@ func parseService(data []byte) (object, error) {
 
 // ServiceList is k8s service list.
 //
-// See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#servicelist-v1-core
+// See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#servicelist-v1-core
 type ServiceList struct {
 	Metadata ListMeta
 	Items    []*Service
@@ -45,7 +45,7 @@ type ServiceList struct {
 
 // Service is k8s service.
 //
-// See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#service-v1-core
+// See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#service-v1-core
 type Service struct {
 	Metadata ObjectMeta
 	Spec     ServiceSpec
@@ -53,7 +53,7 @@ type Service struct {
 
 // ServiceSpec is k8s service spec.
 //
-// See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#servicespec-v1-core
+// See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#servicespec-v1-core
 type ServiceSpec struct {
 	ClusterIP    string
 	ExternalName string
@@ -63,7 +63,7 @@ type ServiceSpec struct {
 
 // ServicePort is k8s service port.
 //
-// See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#serviceport-v1-core
+// See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#serviceport-v1-core
 type ServicePort struct {
 	Name     string
 	Protocol string


### PR DESCRIPTION
### Describe Your Changes

With relabel configuration that can produce on multiple vmagents in a cluster mode same targets with not identical labels the can be an issue, while either same target is discovered multiple times or absent. In this PR VMAgent uses original labels to calculate shard number for a target

Please provide a brief description of the changes you made. Be as specific as possible to help others understand the purpose and impact of your modifications.

### Checklist

The following checks are **mandatory**:

- [ ] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/contributing/).
