### PR TITLE
vmui/logs/fix sorting issues

### DIFF
--- a/app/vmui/packages/vmui/src/pages/ExploreLogs/GroupLogs/GroupLogs.tsx
+++ b/app/vmui/packages/vmui/src/pages/ExploreLogs/GroupLogs/GroupLogs.tsx
@@ -52,8 +52,8 @@ const GroupLogs: FC<Props> = ({ logs, settingsRef }) => {
         const aTimestamp = getNanoTimestamp(a._time);
         const bTimestamp = getNanoTimestamp(b._time);
 
-        if (aTimestamp > bTimestamp) return 1;
-        if (aTimestamp < bTimestamp) return -1;
+        if (aTimestamp < bTimestamp) return 1;
+        if (aTimestamp > bTimestamp) return -1;
         return 0;
       });
 

--- a/app/vmui/packages/vmui/src/pages/ExploreLogs/GroupLogs/GroupLogsFields.tsx
+++ b/app/vmui/packages/vmui/src/pages/ExploreLogs/GroupLogs/GroupLogsFields.tsx
@@ -1,0 +1,52 @@
+import React, { FC, useMemo, useState } from "preact/compat";
+import { Logs } from "../../../api/types";
+import "./style.scss";
+import classNames from "classnames";
+import GroupLogsFieldRow from "./GroupLogsFieldRow";
+import useEventListener from "../../../hooks/useEventListener";
+import { getFromStorage } from "../../../utils/storage";
+
+interface Props {
+  log: Logs;
+}
+
+const GroupLogsFields: FC<Props> = ({ log }) => {
+  const sortedFields = useMemo(() => {
+    return Object.entries(log)
+      .sort(([aKey], [bKey]) => aKey.localeCompare(bKey));
+  }, [log]);
+
+  const [disabledHovers, setDisabledHovers] = useState(!!getFromStorage("LOGS_DISABLED_HOVERS"));
+
+  const handleUpdateStage = () => {
+    const newValDisabledHovers = !!getFromStorage("LOGS_DISABLED_HOVERS");
+    if (newValDisabledHovers !== disabledHovers) {
+      setDisabledHovers(newValDisabledHovers);
+    }
+  };
+
+  useEventListener("storage", handleUpdateStage);
+
+  return (
+    <div
+      className={classNames({
+        "vm-group-logs-row-fields": true,
+        "vm-group-logs-row-fields_interactive": !disabledHovers
+      })}
+    >
+      <table>
+        <tbody>
+          {sortedFields.map(([key, value]) => (
+            <GroupLogsFieldRow
+              key={key}
+              field={key}
+              value={value}
+            />
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+export default GroupLogsFields;

--- a/app/vmui/packages/vmui/src/pages/ExploreLogs/GroupLogs/GroupLogsItem.tsx
+++ b/app/vmui/packages/vmui/src/pages/ExploreLogs/GroupLogs/GroupLogsItem.tsx
@@ -7,13 +7,13 @@ import classNames from "classnames";
 import { useLogsState } from "../../../state/logsPanel/LogsStateContext";
 import dayjs from "dayjs";
 import { useTimeState } from "../../../state/time/TimeStateContext";
-import GroupLogsFieldRow from "./GroupLogsFieldRow";
 import { marked } from "marked";
 import { useSearchParams } from "react-router-dom";
 import { LOGS_DATE_FORMAT, LOGS_URL_PARAMS } from "../../../constants/logs";
 import useEventListener from "../../../hooks/useEventListener";
 import { getFromStorage } from "../../../utils/storage";
 import { parseAnsiToHtml } from "../../../utils/ansiParser";
+import GroupLogsFields from "./GroupLogsFields";
 
 interface Props {
   log: Logs;
@@ -43,8 +43,7 @@ const GroupLogsItem: FC<Props> = ({ log, displayFields = ["_msg"] }) => {
     return marked(log._msg.replace(/```/g, "\n```\n")) as string;
   }, [log._msg, markdownParsing]);
 
-  const fields = useMemo(() => Object.entries(log), [log]);
-  const hasFields = fields.length > 0;
+  const hasFields = Object.keys(log).length > 0;
 
   const displayMessage = useMemo(() => {
     const values: (string | React.ReactNode)[] = [];
@@ -59,13 +58,13 @@ const GroupLogsItem: FC<Props> = ({ log, displayFields = ["_msg"] }) => {
         values.push(value);
       });
     } else {
-      fields.forEach(([key, value]) => {
+      Object.entries(log).forEach(([key, value]) => {
         values.push(`${key}: ${value}`);
       });
     }
 
     return values;
-  }, [log, fields, hasFields, displayFields, ansiParsing]);
+  }, [log, hasFields, displayFields, ansiParsing]);
 
   const [disabledHovers, setDisabledHovers] = useState(!!getFromStorage("LOGS_DISABLED_HOVERS"));
 
@@ -124,26 +123,7 @@ const GroupLogsItem: FC<Props> = ({ log, displayFields = ["_msg"] }) => {
           ))}
         </div>
       </div>
-      {hasFields && isOpenFields && (
-        <div
-          className={classNames({
-            "vm-group-logs-row-fields": true,
-            "vm-group-logs-row-fields_interactive": !disabledHovers
-          })}
-        >
-          <table>
-            <tbody>
-              {fields.map(([key, value]) => (
-                <GroupLogsFieldRow
-                  key={key}
-                  field={key}
-                  value={value}
-                />
-              ))}
-            </tbody>
-          </table>
-        </div>
-      )}
+      {hasFields && isOpenFields && <GroupLogsFields log={log}/>}
     </div>
   );
 };

--- a/docs/victorialogs/CHANGELOG.md
+++ b/docs/victorialogs/CHANGELOG.md
@@ -18,6 +18,8 @@ according to [these docs](https://docs.victoriametrics.com/victorialogs/quicksta
 
 ## tip
 
+* BUGFIX: [web UI](https://docs.victoriametrics.com/victorialogs/querying/#web-ui): fix log entry sorting in group mode (newest logs appear first). See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8726).
+
 ## [v1.21.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.21.0-victorialogs)
 
 Released at 2025-04-25

--- a/docs/victorialogs/CHANGELOG.md
+++ b/docs/victorialogs/CHANGELOG.md
@@ -18,7 +18,7 @@ according to [these docs](https://docs.victoriametrics.com/victorialogs/quicksta
 
 ## tip
 
-* BUGFIX: [web UI](https://docs.victoriametrics.com/victorialogs/querying/#web-ui): fix log entry sorting in group mode (newest logs appear first). See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8726).
+* BUGFIX: [web UI](https://docs.victoriametrics.com/victorialogs/querying/#web-ui): fix log entry sorting in group mode (newest logs appear first). See [#8726](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8726).
 
 ## [v1.21.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.21.0-victorialogs)
 

--- a/docs/victorialogs/CHANGELOG.md
+++ b/docs/victorialogs/CHANGELOG.md
@@ -18,6 +18,8 @@ according to [these docs](https://docs.victoriametrics.com/victorialogs/quicksta
 
 ## tip
 
+* FEATURE: [web UI](https://docs.victoriametrics.com/victorialogs/querying/#web-ui): add sorting of fields by key in the Group tab. See [#8438](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8438).
+
 * BUGFIX: [web UI](https://docs.victoriametrics.com/victorialogs/querying/#web-ui): fix log entry sorting in group mode (newest logs appear first). See [#8726](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8726).
 
 ## [v1.21.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.21.0-victorialogs)
@@ -28,7 +30,6 @@ Released at 2025-04-25
 * FEATURE: [data ingestion](https://docs.victoriametrics.com/victorialogs/data-ingestion/): add an ability to force flush the recently ingested logs, so they become available for querying. See [these docs](https://docs.victoriametrics.com/victorialogs/#forced-flush).
 * FEATURE: [LogsQL](https://docs.victoriametrics.com/victorialogs/logsql/): add [`sample` pipe](https://docs.victoriametrics.com/victorialogs/logsql/#sample-pipe), which returns `1/Nth` random sample for the selected logs.
 * FEATURE: [web UI](https://docs.victoriametrics.com/victorialogs/querying/#web-ui): add a toggle to handle ANSI escape sequences in log messages. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/6614).
-* FEATURE: [web UI](https://docs.victoriametrics.com/victorialogs/querying/#web-ui): add sorting of fields by key in the Group tab. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8438).
 
 * BUGFIX: [web UI](https://docs.victoriametrics.com/victorialogs/querying/#web-ui): fix the Group tab to display raw JSON when `_msg` is missing. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8205).
 * BUGFIX: [web UI](https://docs.victoriametrics.com/victorialogs/querying/#web-ui): fix display of `Query history` icon in mobile view. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8788).

--- a/docs/victorialogs/CHANGELOG.md
+++ b/docs/victorialogs/CHANGELOG.md
@@ -28,6 +28,7 @@ Released at 2025-04-25
 * FEATURE: [data ingestion](https://docs.victoriametrics.com/victorialogs/data-ingestion/): add an ability to force flush the recently ingested logs, so they become available for querying. See [these docs](https://docs.victoriametrics.com/victorialogs/#forced-flush).
 * FEATURE: [LogsQL](https://docs.victoriametrics.com/victorialogs/logsql/): add [`sample` pipe](https://docs.victoriametrics.com/victorialogs/logsql/#sample-pipe), which returns `1/Nth` random sample for the selected logs.
 * FEATURE: [web UI](https://docs.victoriametrics.com/victorialogs/querying/#web-ui): add a toggle to handle ANSI escape sequences in log messages. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/6614).
+* FEATURE: [web UI](https://docs.victoriametrics.com/victorialogs/querying/#web-ui): add sorting of fields by key in the Group tab. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8438).
 
 * BUGFIX: [web UI](https://docs.victoriametrics.com/victorialogs/querying/#web-ui): fix the Group tab to display raw JSON when `_msg` is missing. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8205).
 * BUGFIX: [web UI](https://docs.victoriametrics.com/victorialogs/querying/#web-ui): fix display of `Query history` icon in mobile view. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8788).


### PR DESCRIPTION
### Describe Your Changes

1. Fixed log entry sorting in the "Group" view: newest entries are now displayed at the top again. In v1.18.0, log entries were incorrectly sorted (oldest first) due to changes related to nanosecond precision support. 
    Related issue: #8726
2. Added alphabetical sorting of fields by key in the "Group" view for easier navigation. 
    Related issue: #8438

### Checklist

The following checks are **mandatory**:

- [ ] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/contributing/).
