### PR TITLE
fix auth header always get the same hash thus causing config changes not apply

### DIFF
--- a/docs/victoriametrics/changelog/CHANGELOG.md
+++ b/docs/victoriametrics/changelog/CHANGELOG.md
@@ -21,6 +21,7 @@ See also [LTS releases](https://docs.victoriametrics.com/victoriametrics/lts-rel
 **Update Note 1:** `latest` and `stable` tags for docker images will no longer be updated. It is required to use specific version tags for docker images to continue receiving updates. See [#7336](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/7336) for details.
 
 * BUGFIX: [vmsingle](https://docs.victoriametrics.com/single-server-victoriametrics/), `vminsert` in [VictoriaMetrics cluster](https://docs.victoriametrics.com/cluster-victoriametrics/) and [vmagent](https://docs.victoriametrics.com/vmagent/): fixed duplication in Datadog sketches aggregation metrics. See [#8836](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8836) for details.
+* BUGFIX: [vmagent](https://docs.victoriametrics.com/vmagent/): fixed auth header always get the same hash. See [#8938](https://github.com/VictoriaMetrics/VictoriaMetrics/pull/8938) for details
 
 ## [v1.117.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.117.0)
 

--- a/lib/promauth/config.go
+++ b/lib/promauth/config.go
@@ -681,10 +681,10 @@ func (opts *Options) NewConfig() (*Config, error) {
 	}
 	hd := xxhash.New()
 	for _, kv := range headers {
-		hd.Sum([]byte(kv.key))
-		hd.Sum([]byte("="))
-		hd.Sum([]byte(kv.value))
-		hd.Sum([]byte(","))
+		hd.Write([]byte(kv.key))
+		hd.Write([]byte("="))
+		hd.Write([]byte(kv.value))
+		hd.Write([]byte(","))
 	}
 	headersDigest := fmt.Sprintf("digest(headers)=%d", hd.Sum64())
 

--- a/lib/promauth/config_test.go
+++ b/lib/promauth/config_test.go
@@ -739,3 +739,23 @@ func mustGenerateCertificates() ([]byte, []byte, []byte) {
 
 	return caPEM, certPEM, keyPEM
 }
+
+func TestConfigHeadersHash(t *testing.T) {
+	f := func(headers []string, resultExpected string) {
+		t.Helper()
+		opts := Options{
+			Headers: headers,
+		}
+		var err error
+		c, err := opts.NewConfig()
+		if err != nil {
+			t.Fatalf("create new config error: %v", err)
+		}
+		if c.headersDigest != resultExpected {
+			t.Fatalf("generate wrong hash; got %s want %s", c.headersDigest, resultExpected)
+		}
+	}
+	f(nil, "digest(headers)=17241709254077376921")
+	f([]string{"foo: bar"}, "digest(headers)=16063449615388042431")
+	f([]string{"foo: bar", "X-Forwarded-For: A-B:c"}, "digest(headers)=8240238594493248512")
+}


### PR DESCRIPTION
Fix #8931 

### Describe Your Changes

Details is described in the issue above

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/).
