### PR TITLE
add avx2 version of isConst()

### DIFF
--- a/lib/encoding/encoding.go
+++ b/lib/encoding/encoding.go
@@ -120,7 +120,7 @@ func marshalInt64Array(dst []byte, a []int64, precisionBits uint8) (result []byt
 	if len(a) == 0 {
 		logger.Panicf("BUG: a must contain at least one item")
 	}
-	if isConst(a) {
+	if IsConst(a) {
 		firstValue = a[0]
 		return dst, MarshalTypeConst, firstValue
 	}
@@ -283,28 +283,6 @@ func EnsureNonDecreasingSequence(a []int64, vMin, vMax int64) {
 			i--
 		}
 	}
-}
-
-// isConst returns true if a contains only equal values.
-func isConst(a []int64) bool {
-	if len(a) == 0 {
-		return false
-	}
-	if fastnum.IsInt64Zeros(a) {
-		// Fast path for array containing only zeros.
-		return true
-	}
-	if fastnum.IsInt64Ones(a) {
-		// Fast path for array containing only ones.
-		return true
-	}
-	v1 := a[0]
-	for _, v := range a {
-		if v != v1 {
-			return false
-		}
-	}
-	return true
 }
 
 // isDeltaConst returns true if a contains counter with constant delta.

--- a/lib/encoding/encoding_test.go
+++ b/lib/encoding/encoding_test.go
@@ -6,22 +6,6 @@ import (
 	"testing"
 )
 
-func TestIsConst(t *testing.T) {
-	f := func(a []int64, okExpected bool) {
-		t.Helper()
-		ok := isConst(a)
-		if ok != okExpected {
-			t.Fatalf("unexpected isConst for a=%d; got %v; want %v", a, ok, okExpected)
-		}
-	}
-	f([]int64{}, false)
-	f([]int64{1}, true)
-	f([]int64{1, 2}, false)
-	f([]int64{1, 1}, true)
-	f([]int64{1, 1, 1}, true)
-	f([]int64{1, 1, 2}, false)
-}
-
 func TestIsDeltaConst(t *testing.T) {
 	f := func(a []int64, okExpected bool) {
 		t.Helper()

--- a/lib/encoding/is_const.go
+++ b/lib/encoding/is_const.go
@@ -28,3 +28,16 @@ func IsConst(a []int64) bool {
 	}
 	return true
 }
+
+func AreConstUint64s(a []uint64) bool {
+	if len(a) == 0 {
+		return false
+	}
+	v := a[0]
+	for i := 1; i < len(a); i++ {
+		if v != a[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/lib/encoding/is_const.go
+++ b/lib/encoding/is_const.go
@@ -1,0 +1,30 @@
+//go:build !amd64
+// +build !amd64
+
+package encoding
+
+import (
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/fastnum"
+)
+
+// isConst returns true if a contains only equal values.
+func IsConst(a []int64) bool {
+	if len(a) == 0 {
+		return false
+	}
+	if fastnum.IsInt64Zeros(a) {
+		// Fast path for array containing only zeros.
+		return true
+	}
+	if fastnum.IsInt64Ones(a) {
+		// Fast path for array containing only ones.
+		return true
+	}
+	v1 := a[0]
+	for _, v := range a {
+		if v != v1 {
+			return false
+		}
+	}
+	return true
+}

--- a/lib/encoding/is_const_amd64.go
+++ b/lib/encoding/is_const_amd64.go
@@ -1,0 +1,3 @@
+package encoding
+
+func IsConst(a []int64) bool

--- a/lib/encoding/is_const_amd64.go
+++ b/lib/encoding/is_const_amd64.go
@@ -1,3 +1,13 @@
 package encoding
 
+import "unsafe"
+
 func IsConst(a []int64) bool
+
+func AreConstUint64s(a []uint64) bool {
+	if len(a) == 0 {
+		return false
+	}
+	a1 := unsafe.Slice((*int64)(unsafe.Pointer(&a[0])), len(a))
+	return IsConst(a1)
+}

--- a/lib/encoding/is_const_amd64.s
+++ b/lib/encoding/is_const_amd64.s
@@ -14,6 +14,8 @@ TEXT ·IsConst(SB), NOSPLIT | NOFRAME, $0-25
     ANDQ $-4, R10  // align_len = count & -4
     LEAQ (R8)(R10*8), R11  // align_4_end = in + align_len*8
     MOVQ (R8), R12  // first_value = *current
+    CMPQ R9, $4
+    JLT align_4_end
     VPBROADCASTQ R12, Y1  // Y1 = [first_value,first_value,first_value,first_value]
 align_4:
     CMPQ R8, R11  // if current==align_4_end then goto label_align_4_end

--- a/lib/encoding/is_const_amd64.s
+++ b/lib/encoding/is_const_amd64.s
@@ -1,0 +1,50 @@
+#include "textflag.h"
+
+TEXT ·IsConst(SB), NOSPLIT | NOFRAME, $0-25
+    // frame length:  0
+    // param length: 24 bytes
+    // return value length: 1 bytes
+    MOVQ inPtr+0(FP), R8  // current
+    MOVQ inLen+8(FP), R9  // int64 count
+    // check param
+    CMPQ R9, $0
+    JE not_equal
+    // variables
+    MOVQ R9, R10
+    ANDQ $-4, R10  // align_len = count & -4
+    LEAQ (R8)(R10*8), R11  // align_4_end = in + align_len*8
+    MOVQ (R8), R12  // first_value = *current
+    VPBROADCASTQ R12, Y1  // Y1 = [first_value,first_value,first_value,first_value]
+align_4:
+    CMPQ R8, R11  // if current==align_4_end then goto label_align_4_end
+    JE align_4_end
+    VMOVDQU (R8), Y0  // load_u, 256 bit, 4 x int64
+    ADDQ  $32, R8  // current += 32
+    VPCMPEQQ Y0, Y1, Y2  // y2 = y0==y1
+    VMOVMSKPD Y2, R13  // move mask
+    CMPQ R13, $15  // if mask==15 then goto align_4
+    JE align_4
+    // not equal
+    MOVB $0, ret+24(FP)  // return 0
+    VZEROUPPER
+    RET
+align_4_end:
+    MOVQ R9, R10
+    ANDQ $3, R10  // left_count = count & 3
+    LEAQ (R8)(R10*8), R11  // end = current + left_count*8
+align_1:
+    CMPQ R8, R11
+    JEQ end  // if current==end then goto end
+    MOVQ (R8), R13 // r13 = *current
+    ADDQ $8, R8  // current += 8
+    CMPQ R12,R13  // if *current == first_value then goto align_1
+    JEQ align_1
+    // not equal
+not_equal:
+    MOVB $0, ret+24(FP)  // return 0
+    VZEROUPPER
+    RET
+end:
+    MOVB $1, ret+24(FP)  // return 1
+    VZEROUPPER
+    RET

--- a/lib/encoding/is_const_test.go
+++ b/lib/encoding/is_const_test.go
@@ -1,0 +1,40 @@
+package encoding
+
+import (
+	"math/rand"
+	"testing"
+)
+
+func TestIsConst(t *testing.T) {
+	f := func(a []int64, okExpected bool) {
+		t.Helper()
+		ok := IsConst(a)
+		if ok != okExpected {
+			t.Fatalf("unexpected isConst for a=%d; got %v; want %v", a, ok, okExpected)
+		}
+	}
+	f([]int64{}, false)
+	f([]int64{1}, true)
+	f([]int64{1, 2}, false)
+	f([]int64{1, 1}, true)
+	f([]int64{1, 1, 1}, true)
+	f([]int64{1, 1, 2}, false)
+	//
+	arr1 := getData(1024)
+	f(arr1, true)
+	arr1[len(arr1)-1] = -1
+	f(arr1, false)
+	arr2 := getData(1024 + 3)
+	f(arr2, true)
+	arr2[len(arr2)-3] = -2
+	f(arr2, false)
+}
+
+func getData(cnt int) []int64 {
+	arr := make([]int64, cnt)
+	seed := rand.Int63n(0x7f7f7f7f7f7f7f7f)
+	for i := 0; i < cnt; i++ {
+		arr[i] = seed
+	}
+	return arr
+}

--- a/lib/encoding/is_const_timing_test.go
+++ b/lib/encoding/is_const_timing_test.go
@@ -13,7 +13,7 @@ pkg: github.com/VictoriaMetrics/VictoriaMetrics/lib/encoding
 cpu: Intel(R) Xeon(R) Platinum 8260 CPU @ 2.40GHz
 Benchmark_is_const-8        3028            420935 ns/op        19928.63 MB/s          0 B/op          0 allocs/op
 
-47.9% fast then old version
+47.9% faster then old version.
 */
 func Benchmark_is_const(b *testing.B) {
 	cnt := 1024*1024 + 7

--- a/lib/encoding/is_const_timing_test.go
+++ b/lib/encoding/is_const_timing_test.go
@@ -1,0 +1,72 @@
+package encoding
+
+import (
+	"testing"
+
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/fastnum"
+)
+
+/*
+goos: linux
+goarch: amd64
+pkg: github.com/VictoriaMetrics/VictoriaMetrics/lib/encoding
+cpu: Intel(R) Xeon(R) Platinum 8260 CPU @ 2.40GHz
+Benchmark_is_const-8        3028            420935 ns/op        19928.63 MB/s          0 B/op          0 allocs/op
+
+47.9% fast then old version
+*/
+func Benchmark_is_const(b *testing.B) {
+	cnt := 1024*1024 + 7
+	arr := getData(cnt)
+	b.SetBytes(int64(cnt * 8))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		ret := IsConst(arr)
+		if !ret {
+			b.Fatalf("ret=%v", ret)
+		}
+	}
+}
+
+func isConstSlow(a []int64) bool {
+	if len(a) == 0 {
+		return false
+	}
+	if fastnum.IsInt64Zeros(a) {
+		// Fast path for array containing only zeros.
+		return true
+	}
+	if fastnum.IsInt64Ones(a) {
+		// Fast path for array containing only ones.
+		return true
+	}
+	v1 := a[0]
+	for _, v := range a {
+		if v != v1 {
+			return false
+		}
+	}
+	return true
+}
+
+/*
+goos: linux
+goarch: amd64
+pkg: github.com/VictoriaMetrics/VictoriaMetrics/lib/encoding
+cpu: Intel(R) Xeon(R) Platinum 8260 CPU @ 2.40GHz
+=== RUN   Benchmark_is_const_slow
+Benchmark_is_const_slow
+Benchmark_is_const_slow-8           1348            808103 ns/op        10380.69 MB/s          0 B/op          0 allocs/op
+*/
+func Benchmark_is_const_slow(b *testing.B) {
+	cnt := 1024*1024 + 7
+	arr := getData(cnt)
+	b.SetBytes(int64(cnt * 8))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		ret := isConstSlow(arr)
+		if !ret {
+			b.Fatalf("ret=%v", ret)
+		}
+	}
+}

--- a/lib/logstorage/encoding.go
+++ b/lib/logstorage/encoding.go
@@ -110,7 +110,7 @@ func (sbu *stringsBlockUnmarshaler) unmarshal(dst []string, src []byte, itemsCou
 	dst = slicesutil.SetLength(dst, len(dst)+len(aLens))
 	dstA := dst[len(dst)-len(aLens):]
 
-	if len(aLens) >= 2 && areConstUint64s(aLens) && uint64(len(data)) == aLens[0] {
+	if len(aLens) >= 2 && encoding.AreConstUint64s(aLens) && uint64(len(data)) == aLens[0] {
 		// Special case - decode a constant string
 		s := bytesutil.ToUnsafeString(data)
 		for i := range dstA {
@@ -130,19 +130,6 @@ func (sbu *stringsBlockUnmarshaler) unmarshal(dst []string, src []byte, itemsCou
 	}
 
 	return dst, nil
-}
-
-func areConstUint64s(a []uint64) bool {
-	if len(a) == 0 {
-		return false
-	}
-	v := a[0]
-	for i := 1; i < len(a); i++ {
-		if v != a[i] {
-			return false
-		}
-	}
-	return true
 }
 
 // marshalUint64Block appends marshaled a to dst and returns the result.
@@ -196,7 +183,7 @@ func marshalUint64Items(dst []byte, a []uint64) []byte {
 			nMax = n
 		}
 	}
-	areConsts := len(a) >= 2 && areConstUint64s(a)
+	areConsts := len(a) >= 2 && encoding.AreConstUint64s(a)
 	switch {
 	case nMax < (1 << 8):
 		if areConsts {


### PR DESCRIPTION
### Describe Your Changes

Add avx2 version for func IsConst().
47.9% faster then old version.

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
