### PR TITLE
deployment/rules: add alerting rule `ScrapePoolHasNoTargets` to vmagent

### DIFF
--- a/deployment/docker/rules/alerts-vmagent.yml
+++ b/deployment/docker/rules/alerts-vmagent.yml
@@ -41,6 +41,17 @@ groups:
           summary: "Vmagent fails to scrape one or more targets"
           description: "Job \"{{ $labels.job }}\" on instance {{ $labels.instance }} fails to scrape targets for last 15m"
 
+      - alert: ScrapePoolHasNoTargets
+        expr: sum(vm_promscrape_scrape_pool_targets) without (status) == 0
+        for: 30m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Vmagent has scrape_pool with 0 configured/discovered targets"
+          description: "Vmagent \"{{ $labels.job }}\" on instance {{ $labels.instance }} has scrape_pool \"{{ $labels.scrape_job }}\"
+            with 0 discovered targets. It is likely a misconfiguration. Please follow https://docs.victoriametrics.com/victoriametrics/vmagent/#debugging-scrape-targets
+            to troubleshoot the scraping config."
+
       - alert: TooManyWriteErrors
         expr: |
           (sum(increase(vm_ingestserver_request_errors_total[5m])) without (name,net,type)

--- a/docs/victoriametrics/changelog/CHANGELOG.md
+++ b/docs/victoriametrics/changelog/CHANGELOG.md
@@ -19,6 +19,7 @@ See also [LTS releases](https://docs.victoriametrics.com/victoriametrics/lts-rel
 ## tip
 
 * FEATURE: [vmalert](https://docs.victoriametrics.com/victoriametrics/vmalert/): add `debug` option for [group](https://docs.victoriametrics.com/vmalert/#groups) for enabling [debug mode](https://docs.victoriametrics.com/victoriametrics/vmalert/#debug-mode) for all rules within the group. Thanks to @eyazici90 for [#8658](https://github.com/VictoriaMetrics/VictoriaMetrics/pull/8658).
+* FEATURE: [alerts](https://github.com/VictoriaMetrics/VictoriaMetrics/blob/master/deployment/docker/rules): add alerting rule `ScrapePoolHasNoTargets` to vmagent default rules. The new rule should notify user when there is a job with 0 configured or discovered targets, which is usually a sign of misconfiguration.
 
 * BUGFIX: [vmui](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#vmui): use `retentionFilter` flag name in debugging interface to make it consistent with flag definition. Previously, flag name in debugging interface was different from command-line configuration so copying command-line flags for debugging produced an error. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8697).
 * BUGFIX: [vmalert](https://docs.victoriametrics.com/victoriametrics/vmalert/): fix various UI glitches and tidy up the visual styles. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8773) for details.


### PR DESCRIPTION
The new rule should notify user when there is a job with 0 configured or discovered targets, which is usually a sign of misconfiguration.

### Describe Your Changes

Please provide a brief description of the changes you made. Be as specific as possible to help others understand the purpose and impact of your modifications.

### Checklist

The following checks are **mandatory**:

- [ ] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/).
