### PR TITLE
docs: changed typo in histogram_bucket - metricsQL query was in wrong place

### DIFF
--- a/docs/victoriametrics/stream-aggregation.md
+++ b/docs/victoriametrics/stream-aggregation.md
@@ -445,12 +445,14 @@ See how to aggregate regular histograms [here](#aggregating-histograms).
 
 The results of `histogram_bucket` is equal to the following [MetricsQL](https://docs.victoriametrics.com/victoriametrics/metricsql/) query:
 
-Aggregating irregular and sporadic metrics (received from [Lambdas](https://aws.amazon.com/lambda/)
-or [Cloud Functions](https://cloud.google.com/functions)) can be controlled via [staleness_interval](#staleness) option.
-
 ```metricsql
 sum(histogram_over_time(some_histogram_bucket[interval])) by (vmrange)
 ```
+
+Aggregating irregular and sporadic metrics (received from [Lambdas](https://aws.amazon.com/lambda/)
+or [Cloud Functions](https://cloud.google.com/functions)) can be controlled via [staleness_interval](#staleness) option.
+
+
 
 See also:
 

--- a/docs/victoriametrics/stream-aggregation.md
+++ b/docs/victoriametrics/stream-aggregation.md
@@ -452,10 +452,7 @@ sum(histogram_over_time(some_histogram_bucket[interval])) by (vmrange)
 Aggregating irregular and sporadic metrics (received from [Lambdas](https://aws.amazon.com/lambda/)
 or [Cloud Functions](https://cloud.google.com/functions)) can be controlled via [staleness_interval](#staleness) option.
 
-
-
 See also:
-
 - [quantiles](#quantiles)
 - [avg](#avg)
 - [max](#max)


### PR DESCRIPTION
### Describe Your Changes

MetricsQL code was in wrong place - moved it 5 lines higher

### Checklist

The following checks are **mandatory**:

- [ ] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/).
