### PR TITLE
app/vmauth: expose built-in handlers if `-httpInternalListenAddr` is specified

### DIFF
--- a/app/vmauth/main.go
+++ b/app/vmauth/main.go
@@ -96,20 +96,23 @@ func main() {
 	logger.Infof("starting vmauth at %q...", listenAddrs)
 	startTime := time.Now()
 	initAuthConfig()
+
 	disableInternalRoutes := len(*httpInternalListenAddr) > 0
 	rh := requestHandlerWithInternalRoutes
 	if disableInternalRoutes {
 		rh = requestHandler
 	}
 
-	serveOpts := httpserver.ServeOptions{
-		UseProxyProtocol:     useProxyProtocol,
+	go httpserver.Serve(listenAddrs, rh, httpserver.ServeOptions{
+		UseProxyProtocol: useProxyProtocol,
+		// built-in routes will be exposed at *httpInternalListenAddr
 		DisableBuiltinRoutes: disableInternalRoutes,
-	}
-	go httpserver.Serve(listenAddrs, rh, serveOpts)
+	})
 
 	if len(*httpInternalListenAddr) > 0 {
-		go httpserver.Serve(*httpInternalListenAddr, internalRequestHandler, serveOpts)
+		go httpserver.Serve(*httpInternalListenAddr, internalRequestHandler, httpserver.ServeOptions{
+			UseProxyProtocol: useProxyProtocol,
+		})
 	}
 	logger.Infof("started vmauth in %.3f seconds", time.Since(startTime).Seconds())
 


### PR DESCRIPTION
This functionality was broken in https://github.com/VictoriaMetrics/VictoriaMetrics/commit/0e313e53557f01046e3162abb33ef361ccf4a243

Was caught by integration tests:
```
--- FAIL: TestSingleVMAuthRouterWithInternalAddr (5.00s)
    vmauth_routing_test.go:148: Could not start vmauth: could not extract some or all regexps from stderr: ["pprof handlers are exposed at http://(.*:\\d{1,5})/debug/pprof/"]
```