### PR TITLE
vlstorage: automatically recover missing parts.json files on startup

### DIFF
--- a/docs/victorialogs/CHANGELOG.md
+++ b/docs/victorialogs/CHANGELOG.md
@@ -25,6 +25,7 @@ according to [these docs](https://docs.victoriametrics.com/victorialogs/quicksta
 * BUGFIX: [Datadog](https://docs.victoriametrics.com/victorialogs/data-ingestion/datadog/): respond HTTP 202 instead of HTTP 200 on successful Datadog endpoint ingestion as it's strictly required by Datadog agent. See [#8956](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8956).
 * BUGFIX: [web UI](https://docs.victoriametrics.com/victorialogs/querying/#web-ui): properly escape special characters in field values shown in autocomplete suggestions. See [#8925](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8925).
 * BUGFIX: [LogsQL](https://docs.victoriametrics.com/victorialogs/logsql/): Properly handle time filters when querying vlstorage directly or through vlselect. See [#8985](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8985).
+* BUGFIX: Self-healing from OOM interruption during the creation of a daily partition. See [#8873](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8873).
 
 ## [v1.22.2](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.22.2-victorialogs)
 

--- a/lib/logstorage/datadb.go
+++ b/lib/logstorage/datadb.go
@@ -1167,6 +1167,31 @@ func mustReadPartNames(path string) []string {
 	partNamesPath := filepath.Join(path, partsFilename)
 	data, err := os.ReadFile(partNamesPath)
 	if err != nil {
+		if os.IsNotExist(err) {
+			// The parts.json file is missing. This can happen if VictoriaLogs shuts down uncleanly
+			// (via OOM crash, a panic, SIGKILL or hardware shutdown) in the middle of creating
+			// new per-day partition inside the mustCreatePartition() function.
+			// Check if there are any part directories in the datadb directory.
+			des := fs.MustReadDir(path)
+			var partDirs []string
+			for _, de := range des {
+				if !fs.IsDirOrSymlink(de) {
+					continue
+				}
+				partDirs = append(partDirs, de.Name())
+			}
+
+			if len(partDirs) == 0 {
+				logger.Warnf("creating missing %s with empty parts list, since no part directories found in %s", partNamesPath, path)
+				mustWritePartNames(path, nil, nil)
+				return []string{}
+			}
+
+			// Parts exist but parts.json is missing - this is an unexpected state that requires manual intervention
+			logger.Panicf("FATAL: cannot read %s: %s; found part directories %v in %s. "+
+				"This indicates corruption. Remove %s to rebuild it from the list of existing parts",
+				partNamesPath, err, partDirs, path, partNamesPath)
+		}
 		logger.Panicf("FATAL: cannot read %s: %s", partNamesPath, err)
 	}
 	var partNames []string

--- a/lib/logstorage/datadb.go
+++ b/lib/logstorage/datadb.go
@@ -1189,8 +1189,8 @@ func mustReadPartNames(path string) []string {
 
 			// Parts exist but parts.json is missing - this is an unexpected state that requires manual intervention
 			logger.Panicf("FATAL: cannot read %s: %s; found part directories %v in %s. "+
-				"This indicates corruption. Remove %s to rebuild it from the list of existing parts",
-				partNamesPath, err, partDirs, path, partNamesPath)
+				"This indicates corruption. Manually remove the %s partition directory to resolve the corruption (the partition data will be lost)",
+				partNamesPath, err, partDirs, path, path)
 		}
 		logger.Panicf("FATAL: cannot read %s: %s", partNamesPath, err)
 	}

--- a/lib/logstorage/partition.go
+++ b/lib/logstorage/partition.go
@@ -88,7 +88,7 @@ func mustOpenPartition(s *Storage, path string) *partition {
 		idb:  idb,
 	}
 
-	if !fs.IsPathExist(datadbPath) {
+	if !isDatadbExist {
 		logger.Warnf("creating missing datadb directory %s, this could happen if VictoriaLogs shuts down uncleanly (via OOM crash, a panic, SIGKILL or hardware shutdown) while creating new per-day partition", datadbPath)
 		mustCreateDatadb(datadbPath)
 	}


### PR DESCRIPTION
Fixes [#8873](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8873).

Automatically recover missing `parts.json` files on startup. VictoriaLogs now scans existing part directories and recreates missing `parts.json` files instead of crashing. This aligns with VictoriaMetrics' approach. 