### PR TITLE
app/netstorage: improve validation for address provided at storageNode

### DIFF
--- a/app/vmselect/netstorage/netstorage.go
+++ b/app/vmselect/netstorage/netstorage.go
@@ -3188,10 +3188,12 @@ func initStorageNodes(addrs []string) *storageNodesBucket {
 }
 
 func newStorageNode(ms *metrics.Set, group *storageNodesGroup, addr string) *storageNode {
-	if _, _, err := net.SplitHostPort(addr); err != nil {
-		// Automatically add missing port.
-		addr += ":8401"
+	normalizedAddr, err := netutil.NormalizeAddr(addr, 8401)
+	if err != nil {
+		logger.Fatalf("cannot normalize -storageNode=%q: %s", addr, err)
 	}
+	addr = normalizedAddr
+
 	// There is no need in requests compression, since vmselect requests are usually very small.
 	connPool := netutil.NewConnPool(ms, "vmselect", addr, handshake.VMSelectClient, 0, *vmstorageDialTimeout, *vmstorageUserTimeout)
 

--- a/app/vmselect/prometheus/prometheus.go
+++ b/app/vmselect/prometheus/prometheus.go
@@ -4,7 +4,6 @@ import (
 	"flag"
 	"fmt"
 	"math"
-	"net"
 	"net/http"
 	"runtime"
 	"strconv"
@@ -557,10 +556,11 @@ func resetRollupResultCaches() {
 		return
 	}
 	for _, selectNode := range *selectNodes {
-		if _, _, err := net.SplitHostPort(selectNode); err != nil {
-			// Add missing port
-			selectNode += ":8481"
+		normalizedAddr, err := netutil.NormalizeAddr(selectNode, 8481)
+		if err != nil {
+			logger.Fatalf("cannot normalize -selectNode=%q: %s", selectNode, err)
 		}
+		selectNode = normalizedAddr
 		callURL := fmt.Sprintf("http://%s/internal/resetRollupResultCache", selectNode)
 		resp, err := httpClient.Get(callURL)
 		if err != nil {

--- a/lib/netutil/netutil.go
+++ b/lib/netutil/netutil.go
@@ -68,12 +68,11 @@ var Dialer = &net.Dialer{
 
 // IsErrMissingPort checks if the given error is due to a missing port in the address.
 // It is expected to be used to validate error returned by net.SplitHostPort
+// See https://github.com/golang/go/blob/ed08d2ad0928c0fc77cc2053863616ffb58c5aac/src/net/ipsock.go#L167
 func IsErrMissingPort(err error) bool {
 	if err == nil {
 		return false
 	}
-	// There is no specific error exported for missing port in address.
-	// So we check for the substring.
 	return strings.Contains(err.Error(), "missing port in address")
 }
 
@@ -86,10 +85,9 @@ func NormalizeAddr(addr string, defaultPort int) (string, error) {
 	}
 
 	_, _, err := net.SplitHostPort(addr)
-	if err != nil {
-		if IsErrMissingPort(err) {
-			return fmt.Sprintf("%s:%d", addr, defaultPort), nil
-		}
+	if IsErrMissingPort(err) {
+		return fmt.Sprintf("%s:%d", addr, defaultPort), nil
+	} else if err != nil {
 		return "", fmt.Errorf("invalid address %q; expected format: host:port", addr)
 	}
 	return addr, nil

--- a/lib/netutil/netutil_test.go
+++ b/lib/netutil/netutil_test.go
@@ -1,0 +1,51 @@
+package netutil
+
+import (
+	"net"
+	"testing"
+)
+
+func TestIsErrMissingPort(t *testing.T) {
+	f := func(addr string, expected bool) {
+		_, _, err := net.SplitHostPort(addr)
+		if IsErrMissingPort(err) != expected {
+			t.Fatalf("unexpected result for %q; got %v; want %v", addr, !expected, expected)
+		}
+	}
+
+	f("127.0.0.1", true)
+	f("http://127.0.0.1:8080", false)
+}
+
+func TestNormalizeAddrSuccess(t *testing.T) {
+	f := func(addr string, defaultPort int, expected string) {
+		t.Helper()
+		result, err := NormalizeAddr(addr, defaultPort)
+		if err != nil {
+			t.Fatalf("unexpected error for %q: %v", addr, err)
+		}
+		if result != expected {
+			t.Fatalf("unexpected result for %q; got %q; want %q", addr, result, expected)
+		}
+	}
+
+	f("127.0.0.1", 80, "127.0.0.1:80")
+	f("127.0.0.1:123", 80, "127.0.0.1:123")
+}
+
+func TestNormalizeAddrError(t *testing.T) {
+	f := func(addr string) {
+		t.Helper()
+		_, err := NormalizeAddr(addr, 80)
+		if err == nil {
+			t.Fatalf("expected error for %q, but got none", addr)
+		}
+	}
+
+	// Invalid number of octets in address
+	f("1:2:3:4:5:6:7:8:9:10")
+
+	// Invalid address format
+	f("http://127.0.0.1")
+	f("http://127.0.0.1:80")
+}

--- a/lib/netutil/netutil_test.go
+++ b/lib/netutil/netutil_test.go
@@ -7,6 +7,7 @@ import (
 
 func TestIsErrMissingPort(t *testing.T) {
 	f := func(addr string, expected bool) {
+		t.Helper()
 		_, _, err := net.SplitHostPort(addr)
 		if IsErrMissingPort(err) != expected {
 			t.Fatalf("unexpected result for %q; got %v; want %v", addr, !expected, expected)
@@ -15,6 +16,9 @@ func TestIsErrMissingPort(t *testing.T) {
 
 	f("127.0.0.1", true)
 	f("http://127.0.0.1:8080", false)
+
+	f("[::1]", true)
+	f("http://[::1]:8080", false)
 }
 
 func TestNormalizeAddrSuccess(t *testing.T) {
@@ -31,6 +35,8 @@ func TestNormalizeAddrSuccess(t *testing.T) {
 
 	f("127.0.0.1", 80, "127.0.0.1:80")
 	f("127.0.0.1:123", 80, "127.0.0.1:123")
+	f("[::1]", 80, "[::1]:80")
+	f("[::1]:123", 80, "[::1]:123")
 }
 
 func TestNormalizeAddrError(t *testing.T) {
@@ -44,6 +50,8 @@ func TestNormalizeAddrError(t *testing.T) {
 
 	// Invalid number of octets in address
 	f("1:2:3:4:5:6:7:8:9:10")
+	// Invalid IPv6 address format
+	f("::1:2:3:4:5:6:7:8:9")
 
 	// Invalid address format
 	f("http://127.0.0.1")

--- a/lib/netutil/netutil_test.go
+++ b/lib/netutil/netutil_test.go
@@ -19,6 +19,11 @@ func TestIsErrMissingPort(t *testing.T) {
 
 	f("[::1]", true)
 	f("http://[::1]:8080", false)
+
+	f("vmstorage-0", true)
+	f("vmstorage-0.svc.cluster.local.", true)
+	f("http://vmstorage-0:8080", false)
+	f("http://vmstorage-0.svc.cluster.local.:8080", false)
 }
 
 func TestNormalizeAddrSuccess(t *testing.T) {
@@ -37,6 +42,8 @@ func TestNormalizeAddrSuccess(t *testing.T) {
 	f("127.0.0.1:123", 80, "127.0.0.1:123")
 	f("[::1]", 80, "[::1]:80")
 	f("[::1]:123", 80, "[::1]:123")
+	f("vmstorage-0.svc.cluster.local.", 80, "vmstorage-0.svc.cluster.local.:80")
+	f("vmstorage-0.svc.cluster.local.:123", 80, "vmstorage-0.svc.cluster.local.:123")
 }
 
 func TestNormalizeAddrError(t *testing.T) {
@@ -56,4 +63,6 @@ func TestNormalizeAddrError(t *testing.T) {
 	// Invalid address format
 	f("http://127.0.0.1")
 	f("http://127.0.0.1:80")
+	f("http://vmstorage-0.svc.cluster.local.")
+	f("http://vmstorage-0.svc.cluster.local.:80")
 }


### PR DESCRIPTION
Previously, address was always parsed as "host:port" and added port if it was missing. This leaded to hard to understand errors in case address was provided in "http://host:port" format.

Improve error validation in order to provide more precise error message in case of invalid address format.

See: https://github.com/VictoriaMetrics/VictoriaMetrics/issues/9029

Previous error message: `cannot dial storageNode "http://localhost:8488": dial tcp4: address http://localhost:8488: too many colons in address` and vminsert continue running.
Current error message: `cannot normalize -storageNode="http://localhost:8480": invalid address "http://localhost:8480"; expected format: host:port` and vminsert exists with error status code.
