### PR TITLE
fix for multiple users running tests (testStoragePath ownership issue)

### DIFF
--- a/app/vmalert-tool/unittest/unittest.go
+++ b/app/vmalert-tool/unittest/unittest.go
@@ -13,7 +13,6 @@ import (
 	"path/filepath"
 	"reflect"
 	"sort"
-	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -100,7 +99,11 @@ func UnitTest(files []string, disableGroupLabel bool, externalLabels []string, e
 	}
 
 	// adding time.Now().UnixNano() to avoid possible file conflict when multiple processes run on a single host
-	storagePath = filepath.Join(os.TempDir(), testStoragePath, strconv.FormatInt(time.Now().UnixNano(), 10))
+	tmpFolder, err := os.MkdirTemp(os.TempDir(), testStoragePath)
+	if err != nil {
+		logger.Fatalf("failed to create tmp dir for tests: %v", err)
+	}
+	storagePath = filepath.Join(tmpFolder)
 	processFlags()
 	vminsert.Init()
 	vmselect.Init()

--- a/app/vmalert-tool/unittest/unittest.go
+++ b/app/vmalert-tool/unittest/unittest.go
@@ -98,12 +98,11 @@ func UnitTest(files []string, disableGroupLabel bool, externalLabels []string, e
 		}()
 	}
 
-	// adding time.Now().UnixNano() to avoid possible file conflict when multiple processes run on a single host
 	tmpFolder, err := os.MkdirTemp(os.TempDir(), testStoragePath)
 	if err != nil {
 		logger.Fatalf("failed to create tmp dir for tests: %v", err)
 	}
-	storagePath = filepath.Join(tmpFolder)
+	storagePath = tmpFolder
 	processFlags()
 	vminsert.Init()
 	vmselect.Init()

--- a/docs/victoriametrics/changelog/CHANGELOG.md
+++ b/docs/victoriametrics/changelog/CHANGELOG.md
@@ -18,7 +18,7 @@ See also [LTS releases](https://docs.victoriametrics.com/victoriametrics/lts-rel
 
 ## tip
 
-* BUGFIX: [vmalert-tool](https://docs.victoriametrics.com/victoriametrics/vmalert-tool/): fix for multiple users access conflicts for tmp test folder. See [#9015](https://github.com/VictoriaMetrics/VictoriaMetrics/pull/9015).
+* BUGFIX: [vmalert-tool](https://docs.victoriametrics.com/victoriametrics/vmalert-tool/): fix access conflicts for the temporary test folder when multiple users run tests on the same host. Thanks to @evkuzin for the [pull request](https://github.com/VictoriaMetrics/VictoriaMetrics/pull/9015).
 
 ## [v1.118.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.118.0)
 

--- a/docs/victoriametrics/changelog/CHANGELOG.md
+++ b/docs/victoriametrics/changelog/CHANGELOG.md
@@ -18,6 +18,8 @@ See also [LTS releases](https://docs.victoriametrics.com/victoriametrics/lts-rel
 
 ## tip
 
+* BUGFIX: [vmalert-tool](https://docs.victoriametrics.com/victoriametrics/vmalert-tool/): fix for multiple users access conflicts for tmp test folder. See [#9015](https://github.com/VictoriaMetrics/VictoriaMetrics/pull/9015).
+
 ## [v1.118.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.118.0)
 
 Released at 2025-05-23


### PR DESCRIPTION
### Describe Your Changes

When multiple users run tests on the same instance, the first user creating a folder will own the testStoragePath, which can lead to issues accessing this folder for other users. This change will allow us to create unique folders per user. 

```
% ls -ld /usr/tmp/vmalert-unittest/
drwxr-xr-x 2 some_user users 4096 May 12 17:22 /usr/tmp/vmalert-unittest/
...
2025-05-20T13:56:16.488Z        panic   lib/fs/fs.go:132        FATAL: cannot create directory: mkdir /usr/tmp/vmalert-unittest/1747749376488491648: permission denied
panic: FATAL: cannot create directory: mkdir /usr/tmp/vmalert-unittest/1747749376488491648: permission denied
```

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/).
