### PR TITLE
app/vmalert feat: add flag for continueOnErr during replaying

### DIFF
--- a/app/vmalert/replay.go
+++ b/app/vmalert/replay.go
@@ -29,6 +29,8 @@ var (
 		"Defines how many retries to make before giving up on rule if request for it returns an error.")
 	disableProgressBar = flag.Bool("replay.disableProgressBar", false, "Whether to disable rendering progress bars during the replay. "+
 		"Progress bar rendering might be verbose or break the logs parsing, so it is recommended to be disabled when not used in interactive mode.")
+	continueOnErr = flag.Bool("replay.continueOnError", false,
+		"Whether to continue on an error when a replay fails. ruleRetryAttempts is preserved when it is considered an error.")
 )
 
 func replay(groupsCfg []config.Group, qb datasource.QuerierBuilder, rw remotewrite.RWClient) error {
@@ -73,7 +75,7 @@ func replay(groupsCfg []config.Group, qb datasource.QuerierBuilder, rw remotewri
 	var total int
 	for _, cfg := range groupsCfg {
 		ng := rule.NewGroup(cfg, qb, *evaluationInterval, labels)
-		total += ng.Replay(tFrom, tTo, rw, *replayMaxDatapoints, *replayRuleRetryAttempts, *replayRulesDelay, *disableProgressBar)
+		total += ng.Replay(tFrom, tTo, rw, *replayMaxDatapoints, *replayRuleRetryAttempts, *replayRulesDelay, *disableProgressBar, *continueOnErr)
 	}
 	logger.Infof("replay evaluation finished, generated %d samples", total)
 	if err := rw.Close(); err != nil {

--- a/app/vmalert/rule/group.go
+++ b/app/vmalert/rule/group.go
@@ -517,12 +517,6 @@ func (g *Group) Replay(start, end time.Time, rw remotewrite.RWClient, maxDataPoi
 		fmt.Printf("\nPlease note, `limit: %d` param has no effect during replay.\n",
 			g.Limit)
 	}
-
-	logf := logger.Fatalf
-	if continueOnErr {
-		logf = logger.Errorf
-	}
-
 	for _, rule := range g.Rules {
 		fmt.Printf("> Rule %q (ID: %d)\n", rule, rule.ID())
 		var bar *pb.ProgressBar
@@ -533,7 +527,11 @@ func (g *Group) Replay(start, end time.Time, rw remotewrite.RWClient, maxDataPoi
 		for ri.next() {
 			n, err := replayRule(rule, ri.s, ri.e, rw, replayRuleRetryAttempts)
 			if err != nil {
-				logf("rule %q: %s", rule, err)
+				if continueOnErr {
+					logger.Errorf("rule %q: %s", rule, err)
+				} else {
+					logger.Fatalf("rule %q: %s", rule, err)
+				}
 			}
 			total += n
 			if bar != nil {

--- a/docs/victoriametrics/vmalert.md
+++ b/docs/victoriametrics/vmalert.md
@@ -847,7 +847,7 @@ There are following non-required `replay` flags:
 * `-replay.disableProgressBar` - whether to disable progress bar which shows progress work.
   Progress bar may generate a lot of log records, which is not formatted as standard VictoriaMetrics logger.
   It could break logs parsing by external system and generate additional load on it.
-* `replay.continueOnError` - whether to continue on an error when a replay fails. 
+* `-replay.continueOnError` - whether to continue on an error when a replay fails. 
   ruleRetryAttempts is taken into account when it is considered an error.
   Set it to true if you still want to continue on rule evaluations despite an error.
 

--- a/docs/victoriametrics/vmalert.md
+++ b/docs/victoriametrics/vmalert.md
@@ -847,6 +847,9 @@ There are following non-required `replay` flags:
 * `-replay.disableProgressBar` - whether to disable progress bar which shows progress work.
   Progress bar may generate a lot of log records, which is not formatted as standard VictoriaMetrics logger.
   It could break logs parsing by external system and generate additional load on it.
+* `replay.continueOnError` - whether to continue on an error when a replay fails. 
+  ruleRetryAttempts is taken into account when it is considered an error.
+  Set it to true if you still want to continue on rule evaluations despite an error.
 
 See full description for these flags in `./vmalert -help`.
 
@@ -1435,6 +1438,8 @@ The shortlist of configuration flags is the following:
      Optional TLS server name to use for connections to -remoteWrite.url. By default, the server name from -remoteWrite.url is used
   -remoteWrite.url string
      Optional URL to VictoriaMetrics or vminsert where to persist alerts state and recording rules results in form of timeseries. Supports address in the form of IP address with a port (e.g., http://127.0.0.1:8428) or DNS SRV record. For example, if -remoteWrite.url=http://127.0.0.1:8428 is specified, then the alerts state will be written to http://127.0.0.1:8428/api/v1/write . See also -remoteWrite.disablePathAppend, '-remoteWrite.showURL'.
+  -replay.continueOnError
+     Whether to continue on an error when a replay fails. ruleRetryAttempts is preserved when it is considered an error.
   -replay.disableProgressBar
      Whether to disable rendering progress bars during the replay. Progress bar rendering might be verbose or break the logs parsing, so it is recommended to be disabled when not used in interactive mode.
   -replay.maxDatapointsPerQuery /query_range


### PR DESCRIPTION
### Describe Your Changes

New flag `replay.continueOnError` for vmalert#replay .

This is to continue on vmalert/replaying rules error occurrences when the flag is set. As it currently, uses `FATAL` level that causes process to [terminate immediately(os.Exit)](https://github.com/VictoriaMetrics/VictoriaMetrics/blob/cluster/lib/logger/logger.go#L317) when any issue occurs.

Introducing a new flag to be able to deliberately continue on rule evaluations when it is set.

#### Use case

When thousands of rules are being replayed due to some outage or other issues, we then rely on replaying for both RR(recordingrule) & AR(alertingrule). Some rules failed to be replayed due to some reasons e.g:

> error calling query: `query` template isn't supported in replay mode

Given currently, if any rule evaluation fails due to an error, `vmalert` aborts entire process and terminate with an fatal log. This prevents us replaying thousands of rules due to the fact that solely one rule evaluation failure. Ideally, we would like to continue on rule evaluations during replaying and not let `vmalert` abort all rule evaluations just because of an one rule eval failure.

### Checklist

The following checks are **mandatory**:

- [ ] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/contributing/).
