### PR TITLE
Issue 7599: reuse indexSearch instances again

### DIFF
--- a/lib/storage/index_db.go
+++ b/lib/storage/index_db.go
@@ -601,6 +601,7 @@ func (db *indexDB) putIndexSearch(is *indexSearch) {
 
 	if db != nil {
 		db.indexSearchPool.Put(is)
+		return
 	}
 
 	logger.Panicf("BUG: indexDB must not be nil for non-nil indexSearch")

--- a/lib/storage/index_db.go
+++ b/lib/storage/index_db.go
@@ -590,10 +590,18 @@ func (db *indexDB) getIndexSearchInternal(deadline uint64, sparse bool) *indexSe
 }
 
 func (db *indexDB) putIndexSearch(is *indexSearch) {
+	if is == nil {
+		return
+	}
+
 	is.ts.MustClose()
 	is.kb.Reset()
 	is.mp.Reset()
 	is.deadline = 0
+
+	if db == nil {
+		logger.Panicf("BUG: indexDB must not be nil for non-nil indexSearch")
+	}
 
 	db.indexSearchPool.Put(is)
 }

--- a/lib/storage/index_db.go
+++ b/lib/storage/index_db.go
@@ -599,11 +599,11 @@ func (db *indexDB) putIndexSearch(is *indexSearch) {
 	is.mp.Reset()
 	is.deadline = 0
 
-	if db == nil {
-		logger.Panicf("BUG: indexDB must not be nil for non-nil indexSearch")
+	if db != nil {
+		db.indexSearchPool.Put(is)
 	}
 
-	db.indexSearchPool.Put(is)
+	logger.Panicf("BUG: indexDB must not be nil for non-nil indexSearch")
 }
 
 func generateTSID(dst *TSID, mn *MetricName) {

--- a/lib/storage/index_db_timing_test.go
+++ b/lib/storage/index_db_timing_test.go
@@ -298,12 +298,14 @@ func BenchmarkIndexDBGetTSIDs(b *testing.B) {
 		mnLocal.CopyFrom(&mn)
 		mnLocal.sortTags()
 		for pb.Next() {
+			is := db.getIndexSearch(noDeadline)
 			for i := 0; i < recordsPerLoop; i++ {
 				metricNameLocal = mnLocal.Marshal(metricNameLocal[:0])
-				if !db.getTSIDByMetricName(&tsidLocal, metricNameLocal, date) {
+				if !is.getTSIDByMetricName(&tsidLocal, metricNameLocal, date) {
 					panic(fmt.Errorf("cannot obtain tsid for row %d", i))
 				}
 			}
+			db.putIndexSearch(is)
 		}
 	})
 	b.StopTimer()

--- a/lib/storage/storage.go
+++ b/lib/storage/storage.go
@@ -1914,9 +1914,7 @@ func (s *Storage) RegisterMetricNames(qt *querytracer.Tracer, mrs []MetricRow) {
 		date := uint64(mr.Timestamp) / msecPerDay
 
 		if !idb.HasTimestamp(mr.Timestamp) {
-			if idb != nil && is != nil {
-				idb.putIndexSearch(is)
-			}
+			idb.putIndexSearch(is)
 			s.tb.PutIndexDB(idb)
 			idb = s.tb.MustGetIndexDB(mr.Timestamp)
 			is = idb.getIndexSearch(noDeadline)
@@ -1999,9 +1997,7 @@ func (s *Storage) RegisterMetricNames(qt *querytracer.Tracer, mrs []MetricRow) {
 		s.putSeriesToCache(mr.MetricNameRaw, &lTSID, idb.id, date)
 		newSeriesCount++
 	}
-	if idb != nil && is != nil {
-		idb.putIndexSearch(is)
-	}
+	idb.putIndexSearch(is)
 	s.tb.PutIndexDB(idb)
 
 	s.newTimeseriesCreated.Add(newSeriesCount)
@@ -2084,9 +2080,7 @@ func (s *Storage) add(rows []rawRow, dstMrs []*MetricRow, mrs []MetricRow, preci
 		hour := uint64(r.Timestamp) / msecPerHour
 
 		if !idb.HasTimestamp(r.Timestamp) {
-			if idb != nil && is != nil {
-				idb.putIndexSearch(is)
-			}
+			idb.putIndexSearch(is)
 			s.tb.PutIndexDB(idb)
 			idb = s.tb.MustGetIndexDB(r.Timestamp)
 			is = idb.getIndexSearch(noDeadline)
@@ -2216,9 +2210,7 @@ func (s *Storage) add(rows []rawRow, dstMrs []*MetricRow, mrs []MetricRow, preci
 			logger.Infof("new series created: %s", mn.String())
 		}
 	}
-	if idb != nil && is != nil {
-		idb.putIndexSearch(is)
-	}
+	idb.putIndexSearch(is)
 	s.tb.PutIndexDB(idb)
 
 	s.slowRowInserts.Add(slowInsertsCount)
@@ -2516,9 +2508,7 @@ func (s *Storage) updatePerDateData(rows []rawRow, mrs []*MetricRow, hmPrev, hmC
 
 		timestamp := int64(date) * msecPerDay
 		if !idb.HasTimestamp(timestamp) {
-			if is != nil {
-				idb.putIndexSearch(is)
-			}
+			idb.putIndexSearch(is)
 			s.tb.PutIndexDB(idb)
 			idb = s.tb.MustGetIndexDB(timestamp)
 			is = idb.getIndexSearch(noDeadline)
@@ -2544,9 +2534,7 @@ func (s *Storage) updatePerDateData(rows []rawRow, mrs []*MetricRow, hmPrev, hmC
 			metricID: metricID,
 		})
 	}
-	if is != nil {
-		idb.putIndexSearch(is)
-	}
+	idb.putIndexSearch(is)
 	s.tb.PutIndexDB(idb)
 
 	PutMetricName(mn)

--- a/lib/storage/storage.go
+++ b/lib/storage/storage.go
@@ -1906,6 +1906,7 @@ func (s *Storage) RegisterMetricNames(qt *querytracer.Tracer, mrs []MetricRow) {
 	var seriesRepopulated uint64
 
 	var idb *indexDB
+	var is *indexSearch
 
 	var firstWarn error
 	for i := range mrs {
@@ -1913,8 +1914,12 @@ func (s *Storage) RegisterMetricNames(qt *querytracer.Tracer, mrs []MetricRow) {
 		date := uint64(mr.Timestamp) / msecPerDay
 
 		if !idb.HasTimestamp(mr.Timestamp) {
+			if idb != nil && is != nil {
+				idb.putIndexSearch(is)
+			}
 			s.tb.PutIndexDB(idb)
 			idb = s.tb.MustGetIndexDB(mr.Timestamp)
+			is = idb.getIndexSearch(noDeadline)
 		}
 
 		if s.getTSIDFromCache(&lTSID, mr.MetricNameRaw) {
@@ -1924,7 +1929,7 @@ func (s *Storage) RegisterMetricNames(qt *querytracer.Tracer, mrs []MetricRow) {
 				// Skip row, since it exceeds cardinality limit
 				continue
 			}
-			if !idb.hasMetricID(lTSID.TSID.MetricID) {
+			if !is.hasMetricID(lTSID.TSID.MetricID) {
 				if err := mn.UnmarshalRaw(mr.MetricNameRaw); err != nil {
 					if firstWarn == nil {
 						firstWarn = fmt.Errorf("cannot unmarshal MetricNameRaw %q: %w", mr.MetricNameRaw, err)
@@ -1936,7 +1941,7 @@ func (s *Storage) RegisterMetricNames(qt *querytracer.Tracer, mrs []MetricRow) {
 				idb.createGlobalIndexes(&lTSID.TSID, mn)
 			}
 			if !s.dateMetricIDCache.Has(idb.id, date, lTSID.TSID.MetricID) {
-				if !idb.hasDateMetricID(date, lTSID.TSID.MetricID) {
+				if !is.hasDateMetricID(date, lTSID.TSID.MetricID) {
 					if err := mn.UnmarshalRaw(mr.MetricNameRaw); err != nil {
 						if firstWarn == nil {
 							firstWarn = fmt.Errorf("cannot unmarshal MetricNameRaw %q: %w", mr.MetricNameRaw, err)
@@ -1968,7 +1973,7 @@ func (s *Storage) RegisterMetricNames(qt *querytracer.Tracer, mrs []MetricRow) {
 		mn.sortTags()
 		metricNameBuf = mn.Marshal(metricNameBuf[:0])
 
-		if idb.getTSIDByMetricName(&lTSID.TSID, metricNameBuf, date) {
+		if is.getTSIDByMetricName(&lTSID.TSID, metricNameBuf, date) {
 			// Slower path - the TSID has been found in indexdb.
 
 			if !s.registerSeriesCardinality(lTSID.TSID.MetricID, mr.MetricNameRaw) {
@@ -1993,6 +1998,9 @@ func (s *Storage) RegisterMetricNames(qt *querytracer.Tracer, mrs []MetricRow) {
 		createAllIndexesForMetricName(idb, mn, &lTSID.TSID, date)
 		s.putSeriesToCache(mr.MetricNameRaw, &lTSID, idb.id, date)
 		newSeriesCount++
+	}
+	if idb != nil && is != nil {
+		idb.putIndexSearch(is)
 	}
 	s.tb.PutIndexDB(idb)
 
@@ -2030,6 +2038,7 @@ func (s *Storage) add(rows []rawRow, dstMrs []*MetricRow, mrs []MetricRow, preci
 
 	var lTSID legacyTSID
 	var idb *indexDB
+	var is *indexSearch
 
 	// Log only the first error, since it has no sense in logging all errors.
 	var firstWarn error
@@ -2075,15 +2084,19 @@ func (s *Storage) add(rows []rawRow, dstMrs []*MetricRow, mrs []MetricRow, preci
 		hour := uint64(r.Timestamp) / msecPerHour
 
 		if !idb.HasTimestamp(r.Timestamp) {
+			if idb != nil && is != nil {
+				idb.putIndexSearch(is)
+			}
 			s.tb.PutIndexDB(idb)
 			idb = s.tb.MustGetIndexDB(r.Timestamp)
+			is = idb.getIndexSearch(noDeadline)
 		}
 
 		// Search for TSID for the given mr.MetricNameRaw and store it at r.TSID.
 		if string(mr.MetricNameRaw) == string(prevMetricNameRaw) {
 			// Fast path - the current mr contains the same metric name as the previous mr, so it contains the same TSID.
 			// This path should trigger on bulk imports when many rows contain the same MetricNameRaw.
-			if !idb.hasMetricID(prevTSID.MetricID) {
+			if !is.hasMetricID(prevTSID.MetricID) {
 				if err := mn.UnmarshalRaw(mr.MetricNameRaw); err != nil {
 					if firstWarn == nil {
 						firstWarn = fmt.Errorf("cannot unmarshal MetricNameRaw %q: %w", mr.MetricNameRaw, err)
@@ -2111,7 +2124,7 @@ func (s *Storage) add(rows []rawRow, dstMrs []*MetricRow, mrs []MetricRow, preci
 				continue
 			}
 
-			if !idb.hasMetricID(lTSID.TSID.MetricID) {
+			if !is.hasMetricID(lTSID.TSID.MetricID) {
 				if err := mn.UnmarshalRaw(mr.MetricNameRaw); err != nil {
 					if firstWarn == nil {
 						firstWarn = fmt.Errorf("cannot unmarshal MetricNameRaw %q: %w", mr.MetricNameRaw, err)
@@ -2156,7 +2169,7 @@ func (s *Storage) add(rows []rawRow, dstMrs []*MetricRow, mrs []MetricRow, preci
 		s.metricsTracker.RegisterIngestRequest(0, 0, mn.MetricGroup)
 
 		// Search for TSID for the given mr.MetricNameRaw in the indexdb.
-		if idb.getTSIDByMetricName(&lTSID.TSID, metricNameBuf, date) {
+		if is.getTSIDByMetricName(&lTSID.TSID, metricNameBuf, date) {
 			// Slower path - the TSID has been found in indexdb.
 
 			if !s.registerSeriesCardinality(lTSID.TSID.MetricID, mr.MetricNameRaw) {
@@ -2202,6 +2215,9 @@ func (s *Storage) add(rows []rawRow, dstMrs []*MetricRow, mrs []MetricRow, preci
 		if logNewSeries {
 			logger.Infof("new series created: %s", mn.String())
 		}
+	}
+	if idb != nil && is != nil {
+		idb.putIndexSearch(is)
 	}
 	s.tb.PutIndexDB(idb)
 
@@ -2319,6 +2335,8 @@ func (s *Storage) prefillNextIndexDB(rows []rawRow, mrs []*MetricRow) error {
 
 	idbNext := s.tb.MustGetIndexDB(nextMonth.UnixMilli())
 	defer s.tb.PutIndexDB(idbNext)
+	isNext := idbNext.getIndexSearch(noDeadline)
+	defer idbNext.putIndexSearch(isNext)
 
 	var firstError error
 	var lTSID legacyTSID
@@ -2343,7 +2361,7 @@ func (s *Storage) prefillNextIndexDB(rows []rawRow, mrs []*MetricRow) error {
 		}
 
 		// Check whether the given (date, metricID) is already present in idbNext.
-		if idbNext.hasDateMetricID(date, metricID) {
+		if isNext.hasDateMetricID(date, metricID) {
 			// Indexes are already pre-filled at idbNext.
 			//
 			// Register the (indexDB.id, date, metricID) entry in the cache,
@@ -2491,17 +2509,22 @@ func (s *Storage) updatePerDateData(rows []rawRow, mrs []*MetricRow, hmPrev, hmC
 	var firstError error
 	dateMetricIDsForCache := make(map[uint64][]dateMetricID)
 	mn := GetMetricName()
+	var is *indexSearch
 	for _, dmid := range pendingDateMetricIDs {
 		date := dmid.date
 		metricID := dmid.tsid.MetricID
 
 		timestamp := int64(date) * msecPerDay
 		if !idb.HasTimestamp(timestamp) {
+			if is != nil {
+				idb.putIndexSearch(is)
+			}
 			s.tb.PutIndexDB(idb)
 			idb = s.tb.MustGetIndexDB(timestamp)
+			is = idb.getIndexSearch(noDeadline)
 		}
 
-		if !idb.hasDateMetricID(date, metricID) {
+		if !is.hasDateMetricID(date, metricID) {
 			// The (date, metricID) entry is missing in the indexDB. Add it there together with per-day index.
 			// It is OK if the (date, metricID) entry is added multiple times to indexdb
 			// by concurrent goroutines.
@@ -2520,6 +2543,9 @@ func (s *Storage) updatePerDateData(rows []rawRow, mrs []*MetricRow, hmPrev, hmC
 			date:     date,
 			metricID: metricID,
 		})
+	}
+	if is != nil {
+		idb.putIndexSearch(is)
 	}
 	s.tb.PutIndexDB(idb)
 


### PR DESCRIPTION
This PR partially reverts #8851.

Fresh indexSearch/tableSearch must perform expensive block reading since there is no saved state in underlying partSearches. indexSearch reuse allows amortized this.

### Describe Your Changes

Please provide a brief description of the changes you made. Be as specific as possible to help others understand the purpose and impact of your modifications.

### Checklist

The following checks are **mandatory**:

- [ ] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/).
