### PR TITLE
docs/victoriametrics/quickstart: avoid using word `latest`

### DIFF
--- a/docs/victoriametrics/Quick-Start.md
+++ b/docs/victoriametrics/Quick-Start.md
@@ -54,13 +54,14 @@ and performing [regular upgrades](https://docs.victoriametrics.com/victoriametri
 
 ### Starting VictoriaMetrics Single Node via Docker {anchor="starting-vm-single-via-docker"}
 
-Download the latest available [Docker image of VictoriaMetrics](https://hub.docker.com/r/victoriametrics/victoria-metrics)
-and start it at port `:8428`:
+Download the newest available [VictoriaMetrics release](https://docs.victoriametrics.com/victoriametrics/changelog/)
+from [DockerHub](https://hub.docker.com/r/victoriametrics/victoria-metrics) or [Quay](https://quay.io/repository/victoriametrics/victoria-metrics?tab=tags):
 ```sh
 docker pull victoriametrics/victoria-metrics:v1.116.0
 docker run -it --rm -v `pwd`/victoria-metrics-data:/victoria-metrics-data -p 8428:8428 \
  victoriametrics/victoria-metrics:v1.116.0 --selfScrapeInterval=5s -storageDataPath=victoria-metrics-data
 ```
+_Make sure to choose non-enterprise release flavour, as it requires additional access to run._
 
 You should see:
 ```sh


### PR DESCRIPTION
`latest` seem to confuse users with `:latest` tag
see https://github.com/VictoriaMetrics/VictoriaMetrics/issues/7336#issuecomment-2849382265

Replacing it with `newest` word, which is how dockerhub sorts the tags in its UI at https://hub.docker.com/r/victoriametrics/victoria-metrics/tags

### Describe Your Changes

Please provide a brief description of the changes you made. Be as specific as possible to help others understand the purpose and impact of your modifications.

### Checklist

The following checks are **mandatory**:

- [ ] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/).
