### PR TITLE
improve performance for tokenizer `tokenizeHashes()`

### DIFF
--- a/lib/logstorage/hash_tokenizer.go
+++ b/lib/logstorage/hash_tokenizer.go
@@ -6,6 +6,7 @@ import (
 	"github.com/cespare/xxhash/v2"
 
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/bytesutil"
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/stringsutil"
 )
 
 // tokenizeHashes extracts word tokens from a, hashes them, appends hashes to dst and returns the result.
@@ -66,7 +67,7 @@ func (t *hashTokenizer) reset() {
 }
 
 func (t *hashTokenizer) tokenizeString(dst []uint64, s string) []uint64 {
-	if !isASCII(s) {
+	if !stringsutil.IsASCII(s) {
 		// Slow path - s contains unicode chars
 		return t.tokenizeStringUnicode(dst, s)
 	}

--- a/lib/logstorage/hash_tokenizer_timing_test.go
+++ b/lib/logstorage/hash_tokenizer_timing_test.go
@@ -5,11 +5,62 @@ import (
 	"testing"
 )
 
+/*
+go test -benchmem -v -run=^$ -bench ^BenchmarkTokenizeHashes$ github.com/VictoriaMetrics/VictoriaMetrics/lib/logstorage
+
+goos: linux
+goarch: amd64
+pkg: github.com/VictoriaMetrics/VictoriaMetrics/lib/logstorage
+cpu: Intel(R) Xeon(R) Platinum 8260 CPU @ 2.40GHz
+BenchmarkTokenizeHashes
+BenchmarkTokenizeHashes-8         695058              1627 ns/op        2057.93 MB/s           0 B/op          0 allocs/op
+
+goos: linux  performance improve 3.87%
+goarch: amd64
+pkg: github.com/VictoriaMetrics/VictoriaMetrics/lib/logstorage
+cpu: Intel(R) Xeon(R) Platinum 8260 CPU @ 2.40GHz
+BenchmarkTokenizeHashes
+BenchmarkTokenizeHashes-8         661975              1564 ns/op        2141.33 MB/s           0 B/op          0 allocs/op
+*/
 func BenchmarkTokenizeHashes(b *testing.B) {
 	a := strings.Split(benchLogs, "\n")
 
 	b.ReportAllocs()
 	b.SetBytes(int64(len(benchLogs)))
+	b.RunParallel(func(pb *testing.PB) {
+		var hashes []uint64
+		for pb.Next() {
+			hashes = tokenizeHashes(hashes[:0], a)
+		}
+	})
+}
+
+/*
+go test -benchmem -v -run=^$ -bench ^BenchmarkTokenizeHashesUnicode$ github.com/VictoriaMetrics/VictoriaMetrics/lib/logstorage
+
+goos: linux
+goarch: amd64
+pkg: github.com/VictoriaMetrics/VictoriaMetrics/lib/logstorage
+cpu: Intel(R) Xeon(R) Platinum 8260 CPU @ 2.40GHz
+BenchmarkTokenizeHashesUnicode
+BenchmarkTokenizeHashesUnicode-8          215118              4855 ns/op         721.72 MB/s           0 B/op          0 allocs/op
+
+goos: linux  performance improve 12.17%
+goarch: amd64
+pkg: github.com/VictoriaMetrics/VictoriaMetrics/lib/logstorage
+cpu: Intel(R) Xeon(R) Platinum 8260 CPU @ 2.40GHz
+BenchmarkTokenizeHashesUnicode
+BenchmarkTokenizeHashesUnicode-8          274152              4264 ns/op         821.78 MB/s           0 B/op          0 allocs/op
+*/
+func BenchmarkTokenizeHashesUnicode(b *testing.B) {
+	a := strings.Split(benchLogs, "\n")
+	var totalLen int
+	for i := range a {
+		a[i] += "中文"
+		totalLen += len(a[i])
+	}
+	b.ReportAllocs()
+	b.SetBytes(int64(totalLen))
 	b.RunParallel(func(pb *testing.PB) {
 		var hashes []uint64
 		for pb.Next() {

--- a/lib/logstorage/pipe_collapse_nums.go
+++ b/lib/logstorage/pipe_collapse_nums.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/bytesutil"
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/stringsutil"
 )
 
 // pipeCollapseNums processes '| collapse_nums ...' pipe.
@@ -120,7 +121,7 @@ func parsePipeCollapseNums(lex *lexer) (pipe, error) {
 }
 
 func appendCollapseNums(dst []byte, s string) []byte {
-	if !isASCII(s) {
+	if !stringsutil.IsASCII(s) {
 		return appendCollapseNumsUnicode(dst, s)
 	}
 

--- a/lib/logstorage/tokenizer_timing_test.go
+++ b/lib/logstorage/tokenizer_timing_test.go
@@ -5,6 +5,10 @@ import (
 	"testing"
 )
 
+// go test -benchmem -v -run=^$ -benchmem -bench ^BenchmarkTokenizeStrings$ github.com/VictoriaMetrics/VictoriaMetrics/lib/logstorage
+/*
+BenchmarkTokenizeStrings-8        285720              4444 ns/op         753.30 MB/s           0 B/op          0 allocs/op
+*/
 func BenchmarkTokenizeStrings(b *testing.B) {
 	a := strings.Split(benchLogs, "\n")
 

--- a/lib/stringsutil/is_ascii.go
+++ b/lib/stringsutil/is_ascii.go
@@ -1,0 +1,26 @@
+package stringsutil
+
+import (
+	"unicode/utf8"
+	"unsafe"
+)
+
+func IsASCII(s string) bool {
+	l := len(s)
+	end := l - l&7
+	ptr := unsafe.StringData(s)
+	for start := 0; start < end; start += 8 {
+		// compare 8 bytes at once
+		var chars uint64 = *((*uint64)(unsafe.Add(unsafe.Pointer(ptr), start)))
+		if chars&0x8080808080808080 != 0 {
+			return false
+		}
+	}
+	s = s[end:]
+	for i := range s {
+		if s[i] >= utf8.RuneSelf {
+			return false
+		}
+	}
+	return true
+}

--- a/lib/stringsutil/is_ascii_test.go
+++ b/lib/stringsutil/is_ascii_test.go
@@ -1,0 +1,163 @@
+package stringsutil
+
+import (
+	"math/rand"
+	"testing"
+	"unicode/utf8"
+	"unsafe"
+)
+
+const str32 = "12345678901234567890123456789012"
+const str32NotAscii = "123456789012345678901234567890\x81\x82"
+
+// go test -timeout 30s -v -run ^TestIsASCII$ github.com/VictoriaMetrics/VictoriaMetrics/lib/stringsutil
+func TestIsASCII(t *testing.T) {
+	type args struct {
+		s string
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "ascii 1",
+			args: args{
+				s: "abcdefghijklmnopqrstuvwxyz",
+			},
+			want: true,
+		},
+		{
+			name: "ascii 2",
+			args: args{
+				s: str32,
+			},
+			want: true,
+		},
+		{
+			name: "ascii 3",
+			args: args{
+				s: str32 + str32,
+			},
+			want: true,
+		},
+		{
+			name: "ascii 4",
+			args: args{
+				s: str32 + str32 + "123",
+			},
+			want: true,
+		},
+		{
+			name: "ascii 5",
+			args: args{
+				s: "\x7f",
+			},
+			want: true,
+		},
+		{
+			name: "ascii 5",
+			args: args{
+				s: "\x80",
+			},
+			want: false,
+		},
+		{
+			name: "ascii 5",
+			args: args{
+				s: "中文字符串",
+			},
+			want: false,
+		},
+		{
+			name: "ascii 6",
+			args: args{
+				s: str32NotAscii,
+			},
+			want: false,
+		},
+		{
+			name: "ascii 6",
+			args: args{
+				s: str32 + str32NotAscii + "123",
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsASCII(tt.args.s)
+			if got != tt.want {
+				t.Errorf("IsASCII() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func getRandomString(strLen int) string {
+	buf := make([]byte, strLen)
+	for i := 0; i < strLen; i++ {
+		buf[i] = byte(rand.Intn(128)) // 0-127
+	}
+	return unsafe.String(&buf[0], strLen)
+}
+
+func IsASCII_one_by_one(s string) bool {
+	for i := range s {
+		if s[i] >= utf8.RuneSelf {
+			return false
+		}
+	}
+	return true
+}
+
+// go test -benchmem -v -run=^$ -bench ^Benchmark_is_ascii_one_by_one$ github.com/VictoriaMetrics/VictoriaMetrics/lib/stringsutil
+/*
+goos: linux
+goarch: amd64
+pkg: is_ascii
+cpu: Intel(R) Xeon(R) Platinum 8260 CPU @ 2.40GHz
+// 674.37 MB/s
+
+goos: darwin
+goarch: arm64
+pkg: github.com/VictoriaMetrics/VictoriaMetrics/lib/stringsutil
+cpu: Apple M3 Pro
+Benchmark_is_ascii_one_by_one
+Benchmark_is_ascii_one_by_one-12            2167            576643 ns/op        1818.41 MB/s           0 B/op          0 allocs/op
+*/
+func Benchmark_is_ascii_one_by_one(b *testing.B) {
+	strLen := 1024 * 1024
+	s := getRandomString(strLen)
+	b.SetBytes(int64(strLen))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		ret := IsASCII_one_by_one(s)
+		if !ret {
+			b.Fatalf("ret=%v", ret)
+		}
+	}
+}
+
+/*
+go test -benchmem -v -run=^$ -bench ^Benchmark_is_ascii_one_by_one_faster$ github.com/VictoriaMetrics/VictoriaMetrics/lib/stringsutil
+
+goos: darwin,   performance improve 93.8%
+goarch: arm64
+pkg: github.com/VictoriaMetrics/VictoriaMetrics/lib/stringsutil
+cpu: Apple M3 Pro
+Benchmark_is_ascii_one_by_one_faster
+Benchmark_is_ascii_one_by_one_faster-12            32605             35750 ns/op        29330.44 MB/s          0 B/op          0 allocs/op
+*/
+func Benchmark_is_ascii_one_by_one_faster(b *testing.B) {
+	strLen := 1024 * 1024
+	s := getRandomString(strLen)
+	b.SetBytes(int64(strLen))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		ret := IsASCII(s)
+		if !ret {
+			b.Fatalf("ret=%v", ret)
+		}
+	}
+}


### PR DESCRIPTION
### Describe Your Changes

Optimize the tokenizeHashes function.
Use table lookup to replace multiple conditional judgments.
* When the string is ascii: performance improved by 3.87%
* When the string is unicode: performance improved by 12.17%

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/).
