### PR TITLE
app/vmalert/remotewrite: rm noisy shutdown logs

### DIFF
--- a/app/vmalert/remotewrite/client.go
+++ b/app/vmalert/remotewrite/client.go
@@ -113,7 +113,6 @@ func NewClient(ctx context.Context, cfg Config) (*Client, error) {
 		input:         make(chan prompbmarshal.TimeSeries, cfg.MaxQueueSize),
 	}
 
-	c.wg.Add(cc)
 	for i := 0; i < cc; i++ {
 		c.run(ctx)
 	}
@@ -174,6 +173,7 @@ func (c *Client) run(ctx context.Context) {
 
 		cancel()
 	}
+	c.wg.Add(1)
 	go func() {
 		defer c.wg.Done()
 		defer ticker.Stop()

--- a/app/vmalert/remotewrite/client.go
+++ b/app/vmalert/remotewrite/client.go
@@ -113,6 +113,7 @@ func NewClient(ctx context.Context, cfg Config) (*Client, error) {
 		input:         make(chan prompbmarshal.TimeSeries, cfg.MaxQueueSize),
 	}
 
+	c.wg.Add(cc)
 	for i := 0; i < cc; i++ {
 		c.run(ctx)
 	}
@@ -146,8 +147,13 @@ func (c *Client) Close() error {
 		return fmt.Errorf("client is already closed")
 	}
 	close(c.input)
+
+	start := time.Now()
+	logger.Infof("shutting down remote write client: flushing remained series")
 	close(c.doneCh)
 	c.wg.Wait()
+	logger.Infof("shutting down remote write client: finished in %v", time.Since(start))
+
 	return nil
 }
 
@@ -156,24 +162,18 @@ func (c *Client) run(ctx context.Context) {
 	wr := &prompbmarshal.WriteRequest{}
 	shutdown := func() {
 		lastCtx, cancel := context.WithTimeout(context.Background(), defaultWriteTimeout)
-		logger.Infof("shutting down remote write client and flushing remained series")
 
-		shutdownFlushCnt := 0
 		for ts := range c.input {
 			wr.Timeseries = append(wr.Timeseries, ts)
 			if len(wr.Timeseries) >= c.maxBatchSize {
-				shutdownFlushCnt += len(wr.Timeseries)
 				c.flush(lastCtx, wr)
 			}
 		}
 		// flush the last batch. `flush` will re-check and avoid flushing empty batch.
-		shutdownFlushCnt += len(wr.Timeseries)
 		c.flush(lastCtx, wr)
 
-		logger.Infof("shutting down remote write client flushed %d series", shutdownFlushCnt)
 		cancel()
 	}
-	c.wg.Add(1)
 	go func() {
 		defer c.wg.Done()
 		defer ticker.Stop()


### PR DESCRIPTION
On shutdown, rw client printed two log messages about shutting down and how many series it flushed on shut down.

This commit removes these log messages for the following reasons:
1. These messages were printed for each `client.cc`, which is set to x2 of available CPUs. This behavior generated a lot of useless logs on shutdown.
2. Number of flushed series on shutdown doesn't matter to the user.

Instead, it now prints only two log messages: when shutdown starts and when it ends:
```
^C2025-04-22T07:37:11.932Z      info    VictoriaMetrics/app/vmalert/main.go:189 service received signal interrupt
2025-04-22T07:37:11.932Z        info    VictoriaMetrics/app/vmalert/remotewrite/client.go:152   shutting down remote write client: flushing remained series
2025-04-22T07:37:11.933Z        info    VictoriaMetrics/app/vmalert/remotewrite/client.go:155   shutting down remote write client: finished in 210.917µs
```

-----------

It has no changelog because it is a minor change.