### PR TITLE
issue-7599: Optimize common cases on read path

### DIFF
--- a/lib/storage/storage_test.go
+++ b/lib/storage/storage_test.go
@@ -3339,7 +3339,7 @@ func TestStorageSearchMetricNamesWithoutPerDayIndex(t *testing.T) {
 	)
 	rng := rand.New(rand.NewSource(1))
 	opts := testStorageSearchWithoutPerDayIndexOptions{
-		wantEmpty:        []string{},
+		wantEmpty:        []string(nil),
 		wantPerTimeRange: make(map[TimeRange]any),
 		wantAll:          []string{},
 	}
@@ -3557,7 +3557,7 @@ func TestStorageSearchGraphitePathsWithoutPerDayIndex(t *testing.T) {
 	)
 	rng := rand.New(rand.NewSource(1))
 	opts := testStorageSearchWithoutPerDayIndexOptions{
-		wantEmpty:        []string{},
+		wantEmpty:        []string(nil),
 		wantPerTimeRange: make(map[TimeRange]any),
 		wantAll:          []string{},
 	}


### PR DESCRIPTION
### Describe Your Changes

In common case search requests will cover only one partition - no need for concurrency and synchronization.

Commands to run benchmark
```
BRANCH=$(git branch --show-current); GOEXPERIMENT=synctest GOOS=linux GOARCH=amd64 go test -c -o ~/work/tasks/issue-7599/benchmarks/bin/amd64/$BRANCH github.com/VictoriaMetrics/VictoriaMetrics/lib/storage
OUT=amd64-amd-epyc-7702/ BINARY=issue-7599_speedup_search_and_merge BENCHMARK=BenchmarkStorageSearchMetricNames_VariousTimeRanges; ./bin/amd64/$BINARY -test.count 6 -test.run ^$ -test.bench ^$BENCHMARK$ -test.cpuprofile $OUT/$BINARY-$BENCHMARK.cpu -test.mutexprofile $OUT/$BINARY-$BENCHMARK.mutex 1> $OUT/$BINARY-$BENCHMARK.log 2>/dev/null
```

Tested on two machines:
```
amd64-intel-xeon-6230R benchstat master-BenchmarkStorageSearchMetricNames_VariousTimeRanges.log issue-7599-BenchmarkStorageSearchMetricNames_VariousTimeRanges.log issue-7599_speedup_search_and_merge-BenchmarkStorageSearchMetricNames_VariousTimeRanges.log
goos: linux
goarch: amd64
pkg: github.com/VictoriaMetrics/VictoriaMetrics/lib/storage
cpu: Intel(R) Xeon(R) Gold 6230R CPU @ 2.10GHz
                                                 │ master-BenchmarkStorageSearchMetricNames_VariousTimeRanges.log │ issue-7599-BenchmarkStorageSearchMetricNames_VariousTimeRanges.log │ issue-7599_speedup_search_and_merge-BenchmarkStorageSearchMetricNames_VariousTimeRanges.log │
                                                 │                             sec/op                             │                   sec/op                     vs base               │                                sec/op                                 vs base               │
StorageSearchMetricNames_VariousTimeRanges/1h-12                                                      2.820m ± 4%                                  4.470m ±  3%  +58.53% (p=0.002 n=6)                                                           2.817m ±  6%        ~ (p=0.818 n=6)
StorageSearchMetricNames_VariousTimeRanges/2h-12                                                      2.864m ± 1%                                  4.416m ±  3%  +54.21% (p=0.002 n=6)                                                           2.809m ±  3%   -1.92% (p=0.041 n=6)
StorageSearchMetricNames_VariousTimeRanges/4h-12                                                      2.852m ± 6%                                  4.349m ±  4%  +52.51% (p=0.002 n=6)                                                           2.812m ±  4%        ~ (p=0.394 n=6)
StorageSearchMetricNames_VariousTimeRanges/1d-12                                                      2.899m ± 2%                                  4.443m ±  6%  +53.29% (p=0.002 n=6)                                                           2.784m ±  2%   -3.94% (p=0.002 n=6)
StorageSearchMetricNames_VariousTimeRanges/2d-12                                                      2.877m ± 4%                                  4.429m ±  5%  +53.94% (p=0.002 n=6)                                                           2.781m ±  4%   -3.35% (p=0.041 n=6)
StorageSearchMetricNames_VariousTimeRanges/4d-12                                                      2.862m ± 2%                                  4.504m ±  7%  +57.34% (p=0.002 n=6)                                                           2.821m ±  4%        ~ (p=0.093 n=6)
StorageSearchMetricNames_VariousTimeRanges/1m-12                                                      2.838m ± 3%                                  4.379m ±  4%  +54.32% (p=0.002 n=6)                                                           2.790m ±  6%        ~ (p=0.485 n=6)
StorageSearchMetricNames_VariousTimeRanges/2m-12                                                      2.831m ± 7%                                  3.692m ± 10%  +30.40% (p=0.002 n=6)                                                           3.242m ± 13%  +14.50% (p=0.026 n=6)
StorageSearchMetricNames_VariousTimeRanges/4m-12                                                      2.811m ± 4%                                  3.111m ±  4%  +10.69% (p=0.002 n=6)                                                           2.892m ±  8%        ~ (p=0.589 n=6)
StorageSearchMetricNames_VariousTimeRanges/1y-12                                                      2.749m ± 2%                                  2.550m ±  1%   -7.23% (p=0.002 n=6)                                                           2.515m ±  2%   -8.50% (p=0.002 n=6)
StorageSearchMetricNames_VariousTimeRanges/2y-12                                                      2.817m ± 3%                                  2.584m ±  2%   -8.30% (p=0.002 n=6)                                                           2.561m ±  0%   -9.12% (p=0.002 n=6)
StorageSearchMetricNames_VariousTimeRanges/4y-12                                                      2.765m ± 1%                                  2.621m ±  6%   -5.21% (p=0.041 n=6)                                                           2.594m ±  5%   -6.18% (p=0.002 n=6)
geomean                                                                                               2.832m                                       3.701m        +30.71%                                                                         2.779m         -1.85%


amd64-amd-epyc-7702 benchstat master-BenchmarkStorageSearchMetricNames_VariousTimeRanges.log issue-7599-BenchmarkStorageSearchMetricNames_VariousTimeRanges.log issue-7599_speedup_search_and_merge-BenchmarkStorageSearchMetricNames_VariousTimeRanges.log
goos: linux
goarch: amd64
pkg: github.com/VictoriaMetrics/VictoriaMetrics/lib/storage
cpu: AMD EPYC 7702 64-Core Processor                
                                                 │ master-BenchmarkStorageSearchMetricNames_VariousTimeRanges.log │ issue-7599-BenchmarkStorageSearchMetricNames_VariousTimeRanges.log │ issue-7599_speedup_search_and_merge-BenchmarkStorageSearchMetricNames_VariousTimeRanges.log │
                                                 │                             sec/op                             │                   sec/op                     vs base               │                                sec/op                                 vs base               │
StorageSearchMetricNames_VariousTimeRanges/1h-28                                                      2.371m ± 2%                                   3.543m ± 4%  +49.40% (p=0.002 n=6)                                                            2.298m ± 3%   -3.09% (p=0.002 n=6)
StorageSearchMetricNames_VariousTimeRanges/2h-28                                                      2.366m ± 1%                                   3.511m ± 5%  +48.39% (p=0.002 n=6)                                                            2.251m ± 2%   -4.88% (p=0.002 n=6)
StorageSearchMetricNames_VariousTimeRanges/4h-28                                                      2.297m ± 1%                                   3.501m ± 2%  +52.46% (p=0.002 n=6)                                                            2.320m ± 2%        ~ (p=0.093 n=6)
StorageSearchMetricNames_VariousTimeRanges/1d-28                                                      2.293m ± 1%                                   3.590m ± 1%  +56.54% (p=0.002 n=6)                                                            2.321m ± 3%   +1.21% (p=0.026 n=6)
StorageSearchMetricNames_VariousTimeRanges/2d-28                                                      2.307m ± 3%                                   3.564m ± 4%  +54.48% (p=0.002 n=6)                                                            2.325m ± 2%        ~ (p=0.310 n=6)
StorageSearchMetricNames_VariousTimeRanges/4d-28                                                      2.320m ± 2%                                   3.580m ± 4%  +54.31% (p=0.002 n=6)                                                            2.324m ± 1%        ~ (p=0.589 n=6)
StorageSearchMetricNames_VariousTimeRanges/1m-28                                                      2.328m ± 2%                                   3.564m ± 3%  +53.12% (p=0.002 n=6)                                                            2.357m ± 3%        ~ (p=0.394 n=6)
StorageSearchMetricNames_VariousTimeRanges/2m-28                                                      2.268m ± 2%                                   3.105m ± 5%  +36.90% (p=0.002 n=6)                                                            2.835m ± 7%  +24.97% (p=0.002 n=6)
StorageSearchMetricNames_VariousTimeRanges/4m-28                                                      2.391m ± 2%                                   2.808m ± 7%  +17.43% (p=0.002 n=6)                                                            2.512m ± 5%   +5.03% (p=0.002 n=6)
StorageSearchMetricNames_VariousTimeRanges/1y-28                                                      2.373m ± 2%                                   1.920m ± 2%  -19.07% (p=0.002 n=6)                                                            1.870m ± 1%  -21.22% (p=0.002 n=6)
StorageSearchMetricNames_VariousTimeRanges/2y-28                                                      2.362m ± 0%                                   1.969m ± 2%  -16.65% (p=0.002 n=6)                                                            1.944m ± 2%  -17.70% (p=0.002 n=6)
StorageSearchMetricNames_VariousTimeRanges/4y-28                                                      2.368m ± 1%                                   2.434m ± 8%        ~ (p=0.065 n=6)                                                            2.356m ± 8%        ~ (p=1.000 n=6)
geomean                                                                                               2.337m                                        3.018m       +29.15%                                                                          2.298m        -1.68%
```

### Checklist

The following checks are **mandatory**:

- [ ] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/).
