### PR TITLE
prefetchedMetricNames per idb

### DIFF
--- a/app/vmstorage/main.go
+++ b/app/vmstorage/main.go
@@ -549,7 +549,7 @@ func writeStorageMetrics(w io.Writer, strg *storage.Storage) {
 	metrics.WriteCounterUint64(w, `vm_new_timeseries_created_total`, m.NewTimeseriesCreated)
 	metrics.WriteCounterUint64(w, `vm_slow_row_inserts_total`, m.SlowRowInserts)
 	metrics.WriteCounterUint64(w, `vm_slow_per_day_index_inserts_total`, m.SlowPerDayIndexInserts)
-	metrics.WriteCounterUint64(w, `vm_slow_metric_name_loads_total`, m.SlowMetricNameLoads)
+	metrics.WriteCounterUint64(w, `vm_slow_metric_name_loads_total`, idbm.SlowMetricNameLoads)
 
 	if *maxHourlySeries > 0 {
 		metrics.WriteGaugeUint64(w, `vm_hourly_series_limit_current_series`, m.HourlySeriesLimitCurrentSeries)
@@ -594,7 +594,7 @@ func writeStorageMetrics(w io.Writer, strg *storage.Storage) {
 	metrics.WriteGaugeUint64(w, `vm_cache_entries{type="indexdb/tagFiltersToMetricIDs"}`, idbm.TagFiltersToMetricIDsCacheSize)
 	metrics.WriteGaugeUint64(w, `vm_cache_entries{type="storage/regexps"}`, uint64(storage.RegexpCacheSize()))
 	metrics.WriteGaugeUint64(w, `vm_cache_entries{type="storage/regexpPrefixes"}`, uint64(storage.RegexpPrefixesCacheSize()))
-	metrics.WriteGaugeUint64(w, `vm_cache_entries{type="storage/prefetchedMetricIDs"}`, m.PrefetchedMetricIDsSize)
+	metrics.WriteGaugeUint64(w, `vm_cache_entries{type="indexdb/prefetchedMetricIDs"}`, idbm.PrefetchedMetricIDsSize)
 
 	metrics.WriteGaugeUint64(w, `vm_cache_size_bytes{type="storage/tsid"}`, m.TSIDCacheSizeBytes)
 	metrics.WriteGaugeUint64(w, `vm_cache_size_bytes{type="storage/metricIDs"}`, m.MetricIDCacheSizeBytes)
@@ -607,9 +607,9 @@ func writeStorageMetrics(w io.Writer, strg *storage.Storage) {
 	metrics.WriteGaugeUint64(w, `vm_cache_size_bytes{type="storage/hour_metric_ids"}`, m.HourMetricIDCacheSizeBytes)
 	metrics.WriteGaugeUint64(w, `vm_cache_size_bytes{type="storage/next_day_metric_ids"}`, m.NextDayMetricIDCacheSizeBytes)
 	metrics.WriteGaugeUint64(w, `vm_cache_size_bytes{type="indexdb/tagFiltersToMetricIDs"}`, idbm.TagFiltersToMetricIDsCacheSizeBytes)
+	metrics.WriteGaugeUint64(w, `vm_cache_size_bytes{type="indexdb/prefetchedMetricIDs"}`, idbm.PrefetchedMetricIDsSizeBytes)
 	metrics.WriteGaugeUint64(w, `vm_cache_size_bytes{type="storage/regexps"}`, uint64(storage.RegexpCacheSizeBytes()))
 	metrics.WriteGaugeUint64(w, `vm_cache_size_bytes{type="storage/regexpPrefixes"}`, uint64(storage.RegexpPrefixesCacheSizeBytes()))
-	metrics.WriteGaugeUint64(w, `vm_cache_size_bytes{type="storage/prefetchedMetricIDs"}`, m.PrefetchedMetricIDsSizeBytes)
 
 	metrics.WriteGaugeUint64(w, `vm_cache_size_max_bytes{type="storage/tsid"}`, m.TSIDCacheSizeMaxBytes)
 	metrics.WriteGaugeUint64(w, `vm_cache_size_max_bytes{type="storage/metricIDs"}`, m.MetricIDCacheSizeMaxBytes)

--- a/lib/storage/index_db.go
+++ b/lib/storage/index_db.go
@@ -24,6 +24,7 @@ import (
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/mergeset"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/querytracer"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/slicesutil"
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/timeutil"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/uint64set"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/workingsetcache"
 )
@@ -91,6 +92,8 @@ type indexDB struct {
 	// High rate may mean corrupted indexDB due to unclean shutdown.
 	// The db must be automatically recovered after that.
 	missingMetricNamesForMetricID atomic.Uint64
+
+	slowMetricNameLoads atomic.Uint64
 
 	// minMissingTimestampByKey holds the minimum timestamps by index search key,
 	// which is missing in the given indexDB.
@@ -164,6 +167,13 @@ type indexDB struct {
 	deletedMetricIDsUpdateLock sync.Mutex
 
 	indexSearchPool sync.Pool
+
+	// prefetchedMetricIDs contains metricIDs for pre-fetched metricNames in the prefetchMetricNames function.
+	prefetchedMetricIDsLock sync.Mutex
+	prefetchedMetricIDs     *uint64set.Set
+
+	// prefetchedMetricIDsDeadline is used for periodic reset of prefetchedMetricIDs in order to limit its size under high rate of creating new series.
+	prefetchedMetricIDsDeadline atomic.Uint64
 }
 
 var maxTagFiltersCacheSize int
@@ -199,6 +209,7 @@ func mustOpenIndexDB(id uint64, tr TimeRange, name, path string, s *Storage, isR
 		s:                          s,
 		loopsPerDateTagFilterCache: workingsetcache.New(mem / 128),
 		metricIDCache:              make(map[uint64]struct{}),
+		prefetchedMetricIDs:        &uint64set.Set{},
 	}
 	tb := mergeset.MustOpenTable(path, dataFlushInterval, db.invalidateTagFiltersCache, mergeTagToMetricIDsRows, isReadOnly)
 	db.tb = tb
@@ -232,6 +243,11 @@ type IndexDBMetrics struct {
 	GlobalSearchCalls    uint64
 
 	MissingMetricNamesForMetricID uint64
+
+	SlowMetricNameLoads uint64
+
+	PrefetchedMetricIDsSize      uint64
+	PrefetchedMetricIDsSizeBytes uint64
 
 	IndexBlocksWithMetricIDsProcessed      uint64
 	IndexBlocksWithMetricIDsIncorrectOrder uint64
@@ -280,6 +296,14 @@ func (db *indexDB) UpdateMetrics(m *IndexDBMetrics) {
 	m.GlobalSearchCalls += db.globalSearchCalls.Load()
 
 	m.MissingMetricNamesForMetricID += db.missingMetricNamesForMetricID.Load()
+
+	m.SlowMetricNameLoads += db.slowMetricNameLoads.Load()
+
+	db.prefetchedMetricIDsLock.Lock()
+	prefetchedMetricIDs := db.prefetchedMetricIDs
+	m.PrefetchedMetricIDsSize += uint64(prefetchedMetricIDs.Len())
+	m.PrefetchedMetricIDsSizeBytes += prefetchedMetricIDs.SizeBytes()
+	db.prefetchedMetricIDsLock.Unlock()
 
 	db.tb.UpdateMetrics(&m.TableMetrics)
 	db.doExtDB(func(extDB *indexDB) {
@@ -1902,6 +1926,91 @@ func (db *indexDB) getTSIDsFromMetricIDs(qt *querytracer.Tracer, metricIDs []uin
 		db.deleteMetricIDs(metricIDsToDelete)
 	}
 	return tsids, nil
+}
+
+// prefetchMetricNames pre-fetches metric names for the given srcMetricIDs into metricID->metricName cache.
+//
+// This should speed-up further searchMetricNameWithCache calls for srcMetricIDs from tsids.
+//
+// It is expected that srcMetricIDs are already sorted by the caller. Otherwise the pre-fetching may be slow.
+func (idb *indexDB) prefetchMetricNames(qt *querytracer.Tracer, srcMetricIDs []uint64, deadline uint64) error {
+	qt = qt.NewChild("prefetch metric names for %d metricIDs", len(srcMetricIDs))
+	defer qt.Done()
+
+	if len(srcMetricIDs) < 500 {
+		qt.Printf("skip pre-fetching metric names for low number of metric ids=%d", len(srcMetricIDs))
+		return nil
+	}
+
+	var metricIDs []uint64
+	idb.prefetchedMetricIDsLock.Lock()
+	prefetchedMetricIDs := idb.prefetchedMetricIDs
+	for _, metricID := range srcMetricIDs {
+		if prefetchedMetricIDs.Has(metricID) {
+			continue
+		}
+		metricIDs = append(metricIDs, metricID)
+	}
+	idb.prefetchedMetricIDsLock.Unlock()
+
+	qt.Printf("%d out of %d metric names must be pre-fetched", len(metricIDs), len(srcMetricIDs))
+	if len(metricIDs) < 500 {
+		// It is cheaper to skip pre-fetching and obtain metricNames inline.
+		qt.Printf("skip pre-fetching metric names for low number of missing metric ids=%d", len(metricIDs))
+		return nil
+	}
+	idb.slowMetricNameLoads.Add(uint64(len(metricIDs)))
+
+	// Pre-fetch metricIDs.
+	var missingMetricIDs []uint64
+	var metricName []byte
+	var err error
+	is := idb.getIndexSearch(deadline)
+	defer idb.putIndexSearch(is)
+	for loops, metricID := range metricIDs {
+		if loops&paceLimiterSlowIterationsMask == 0 {
+			if err := checkSearchDeadlineAndPace(is.deadline); err != nil {
+				return err
+			}
+		}
+		var ok bool
+		metricName, ok = is.searchMetricNameWithCache(metricName[:0], metricID)
+		if !ok {
+			missingMetricIDs = append(missingMetricIDs, metricID)
+			continue
+		}
+	}
+	idb.doExtDB(func(extDB *indexDB) {
+		is := extDB.getIndexSearch(deadline)
+		defer extDB.putIndexSearch(is)
+		for loops, metricID := range missingMetricIDs {
+			if loops&paceLimiterSlowIterationsMask == 0 {
+				if err = checkSearchDeadlineAndPace(is.deadline); err != nil {
+					return
+				}
+			}
+			metricName, _ = is.searchMetricNameWithCache(metricName[:0], metricID)
+		}
+	})
+	if err != nil && err != io.EOF {
+		return err
+	}
+	qt.Printf("pre-fetch metric names for %d metric ids", len(metricIDs))
+
+	// Store the pre-fetched metricIDs, so they aren't pre-fetched next time.
+	idb.prefetchedMetricIDsLock.Lock()
+	if fasttime.UnixTimestamp() > idb.prefetchedMetricIDsDeadline.Load() {
+		// Periodically reset the prefetchedMetricIDs in order to limit its size.
+		idb.prefetchedMetricIDs = &uint64set.Set{}
+		d := timeutil.AddJitterToDuration(time.Second * 20 * 60)
+		metricIDsDeadline := fasttime.UnixTimestamp() + uint64(d.Seconds())
+		idb.prefetchedMetricIDsDeadline.Store(metricIDsDeadline)
+	}
+	idb.prefetchedMetricIDs.AddMulti(metricIDs)
+	idb.prefetchedMetricIDsLock.Unlock()
+
+	qt.Printf("cache metric ids for pre-fetched metric names")
+	return nil
 }
 
 var tagFiltersKeyBufPool bytesutil.ByteBufferPool

--- a/lib/storage/search.go
+++ b/lib/storage/search.go
@@ -210,7 +210,7 @@ func (s *Search) searchTSIDs(qt *querytracer.Tracer, tfss []*TagFilters, tr Time
 		if err == nil {
 			tsids, err = idb.getTSIDsFromMetricIDs(qt, metricIDs, deadline)
 			if err == nil {
-				err = s.storage.prefetchMetricNames(qt, idb, metricIDs, deadline)
+				err = idb.prefetchMetricNames(qt, metricIDs, deadline)
 			}
 		}
 		return tsids, err


### PR DESCRIPTION
### Describe Your Changes

Move prefetchedMetricNames from storage to each idb. Task 70 & 74 from https://docs.google.com/spreadsheets/d/1tGX-im3QyhUxsYOrD715kVS48SusPzTIaAOai4oPWPA/edit?gid=0#gid=0

### Checklist

The following checks are **mandatory**:

- [ ] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/contributing/).
