### PR TITLE
app/vmui/logs: add 0 label to the Y axis

### DIFF
--- a/app/vmui/packages/vmui/src/components/Chart/BarHitsChart/hooks/useBarHitsOptions.ts
+++ b/app/vmui/packages/vmui/src/components/Chart/BarHitsChart/hooks/useBarHitsOptions.ts
@@ -1,5 +1,5 @@
 import { useMemo, useState } from "preact/compat";
-import { getAxes, handleDestroy, setSelect } from "../../../../utils/uplot";
+import { getAxes, getMinMaxBuffer, handleDestroy, setSelect } from "../../../../utils/uplot";
 import dayjs from "dayjs";
 import { dateFromSeconds, formatDateForNativeInput } from "../../../../utils/time";
 import uPlot, { AlignedData, Band, Options, Series } from "uplot";
@@ -9,6 +9,7 @@ import { MinMax, SetMinMax } from "../../../../types";
 import { LogHits } from "../../../../api/types";
 import getSeriesPaths from "../../../../utils/uplot/paths";
 import { GraphOptions, GRAPH_STYLES } from "../types";
+import { getMaxFromArray } from "../../../../utils/math";
 
 const seriesColors = [
   "color-log-hits-bar-1",
@@ -42,6 +43,12 @@ export const getLabelFromLogHit = (logHit: LogHits) => {
   if (logHit?._isOther) return OTHER_HITS_LABEL;
   const fields = Object.values(logHit?.fields || {});
   return fields.map((value) => value || "\"\"").join(", ");
+};
+
+const getYRange = (u: uPlot, _initMin = 0, initMax = 1) => {
+  const maxValues = u.series.filter(({ scale }) => scale === "y").map(({ max }) => max || initMax);
+  const max = getMaxFromArray(maxValues);
+  return getMinMaxBuffer(0, max || initMax);
 };
 
 const useBarHitsOptions = ({
@@ -99,6 +106,9 @@ const useBarHitsOptions = ({
       x: {
         time: true,
         range: () => [xRange.min, xRange.max]
+      },
+      y: {
+        range: getYRange
       }
     },
     hooks: {

--- a/docs/victorialogs/CHANGELOG.md
+++ b/docs/victorialogs/CHANGELOG.md
@@ -19,6 +19,8 @@ according to [these docs](https://docs.victoriametrics.com/victorialogs/quicksta
 * FEATURE: [dashboards/cluster](https://grafana.com/grafana/dashboards/23274): add Grafana dashboard for cluster version of VictoriaLogs. The source of the dashboard is available [here](https://github.com/VictoriaMetrics/VictoriaMetrics/blob/master/dashboards/victorialogs-cluster.json) and will continue improving with time.
 * FEATURE: [deployment/docker](https://github.com/VictoriaMetrics/VictoriaMetrics/tree/master/deployment/docker#readme): add [docker-compose environment for VictoriaLogs cluster](https://github.com/VictoriaMetrics/VictoriaMetrics/tree/master/deployment/docker#victorialogs-cluster) deployment. It is intended for demonstrative purposes, includes alerting and Grafana dashboards. 
 
+* BUGFIX: [web UI](https://docs.victoriametrics.com/victorialogs/querying/#web-ui): add 0 label to the Y axis. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8409).
+
 ## [v1.19.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.19.0-victorialogs)
 
 Released at 2025-04-17


### PR DESCRIPTION
### Describe Your Changes

Related issue: #8409 

Added 0 label to the Y axis on VictoriaLogs chart.
<img width="727" alt="image" src="https://github.com/user-attachments/assets/287f7be3-7e89-4c42-933a-da5527786efc" />


### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/contributing/).
