### PR TITLE
vmui/logs: fix oversized `Query History` button on mobile

### DIFF
--- a/app/vmui/packages/vmui/src/components/Main/Button/style.scss
+++ b/app/vmui/packages/vmui/src/components/Main/Button/style.scss
@@ -83,7 +83,7 @@ $button-radius: 6px;
 
   // Color variants
   @mixin contained-button($name, $color, $text-color: $color-white) {
-    &_contained_#{$name} {
+    &_contained_#{"" + $name} {
       background-color: $color;
       color: $text-color;
 
@@ -94,7 +94,7 @@ $button-radius: 6px;
   }
 
   @mixin outlined-button($name, $border-color, $text-color: $border-color) {
-    &_outlined_#{$name} {
+    &_outlined_#{"" + $name} {
       background-color: transparent;
       border-color: $border-color;
       color: $text-color;
@@ -107,7 +107,7 @@ $button-radius: 6px;
   }
 
   @mixin text-button($name, $text-color: $color-white) {
-    &_text_#{$name} {
+    &_text_#{"" + $name} {
       background-color: transparent;
       color: $text-color;
 

--- a/app/vmui/packages/vmui/src/pages/ExploreLogs/ExploreLogsHeader/ExploreLogsHeader.tsx
+++ b/app/vmui/packages/vmui/src/pages/ExploreLogs/ExploreLogsHeader/ExploreLogsHeader.tsx
@@ -143,23 +143,25 @@ const ExploreLogsHeader: FC<ExploreLogHeaderProps> = ({
             Documentation
           </a>
         </div>
-        <QueryHistory
-          handleSelectQuery={handleSelectHistory}
-          historyKey={"LOGS_QUERY_HISTORY"}
-        />
-        <div className="vm-explore-logs-header-bottom-execute">
-          <Button
-            startIcon={isLoading ? <SpinnerIcon/> : <PlayIcon/>}
-            onClick={onRun}
-            fullWidth
-          >
-            <div>
-              <span className="vm-explore-logs-header-bottom-execute__text">
-                {isLoading ? "Cancel Query" : "Execute Query"}
-              </span>
-              <span className="vm-explore-logs-header-bottom-execute__text_hidden">Execute Query</span>
-            </div>
-          </Button>
+        <div className="vm-explore-logs-header-bottom-buttons">
+          <QueryHistory
+            handleSelectQuery={handleSelectHistory}
+            historyKey={"LOGS_QUERY_HISTORY"}
+          />
+          <div className="vm-explore-logs-header-bottom-execute">
+            <Button
+              startIcon={isLoading ? <SpinnerIcon/> : <PlayIcon/>}
+              onClick={onRun}
+              fullWidth
+            >
+              <div>
+                <span className="vm-explore-logs-header-bottom-execute__text">
+                  {isLoading ? "Cancel Query" : "Execute Query"}
+                </span>
+                <span className="vm-explore-logs-header-bottom-execute__text_hidden">Execute Query</span>
+              </div>
+            </Button>
+          </div>
         </div>
       </div>
     </div>

--- a/app/vmui/packages/vmui/src/pages/ExploreLogs/ExploreLogsHeader/style.scss
+++ b/app/vmui/packages/vmui/src/pages/ExploreLogs/ExploreLogsHeader/style.scss
@@ -32,6 +32,12 @@
       flex-grow: 1;
     }
 
+    &-buttons {
+      display: grid;
+      grid-template-columns: auto 1fr;
+      gap: $padding-small;
+    }
+
     &-execute {
       position: relative;
       display: grid;

--- a/docs/victorialogs/CHANGELOG.md
+++ b/docs/victorialogs/CHANGELOG.md
@@ -20,6 +20,7 @@ according to [these docs](https://docs.victoriametrics.com/victorialogs/quicksta
 * FEATURE: [web UI](https://docs.victoriametrics.com/victorialogs/querying/#web-ui): add a toggle to handle ANSI escape sequences in log messages. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/6614).
 
 * BUGFIX: [web UI](https://docs.victoriametrics.com/victorialogs/querying/#web-ui): fix the Group tab to display raw JSON when `_msg` is missing. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8205).
+* BUGFIX: [web UI](https://docs.victoriametrics.com/victorialogs/querying/#web-ui): fix display of `Query history` icon in mobile view. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8788).
 
 ## [v1.20.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.20.0-victorialogs)
 


### PR DESCRIPTION
### Describe Your Changes

Fixes oversized `Query History` button on mobile in logs UI.
Related issue: #8788 

### Checklist

The following checks are **mandatory**:

- [ ] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/contributing/).
