### PR TITLE
deployment/logs-benchmark: fix URLs to benchmark data

### DIFF
--- a/deployment/logs-benchmark/source_logs/download.sh
+++ b/deployment/logs-benchmark/source_logs/download.sh
@@ -4,27 +4,27 @@ set -ex
 
 # Unarchived size: 5.1M Apache.log
 if [ ! -f Apache.tar.gz ]; then
-  curl -o Apache.tar.gz -C - https://zenodo.org/record/3227177/files/Apache.tar.gz?download=1
+  curl -o Apache.tar.gz -L -C - https://zenodo.org/records/3227177/files/Apache.tar.gz?download=1
 fi
 
 # Unarchived size: 13G hadoop-*.log
 if [ ! -f HDFS_2.tar.gz ]; then
-  curl -o HDFS_2.tar.gz -C - https://zenodo.org/record/3227177/files/HDFS_2.tar.gz?download=1
+  curl -o HDFS_2.tar.gz -L -C - https://zenodo.org/records/3227177/files/HDFS_2.tar.gz?download=1
 fi
 
 # Unarchived size: 2.3M Linux.log
 if [ ! -f Linux.tar.gz ]; then
-  curl -o Linux.tar.gz -C - https://zenodo.org/record/3227177/files/Linux.tar.gz?download=1
+  curl -o Linux.tar.gz -L -C - https://zenodo.org/records/3227177/files/Linux.tar.gz?download=1
 fi
 
 # Unarchived size: 32G Thunderbird.log
 if [ ! -f Thunderbird.tar.gz ]; then
-  curl -o Thunderbird.tar.gz -C - https://zenodo.org/record/3227177/files/Thunderbird.tar.gz?download=1
+  curl -o Thunderbird.tar.gz -L -C - https://zenodo.org/records/3227177/files/Thunderbird.tar.gz?download=1
 fi
 
 # Unarchived size: 73M SSH.log
 if [ ! -f SSH.tar.gz ]; then
-  curl -o SSH.tar.gz -C - https://zenodo.org/record/3227177/files/SSH.tar.gz?download=1
+  curl -o SSH.tar.gz -L -C - https://zenodo.org/records/3227177/files/SSH.tar.gz?download=1
 fi
 
 mkdir -p logs


### PR DESCRIPTION
### Describe Your Changes

When downloading archives for benchmarks, an error appears saying that the archive was placed in a new path. 

The error could have been prevented by providing the `-L (--location)` flag that would tell curl to follow the redirect, so in addition to updating the paths, this flag was added.

### Checklist

The following checks are **mandatory**:

- [X] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/).
