### PR TITLE
app/vlinsert: improve error handling in _bulk handler

### DIFF
--- a/app/vlinsert/elasticsearch/bulk_response.qtpl
+++ b/app/vlinsert/elasticsearch/bulk_response.qtpl
@@ -1,16 +1,29 @@
 {% stripspace %}
 
-{% func BulkResponse(n int, tookMs int64) %}
+{% func BulkResponse(n int, errs []parseError, tookMs int64) %}
 {
 	"took":{%dl tookMs %},
-	"errors":false,
+	"errors": {% if len(errs) > 0 %} true {% else %} false {% endif %},
 	"items":[
 		{% for i := 0; i < n; i++ %}
-		{
-			"create":{
-				"status":201
-			}
-		}
+			{% if len(errs) > 0 && errs[0].pos == i %}
+				{
+					"create":{
+						"status":400,
+						"error":{
+							"type":"document_parsing_exception",
+							"reason": {%q= errs[0].err.Error() %}
+						}
+					}
+				}
+				{% code errs = errs[1:] %}
+			{% else %}
+				{
+					"create":{
+						"status":201
+					}
+				}
+			{% endif %}
 		{% if i+1 < n %},{% endif %}
 		{% endfor %}
 	]

--- a/app/vlinsert/elasticsearch/bulk_response.qtpl.go
+++ b/app/vlinsert/elasticsearch/bulk_response.qtpl.go
@@ -18,52 +18,79 @@ var (
 )
 
 //line app/vlinsert/elasticsearch/bulk_response.qtpl:3
-func StreamBulkResponse(qw422016 *qt422016.Writer, n int, tookMs int64) {
+func StreamBulkResponse(qw422016 *qt422016.Writer, n int, errs []parseError, tookMs int64) {
 //line app/vlinsert/elasticsearch/bulk_response.qtpl:3
 	qw422016.N().S(`{"took":`)
 //line app/vlinsert/elasticsearch/bulk_response.qtpl:5
 	qw422016.N().DL(tookMs)
 //line app/vlinsert/elasticsearch/bulk_response.qtpl:5
-	qw422016.N().S(`,"errors":false,"items":[`)
+	qw422016.N().S(`,"errors":`)
+//line app/vlinsert/elasticsearch/bulk_response.qtpl:6
+	if len(errs) > 0 {
+//line app/vlinsert/elasticsearch/bulk_response.qtpl:6
+		qw422016.N().S(`true`)
+//line app/vlinsert/elasticsearch/bulk_response.qtpl:6
+	} else {
+//line app/vlinsert/elasticsearch/bulk_response.qtpl:6
+		qw422016.N().S(`false`)
+//line app/vlinsert/elasticsearch/bulk_response.qtpl:6
+	}
+//line app/vlinsert/elasticsearch/bulk_response.qtpl:6
+	qw422016.N().S(`,"items":[`)
 //line app/vlinsert/elasticsearch/bulk_response.qtpl:8
 	for i := 0; i < n; i++ {
-//line app/vlinsert/elasticsearch/bulk_response.qtpl:8
-		qw422016.N().S(`{"create":{"status":201}}`)
-//line app/vlinsert/elasticsearch/bulk_response.qtpl:14
-		if i+1 < n {
-//line app/vlinsert/elasticsearch/bulk_response.qtpl:14
-			qw422016.N().S(`,`)
-//line app/vlinsert/elasticsearch/bulk_response.qtpl:14
+//line app/vlinsert/elasticsearch/bulk_response.qtpl:9
+		if len(errs) > 0 && errs[0].pos == i {
+//line app/vlinsert/elasticsearch/bulk_response.qtpl:9
+			qw422016.N().S(`{"create":{"status":400,"error":{"type":"document_parsing_exception","reason":`)
+//line app/vlinsert/elasticsearch/bulk_response.qtpl:15
+			qw422016.N().Q(errs[0].err.Error())
+//line app/vlinsert/elasticsearch/bulk_response.qtpl:15
+			qw422016.N().S(`}}}`)
+//line app/vlinsert/elasticsearch/bulk_response.qtpl:19
+			errs = errs[1:]
+
+//line app/vlinsert/elasticsearch/bulk_response.qtpl:20
+		} else {
+//line app/vlinsert/elasticsearch/bulk_response.qtpl:20
+			qw422016.N().S(`{"create":{"status":201}}`)
+//line app/vlinsert/elasticsearch/bulk_response.qtpl:26
 		}
-//line app/vlinsert/elasticsearch/bulk_response.qtpl:15
+//line app/vlinsert/elasticsearch/bulk_response.qtpl:27
+		if i+1 < n {
+//line app/vlinsert/elasticsearch/bulk_response.qtpl:27
+			qw422016.N().S(`,`)
+//line app/vlinsert/elasticsearch/bulk_response.qtpl:27
+		}
+//line app/vlinsert/elasticsearch/bulk_response.qtpl:28
 	}
-//line app/vlinsert/elasticsearch/bulk_response.qtpl:15
+//line app/vlinsert/elasticsearch/bulk_response.qtpl:28
 	qw422016.N().S(`]}`)
-//line app/vlinsert/elasticsearch/bulk_response.qtpl:18
+//line app/vlinsert/elasticsearch/bulk_response.qtpl:31
 }
 
-//line app/vlinsert/elasticsearch/bulk_response.qtpl:18
-func WriteBulkResponse(qq422016 qtio422016.Writer, n int, tookMs int64) {
-//line app/vlinsert/elasticsearch/bulk_response.qtpl:18
+//line app/vlinsert/elasticsearch/bulk_response.qtpl:31
+func WriteBulkResponse(qq422016 qtio422016.Writer, n int, errs []parseError, tookMs int64) {
+//line app/vlinsert/elasticsearch/bulk_response.qtpl:31
 	qw422016 := qt422016.AcquireWriter(qq422016)
-//line app/vlinsert/elasticsearch/bulk_response.qtpl:18
-	StreamBulkResponse(qw422016, n, tookMs)
-//line app/vlinsert/elasticsearch/bulk_response.qtpl:18
+//line app/vlinsert/elasticsearch/bulk_response.qtpl:31
+	StreamBulkResponse(qw422016, n, errs, tookMs)
+//line app/vlinsert/elasticsearch/bulk_response.qtpl:31
 	qt422016.ReleaseWriter(qw422016)
-//line app/vlinsert/elasticsearch/bulk_response.qtpl:18
+//line app/vlinsert/elasticsearch/bulk_response.qtpl:31
 }
 
-//line app/vlinsert/elasticsearch/bulk_response.qtpl:18
-func BulkResponse(n int, tookMs int64) string {
-//line app/vlinsert/elasticsearch/bulk_response.qtpl:18
+//line app/vlinsert/elasticsearch/bulk_response.qtpl:31
+func BulkResponse(n int, errs []parseError, tookMs int64) string {
+//line app/vlinsert/elasticsearch/bulk_response.qtpl:31
 	qb422016 := qt422016.AcquireByteBuffer()
-//line app/vlinsert/elasticsearch/bulk_response.qtpl:18
-	WriteBulkResponse(qb422016, n, tookMs)
-//line app/vlinsert/elasticsearch/bulk_response.qtpl:18
+//line app/vlinsert/elasticsearch/bulk_response.qtpl:31
+	WriteBulkResponse(qb422016, n, errs, tookMs)
+//line app/vlinsert/elasticsearch/bulk_response.qtpl:31
 	qs422016 := string(qb422016.B)
-//line app/vlinsert/elasticsearch/bulk_response.qtpl:18
+//line app/vlinsert/elasticsearch/bulk_response.qtpl:31
 	qt422016.ReleaseByteBuffer(qb422016)
-//line app/vlinsert/elasticsearch/bulk_response.qtpl:18
+//line app/vlinsert/elasticsearch/bulk_response.qtpl:31
 	return qs422016
-//line app/vlinsert/elasticsearch/bulk_response.qtpl:18
+//line app/vlinsert/elasticsearch/bulk_response.qtpl:31
 }

--- a/app/vlinsert/elasticsearch/elasticsearch_test.go
+++ b/app/vlinsert/elasticsearch/elasticsearch_test.go
@@ -3,12 +3,13 @@ package elasticsearch
 import (
 	"bytes"
 	"fmt"
+	"io"
+	"testing"
+
 	"github.com/golang/snappy"
 	"github.com/klauspost/compress/gzip"
 	"github.com/klauspost/compress/zlib"
 	"github.com/klauspost/compress/zstd"
-	"io"
-	"testing"
 
 	"github.com/VictoriaMetrics/VictoriaMetrics/app/vlinsert/insertutil"
 )
@@ -19,12 +20,15 @@ func TestReadBulkRequest_Failure(t *testing.T) {
 
 		tlp := &insertutil.TestLogMessageProcessor{}
 		r := bytes.NewBufferString(data)
-		rows, err := readBulkRequest("test", r, "", []string{"_time"}, []string{"_msg"}, tlp)
+		rows, parseErrors, err := readBulkRequest("test", r, "", []string{"_time"}, []string{"_msg"}, tlp)
 		if err == nil {
 			t.Fatalf("expecting non-empty error")
 		}
 		if rows != 0 {
 			t.Fatalf("unexpected non-zero rows=%d", rows)
+		}
+		if len(parseErrors) > 0 {
+			t.Fatalf("unexpected parse errors: %v", parseErrors)
 		}
 	}
 	f("foobar")
@@ -32,12 +36,10 @@ func TestReadBulkRequest_Failure(t *testing.T) {
 	f(`{"create":{}}`)
 	f(`{"creat":{}}
 {}`)
-	f(`{"create":{}}
-foobar`)
 }
 
 func TestReadBulkRequest_Success(t *testing.T) {
-	f := func(data, encoding, timeField, msgField string, timestampsExpected []int64, resultExpected string) {
+	f := func(data, encoding, timeField, msgField string, rowsExpected int, errPositionsExpected []int, timestampsExpected []int64, resultExpected string) {
 		t.Helper()
 
 		timeFields := []string{"non_existing_foo", timeField, "non_existing_bar"}
@@ -46,15 +48,23 @@ func TestReadBulkRequest_Success(t *testing.T) {
 
 		// Read the request without compression
 		r := bytes.NewBufferString(data)
-		rows, err := readBulkRequest("test", r, "", timeFields, msgFields, tlp)
+		rows, parseErrors, err := readBulkRequest("test", r, "", timeFields, msgFields, tlp)
 		if err != nil {
 			t.Fatalf("unexpected error: %s", err)
 		}
-		if rows != len(timestampsExpected) {
-			t.Fatalf("unexpected rows read; got %d; want %d", rows, len(timestampsExpected))
+		if rows != rowsExpected {
+			t.Fatalf("unexpected rows read; got %d; want %d", rows, rowsExpected)
 		}
 		if err := tlp.Verify(timestampsExpected, resultExpected); err != nil {
 			t.Fatal(err)
+		}
+		if len(parseErrors) != len(errPositionsExpected) {
+			t.Fatalf("unexpected parse errors: %#v", parseErrors)
+		}
+		for i, errPos := range errPositionsExpected {
+			if parseErrors[i].pos != errPos {
+				t.Fatalf("unexpected position of parse error; got %d; want %d", parseErrors[i].pos, errPos)
+			}
 		}
 
 		// Read the request with compression
@@ -63,44 +73,71 @@ func TestReadBulkRequest_Success(t *testing.T) {
 			data = compressData(data, encoding)
 		}
 		r = bytes.NewBufferString(data)
-		rows, err = readBulkRequest("test", r, encoding, timeFields, msgFields, tlp)
+		rows, parseErrors, err = readBulkRequest("test", r, encoding, timeFields, msgFields, tlp)
 		if err != nil {
 			t.Fatalf("unexpected error: %s", err)
 		}
-		if rows != len(timestampsExpected) {
-			t.Fatalf("unexpected rows read; got %d; want %d", rows, len(timestampsExpected))
+		if rows != rowsExpected {
+			t.Fatalf("unexpected rows read; got %d; want %d", rows, rowsExpected)
 		}
 		if err := tlp.Verify(timestampsExpected, resultExpected); err != nil {
 			t.Fatalf("verification failure after compression: %s", err)
 		}
+		if len(parseErrors) != len(errPositionsExpected) {
+			t.Fatalf("unexpected parse errors: %#v", parseErrors)
+		}
+		for i, errPos := range errPositionsExpected {
+			if parseErrors[i].pos != errPos {
+				t.Fatalf("unexpected position of parse error; got %d; want %d", parseErrors[i].pos, errPos)
+			}
+		}
 	}
 
 	// Verify an empty data
-	f("", "gzip", "_time", "_msg", nil, "")
-	f("\n", "gzip", "_time", "_msg", nil, "")
-	f("\n\n", "gzip", "_time", "_msg", nil, "")
+	f("", "gzip", "_time", "_msg", 0, nil, nil, "")
+	f("\n", "gzip", "_time", "_msg", 0, nil, nil, "")
+	f("\n\n", "gzip", "_time", "_msg", 0, nil, nil, "")
+
+	// Do not return an error if all log entry lines are invalid
+	f(`{"create":{}}
+foobar`, "gzip", "_time", "_msg", 1, []int{0}, nil, "")
+	f(`{"create":{}}
+foobar
+{"create":{}}
+foobar
+{"create":{}}
+foobar`, "gzip", "_time", "_msg", 3, []int{0, 1, 2}, nil, "")
 
 	// Verify non-empty data
 	data := `{"create":{"_index":"filebeat-8.8.0"}}
 {"@timestamp":"2023-06-06T04:48:11.735Z","log":{"offset":71770,"file":{"path":"/var/log/auth.log"}},"message":"foobar"}
 {"create":{"_index":"filebeat-8.8.0"}}
+{"_msg":"foo bar","@timestamp":"invalid"}
+{"create":{"_index":"filebeat-8.8.0"}}
 {"@timestamp":"2023-06-06 04:48:12.735+01:00","message":"baz"}
 {"index":{"_index":"filebeat-8.8.0"}}
 {"message":"xyz","@timestamp":"1686026893735","x":"y"}
 {"create":{"_index":"filebeat-8.8.0"}}
+must skip invalid json lines
+{"create":{"_index":"filebeat-8.8.0"}}
+"must skip non-object JSON lines"
+{"create":{"_index":"filebeat-8.8.0"}}
 {"message":"qwe rty","@timestamp":"1686026893"}
+{"create":{"_index":"filebeat-8.8.0"}}
+42
 {"create":{"_index":"filebeat-8.8.0"}}
 {"message":"qwe rty float","@timestamp":"1686026123.62"}
 `
 	timeField := "@timestamp"
 	msgField := "message"
 	timestampsExpected := []int64{1686026891735000000, 1686023292735000000, 1686026893735000000, 1686026893000000000, 1686026123620000000}
+	errsPosExpected := []int{1, 4, 5, 7}
 	resultExpected := `{"log.offset":"71770","log.file.path":"/var/log/auth.log","_msg":"foobar"}
 {"_msg":"baz"}
 {"_msg":"xyz","x":"y"}
 {"_msg":"qwe rty"}
 {"_msg":"qwe rty float"}`
-	f(data, "zstd", timeField, msgField, timestampsExpected, resultExpected)
+	f(data, "zstd", timeField, msgField, 9, errsPosExpected, timestampsExpected, resultExpected)
 }
 
 func compressData(s string, encoding string) string {

--- a/app/vlinsert/elasticsearch/elasticsearch_timing_test.go
+++ b/app/vlinsert/elasticsearch/elasticsearch_timing_test.go
@@ -50,9 +50,12 @@ func benchmarkReadBulkRequest(b *testing.B, encoding string) {
 		r := &bytes.Reader{}
 		for pb.Next() {
 			r.Reset(dataBytes)
-			_, err := readBulkRequest("test", r, encoding, timeFields, msgFields, blp)
+			_, parseErrors, err := readBulkRequest("test", r, encoding, timeFields, msgFields, blp)
 			if err != nil {
 				panic(fmt.Errorf("unexpected error: %w", err))
+			}
+			if len(parseErrors) > 0 {
+				panic(fmt.Errorf("unexpected parse errors: %v", parseErrors))
 			}
 		}
 	})


### PR DESCRIPTION
### Describe Your Changes

This PR introduces enhanced error handling in the `/insert/elasticsearch/bulk` handler to improve the user experience when inserting invalid log entries. The goal is to make error handling behavior as close as possible to Elasticsearch, without introducing unnecessary complexity.

Related issue: #8818

Change list:

* VictoriaLogs now continues processing `/_bulk` requests even if some log entries fail to parse. This matches Elasticsearch behavior. Previously, parsing stopped at the first error with status code 200 OK and empty response.
* A 400 Bad Request is now returned if the `/_bulk` request itself is malformed (e.g., protocol-level error). This matches Elasticsearch behavior. Previously, VictoriaLogs returned 200 OK.
* All individual parse errors are now returned to the client. This matches Elasticsearch behavior. Previously, VictoriaLogs did not return an error.

Known deviation from Elasticsearch:

* VictoriaLogs still does not return an error if the request lacks any action lines (e.g., no `{ "index": {} }`), while Elasticsearch does.

There is an issue with infinitely long streams, in which case we could potentially accumulate a large list of errors. It seems to me that the `/_bulk` handler shouldn't address this issue, but as an option, we could terminate the stream if more than N errors occur.

### Checklist

The following checks are **mandatory**:

- [X] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/).
