### PR TITLE
make: remove -victorialogs suffix from docker image tags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ PKG_TAG ?= $(shell git tag -l --points-at HEAD)
 ifeq ($(PKG_TAG),)
 PKG_TAG := $(BUILDINFO_TAG)
 endif
+PKG_TAG := $(subst -victorialogs,,$(PKG_TAG))
 
 GO_BUILDINFO = -X '$(PKG_PREFIX)/lib/buildinfo.Version=$(APP_NAME)-$(DATEINFO_TAG)-$(BUILDINFO_TAG)'
 TAR_OWNERSHIP ?= --owner=1000 --group=1000


### PR DESCRIPTION
### Describe Your Changes

stripping `-victorialogs` suffix from docker images for consistency

### Checklist

The following checks are **mandatory**:

- [ ] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
