### PR TITLE
lib/logstorage: do not finalize results on intermediate nodes in multlevel setup

### DIFF
--- a/app/vlselect/internalselect/internalselect.go
+++ b/app/vlselect/internalselect/internalselect.go
@@ -23,6 +23,7 @@ import (
 )
 
 var disableSelect = flag.Bool("internalselect.disable", false, "Whether to disable /internal/select/* HTTP endpoints")
+var intermediateKey = any("intermediate")
 
 // RequestHandler processes requests to /internal/select/*
 func RequestHandler(ctx context.Context, w http.ResponseWriter, r *http.Request) {
@@ -41,6 +42,7 @@ func RequestHandler(ctx context.Context, w http.ResponseWriter, r *http.Request)
 	}
 
 	metrics.GetOrCreateCounter(fmt.Sprintf(`vl_http_requests_total{path=%q}`, path)).Inc()
+	ctx = context.WithValue(ctx, intermediateKey, true)
 	if err := rh(ctx, w, r); err != nil && !netutil.IsTrivialNetworkError(err) {
 		metrics.GetOrCreateCounter(fmt.Sprintf(`vl_http_request_errors_total{path=%q}`, path)).Inc()
 		httpserver.Errorf(w, r, "%s", err)

--- a/docs/victorialogs/CHANGELOG.md
+++ b/docs/victorialogs/CHANGELOG.md
@@ -25,6 +25,7 @@ according to [these docs](https://docs.victoriametrics.com/victorialogs/quicksta
 * BUGFIX: [Datadog](https://docs.victoriametrics.com/victorialogs/data-ingestion/datadog/): respond HTTP 202 instead of HTTP 200 on successful Datadog endpoint ingestion as it's strictly required by Datadog agent. See [#8956](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8956).
 * BUGFIX: [web UI](https://docs.victoriametrics.com/victorialogs/querying/#web-ui): properly escape special characters in field values shown in autocomplete suggestions. See [#8925](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8925).
 * BUGFIX: [LogsQL](https://docs.victoriametrics.com/victorialogs/logsql/): Properly handle time filters when querying vlstorage directly or through vlselect. See [#8985](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8985).
+* BUGFIX: [cluster mode](https://docs.victoriametrics.com/victorialogs/cluster/): Disable writing intermediate `stats` results, which breaks multilevel VictoriaLogs cluster setup. See [#8815](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8815).
 
 ## [v1.22.2](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.22.2-victorialogs)
 

--- a/lib/logstorage/pipe.go
+++ b/lib/logstorage/pipe.go
@@ -76,7 +76,7 @@ type pipeProcessor interface {
 	// flush is called after all the worker goroutines are stopped.
 	//
 	// It is guaranteed that flush() is called for every pipeProcessor returned from pipe.newPipeProcessor().
-	flush() error
+	flush(bool) error
 }
 
 type noopPipeProcessor func(workerID uint, br *blockResult)
@@ -89,7 +89,7 @@ func (npp noopPipeProcessor) writeBlock(workerID uint, br *blockResult) {
 	npp(workerID, br)
 }
 
-func (npp noopPipeProcessor) flush() error {
+func (npp noopPipeProcessor) flush(bool) error {
 	logger.Panicf("BUG: mustn't be called!")
 	return nil
 }

--- a/lib/logstorage/pipe_block_stats.go
+++ b/lib/logstorage/pipe_block_stats.go
@@ -107,7 +107,7 @@ func (psp *pipeBlockStatsProcessor) writeBlock(workerID uint, br *blockResult) {
 	shard.wctx.reset()
 }
 
-func (psp *pipeBlockStatsProcessor) flush() error {
+func (psp *pipeBlockStatsProcessor) flush(_ bool) error {
 	return nil
 }
 

--- a/lib/logstorage/pipe_blocks_count.go
+++ b/lib/logstorage/pipe_blocks_count.go
@@ -79,7 +79,7 @@ func (pcp *pipeBlocksCountProcessor) writeBlock(workerID uint, _ *blockResult) {
 	shard.blocksCount++
 }
 
-func (pcp *pipeBlocksCountProcessor) flush() error {
+func (pcp *pipeBlocksCountProcessor) flush(_ bool) error {
 	if needStop(pcp.stopCh) {
 		return nil
 	}

--- a/lib/logstorage/pipe_copy.go
+++ b/lib/logstorage/pipe_copy.go
@@ -91,7 +91,7 @@ func (pcp *pipeCopyProcessor) writeBlock(workerID uint, br *blockResult) {
 	pcp.ppNext.writeBlock(workerID, br)
 }
 
-func (pcp *pipeCopyProcessor) flush() error {
+func (pcp *pipeCopyProcessor) flush(_ bool) error {
 	return nil
 }
 

--- a/lib/logstorage/pipe_delete.go
+++ b/lib/logstorage/pipe_delete.go
@@ -71,7 +71,7 @@ func (pdp *pipeDeleteProcessor) writeBlock(workerID uint, br *blockResult) {
 	pdp.ppNext.writeBlock(workerID, br)
 }
 
-func (pdp *pipeDeleteProcessor) flush() error {
+func (pdp *pipeDeleteProcessor) flush(_ bool) error {
 	return nil
 }
 

--- a/lib/logstorage/pipe_drop_empty_fields.go
+++ b/lib/logstorage/pipe_drop_empty_fields.go
@@ -104,7 +104,7 @@ func (pdp *pipeDropEmptyFieldsProcessor) writeBlock(workerID uint, br *blockResu
 	shard.wctx.flush()
 }
 
-func (pdp *pipeDropEmptyFieldsProcessor) flush() error {
+func (pdp *pipeDropEmptyFieldsProcessor) flush(_ bool) error {
 	return nil
 }
 

--- a/lib/logstorage/pipe_extract.go
+++ b/lib/logstorage/pipe_extract.go
@@ -233,7 +233,7 @@ func (pep *pipeExtractProcessor) writeBlock(workerID uint, br *blockResult) {
 	shard.a.reset()
 }
 
-func (pep *pipeExtractProcessor) flush() error {
+func (pep *pipeExtractProcessor) flush(_ bool) error {
 	return nil
 }
 

--- a/lib/logstorage/pipe_extract_regexp.go
+++ b/lib/logstorage/pipe_extract_regexp.go
@@ -264,7 +264,7 @@ func (pep *pipeExtractRegexpProcessor) writeBlock(workerID uint, br *blockResult
 	shard.a.reset()
 }
 
-func (pep *pipeExtractRegexpProcessor) flush() error {
+func (pep *pipeExtractRegexpProcessor) flush(_ bool) error {
 	return nil
 }
 

--- a/lib/logstorage/pipe_facets.go
+++ b/lib/logstorage/pipe_facets.go
@@ -335,7 +335,7 @@ func (pfp *pipeFacetsProcessor) writeBlock(workerID uint, br *blockResult) {
 	shard.writeBlock(br)
 }
 
-func (pfp *pipeFacetsProcessor) flush() error {
+func (pfp *pipeFacetsProcessor) flush(_ bool) error {
 	if n := pfp.stateSizeBudget.Load(); n <= 0 {
 		return fmt.Errorf("cannot calculate [%s], since it requires more than %dMB of memory", pfp.pf.String(), pfp.maxStateSize/(1<<20))
 	}

--- a/lib/logstorage/pipe_field_names.go
+++ b/lib/logstorage/pipe_field_names.go
@@ -136,7 +136,7 @@ func (shard *pipeFieldNamesProcessorShard) updateColumnHits(columnName string, h
 	*pHits += hits
 }
 
-func (pfp *pipeFieldNamesProcessor) flush() error {
+func (pfp *pipeFieldNamesProcessor) flush(_ bool) error {
 	if needStop(pfp.stopCh) {
 		return nil
 	}

--- a/lib/logstorage/pipe_field_values_local.go
+++ b/lib/logstorage/pipe_field_values_local.go
@@ -96,7 +96,7 @@ func (pfp *pipeFieldValuesLocalProcessor) writeBlock(workerID uint, br *blockRes
 	}
 }
 
-func (pfp *pipeFieldValuesLocalProcessor) flush() error {
+func (pfp *pipeFieldValuesLocalProcessor) flush(_ bool) error {
 	pf := pfp.pf.pf
 	shards := pfp.shards.All()
 	if len(shards) == 0 {

--- a/lib/logstorage/pipe_fields.go
+++ b/lib/logstorage/pipe_fields.go
@@ -93,7 +93,7 @@ func (pfp *pipeFieldsProcessor) writeBlock(workerID uint, br *blockResult) {
 	pfp.ppNext.writeBlock(workerID, br)
 }
 
-func (pfp *pipeFieldsProcessor) flush() error {
+func (pfp *pipeFieldsProcessor) flush(_ bool) error {
 	return nil
 }
 

--- a/lib/logstorage/pipe_filter.go
+++ b/lib/logstorage/pipe_filter.go
@@ -102,7 +102,7 @@ func (pfp *pipeFilterProcessor) writeBlock(workerID uint, br *blockResult) {
 	pfp.ppNext.writeBlock(workerID, &shard.br)
 }
 
-func (pfp *pipeFilterProcessor) flush() error {
+func (pfp *pipeFilterProcessor) flush(_ bool) error {
 	return nil
 }
 

--- a/lib/logstorage/pipe_format.go
+++ b/lib/logstorage/pipe_format.go
@@ -178,7 +178,7 @@ func (pfp *pipeFormatProcessor) writeBlock(workerID uint, br *blockResult) {
 	shard.rc.reset()
 }
 
-func (pfp *pipeFormatProcessor) flush() error {
+func (pfp *pipeFormatProcessor) flush(_ bool) error {
 	return nil
 }
 

--- a/lib/logstorage/pipe_hash.go
+++ b/lib/logstorage/pipe_hash.go
@@ -151,7 +151,7 @@ func getFloat64CompatibleHash(v string) float64 {
 	return float64(h)
 }
 
-func (php *pipeHashProcessor) flush() error {
+func (php *pipeHashProcessor) flush(_ bool) error {
 	return nil
 }
 

--- a/lib/logstorage/pipe_join.go
+++ b/lib/logstorage/pipe_join.go
@@ -154,7 +154,7 @@ func (pjp *pipeJoinProcessor) writeBlock(workerID uint, br *blockResult) {
 	shard.wctx.reset()
 }
 
-func (pjp *pipeJoinProcessor) flush() error {
+func (pjp *pipeJoinProcessor) flush(_ bool) error {
 	return nil
 }
 

--- a/lib/logstorage/pipe_json_array_len.go
+++ b/lib/logstorage/pipe_json_array_len.go
@@ -159,7 +159,7 @@ func (shard *pipeJSONArrayLenProcessorShard) getJSONArrayLen(v string) int {
 	return len(shard.tmpValues)
 }
 
-func (plp *pipeJSONArrayLenProcessor) flush() error {
+func (plp *pipeJSONArrayLenProcessor) flush(_ bool) error {
 	return nil
 }
 

--- a/lib/logstorage/pipe_len.go
+++ b/lib/logstorage/pipe_len.go
@@ -142,7 +142,7 @@ func (shard *pipeLenProcessorShard) getEncodedLen(v string) string {
 	return bytesutil.ToUnsafeString(shard.a.b[bLen:])
 }
 
-func (plp *pipeLenProcessor) flush() error {
+func (plp *pipeLenProcessor) flush(_ bool) error {
 	return nil
 }
 

--- a/lib/logstorage/pipe_limit.go
+++ b/lib/logstorage/pipe_limit.go
@@ -92,7 +92,7 @@ func (plp *pipeLimitProcessor) writeBlock(workerID uint, br *blockResult) {
 	plp.cancel()
 }
 
-func (plp *pipeLimitProcessor) flush() error {
+func (plp *pipeLimitProcessor) flush(_ bool) error {
 	return nil
 }
 

--- a/lib/logstorage/pipe_math.go
+++ b/lib/logstorage/pipe_math.go
@@ -436,7 +436,7 @@ func (pmp *pipeMathProcessor) writeBlock(workerID uint, br *blockResult) {
 	shard.a.reset()
 }
 
-func (pmp *pipeMathProcessor) flush() error {
+func (pmp *pipeMathProcessor) flush(_ bool) error {
 	return nil
 }
 

--- a/lib/logstorage/pipe_offset.go
+++ b/lib/logstorage/pipe_offset.go
@@ -75,7 +75,7 @@ func (pop *pipeOffsetProcessor) writeBlock(workerID uint, br *blockResult) {
 	pop.ppNext.writeBlock(workerID, br)
 }
 
-func (pop *pipeOffsetProcessor) flush() error {
+func (pop *pipeOffsetProcessor) flush(_ bool) error {
 	return nil
 }
 

--- a/lib/logstorage/pipe_pack.go
+++ b/lib/logstorage/pipe_pack.go
@@ -104,7 +104,7 @@ func (ppp *pipePackProcessor) writeBlock(workerID uint, br *blockResult) {
 	shard.rc.reset()
 }
 
-func (ppp *pipePackProcessor) flush() error {
+func (ppp *pipePackProcessor) flush(_ bool) error {
 	return nil
 }
 

--- a/lib/logstorage/pipe_rename.go
+++ b/lib/logstorage/pipe_rename.go
@@ -95,7 +95,7 @@ func (prp *pipeRenameProcessor) writeBlock(workerID uint, br *blockResult) {
 	prp.ppNext.writeBlock(workerID, br)
 }
 
-func (prp *pipeRenameProcessor) flush() error {
+func (prp *pipeRenameProcessor) flush(_ bool) error {
 	return nil
 }
 

--- a/lib/logstorage/pipe_sample.go
+++ b/lib/logstorage/pipe_sample.go
@@ -121,7 +121,7 @@ func (shard *pipeSampleProcessorShard) writeRow(workerID uint, br *blockResult, 
 	shard.br.reset()
 }
 
-func (psp *pipeSampleProcessor) flush() error {
+func (psp *pipeSampleProcessor) flush(_ bool) error {
 	return nil
 }
 

--- a/lib/logstorage/pipe_sort.go
+++ b/lib/logstorage/pipe_sort.go
@@ -450,7 +450,7 @@ func (psp *pipeSortProcessor) writeBlock(workerID uint, br *blockResult) {
 	shard.writeBlock(br)
 }
 
-func (psp *pipeSortProcessor) flush() error {
+func (psp *pipeSortProcessor) flush(_ bool) error {
 	if n := psp.stateSizeBudget.Load(); n <= 0 {
 		return fmt.Errorf("cannot calculate [%s], since it requires more than %dMB of memory", psp.ps.String(), psp.maxStateSize/(1<<20))
 	}

--- a/lib/logstorage/pipe_sort_topk.go
+++ b/lib/logstorage/pipe_sort_topk.go
@@ -378,7 +378,7 @@ func (ptp *pipeTopkProcessor) writeBlock(workerID uint, br *blockResult) {
 	shard.writeBlock(br)
 }
 
-func (ptp *pipeTopkProcessor) flush() error {
+func (ptp *pipeTopkProcessor) flush(_ bool) error {
 	if n := ptp.stateSizeBudget.Load(); n <= 0 {
 		return fmt.Errorf("cannot calculate [%s], since it requires more than %dMB of memory", ptp.ps.String(), ptp.maxStateSize/(1<<20))
 	}

--- a/lib/logstorage/pipe_stream_context.go
+++ b/lib/logstorage/pipe_stream_context.go
@@ -625,7 +625,7 @@ func (pcp *pipeStreamContextProcessor) writeBlock(workerID uint, br *blockResult
 	shard.writeBlock(pcp, br)
 }
 
-func (pcp *pipeStreamContextProcessor) flush() error {
+func (pcp *pipeStreamContextProcessor) flush(_ bool) error {
 	n := pcp.stateSizeBudget.Load()
 	if n <= 0 {
 		return fmt.Errorf("cannot calculate [%s], since it requires more than %dMB of memory", pcp.pc.String(), pcp.maxStateSize/(1<<20))

--- a/lib/logstorage/pipe_top.go
+++ b/lib/logstorage/pipe_top.go
@@ -306,7 +306,7 @@ func (ptp *pipeTopProcessor) writeBlock(workerID uint, br *blockResult) {
 	shard.writeBlock(br)
 }
 
-func (ptp *pipeTopProcessor) flush() error {
+func (ptp *pipeTopProcessor) flush(_ bool) error {
 	if n := ptp.stateSizeBudget.Load(); n <= 0 {
 		return fmt.Errorf("cannot calculate [%s], since it requires more than %dMB of memory", ptp.pt.String(), ptp.maxStateSize/(1<<20))
 	}

--- a/lib/logstorage/pipe_union.go
+++ b/lib/logstorage/pipe_union.go
@@ -74,7 +74,7 @@ func (pup *pipeUnionProcessor) writeBlock(workerID uint, br *blockResult) {
 	pup.ppNext.writeBlock(workerID, br)
 }
 
-func (pup *pipeUnionProcessor) flush() error {
+func (pup *pipeUnionProcessor) flush(_ bool) error {
 	// execute the query to union
 	ctxWithCancel, cancel := contextutil.NewStopChanContext(pup.stopCh)
 	defer cancel()

--- a/lib/logstorage/pipe_uniq.go
+++ b/lib/logstorage/pipe_uniq.go
@@ -271,7 +271,7 @@ func (pup *pipeUniqProcessor) writeBlock(workerID uint, br *blockResult) {
 	}
 }
 
-func (pup *pipeUniqProcessor) flush() error {
+func (pup *pipeUniqProcessor) flush(_ bool) error {
 	if n := pup.stateSizeBudget.Load(); n <= 0 {
 		return fmt.Errorf("cannot calculate [%s], since it requires more than %dMB of memory", pup.pu.String(), pup.maxStateSize/(1<<20))
 	}

--- a/lib/logstorage/pipe_uniq_local.go
+++ b/lib/logstorage/pipe_uniq_local.go
@@ -124,7 +124,7 @@ func getColumnValuess(br *blockResult, fields []string) [][]string {
 	return columnValuess
 }
 
-func (pup *pipeUniqLocalProcessor) flush() error {
+func (pup *pipeUniqLocalProcessor) flush(_ bool) error {
 	pu := pup.pu.pu
 	shards := pup.shards.All()
 	if len(shards) == 0 {

--- a/lib/logstorage/pipe_unpack.go
+++ b/lib/logstorage/pipe_unpack.go
@@ -194,7 +194,7 @@ func (pup *pipeUnpackProcessor) writeBlock(workerID uint, br *blockResult) {
 	shard.uctx.reset()
 }
 
-func (pup *pipeUnpackProcessor) flush() error {
+func (pup *pipeUnpackProcessor) flush(_ bool) error {
 	return nil
 }
 

--- a/lib/logstorage/pipe_unpack_words.go
+++ b/lib/logstorage/pipe_unpack_words.go
@@ -131,7 +131,7 @@ func (pup *pipeUnpackWordsProcessor) writeBlock(workerID uint, br *blockResult) 
 	shard.a.reset()
 }
 
-func (pup *pipeUnpackWordsProcessor) flush() error {
+func (pup *pipeUnpackWordsProcessor) flush(_ bool) error {
 	return nil
 }
 

--- a/lib/logstorage/pipe_unroll.go
+++ b/lib/logstorage/pipe_unroll.go
@@ -199,7 +199,7 @@ func (shard *pipeUnrollProcessorShard) writeUnrolledFields(fieldNames []string, 
 	shard.fields = fields
 }
 
-func (pup *pipeUnrollProcessor) flush() error {
+func (pup *pipeUnrollProcessor) flush(_ bool) error {
 	return nil
 }
 

--- a/lib/logstorage/pipe_update.go
+++ b/lib/logstorage/pipe_update.go
@@ -99,6 +99,6 @@ func (pup *pipeUpdateProcessor) writeBlock(workerID uint, br *blockResult) {
 	shard.a.reset()
 }
 
-func (pup *pipeUpdateProcessor) flush() error {
+func (pup *pipeUpdateProcessor) flush(_ bool) error {
 	return nil
 }

--- a/lib/logstorage/pipe_utils_test.go
+++ b/lib/logstorage/pipe_utils_test.go
@@ -62,7 +62,7 @@ func expectPipeResults(t *testing.T, pipeStr string, rows, rowsExpected [][]Fiel
 		brw.writeRow(row)
 	}
 	brw.flush()
-	pp.flush()
+	pp.flush(false)
 
 	ppTest.expectRows(t, rowsExpected)
 }
@@ -155,7 +155,7 @@ func (pp *testPipeProcessor) writeBlock(_ uint, br *blockResult) {
 	}
 }
 
-func (pp *testPipeProcessor) flush() error {
+func (pp *testPipeProcessor) flush(_ bool) error {
 	return nil
 }
 

--- a/lib/logstorage/storage_search.go
+++ b/lib/logstorage/storage_search.go
@@ -160,6 +160,7 @@ func (s *Storage) runQuery(ctx context.Context, tenantIDs []TenantID, q *Query, 
 type searchFunc func(stopCh <-chan struct{}, writeBlock writeBlockResultFunc) error
 
 func runPipes(ctx context.Context, pipes []pipe, search searchFunc, writeBlock writeBlockResultFunc, concurrency int) error {
+	intermediate, _ := ctx.Value("intermediate").(bool)
 	stopCh := ctx.Done()
 	if len(pipes) == 0 {
 		// Fast path when there are no pipes
@@ -185,7 +186,7 @@ func runPipes(ctx context.Context, pipes []pipe, search searchFunc, writeBlock w
 
 	var errFlush error
 	for i, pp := range pps {
-		if err := pp.flush(); err != nil && errFlush == nil {
+		if err := pp.flush(intermediate); err != nil && errFlush == nil {
 			errFlush = err
 		}
 		cancel := cancels[i]


### PR DESCRIPTION
fixes https://github.com/VictoriaMetrics/VictoriaLogs/issues/161

### Describe Your Changes

while using `stats` pipe in multilevel VictoriaLogs setups intermediate vlselect nodes writing local final results, which are not properly parsed by nodes on upper levels. This breaks using stats pipe results on 2+ level cluster setup. Added `intermediate` variable, which is set to `true`, while using internal API to identify if local node results should be treated as intermediate.
I'm not sure it's the best option, as it makes request to internal API intermediate by default, maybe it's worth adding a HTTP query argument or logsql query option for this

### Checklist

The following checks are **mandatory**:

- [ ] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/).
