### PR TITLE
vmui: hide duplicate legend items in Raw Query

### DIFF
--- a/app/vmui/packages/vmui/src/components/Chart/Line/Legend/hooks/useGroupSeries.ts
+++ b/app/vmui/packages/vmui/src/components/Chart/Line/Legend/hooks/useGroupSeries.ts
@@ -31,7 +31,10 @@ const getGroupSeries = (
     }
 
     const groupEntry = groupMap.get(groupKey) as QueryGroup;
-    groupEntry.items.push(label);
+    const isDuplicate = groupEntry.items.some(item => item.label === label.label);
+    if (!isDuplicate) {
+      groupEntry.items.push(label);
+    }
   }
 
   return Array.from(groupMap.values());

--- a/docs/victoriametrics/changelog/CHANGELOG.md
+++ b/docs/victoriametrics/changelog/CHANGELOG.md
@@ -41,6 +41,7 @@ See also [LTS releases](https://docs.victoriametrics.com/lts-releases/).
 * BUGFIX: [vmselect](https://docs.victoriametrics.com/cluster-victoriametrics/) in [VictoriaMetrics cluster](https://docs.victoriametrics.com/cluster-victoriametrics/): fix [metric query stats API](https://docs.victoriametrics.com/#track-ingested-metrics-usage) to correctly handle metric names longer than 256 bytes, respecting the `-maxLabelValueLen` flag. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8759) for details.
 * BUGFIX: [vmbackup](https://docs.victoriametrics.com/vmbackup/), [vmrestore](https://docs.victoriametrics.com/vmrestore/), [vmbackupmanager](https://docs.victoriametrics.com/vmbackupmanager/): enable support of HTTP/2 for connections to S3-compatible storage endpoints. It was disabled in [v1.115.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.115.0) and could lead to connection errors with some S3-compatible storage providers.
 * BUGFIX: [vmalert](https://docs.victoriametrics.com/vmalert/): correctly update the `debug` param for recording rule when updating the rule group.
+* BUGFIX: [vmui](https://docs.victoriametrics.com/#vmui): fix duplicated series in the legend on the Raw Query page when deduplication is disabled. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8688).
 
 ## [v1.115.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.115.0)
 


### PR DESCRIPTION
### Describe Your Changes

Hide identical series in the legend on the Raw Query page when deduplication is disabled.

Related issue: #8688

### Checklist

The following checks are **mandatory**:

- [ ] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/contributing/).
