### PR TITLE
app/vmui: add command to run VictoriaLogs with playground env

### DIFF
--- a/app/vmui/packages/vmui/package.json
+++ b/app/vmui/packages/vmui/package.json
@@ -29,6 +29,7 @@
     "prestart": "npm run copy-metricsql-docs",
     "start": "vite",
     "start:logs": "vite --mode victorialogs",
+    "start:logs:playground": "cross-env PLAYGROUND=LOGS npm run start:logs",
     "start:anomaly": "vite --mode vmanomaly",
     "build": "vite build",
     "build:logs": "vite build --mode victorialogs",

--- a/app/vmui/packages/vmui/src/components/Configurators/QueryEditor/LogsQL/useFetchLogsQLOptions.tsx
+++ b/app/vmui/packages/vmui/src/components/Configurators/QueryEditor/LogsQL/useFetchLogsQLOptions.tsx
@@ -9,7 +9,7 @@ import { useCallback } from "react";
 import { AUTOCOMPLETE_LIMITS } from "../../../../constants/queryAutocomplete";
 import { LogsFiledValues } from "../../../../api/types";
 import { useLogsDispatch, useLogsState } from "../../../../state/logsPanel/LogsStateContext";
-import { useSearchParams } from "react-router-dom";
+import { useTenant } from "../../../../hooks/useTenant";
 
 type FetchDataArgs = {
   urlSuffix: string;
@@ -28,12 +28,11 @@ const icons = {
 };
 
 export const useFetchLogsQLOptions = (contextData?: ContextData) => {
-  const [searchParams] = useSearchParams();
-
   const { serverUrl } = useAppState();
   const { period: { start, end } } = useTimeState();
   const { autocompleteCache } = useLogsState();
   const dispatch = useLogsDispatch();
+  const tenant = useTenant();
 
   const [loading, setLoading] = useState(false);
 
@@ -66,11 +65,6 @@ export const useFetchLogsQLOptions = (contextData?: ContextData) => {
     abortControllerRef.current.abort();
     abortControllerRef.current = new AbortController();
     const { signal } = abortControllerRef.current;
-
-    const tenant = {
-      AccountID: searchParams.get("accountID") || "0",
-      ProjectID: searchParams.get("projectID") || "0"
-    };
     const tenantString = new URLSearchParams(tenant).toString();
 
     const key = `${urlSuffix}?${params?.toString()}&${tenantString}`;

--- a/app/vmui/packages/vmui/src/hooks/useTenant.ts
+++ b/app/vmui/packages/vmui/src/hooks/useTenant.ts
@@ -1,0 +1,11 @@
+import { useMemo } from "react";
+import { useSearchParams } from "react-router-dom";
+
+export const useTenant = () => {
+  const [searchParams] = useSearchParams();
+
+  return useMemo(() => ({
+    AccountID: searchParams.get("accountID") || "0",
+    ProjectID: searchParams.get("projectID") || "0",
+  }), [searchParams]);
+};

--- a/app/vmui/packages/vmui/src/pages/ExploreLogs/hooks/useFetchLogHits.ts
+++ b/app/vmui/packages/vmui/src/pages/ExploreLogs/hooks/useFetchLogHits.ts
@@ -2,26 +2,20 @@ import { useCallback, useMemo, useRef, useState } from "preact/compat";
 import { getLogHitsUrl } from "../../../api/logs";
 import { ErrorTypes, TimeParams } from "../../../types";
 import { LogHits } from "../../../api/types";
-import { useSearchParams } from "react-router-dom";
 import { getHitsTimeParams } from "../../../utils/logs";
 import { LOGS_GROUP_BY, LOGS_LIMIT_HITS } from "../../../constants/logs";
 import { isEmptyObject } from "../../../utils/object";
 import { useEffect } from "react";
+import { useTenant } from "../../../hooks/useTenant";
 
 export const useFetchLogHits = (server: string, query: string) => {
-  const [searchParams] = useSearchParams();
-
+  const tenant = useTenant();
   const [logHits, setLogHits] = useState<LogHits[]>([]);
   const [isLoading, setIsLoading] = useState<{[key: number]: boolean;}>([]);
   const [error, setError] = useState<ErrorTypes | string>();
   const abortControllerRef = useRef(new AbortController());
 
   const url = useMemo(() => getLogHitsUrl(server), [server]);
-
-  const tenant = useMemo(() => ({
-    AccountID: searchParams.get("accountID") || "0",
-    ProjectID: searchParams.get("projectID") || "0",
-  }), [searchParams]);
 
   const getOptions = (query: string, period: TimeParams, signal: AbortSignal) => {
     const { start, end, step } = getHitsTimeParams(period);
@@ -80,7 +74,7 @@ export const useFetchLogHits = (server: string, query: string) => {
       }
     }
     setIsLoading(prev => ({ ...prev, [id]: false }));
-  }, [url, query, searchParams]);
+  }, [url, query]);
 
   useEffect(() => {
     return () => {

--- a/app/vmui/packages/vmui/src/pages/ExploreLogs/hooks/useFetchLogs.ts
+++ b/app/vmui/packages/vmui/src/pages/ExploreLogs/hooks/useFetchLogs.ts
@@ -3,10 +3,10 @@ import { getLogsUrl } from "../../../api/logs";
 import { ErrorTypes, TimeParams } from "../../../types";
 import { Logs } from "../../../api/types";
 import dayjs from "dayjs";
-import { useSearchParams } from "react-router-dom";
+import { useTenant } from "../../../hooks/useTenant";
 
 export const useFetchLogs = (server: string, query: string, limit: number) => {
-  const [searchParams] = useSearchParams();
+  const tenant = useTenant();
 
   const [logs, setLogs] = useState<Logs[]>([]);
   const [isLoading, setIsLoading] = useState<{ [key: number]: boolean }>({});
@@ -14,11 +14,6 @@ export const useFetchLogs = (server: string, query: string, limit: number) => {
   const abortControllerRef = useRef(new AbortController());
 
   const url = useMemo(() => getLogsUrl(server), [server]);
-
-  const tenant = useMemo(() => ({
-    AccountID: searchParams.get("accountID") || "0",
-    ProjectID: searchParams.get("projectID") || "0",
-  }), [searchParams]);
 
   const getOptions = (query: string, period: TimeParams, limit: number, signal: AbortSignal) => ({
     signal,

--- a/app/vmui/packages/vmui/src/utils/default-server-url.ts
+++ b/app/vmui/packages/vmui/src/utils/default-server-url.ts
@@ -6,7 +6,7 @@ import { getFromStorage } from "./storage";
 export const getDefaultServer = (tenantId?: string): string => {
   const { serverURL } = getAppModeParams();
   const storageURL = getFromStorage("SERVER_URL") as string;
-  const logsURL = window.location.href.replace(/\/(select\/)?(vmui)\/.*/, "");
+  const logsURL = window.location.href.replace(/(\/(select\/)?vmui\/.*|\/#\/.*)/, "");
   const anomalyURL = `${window.location.origin}${window.location.pathname.replace(/^\/vmui/, "")}`;
   const defaultURL = window.location.href.replace(/\/(?:prometheus\/)?(?:graph|vmui)\/.*/, "/prometheus");
   const url = serverURL || storageURL || defaultURL;

--- a/app/vmui/packages/vmui/vite.config.ts
+++ b/app/vmui/packages/vmui/vite.config.ts
@@ -1,8 +1,36 @@
 import * as path from "path";
 
-import { defineConfig } from "vite";
+import { defineConfig, ProxyOptions } from "vite";
 import preact from "@preact/preset-vite";
 import dynamicIndexHtmlPlugin from "./config/plugins/dynamicIndexHtml";
+
+const getProxy = (): Record<string, ProxyOptions> | undefined => {
+  const playground = process.env.PLAYGROUND;
+
+  switch (playground) {
+    case "LOGS": {
+      return {
+        "^/select/.*": {
+          target: "https://play-vmlogs.victoriametrics.com",
+          changeOrigin: true,
+          configure: (proxy) => {
+            proxy.on("proxyReq", (proxyReq) => {
+              proxyReq.removeHeader("AccountID");
+              proxyReq.removeHeader("ProjectID");
+            });
+
+            proxy.on("error", (err) => {
+              console.error("[proxy error]", err.message);
+            });
+          }
+        }
+      };
+    }
+    default: {
+      return undefined;
+    }
+  }
+};
 
 export default defineConfig(({ mode }) => {
   return {
@@ -15,6 +43,7 @@ export default defineConfig(({ mode }) => {
     server: {
       open: true,
       port: 3000,
+      proxy: getProxy(),
     },
     resolve: {
       alias: {
@@ -35,5 +64,6 @@ export default defineConfig(({ mode }) => {
     },
   };
 });
+
 
 


### PR DESCRIPTION
### Describe Your Changes

Added npm command `npm run start:logs:playground` to run VictoriaLogs UI with playground env.

### Checklist

The following checks are **mandatory**:

- [ ] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/).
