### PR TITLE
apptest: run tests in parallel to imrpove testing speed

### DIFF
--- a/apptest/testcase.go
+++ b/apptest/testcase.go
@@ -27,6 +27,7 @@ type Stopper interface {
 
 // NewTestCase creates a new test case.
 func NewTestCase(t *testing.T) *TestCase {
+	t.Parallel()
 	return &TestCase{t, NewClient(), make(map[string]Stopper)}
 }
 


### PR DESCRIPTION
This change reduces integration tests time from 90s to 30s:
1. before https://github.com/VictoriaMetrics/VictoriaMetrics/actions/runs/15321154610/job/43105211053?pr=9048#step:5:2
2. after https://github.com/VictoriaMetrics/VictoriaMetrics/actions/runs/15324035886/job/43114340500#step:5:2