### PR TITLE
vmui/logs: fix freeze on timeline zoom

### DIFF
--- a/app/vmui/packages/vmui/src/api/tsdb.ts
+++ b/app/vmui/packages/vmui/src/api/tsdb.ts
@@ -22,8 +22,6 @@ export const getMetricNamesStats = (server: string, params: MetricNamesStatsPara
     Object.entries(params).filter(([_, value]) => value != null)
   ).toString();
 
-  console.log("searchParams", searchParams);
-
   return `${server}/api/v1/status/metric_names_stats?${searchParams}`;
 };
 

--- a/app/vmui/packages/vmui/src/pages/ExploreLogs/ExploreLogs.tsx
+++ b/app/vmui/packages/vmui/src/pages/ExploreLogs/ExploreLogs.tsx
@@ -53,7 +53,6 @@ const ExploreLogs: FC = () => {
   const { fetchLogHits, ...dataLogHits } = useFetchLogHits(serverUrl, query);
 
   const fetchData = (p: TimeParams, hits: boolean) => {
-    console.log("hits", hits);
     fetchLogs(p).then((isSuccess) => {
       isSuccess && hits && fetchLogHits(p);
     }).catch(() => {/* ignore, handled elsewhere */});

--- a/docs/victorialogs/CHANGELOG.md
+++ b/docs/victorialogs/CHANGELOG.md
@@ -22,7 +22,9 @@ according to [these docs](https://docs.victoriametrics.com/victorialogs/quicksta
 * FEATURE: [JSON lines data ingestion](https://docs.victoriametrics.com/victorialogs/data-ingestion/#json-stream-api): return `400 Bad Request` if no logs were successfully processed. This improves error visibility for malformed requests. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8818).
 
 * BUGFIX: [web UI](https://docs.victoriametrics.com/victorialogs/querying/#web-ui): fix log entry sorting in group mode (newest logs appear first). See [#8726](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8726).
+* BUGFIX: [web UI](https://docs.victoriametrics.com/victorialogs/querying/#web-ui): fix page freeze after timeline zooming and panning. See [#8655](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8655).
 * BUGFIX: [replace_regexp](https://docs.victoriametrics.com/victorialogs/logsql/#replace_regexp-pipe): fixed infinite loop when regex pattern matches empty strings (e.g. `\d*`, `()`, `\b`). Also fixed incorrect behavior with anchors (`^`) due to repeated string slicing. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8625).
+
 ## [v1.21.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.21.0-victorialogs)
 
 Released at 2025-04-25


### PR DESCRIPTION
### Describe Your Changes

Fixes UI freeze in logs timeline after repeated zooming and panning.

The issue was caused by excessive query requests triggered during fast timeline interactions. Added debounce to limit the frequency of requests, similar to the approach used in vmui for metrics.

Related issue: #8655

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/).
