### PR TITLE
Reuse indexdb/indexSearch

### DIFF
--- a/lib/storage/index_db.go
+++ b/lib/storage/index_db.go
@@ -642,6 +642,11 @@ func putIndexItems(ii *indexItems) {
 
 var indexItemsPool sync.Pool
 
+// HasTimestamp checks if index contains given timestamp.
+func (db *indexDB) HasTimestamp(timestamp int64) bool {
+	return timestamp >= db.tr.MinTimestamp && timestamp <= db.tr.MaxTimestamp
+}
+
 // SearchLabelNames returns all the label names, which match the given tfss on
 // the given tr.
 func (db *indexDB) SearchLabelNames(qt *querytracer.Tracer, tfss []*TagFilters, tr TimeRange, maxLabelNames, maxMetrics int, deadline uint64) ([]string, error) {


### PR DESCRIPTION
### Describe Your Changes

Reuse indexdb/indexSearch if possible - reduce pressure on atomic counters

Before:
```
GOMAXPROCS=20 ./storage-test -test.v -test.run ^$ -test.bench ^BenchmarkStorageAddRows$ 2> /dev/null
goos: linux
goarch: amd64
pkg: github.com/VictoriaMetrics/VictoriaMetrics/lib/storage
cpu: Intel(R) Xeon(R) Gold 6230R CPU @ 2.10GHz
BenchmarkStorageAddRows
BenchmarkStorageAddRows/1
BenchmarkStorageAddRows/1-20                    	  305073	      3713 ns/op	   0.27 MB/s	     581 B/op	       0 allocs/op
BenchmarkStorageAddRows/10
BenchmarkStorageAddRows/10-20                   	  121305	     10187 ns/op	   0.98 MB/s	    1458 B/op	       0 allocs/op
BenchmarkStorageAddRows/100
BenchmarkStorageAddRows/100-20                  	   14506	     83855 ns/op	   1.19 MB/s	   12309 B/op	       0 allocs/op
BenchmarkStorageAddRows/1000
BenchmarkStorageAddRows/1000-20                 	    1533	    795994 ns/op	   1.26 MB/s	  118084 B/op	      52 allocs/op
BenchmarkStorageAddRows/10000
BenchmarkStorageAddRows/10000-20                	     151	   7717407 ns/op	   1.30 MB/s	 1386506 B/op	    5304 allocs/op
```

After:
```
GOMAXPROCS=20 ./storage-test2 -test.v -test.run ^$ -test.bench ^BenchmarkStorageAddRows$ 2> /dev/null
BenchmarkStorageAddRows
BenchmarkStorageAddRows/1
BenchmarkStorageAddRows/1-20                    	  296821	      3837 ns/op	   0.26 MB/s	     595 B/op	       0 allocs/op
BenchmarkStorageAddRows/10
BenchmarkStorageAddRows/10-20                   	  287047	      3938 ns/op	   2.54 MB/s	     616 B/op	       0 allocs/op
BenchmarkStorageAddRows/100
BenchmarkStorageAddRows/100-20                  	  123474	     12458 ns/op	   8.03 MB/s	    5849 B/op	       0 allocs/op
BenchmarkStorageAddRows/1000
BenchmarkStorageAddRows/1000-20                 	   15288	    112978 ns/op	   8.85 MB/s	   58101 B/op	       5 allocs/op
BenchmarkStorageAddRows/10000
BenchmarkStorageAddRows/10000-20                	    1113	   1182727 ns/op	   8.46 MB/s	  657111 B/op	     723 allocs/op
```

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/contributing/).
