### PR TITLE
deps: remove pin for prometheus/prometheus

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,12 +8,6 @@ go 1.24.3
 // TODO: remove this entry after https://github.com/googleapis/google-cloud-go/issues/11448 is fixed
 replace cloud.google.com/go/storage => cloud.google.com/go/storage v1.43.0
 
-// This is needed in order to avoid breaking builds as Prometheus with v0.63.0
-// version is not released yet.
-//
-// TODO: remove this after the build error `undefined: promslog.AllowedFormat` is fixed.
-replace github.com/prometheus/common => github.com/prometheus/common v0.62.0
-
 // Pin AWS libraries to version before 2025-01-15
 // Release notes: https://github.com/aws/aws-sdk-go-v2/releases/tag/release-2025-01-15
 // This version enabled request and response checksum verification by default which
@@ -57,7 +51,7 @@ require (
 	github.com/influxdata/influxdb v1.12.0
 	github.com/klauspost/compress v1.18.0
 	github.com/mattn/go-isatty v0.0.20
-	github.com/prometheus/prometheus v0.303.0
+	github.com/prometheus/prometheus v0.303.1
 	github.com/urfave/cli/v2 v2.27.6
 	github.com/valyala/fastjson v1.6.4
 	github.com/valyala/fastrand v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -319,12 +319,12 @@ github.com/prometheus/client_golang v1.22.0 h1:rb93p9lokFEsctTys46VnV1kLCDpVZ0a/
 github.com/prometheus/client_golang v1.22.0/go.mod h1:R7ljNsLXhuQXYZYtw6GAE9AZg8Y7vEW5scdCXrWRXC0=
 github.com/prometheus/client_model v0.6.2 h1:oBsgwpGs7iVziMvrGhE53c/GrLUsZdHnqNwqPLxwZyk=
 github.com/prometheus/client_model v0.6.2/go.mod h1:y3m2F6Gdpfy6Ut/GBsUqTWZqCUvMVzSfMLjcu6wAwpE=
-github.com/prometheus/common v0.62.0 h1:xasJaQlnWAeyHdUBeGjXmutelfJHWMRr+Fg4QszZ2Io=
-github.com/prometheus/common v0.62.0/go.mod h1:vyBcEuLSvWos9B1+CyL7JZ2up+uFzXhkqml0W5zIY1I=
+github.com/prometheus/common v0.63.0 h1:YR/EIY1o3mEFP/kZCD7iDMnLPlGyuU2Gb3HIcXnA98k=
+github.com/prometheus/common v0.63.0/go.mod h1:VVFF/fBIoToEnWRVkYoXEkq3R3paCoxG9PXP74SnV18=
 github.com/prometheus/procfs v0.16.1 h1:hZ15bTNuirocR6u0JZ6BAHHmwS1p8B4P6MRqxtzMyRg=
 github.com/prometheus/procfs v0.16.1/go.mod h1:teAbpZRB1iIAJYREa1LsoWUXykVXA1KlTmWl8x/U+Is=
-github.com/prometheus/prometheus v0.303.0 h1:wsNNsbd4EycMCphYnTmNY9JASBVbp7NWwJna857cGpA=
-github.com/prometheus/prometheus v0.303.0/go.mod h1:8PMRi+Fk1WzopMDeb0/6hbNs9nV6zgySkU/zds5Lu3o=
+github.com/prometheus/prometheus v0.303.1 h1:He/2jRE6sB23Ew38AIoR1WRR3fCMgPlJA2E0obD2WSY=
+github.com/prometheus/prometheus v0.303.1/go.mod h1:WEq2ogBPZoLjj9x5K67VEk7ECR0nRD9XCjaOt1lsYck=
 github.com/prometheus/sigv4 v0.1.2 h1:R7570f8AoM5YnTUPFm3mjZH5q2k4D+I/phCWvZ4PXG8=
 github.com/prometheus/sigv4 v0.1.2/go.mod h1:GF9fwrvLgkQwDdQ5BXeV9XUSCH/IPNqzvAoaohfjqMU=
 github.com/puzpuzpuz/xsync/v3 v3.5.1 h1:GJYJZwO6IdxN/IKbneznS6yPkVC+c3zyY/j19c++5Fg=

--- a/vendor/github.com/prometheus/common/config/headers.go
+++ b/vendor/github.com/prometheus/common/config/headers.go
@@ -24,9 +24,9 @@ import (
 	"strings"
 )
 
-// reservedHeaders that change the connection, are set by Prometheus, or can
+// ReservedHeaders that change the connection, are set by Prometheus, or can
 // be changed otherwise.
-var reservedHeaders = map[string]struct{}{
+var ReservedHeaders = map[string]struct{}{
 	"Authorization":                       {},
 	"Host":                                {},
 	"Content-Encoding":                    {},
@@ -72,7 +72,7 @@ func (h *Headers) SetDirectory(dir string) {
 // Validate validates the Headers config.
 func (h *Headers) Validate() error {
 	for n := range h.Headers {
-		if _, ok := reservedHeaders[http.CanonicalHeaderKey(n)]; ok {
+		if _, ok := ReservedHeaders[http.CanonicalHeaderKey(n)]; ok {
 			return fmt.Errorf("setting header %q is not allowed", http.CanonicalHeaderKey(n))
 		}
 	}

--- a/vendor/github.com/prometheus/common/model/alert.go
+++ b/vendor/github.com/prometheus/common/model/alert.go
@@ -65,7 +65,7 @@ func (a *Alert) Resolved() bool {
 	return a.ResolvedAt(time.Now())
 }
 
-// ResolvedAt returns true off the activity interval ended before
+// ResolvedAt returns true iff the activity interval ended before
 // the given timestamp.
 func (a *Alert) ResolvedAt(ts time.Time) bool {
 	if a.EndsAt.IsZero() {

--- a/vendor/github.com/prometheus/common/model/labels.go
+++ b/vendor/github.com/prometheus/common/model/labels.go
@@ -22,7 +22,7 @@ import (
 )
 
 const (
-	// AlertNameLabel is the name of the label containing the an alert's name.
+	// AlertNameLabel is the name of the label containing the alert's name.
 	AlertNameLabel = "alertname"
 
 	// ExportedLabelPrefix is the prefix to prepend to the label names present in

--- a/vendor/github.com/prometheus/common/model/metric.go
+++ b/vendor/github.com/prometheus/common/model/metric.go
@@ -27,13 +27,25 @@ import (
 )
 
 var (
-	// NameValidationScheme determines the method of name validation to be used by
-	// all calls to IsValidMetricName() and LabelName IsValid(). Setting UTF-8
-	// mode in isolation from other components that don't support UTF-8 may result
-	// in bugs or other undefined behavior. This value can be set to
-	// LegacyValidation during startup if a binary is not UTF-8-aware binaries. To
-	// avoid need for locking, this value should be set once, ideally in an
-	// init(), before multiple goroutines are started.
+	// NameValidationScheme determines the global default method of the name
+	// validation to be used by all calls to IsValidMetricName() and LabelName
+	// IsValid().
+	//
+	// Deprecated: This variable should not be used and might be removed in the
+	// far future. If you wish to stick to the legacy name validation use
+	// `IsValidLegacyMetricName()` and `LabelName.IsValidLegacy()` methods
+	// instead. This variable is here as an escape hatch for emergency cases,
+	// given the recent change from `LegacyValidation` to `UTF8Validation`, e.g.,
+	// to delay UTF-8 migrations in time or aid in debugging unforeseen results of
+	// the change. In such a case, a temporary assignment to `LegacyValidation`
+	// value in the `init()` function in your main.go or so, could be considered.
+	//
+	// Historically we opted for a global variable for feature gating different
+	// validation schemes in operations that were not otherwise easily adjustable
+	// (e.g. Labels yaml unmarshaling). That could have been a mistake, a separate
+	// Labels structure or package might have been a better choice. Given the
+	// change was made and many upgraded the common already, we live this as-is
+	// with this warning and learning for the future.
 	NameValidationScheme = UTF8Validation
 
 	// NameEscapingScheme defines the default way that names will be escaped when
@@ -50,7 +62,7 @@ var (
 type ValidationScheme int
 
 const (
-	// LegacyValidation is a setting that requirets that metric and label names
+	// LegacyValidation is a setting that requires that all metric and label names
 	// conform to the original Prometheus character requirements described by
 	// MetricNameRE and LabelNameRE.
 	LegacyValidation ValidationScheme = iota

--- a/vendor/github.com/prometheus/common/promslog/slog.go
+++ b/vendor/github.com/prometheus/common/promslog/slog.go
@@ -25,73 +25,43 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 )
 
+// LogStyle represents the common logging formats in the Prometheus ecosystem.
 type LogStyle string
 
 const (
 	SlogStyle  LogStyle = "slog"
 	GoKitStyle LogStyle = "go-kit"
+
+	reservedKeyPrefix = "logged_"
 )
 
 var (
-	LevelFlagOptions  = []string{"debug", "info", "warn", "error"}
+	// LevelFlagOptions represents allowed logging levels.
+	LevelFlagOptions = []string{"debug", "info", "warn", "error"}
+	// FormatFlagOptions represents allowed formats.
 	FormatFlagOptions = []string{"logfmt", "json"}
 
-	callerAddFunc             = false
-	defaultWriter             = os.Stderr
-	goKitStyleReplaceAttrFunc = func(groups []string, a slog.Attr) slog.Attr {
-		key := a.Key
-		switch key {
-		case slog.TimeKey:
-			a.Key = "ts"
-
-			// This timestamp format differs from RFC3339Nano by using .000 instead
-			// of .999999999 which changes the timestamp from 9 variable to 3 fixed
-			// decimals (.130 instead of .130987456).
-			t := a.Value.Time()
-			a.Value = slog.StringValue(t.UTC().Format("2006-01-02T15:04:05.000Z07:00"))
-		case slog.SourceKey:
-			a.Key = "caller"
-			src, _ := a.Value.Any().(*slog.Source)
-
-			switch callerAddFunc {
-			case true:
-				a.Value = slog.StringValue(filepath.Base(src.File) + "(" + filepath.Base(src.Function) + "):" + strconv.Itoa(src.Line))
-			default:
-				a.Value = slog.StringValue(filepath.Base(src.File) + ":" + strconv.Itoa(src.Line))
-			}
-		case slog.LevelKey:
-			a.Value = slog.StringValue(strings.ToLower(a.Value.String()))
-		default:
-		}
-
-		return a
-	}
-	defaultReplaceAttrFunc = func(groups []string, a slog.Attr) slog.Attr {
-		key := a.Key
-		switch key {
-		case slog.TimeKey:
-			t := a.Value.Time()
-			a.Value = slog.TimeValue(t.UTC())
-		case slog.SourceKey:
-			src, _ := a.Value.Any().(*slog.Source)
-			a.Value = slog.StringValue(filepath.Base(src.File) + ":" + strconv.Itoa(src.Line))
-		default:
-		}
-
-		return a
-	}
+	defaultWriter = os.Stderr
 )
 
-// AllowedLevel is a settable identifier for the minimum level a log entry
-// must be have.
-type AllowedLevel struct {
-	s   string
+// Level controls a logging level, with an info default.
+// It wraps slog.LevelVar with string-based level control.
+// Level is safe to be used concurrently.
+type Level struct {
 	lvl *slog.LevelVar
 }
 
-func (l *AllowedLevel) UnmarshalYAML(unmarshal func(interface{}) error) error {
+// NewLevel returns a new Level.
+func NewLevel() *Level {
+	return &Level{
+		lvl: &slog.LevelVar{},
+	}
+}
+
+func (l *Level) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	var s string
 	type plain string
 	if err := unmarshal((*plain)(&s)); err != nil {
@@ -100,55 +70,60 @@ func (l *AllowedLevel) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	if s == "" {
 		return nil
 	}
-	lo := &AllowedLevel{}
-	if err := lo.Set(s); err != nil {
+	if err := l.Set(s); err != nil {
 		return err
 	}
-	*l = *lo
 	return nil
 }
 
-func (l *AllowedLevel) String() string {
-	return l.s
+// String returns the current level.
+func (l *Level) String() string {
+	switch l.lvl.Level() {
+	case slog.LevelDebug:
+		return "debug"
+	case slog.LevelInfo:
+		return "info"
+	case slog.LevelWarn:
+		return "warn"
+	case slog.LevelError:
+		return "error"
+	default:
+		return ""
+	}
 }
 
-// Set updates the value of the allowed level.
-func (l *AllowedLevel) Set(s string) error {
-	if l.lvl == nil {
-		l.lvl = &slog.LevelVar{}
-	}
-
+// Set updates the logging level with the validation.
+func (l *Level) Set(s string) error {
 	switch strings.ToLower(s) {
 	case "debug":
 		l.lvl.Set(slog.LevelDebug)
-		callerAddFunc = true
 	case "info":
 		l.lvl.Set(slog.LevelInfo)
-		callerAddFunc = false
 	case "warn":
 		l.lvl.Set(slog.LevelWarn)
-		callerAddFunc = false
 	case "error":
 		l.lvl.Set(slog.LevelError)
-		callerAddFunc = false
 	default:
 		return fmt.Errorf("unrecognized log level %s", s)
 	}
-	l.s = s
 	return nil
 }
 
-// AllowedFormat is a settable identifier for the output format that the logger can have.
-type AllowedFormat struct {
+// Format controls a logging output format.
+// Not concurrency-safe.
+type Format struct {
 	s string
 }
 
-func (f *AllowedFormat) String() string {
+// NewFormat creates a new Format.
+func NewFormat() *Format { return &Format{} }
+
+func (f *Format) String() string {
 	return f.s
 }
 
 // Set updates the value of the allowed format.
-func (f *AllowedFormat) Set(s string) error {
+func (f *Format) Set(s string) error {
 	switch s {
 	case "logfmt", "json":
 		f.s = s
@@ -160,18 +135,113 @@ func (f *AllowedFormat) Set(s string) error {
 
 // Config is a struct containing configurable settings for the logger
 type Config struct {
-	Level  *AllowedLevel
-	Format *AllowedFormat
+	Level  *Level
+	Format *Format
 	Style  LogStyle
 	Writer io.Writer
+}
+
+func newGoKitStyleReplaceAttrFunc(lvl *Level) func(groups []string, a slog.Attr) slog.Attr {
+	return func(groups []string, a slog.Attr) slog.Attr {
+		key := a.Key
+		switch key {
+		case slog.TimeKey, "ts":
+			if t, ok := a.Value.Any().(time.Time); ok {
+				a.Key = "ts"
+
+				// This timestamp format differs from RFC3339Nano by using .000 instead
+				// of .999999999 which changes the timestamp from 9 variable to 3 fixed
+				// decimals (.130 instead of .130987456).
+				a.Value = slog.StringValue(t.UTC().Format("2006-01-02T15:04:05.000Z07:00"))
+			} else {
+				// If we can't cast the any from the value to a
+				// time.Time, it means the caller logged
+				// another attribute with a key of `ts`.
+				// Prevent duplicate keys (necessary for proper
+				// JSON) by renaming the key to `logged_ts`.
+				a.Key = reservedKeyPrefix + key
+			}
+		case slog.SourceKey, "caller":
+			if src, ok := a.Value.Any().(*slog.Source); ok {
+				a.Key = "caller"
+				switch lvl.String() {
+				case "debug":
+					a.Value = slog.StringValue(filepath.Base(src.File) + "(" + filepath.Base(src.Function) + "):" + strconv.Itoa(src.Line))
+				default:
+					a.Value = slog.StringValue(filepath.Base(src.File) + ":" + strconv.Itoa(src.Line))
+				}
+			} else {
+				// If we can't cast the any from the value to
+				// an *slog.Source, it means the caller logged
+				// another attribute with a key of `caller`.
+				// Prevent duplicate keys (necessary for proper
+				// JSON) by renaming the key to
+				// `logged_caller`.
+				a.Key = reservedKeyPrefix + key
+			}
+		case slog.LevelKey:
+			if lvl, ok := a.Value.Any().(slog.Level); ok {
+				a.Value = slog.StringValue(strings.ToLower(lvl.String()))
+			} else {
+				// If we can't cast the any from the value to
+				// an slog.Level, it means the caller logged
+				// another attribute with a key of `level`.
+				// Prevent duplicate keys (necessary for proper
+				// JSON) by renaming the key to `logged_level`.
+				a.Key = reservedKeyPrefix + key
+			}
+		default:
+		}
+		return a
+	}
+}
+
+func defaultReplaceAttr(_ []string, a slog.Attr) slog.Attr {
+	key := a.Key
+	switch key {
+	case slog.TimeKey:
+		if t, ok := a.Value.Any().(time.Time); ok {
+			a.Value = slog.TimeValue(t.UTC())
+		} else {
+			// If we can't cast the any from the value to a
+			// time.Time, it means the caller logged
+			// another attribute with a key of `time`.
+			// Prevent duplicate keys (necessary for proper
+			// JSON) by renaming the key to `logged_time`.
+			a.Key = reservedKeyPrefix + key
+		}
+	case slog.SourceKey:
+		if src, ok := a.Value.Any().(*slog.Source); ok {
+			a.Value = slog.StringValue(filepath.Base(src.File) + ":" + strconv.Itoa(src.Line))
+		} else {
+			// If we can't cast the any from the value to
+			// an *slog.Source, it means the caller logged
+			// another attribute with a key of `source`.
+			// Prevent duplicate keys (necessary for proper
+			// JSON) by renaming the key to
+			// `logged_source`.
+			a.Key = reservedKeyPrefix + key
+		}
+	case slog.LevelKey:
+		if _, ok := a.Value.Any().(slog.Level); !ok {
+			// If we can't cast the any from the value to
+			// an slog.Level, it means the caller logged
+			// another attribute with a key of `level`.
+			// Prevent duplicate keys (necessary for proper
+			// JSON) by renaming the key to
+			// `logged_level`.
+			a.Key = reservedKeyPrefix + key
+		}
+	default:
+	}
+	return a
 }
 
 // New returns a new slog.Logger. Each logged line will be annotated
 // with a timestamp. The output always goes to stderr.
 func New(config *Config) *slog.Logger {
 	if config.Level == nil {
-		config.Level = &AllowedLevel{}
-		_ = config.Level.Set("info")
+		config.Level = NewLevel()
 	}
 
 	if config.Writer == nil {
@@ -181,11 +251,11 @@ func New(config *Config) *slog.Logger {
 	logHandlerOpts := &slog.HandlerOptions{
 		Level:       config.Level.lvl,
 		AddSource:   true,
-		ReplaceAttr: defaultReplaceAttrFunc,
+		ReplaceAttr: defaultReplaceAttr,
 	}
 
 	if config.Style == GoKitStyle {
-		logHandlerOpts.ReplaceAttr = goKitStyleReplaceAttrFunc
+		logHandlerOpts.ReplaceAttr = newGoKitStyleReplaceAttrFunc(config.Level)
 	}
 
 	if config.Format != nil && config.Format.s == "json" {

--- a/vendor/github.com/prometheus/prometheus/config/config.go
+++ b/vendor/github.com/prometheus/prometheus/config/config.go
@@ -840,6 +840,7 @@ func (c *ScrapeConfig) Validate(globalConfig GlobalConfig) error {
 	switch globalConfig.MetricNameValidationScheme {
 	case LegacyValidationConfig:
 	case "", UTF8ValidationConfig:
+		//nolint:staticcheck
 		if model.NameValidationScheme != model.UTF8Validation {
 			panic("utf8 name validation requested but model.NameValidationScheme is not set to UTF8")
 		}

--- a/vendor/github.com/prometheus/prometheus/model/labels/labels_common.go
+++ b/vendor/github.com/prometheus/prometheus/model/labels/labels_common.go
@@ -104,6 +104,7 @@ func (ls Labels) IsValid(validationScheme model.ValidationScheme) bool {
 		if l.Name == model.MetricNameLabel {
 			// If the default validation scheme has been overridden with legacy mode,
 			// we need to call the special legacy validation checker.
+			//nolint:staticcheck
 			if validationScheme == model.LegacyValidation && model.NameValidationScheme == model.UTF8Validation && !model.IsValidLegacyMetricName(string(model.LabelValue(l.Value))) {
 				return strconv.ErrSyntax
 			}
@@ -111,6 +112,7 @@ func (ls Labels) IsValid(validationScheme model.ValidationScheme) bool {
 				return strconv.ErrSyntax
 			}
 		}
+		//nolint:staticcheck
 		if validationScheme == model.LegacyValidation && model.NameValidationScheme == model.UTF8Validation {
 			if !model.LabelName(l.Name).IsValidLegacy() || !model.LabelValue(l.Value).IsValid() {
 				return strconv.ErrSyntax

--- a/vendor/github.com/prometheus/prometheus/model/relabel/relabel.go
+++ b/vendor/github.com/prometheus/prometheus/model/relabel/relabel.go
@@ -135,6 +135,7 @@ func (c *Config) Validate() error {
 		// Design escaping mechanism to allow that, once valid use case appears.
 		return model.LabelName(value).IsValid()
 	}
+	//nolint:staticcheck
 	if model.NameValidationScheme == model.LegacyValidation {
 		isValidLabelNameWithRegexVarFn = func(value string) bool {
 			return relabelTargetLegacy.MatchString(value)

--- a/vendor/github.com/prometheus/prometheus/storage/remote/write_handler.go
+++ b/vendor/github.com/prometheus/prometheus/storage/remote/write_handler.go
@@ -250,6 +250,7 @@ func (h *writeHandler) write(ctx context.Context, req *prompb.WriteRequest) (err
 
 		// TODO(bwplotka): Even as per 1.0 spec, this should be a 400 error, while other samples are
 		// potentially written. Perhaps unify with fixed writeV2 implementation a bit.
+		//nolint:staticcheck
 		if !ls.Has(labels.MetricName) || !ls.IsValid(model.NameValidationScheme) {
 			h.logger.Warn("Invalid metric names or labels", "got", ls.String())
 			samplesWithInvalidLabels++
@@ -391,6 +392,7 @@ func (h *writeHandler) appendV2(app storage.Appender, req *writev2.Request, rs *
 		// Validate series labels early.
 		// NOTE(bwplotka): While spec allows UTF-8, Prometheus Receiver may impose
 		// specific limits and follow https://prometheus.io/docs/specs/remote_write_spec_2_0/#invalid-samples case.
+		//nolint:staticcheck
 		if !ls.Has(labels.MetricName) || !ls.IsValid(model.NameValidationScheme) {
 			badRequestErrs = append(badRequestErrs, fmt.Errorf("invalid metric name or labels, got %v", ls.String()))
 			samplesWithInvalidLabels += len(ts.Samples) + len(ts.Histograms)

--- a/vendor/github.com/prometheus/prometheus/util/logging/file.go
+++ b/vendor/github.com/prometheus/prometheus/util/logging/file.go
@@ -45,7 +45,7 @@ func NewJSONFileLogger(s string) (*JSONFileLogger, error) {
 		return nil, fmt.Errorf("can't create json log file: %w", err)
 	}
 
-	jsonFmt := &promslog.AllowedFormat{}
+	jsonFmt := promslog.NewFormat()
 	_ = jsonFmt.Set("json")
 	return &JSONFileLogger{
 		handler: promslog.New(&promslog.Config{Format: jsonFmt, Writer: f}).Handler(),

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -531,7 +531,7 @@ github.com/prometheus/client_golang/prometheus/testutil/promlint/validations
 # github.com/prometheus/client_model v0.6.2
 ## explicit; go 1.22.0
 github.com/prometheus/client_model/go
-# github.com/prometheus/common v0.63.0 => github.com/prometheus/common v0.62.0
+# github.com/prometheus/common v0.63.0
 ## explicit; go 1.21
 github.com/prometheus/common/config
 github.com/prometheus/common/expfmt
@@ -543,7 +543,7 @@ github.com/prometheus/common/version
 github.com/prometheus/procfs
 github.com/prometheus/procfs/internal/fs
 github.com/prometheus/procfs/internal/util
-# github.com/prometheus/prometheus v0.303.0
+# github.com/prometheus/prometheus v0.303.1
 ## explicit; go 1.23.0
 github.com/prometheus/prometheus/config
 github.com/prometheus/prometheus/discovery
@@ -1003,7 +1003,6 @@ k8s.io/utils/clock
 ## explicit; go 1.12
 sigs.k8s.io/yaml/goyaml.v3
 # cloud.google.com/go/storage => cloud.google.com/go/storage v1.43.0
-# github.com/prometheus/common => github.com/prometheus/common v0.62.0
 # github.com/aws/aws-sdk-go-v2 => github.com/aws/aws-sdk-go-v2 v1.32.8
 # github.com/aws/aws-sdk-go-v2/config => github.com/aws/aws-sdk-go-v2/config v1.28.11
 # github.com/aws/aws-sdk-go-v2/credentials => github.com/aws/aws-sdk-go-v2/credentials v1.17.52


### PR DESCRIPTION

### Describe Your Changes
Version with the latest changes from prometheus/common have been released as v0.303.1 so builds are no longer failing.

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/).
