### PR TITLE
vmagent: use tmp dir in integrations tests

### DIFF
--- a/apptest/tests/vmagent_remotewrite_test.go
+++ b/apptest/tests/vmagent_remotewrite_test.go
@@ -33,6 +33,7 @@ func testSingleVMAgentRemoteWrite(t *testing.T, forcePromProto bool) {
 		`-remoteWrite.flushInterval=50ms`,
 		fmt.Sprintf(`-remoteWrite.forcePromProto=%v`, forcePromProto),
 		fmt.Sprintf(`-remoteWrite.url=http://%s/api/v1/write`, vmsingle.HTTPAddr()),
+		"-remoteWrite.tmpDataPath=" + tc.Dir() + "/vmagent",
 	}, ``)
 
 	vmagent.APIV1ImportPrometheus(t, []string{
@@ -81,6 +82,7 @@ func TestSingleVMAgentUnsupportedMediaTypeDropIfSnappy(t *testing.T) {
 		`-remoteWrite.flushInterval=50ms`,
 		`-remoteWrite.forcePromProto=true`,
 		fmt.Sprintf(`-remoteWrite.url=%s/api/v1/write`, remoteWriteSrv.URL),
+		"-remoteWrite.tmpDataPath=" + tc.Dir() + "/vmagent",
 	}, ``)
 
 	vmagent.APIV1ImportPrometheusNoWaitFlush(t, []string{
@@ -143,6 +145,7 @@ func TestSingleVMAgentDowngradeRemoteWriteProtocol(t *testing.T) {
 	vmagent := tc.MustStartVmagent("vmagent", []string{
 		`-remoteWrite.flushInterval=50ms`,
 		fmt.Sprintf(`-remoteWrite.url=%s/api/v1/write`, remoteWriteSrv.URL),
+		"-remoteWrite.tmpDataPath=" + tc.Dir() + "/vmagent",
 	}, ``)
 
 	// Send request encoded with `zstd`; it fails, gets repacked as `snappy`, and retries successfully.

--- a/apptest/vmagent.go
+++ b/apptest/vmagent.go
@@ -3,6 +3,7 @@ package apptest
 import (
 	"fmt"
 	"net/http"
+	"os"
 	"regexp"
 	"strings"
 	"testing"
@@ -28,8 +29,9 @@ func StartVmagent(instance string, flags []string, cli *Client, promScrapeConfig
 
 	app, stderrExtracts, err := startApp(instance, "../../bin/vmagent", flags, &appOptions{
 		defaultFlags: map[string]string{
-			"-httpListenAddr":    "127.0.0.1:0",
-			"-promscrape.config": promScrapeConfigFilePath,
+			"-httpListenAddr":          "127.0.0.1:0",
+			"-promscrape.config":       promScrapeConfigFilePath,
+			"-remoteWrite.tmpDataPath": fmt.Sprintf("%s/%s-%d", os.TempDir(), instance, time.Now().UnixNano()),
 		},
 		extractREs: extractREs,
 	})


### PR DESCRIPTION
### Describe Your Changes

Before the change, the vmagent integration tests created their directory and files inside apptest/tests.
After the change, vmagent is instructed to store all files in a real temporary directory, which is automatically deleted after the tests complete.

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/contributing/).
