### PR TITLE
fix: include extra_filters in rollupCache key for multi-tenant support

### DIFF
--- a/app/vmselect/netstorage/tenant_filters.go
+++ b/app/vmselect/netstorage/tenant_filters.go
@@ -25,6 +25,10 @@ func GetTenantTokensFromFilters(qt *querytracer.Tracer, tr storage.TimeRange, tf
 		return nil, nil, fmt.Errorf("cannot apply filters to tenants: %w", err)
 	}
 
+	if len(tts) == 0 { // Avoid global query if tenant does not exist
+		return tts, tfs, nil
+	}
+
 	return tts, otherFilters, nil
 }
 

--- a/app/vmselect/promql/rollup_result_cache.go
+++ b/app/vmselect/promql/rollup_result_cache.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"strconv"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -237,11 +238,15 @@ func (rrc *rollupResultCache) GetSeries(qt *querytracer.Tracer, ec *EvalConfig, 
 	bb := bbPool.Get()
 	defer bbPool.Put(bb)
 	var at *auth.Token
+	etfs := ec.EnforcedTagFilterss
+
 	if !ec.IsMultiTenant {
 		at = ec.AuthTokens[0]
+	} else {
+		etfs = getFiltersWithTenants(ec)
 	}
 
-	bb.B = marshalRollupResultCacheKeyForSeries(bb.B[:0], at, expr, window, ec.Step, ec.EnforcedTagFilterss)
+	bb.B = marshalRollupResultCacheKeyForSeries(bb.B[:0], at, expr, window, ec.Step, etfs)
 	metainfoBuf := rrc.c.Get(nil, bb.B)
 	if len(metainfoBuf) == 0 {
 		qt.Printf("nothing found")
@@ -263,7 +268,7 @@ func (rrc *rollupResultCache) GetSeries(qt *querytracer.Tracer, ec *EvalConfig, 
 	if !ok {
 		mi.RemoveKey(key)
 		metainfoBuf = mi.Marshal(metainfoBuf[:0])
-		bb.B = marshalRollupResultCacheKeyForSeries(bb.B[:0], at, expr, window, ec.Step, ec.EnforcedTagFilterss)
+		bb.B = marshalRollupResultCacheKeyForSeries(bb.B[:0], at, expr, window, ec.Step, etfs)
 		rrc.c.Set(bb.B, metainfoBuf)
 		return nil, ec.Start
 	}
@@ -369,11 +374,14 @@ func (rrc *rollupResultCache) PutSeries(qt *querytracer.Tracer, ec *EvalConfig, 
 	metainfoBuf := bbPool.Get()
 	defer bbPool.Put(metainfoBuf)
 
+	etfs := ec.EnforcedTagFilterss
 	var at *auth.Token
 	if !ec.IsMultiTenant {
 		at = ec.AuthTokens[0]
+	} else {
+		etfs = getFiltersWithTenants(ec)
 	}
-	metainfoKey.B = marshalRollupResultCacheKeyForSeries(metainfoKey.B[:0], at, expr, window, ec.Step, ec.EnforcedTagFilterss)
+	metainfoKey.B = marshalRollupResultCacheKeyForSeries(metainfoKey.B[:0], at, expr, window, ec.Step, etfs)
 	metainfoBuf.B = rrc.c.Get(metainfoBuf.B[:0], metainfoKey.B)
 	var mi rollupResultCacheMetainfo
 	if len(metainfoBuf.B) > 0 {
@@ -407,6 +415,26 @@ func (rrc *rollupResultCache) PutSeries(qt *querytracer.Tracer, ec *EvalConfig, 
 	mi.AddKey(key, timestamps[0], timestamps[len(timestamps)-1])
 	metainfoBuf.B = mi.Marshal(metainfoBuf.B[:0])
 	rrc.c.Set(metainfoKey.B, metainfoBuf.B)
+}
+
+func getFiltersWithTenants(ec *EvalConfig) [][]storage.TagFilter {
+	etfs := ec.EnforcedTagFilterss
+	var f []storage.TagFilter
+	for _, ts := range ec.AuthTokens {
+		f = f[:0]
+		f = append(f,
+			storage.TagFilter{
+				Key:   []byte("vm_account_id"),
+				Value: strconv.AppendUint(nil, uint64(ts.AccountID), 10),
+			},
+			storage.TagFilter{
+				Key:   []byte("vm_project_id"),
+				Value: strconv.AppendUint(nil, uint64(ts.ProjectID), 10),
+			},
+		)
+		etfs = append(etfs, append([]storage.TagFilter(nil), f...))
+	}
+	return etfs
 }
 
 var (

--- a/apptest/tests/multitenant_test.go
+++ b/apptest/tests/multitenant_test.go
@@ -150,6 +150,44 @@ func TestClusterMultiTenantSelect(t *testing.T) {
 		t.Errorf("unexpected response (-want, +got):\n%s", diff)
 	}
 
+	want = apptest.NewPrometheusAPIV1QueryResponse(t,
+		`{"data":
+	   {"result":[
+	        {"metric":{"__name__":"foo_bar","vm_account_id":"5","vm_project_id": "0"},"values":[[1652169720,"1"],[1652169780,"1"]]},
+	        {"metric":{"__name__":"foo_bar","vm_account_id":"5","vm_project_id":"15"},"values":[[1652169720,"3"],[1652169780,"3"]]}
+	               ]
+	   }
+	}`,
+	)
+
+	got = vmselect.PrometheusAPIV1QueryRange(t, `foo_bar{}`, apptest.QueryOpts{
+		Tenant:       "multitenant",
+		Start:        "2022-05-10T07:59:00.000Z",
+		End:          "2022-05-10T08:05:00.000Z",
+		Step:         "1m",
+		ExtraFilters: []string{`{vm_account_id="5",vm_project_id="15"}`, `{vm_account_id="5",vm_project_id="0"}`},
+	})
+	if diff := cmp.Diff(want, got, cmpOpt); diff != "" {
+		t.Errorf("unexpected response (-want, +got):\n%s", diff)
+	}
+
+	want = apptest.NewPrometheusAPIV1QueryResponse(t,
+		`{"data":
+	   {"result":[]}
+	}`,
+	)
+
+	got = vmselect.PrometheusAPIV1QueryRange(t, `foo_bar{}`, apptest.QueryOpts{
+		Tenant:       "multitenant",
+		Start:        "2022-05-10T07:59:00.000Z",
+		End:          "2022-05-10T08:05:00.000Z",
+		Step:         "1m",
+		ExtraFilters: []string{`{vm_account_id="99",vm_project_id="99"}`},
+	})
+	if diff := cmp.Diff(want, got, cmpOpt); diff != "" {
+		t.Errorf("unexpected response (-want, +got):\n%s", diff)
+	}
+
 	// /api/v1/series with extra_filters
 
 	wantSR = apptest.NewPrometheusAPIV1SeriesResponse(t,


### PR DESCRIPTION
### Describe Your Changes

This PR addresses two issues:

When tenant labels (e.g. vm_account_id, vm_project_id) are passed via extra_filters, they were not included in the rollupCache key. This could cause cache entries to be reused across different tenants, resulting in incorrect query results.
If a tenant is specified only via extra_filters, and that tenant does not exist in TenantsCached, it gets silently filtered out by GetTenantTokensFromFilters, causing the query to fall back to a global (non-tenant) query — which is likely unexpected and potentially unsafe.
This fix ensures correct tenant scoping and avoids unintended data exposure or cache pollution.

Related issue https://github.com/VictoriaMetrics/VictoriaMetrics/issues/9001

### Checklist

The following checks are **mandatory**:

- [ ] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/).
