### PR TITLE
feat(vmagent): Add ability to tolerate partial scrapes for streamParse

### DIFF
--- a/lib/promscrape/scrapework.go
+++ b/lib/promscrape/scrapework.go
@@ -41,6 +41,8 @@ var (
 	suppressScrapeErrors = flag.Bool("promscrape.suppressScrapeErrors", false, "Whether to suppress scrape errors logging. "+
 		"The last error for each target is always available at '/targets' page even if scrape errors logging is suppressed. "+
 		"See also -promscrape.suppressScrapeErrorsDelay")
+	acceptPartialScrapesForStreamParse = flag.Bool("promscrape.acceptPartialScrapesForStreamParse", false, "Whether to accept partial scrapes. "+
+		"When using either 'sample_limit' and/or 'series_limit', streamParse can lead to partial scrapes.")
 	suppressScrapeErrorsDelay = flag.Duration("promscrape.suppressScrapeErrorsDelay", 0, "The delay for suppressing repeated scrape errors logging per each scrape targets. "+
 		"This may be used for reducing the number of log lines related to scrape errors. See also -promscrape.suppressScrapeErrors")
 	minResponseSizeForStreamParse = flagutil.NewBytes("promscrape.minResponseSizeForStreamParse", 1e6, "The minimum target response size for automatic switching to stream parsing mode, which can reduce memory usage. See https://docs.victoriametrics.com/vmagent/#stream-parsing-mode")
@@ -159,7 +161,7 @@ type ScrapeWork struct {
 func (sw *ScrapeWork) canSwitchToStreamParseMode() bool {
 	// Deny switching to stream parse mode if `sample_limit` or `series_limit` options are set,
 	// since these limits cannot be applied in stream parsing mode.
-	return sw.SampleLimit <= 0 && sw.SeriesLimit <= 0
+	return (sw.SampleLimit <= 0 && sw.SeriesLimit <= 0) || *acceptPartialScrapesForStreamParse
 }
 
 // key returns unique identifier for the given sw.


### PR DESCRIPTION
### Describe Your Changes

As a user who is using `sample_limit`, we observed that the automatic mechanism which switches individual targets (where the size is >= 1'000'000) to streamParse, will no longer switch (as it can lead to the situation that targets are partially scraped).

The function `canSwitchToStreamParseMode()` today evaluate whether either `sample_limit` or `series_limit` is active for that target. In that case, it returns `false`.

With my extension, users can accept partial scrapes and keep the automatic switching capability.

### Proof
#### cluster 1 (dev env)
I created a new container image with a special build (based on the tag v1.102.18) using `make package-vmagent-amd64` and deployed it to one of our K8s clusters by using the extra argument `- '--promscrape.acceptPartialScrapesForStreamParse'`. It helped a lot, even on a development stage:
<img src="https://github.com/user-attachments/assets/67665a19-21b8-4ce9-b6d9-3ce47e2e4ef4" width=50% height=50% alt="development stage">

And here is a size overview of the targets:
<img src="https://github.com/user-attachments/assets/4f0ce2c1-305d-47e0-a353-8a944d0d9de7" width=50% height=50% alt="development stage - target size overview">

---

#### cluster 2 (staging env)
<img src="https://github.com/user-attachments/assets/7ec4ebe7-66ef-451d-9a02-2bb93418bd68" width=50% height=50% alt="staging env">

Target size overview of this `staging env` cluster
<img src="https://github.com/user-attachments/assets/310e68e7-b13f-4fe2-8b78-44265e025a83" width=50% height=50% alt="staging env - target size overview">

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/contributing/).
