### PR TITLE
fix: compatibility for FIPS builds

### DIFF
--- a/app/vmalert/config/config.go
+++ b/app/vmalert/config/config.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"bytes"
-	"crypto/md5"
 	"flag"
 	"fmt"
 	"hash/fnv"
@@ -11,11 +10,12 @@ import (
 	"sort"
 	"strings"
 
+	"gopkg.in/yaml.v2"
+
 	"github.com/VictoriaMetrics/VictoriaMetrics/app/vmalert/config/log"
 	"github.com/VictoriaMetrics/VictoriaMetrics/app/vmalert/vmalertutil"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/envtemplate"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/promutil"
-	"gopkg.in/yaml.v2"
 )
 
 var (
@@ -67,7 +67,7 @@ func (g *Group) UnmarshalYAML(unmarshal func(any) error) error {
 	if g.Type.Get() == "" {
 		g.Type = NewRawType(*defaultRuleType)
 	}
-	h := md5.New()
+	h := fnv.New64a()
 	h.Write(b)
 	g.Checksum = fmt.Sprintf("%x", h.Sum(nil))
 	return nil

--- a/app/vmalert/notifier/config.go
+++ b/app/vmalert/notifier/config.go
@@ -1,8 +1,8 @@
 package notifier
 
 import (
-	"crypto/md5"
 	"fmt"
+	"hash/fnv"
 	"net/url"
 	"os"
 	"path"
@@ -99,7 +99,7 @@ func (cfg *Config) UnmarshalYAML(unmarshal func(any) error) error {
 	if err != nil {
 		return fmt.Errorf("failed to marshal configuration for checksum: %w", err)
 	}
-	h := md5.New()
+	h := fnv.New64a()
 	h.Write(b)
 	cfg.Checksum = fmt.Sprintf("%x", h.Sum(nil))
 	return nil

--- a/lib/awsapi/sign_test.go
+++ b/lib/awsapi/sign_test.go
@@ -1,6 +1,7 @@
 package awsapi
 
 import (
+	"strings"
 	"testing"
 	"time"
 )
@@ -11,8 +12,8 @@ func TestNewSignedRequest(t *testing.T) {
 		service := "ec2"
 		region := "us-east-1"
 		ac := &credentials{
-			AccessKeyID:     "fake-access-key",
-			SecretAccessKey: "foobar",
+			AccessKeyID:     strings.Repeat("fake-access-key", 2),
+			SecretAccessKey: strings.Repeat("foobar", 10),
 		}
 		ct := time.Unix(0, 0).UTC()
 		req, err := newSignedGetRequestWithTime(apiURL, service, region, ac, ct)
@@ -25,5 +26,5 @@ func TestNewSignedRequest(t *testing.T) {
 		}
 	}
 	f("https://ec2.amazonaws.com/?Action=DescribeRegions&Version=2013-10-15",
-		"AWS4-HMAC-SHA256 Credential=fake-access-key/19700101/us-east-1/ec2/aws4_request, SignedHeaders=host;x-amz-date, Signature=79dc8f54719a4c11edcd5811824a071361b3514172a3f5c903b7e279dfa6a710")
+		"AWS4-HMAC-SHA256 Credential=fake-access-keyfake-access-key/19700101/us-east-1/ec2/aws4_request, SignedHeaders=host;x-amz-date, Signature=e6c0f635693173f83eea9f443ae364d9099c98b0f5e7b1356e7cfc9c742daea2")
 }

--- a/lib/promauth/config_test.go
+++ b/lib/promauth/config_test.go
@@ -679,7 +679,7 @@ func TestTLSConfigWithCertificatesFilesUpdate(t *testing.T) {
 
 func mustGenerateCertificates() ([]byte, []byte, []byte) {
 	// Small key size for faster tests
-	const testCertificateBits = 1024
+	const testCertificateBits = 4096
 
 	ca := &x509.Certificate{
 		SerialNumber: big.NewInt(2024),
@@ -692,6 +692,7 @@ func mustGenerateCertificates() ([]byte, []byte, []byte) {
 		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
 		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
 		BasicConstraintsValid: true,
+		SubjectKeyId:          []byte{1, 2, 3, 4},
 	}
 	caPrivKey, err := rsa.GenerateKey(rand.Reader, testCertificateBits)
 	if err != nil {


### PR DESCRIPTION
### Describe Your Changes

Fixes which are required in order to build FIPS-compliant binaries. These changes were originally added for enterprise version and synced to opensource for consistency and easier maintenance.

- consistently use `hash/fnv` at `app/vmalert` when calculating checksums. Usage of md5 is not allowed in FIPS mode.
- increase encryption keys size used in testing in order to allow tests to successfully run in FIPS mode

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/contributing/).
