### PR TITLE
app/vmlogs: Replace elasticsearch plugin with opensearch plugin of logstash

### DIFF
--- a/deployment/docker/victorialogs/logstash/Dockerfile
+++ b/deployment/docker/victorialogs/logstash/Dockerfile
@@ -1,5 +1,4 @@
 FROM docker.elastic.co/logstash/logstash:8.15.0
 
 RUN bin/logstash-plugin install \
-    logstash-output-opensearch \
     logstash-output-loki

--- a/deployment/docker/victorialogs/logstash/elasticsearch/pipeline.conf
+++ b/deployment/docker/victorialogs/logstash/elasticsearch/pipeline.conf
@@ -5,7 +5,7 @@ input {
 }
 
 output {
-  opensearch {
+  elasticsearch {
     hosts => ["http://victorialogs:9428/insert/elasticsearch"]
     custom_headers => {
         "AccountID" => "0"


### PR DESCRIPTION
### Describe your changes

1. When I used the opensearch plugin in the reference example, I found a bug that caused memory exhaustion and stopped working. There is a similar issue in the opensearch community: https://github.com/opensearch-project/logstash-output-opensearch/issues/186, @chadmyers raised this issue, but it has not been fixed yet. It has been verified that the elasticsearch plugin does not have this problem.
![image](https://github.com/user-attachments/assets/cc2cbbfc-6dde-43af-8aca-3c1e371e1890)


2. In the vmlogs logstash docking example, it is consistent with the official document's example of using the elasticsearch plugin. https://docs.victoriametrics.com/victorialogs/data-ingestion/logstash/

### Checklist

The following checks are **required**:

- [x] My changes follow the [VictoriaMetrics Contribution Guide](https://docs.victoriametrics.com/contributing/).