### PR TITLE
vmui/logs: add sort pipe handling

### DIFF
--- a/app/vmui/packages/vmui/src/components/Configurators/QueryEditor/LogsQL/utils/sort.test.ts
+++ b/app/vmui/packages/vmui/src/components/Configurators/QueryEditor/LogsQL/utils/sort.test.ts
@@ -1,0 +1,43 @@
+import { hasSortPipe } from "./sort";
+
+describe("hasSortPipe()", () => {
+  /** Queries that MUST be recognised as containing a sort/order pipe. */
+  const positive: string[] = [
+    // ───── basic usage ─────
+    "sort by (_time)",
+    "| sort by (_time)",
+    "|sort(_time) desc",
+    "| order by (foo desc)",
+    "_time:5m | sort by (_stream, _time)",
+
+    // ───── documented options ─────
+    "_time:1h | sort by (request_duration desc) limit 10",
+    "_time:1h | sort by (request_duration desc) partition by (host) limit 3",
+    "_time:5m | sort by (_time) rank as position",
+
+    // ───── whitespace / tabs ─────
+    "|\t  sort\tby (host)",
+
+    // ───── no space after the pipe ─────
+    "foo|sort by (_time)",
+  ];
+
+  /** Queries that MUST **not** be recognised (false positives). */
+  const negative: string[] = [
+    "",                                   // empty
+    "error | sample 100",                 // no sort
+    "|sorted(field)",                     // 'sorted' ≠ 'sort'
+    "|sorter(field)",                     // 'sorter' ≠ 'sort'
+    "my_sort(field)",                     // function name
+    "| sorta by (field)",                 // 'sorta'
+    "foo | orderliness by (bar)",         // 'orderliness' ≠ 'order'
+  ];
+
+  it.each(positive)("detects pipe in ➜  %s", query => {
+    expect(hasSortPipe(query)).toBe(true);
+  });
+
+  it.each(negative)("does NOT detect pipe in ➜  %s", query => {
+    expect(hasSortPipe(query)).toBe(false);
+  });
+});

--- a/app/vmui/packages/vmui/src/components/Configurators/QueryEditor/LogsQL/utils/sort.ts
+++ b/app/vmui/packages/vmui/src/components/Configurators/QueryEditor/LogsQL/utils/sort.ts
@@ -1,0 +1,5 @@
+const hasSortPipeRe = /(?:^|\|)\s*(?:sort|order)\b/i;
+
+export function hasSortPipe(query: string): boolean {
+  return hasSortPipeRe.test(query);
+}

--- a/app/vmui/packages/vmui/src/components/LogsConfigurators/GroupLogsConfigurators/GroupLogsConfigurators.tsx
+++ b/app/vmui/packages/vmui/src/components/LogsConfigurators/GroupLogsConfigurators/GroupLogsConfigurators.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useMemo, useState } from "preact/compat";
+import { FC, useMemo, useState } from "preact/compat";
 import useBoolean from "../../../hooks/useBoolean";
 import { RestartIcon, SettingsIcon } from "../../Main/Icons";
 import Button from "../../Main/Button/Button";
@@ -62,7 +62,8 @@ const GroupLogsConfigurators: FC<Props> = ({ logs }) => {
   ].some(Boolean);
 
   const logsKeys = useMemo(() => {
-    return Array.from(new Set(logs.map(l => Object.keys(l)).flat()));
+    const uniqueKeys = new Set(logs.map(l => Object.keys(l)).flat());
+    return Array.from(uniqueKeys).sort((a, b) => a.localeCompare(b));
   }, [logs]);
 
   const {

--- a/app/vmui/packages/vmui/src/components/Table/TableSettings/TableSettings.tsx
+++ b/app/vmui/packages/vmui/src/components/Table/TableSettings/TableSettings.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useEffect, useRef, useMemo } from "preact/compat";
+import { FC, useEffect, useRef, useMemo } from "preact/compat";
 import Button from "../../Main/Button/Button";
 import { SearchIcon, SettingsIcon } from "../../Main/Icons";
 import "./style.scss";
@@ -49,8 +49,8 @@ const TableSettings: FC<TableSettingsProps> = ({
 
   const filteredColumns = useMemo(() => {
     const allColumns = customColumns.concat(columns);
-    if (!searchColumn) return allColumns;
-    return allColumns.filter(col => col.includes(searchColumn));
+    const result = searchColumn ? allColumns.filter(col => col.includes(searchColumn)) : allColumns;
+    return result.sort((a, b) => a.localeCompare(b));
   }, [columns, customColumns, searchColumn]);
 
   const isAllChecked = useMemo(() => {

--- a/app/vmui/packages/vmui/src/pages/ExploreLogs/ExploreLogsBody/views/TableView/TableView.tsx
+++ b/app/vmui/packages/vmui/src/pages/ExploreLogs/ExploreLogsBody/views/TableView/TableView.tsx
@@ -27,7 +27,7 @@ const TableView: FC<ViewProps> = ({ data, settingsRef }) => {
         keys.add(key);
       }
     }
-    return Array.from(keys);
+    return Array.from(keys).sort((a,b) => a.localeCompare(b));
   }, [data]);
 
   const handleSetRowsPerPage = (limit: number) => {
@@ -77,4 +77,4 @@ const TableView: FC<ViewProps> = ({ data, settingsRef }) => {
   );
 };
 
-export default TableView; 
+export default TableView;

--- a/docs/victorialogs/CHANGELOG.md
+++ b/docs/victorialogs/CHANGELOG.md
@@ -18,6 +18,8 @@ according to [these docs](https://docs.victoriametrics.com/victorialogs/quicksta
 
 ## tip
 
+* BUGFIX: [web UI](https://docs.victoriametrics.com/victorialogs/querying/#web-ui): correctly handle `sort` pipe in queries — UI now respects the server-defined sort order instead of always sorting by time. See [#8660](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8660).
+
 ## [v1.23.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.23.0-victorialogs)
 
 Released at 2025-05-28

--- a/docs/victorialogs/CHANGELOG.md
+++ b/docs/victorialogs/CHANGELOG.md
@@ -19,6 +19,7 @@ according to [these docs](https://docs.victoriametrics.com/victorialogs/quicksta
 ## tip
 
 * BUGFIX: [web UI](https://docs.victoriametrics.com/victorialogs/querying/#web-ui): correctly handle `sort` pipe in queries — UI now respects the server-defined sort order instead of always sorting by time. See [#8660](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8660).
+* BUGFIX: [web UI](https://docs.victoriametrics.com/victorialogs/querying/#web-ui): add alphabetical sorting for record fields in selectors and table view. See [#8438](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8438).
 
 ## [v1.23.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.23.0-victorialogs)
 


### PR DESCRIPTION
### Describe Your Changes

* UI now respects the `sort by` pipe in queries — if it's present, the order returned by the server is preserved. Related issue: #8660.
* If no `sort by` pipe is used, logs are reversed on the client to show the newest entries first (since VictoriaLogs returns them in ascending time order — [see this in the code](https://github.com/VictoriaMetrics/VictoriaMetrics/blob/master/app/vlselect/logsql/logsql.go#L1047)).
* Removed redundant client-side time-based sorting logic.

Additionally:

* Log record fields are now sorted alphabetically in UI selectors such as **Group by field**, **Display fields**, and **Customize columns**. Related issue: #8438.

### Checklist

The following checks are **mandatory**:

- [ ] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/).
