### PR TITLE
lib/httpserver: move ServeWithOpts to Serve

### DIFF
--- a/app/victoria-logs/main.go
+++ b/app/victoria-logs/main.go
@@ -46,7 +46,9 @@ func main() {
 	vlselect.Init()
 	vlinsert.Init()
 
-	go httpserver.Serve(listenAddrs, useProxyProtocol, requestHandler)
+	go httpserver.Serve(listenAddrs, requestHandler, httpserver.ServeOptions{
+		UseProxyProtocol: useProxyProtocol,
+	})
 	logger.Infof("started VictoriaLogs in %.3f seconds; see https://docs.victoriametrics.com/victorialogs/", time.Since(startTime).Seconds())
 
 	pushmetrics.Init()

--- a/app/victoria-metrics/main.go
+++ b/app/victoria-metrics/main.go
@@ -101,7 +101,9 @@ func main() {
 
 	startSelfScraper()
 
-	go httpserver.Serve(listenAddrs, useProxyProtocol, requestHandler)
+	go httpserver.Serve(listenAddrs, requestHandler, httpserver.ServeOptions{
+		UseProxyProtocol: useProxyProtocol,
+	})
 	logger.Infof("started VictoriaMetrics in %.3f seconds", time.Since(startTime).Seconds())
 
 	pushmetrics.Init()

--- a/app/victoria-metrics/main_test.go
+++ b/app/victoria-metrics/main_test.go
@@ -185,7 +185,9 @@ func setUp() {
 	vmstorage.Init(promql.ResetRollupResultCacheIfNeeded)
 	vmselect.Init()
 	vminsert.Init()
-	go httpserver.Serve(*httpListenAddrs, useProxyProtocol, requestHandler)
+	go httpserver.Serve(*httpListenAddrs, requestHandler, httpserver.ServeOptions{
+		UseProxyProtocol: useProxyProtocol,
+	})
 	readyStorageCheckFunc := func() bool {
 		resp, err := http.Get(testHealthHTTPPath)
 		if err != nil {

--- a/app/victoria-metrics/main_test.go
+++ b/app/victoria-metrics/main_test.go
@@ -185,9 +185,7 @@ func setUp() {
 	vmstorage.Init(promql.ResetRollupResultCacheIfNeeded)
 	vmselect.Init()
 	vminsert.Init()
-	go httpserver.Serve(*httpListenAddrs, requestHandler, httpserver.ServeOptions{
-		UseProxyProtocol: useProxyProtocol,
-	})
+	go httpserver.Serve(*httpListenAddrs, useProxyProtocol, requestHandler)
 	readyStorageCheckFunc := func() bool {
 		resp, err := http.Get(testHealthHTTPPath)
 		if err != nil {

--- a/app/vmagent/main.go
+++ b/app/vmagent/main.go
@@ -165,7 +165,9 @@ func main() {
 
 	promscrape.Init(remotewrite.PushDropSamplesOnFailure)
 
-	go httpserver.Serve(listenAddrs, useProxyProtocol, requestHandler)
+	go httpserver.Serve(listenAddrs, requestHandler, httpserver.ServeOptions{
+		UseProxyProtocol: useProxyProtocol,
+	})
 	logger.Infof("started vmagent in %.3f seconds", time.Since(startTime).Seconds())
 
 	pushmetrics.Init()

--- a/app/vmalert/main.go
+++ b/app/vmalert/main.go
@@ -182,7 +182,9 @@ func main() {
 		listenAddrs = []string{":8880"}
 	}
 	rh := &requestHandler{m: manager}
-	go httpserver.Serve(listenAddrs, useProxyProtocol, rh.handler)
+	go httpserver.Serve(listenAddrs, rh.handler, httpserver.ServeOptions{
+		UseProxyProtocol: useProxyProtocol,
+	})
 
 	pushmetrics.Init()
 	sig := procutil.WaitForSigterm()

--- a/app/vmauth/main.go
+++ b/app/vmauth/main.go
@@ -106,10 +106,10 @@ func main() {
 		UseProxyProtocol:     useProxyProtocol,
 		DisableBuiltinRoutes: disableInternalRoutes,
 	}
-	go httpserver.ServeWithOpts(listenAddrs, rh, serveOpts)
+	go httpserver.Serve(listenAddrs, rh, serveOpts)
 
 	if len(*httpInternalListenAddr) > 0 {
-		go httpserver.Serve(*httpInternalListenAddr, nil, internalRequestHandler)
+		go httpserver.Serve(*httpInternalListenAddr, internalRequestHandler, serveOpts)
 	}
 	logger.Infof("started vmauth in %.3f seconds", time.Since(startTime).Seconds())
 

--- a/app/vmbackup/main.go
+++ b/app/vmbackup/main.go
@@ -95,7 +95,7 @@ func main() {
 	}
 
 	listenAddrs := []string{*httpListenAddr}
-	go httpserver.Serve(listenAddrs, nil, nil)
+	go httpserver.Serve(listenAddrs, nil, httpserver.ServeOptions{})
 
 	pushmetrics.Init()
 	err := makeBackup()

--- a/app/vmrestore/main.go
+++ b/app/vmrestore/main.go
@@ -38,7 +38,7 @@ func main() {
 	logger.Init()
 
 	listenAddrs := []string{*httpListenAddr}
-	go httpserver.Serve(listenAddrs, nil, nil)
+	go httpserver.Serve(listenAddrs, nil, httpserver.ServeOptions{})
 
 	srcFS, err := newSrcFS()
 	if err != nil {

--- a/lib/httpserver/httpserver.go
+++ b/lib/httpserver/httpserver.go
@@ -100,35 +100,7 @@ type ServeOptions struct {
 // Serve starts an http server on the given addrs with the given optional rh.
 //
 // By default all the responses are transparently compressed, since egress traffic is usually expensive.
-//
-// The compression can be disabled by specifying -http.disableResponseCompression command-line flag.
-//
-// If useProxyProtocol is set to true for the corresponding addr, then the incoming connections are accepted via proxy protocol.
-// See https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt
-func Serve(addrs []string, useProxyProtocol *flagutil.ArrayBool, rh RequestHandler) {
-	if rh == nil {
-		rh = func(_ http.ResponseWriter, _ *http.Request) bool {
-			return false
-		}
-	}
-	opts := ServeOptions{
-		UseProxyProtocol: useProxyProtocol,
-	}
-	for idx, addr := range addrs {
-		if addr == "" {
-			continue
-		}
-		go serve(addr, rh, idx, opts)
-	}
-}
-
-// ServeWithOpts starts an http server on the given addrs with the given optional request handlers.
-//
-// By default all the responses are transparently compressed, since egress traffic is usually expensive.
-//
-// The compression can be disabled by specifying -http.disableResponseCompression command-line flag.
-// TODO: rename to Serve and update Serve usage with new signature
-func ServeWithOpts(addrs []string, rh RequestHandler, opts ServeOptions) {
+func Serve(addrs []string, rh RequestHandler, opts ServeOptions) {
 	if rh == nil {
 		rh = func(_ http.ResponseWriter, _ *http.Request) bool {
 			return false


### PR DESCRIPTION
This addresses that todo in the codebase, and updates all callsites to the new signature.

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/contributing/).
