### PR TITLE
Fix link in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,1 +1,1 @@
-The document has been moved [here](https://docs.victoriametrics.com/contributing/).
+The document has been moved [here](https://docs.victoriametrics.com/victoriametrics/contributing/).


### PR DESCRIPTION
### Describe Your Changes

Since https://github.com/VictoriaMetrics/VictoriaMetrics/pull/8595 the doc link in the top level CONTRIBUTING.md has been broken. Tiny fix to point it at the appropriate link.

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/contributing/).
