### PR TITLE
improve performance for isDeltaConst() (avx2 version)

### DIFF
--- a/lib/encoding/encoding.go
+++ b/lib/encoding/encoding.go
@@ -124,7 +124,7 @@ func marshalInt64Array(dst []byte, a []int64, precisionBits uint8) (result []byt
 		firstValue = a[0]
 		return dst, MarshalTypeConst, firstValue
 	}
-	if isDeltaConst(a) {
+	if IsDeltaConst(a) {
 		firstValue = a[0]
 		dst = MarshalVarInt64(dst, a[1]-a[0])
 		return dst, MarshalTypeDeltaConst, firstValue
@@ -303,22 +303,6 @@ func isConst(a []int64) bool {
 		if v != v1 {
 			return false
 		}
-	}
-	return true
-}
-
-// isDeltaConst returns true if a contains counter with constant delta.
-func isDeltaConst(a []int64) bool {
-	if len(a) < 2 {
-		return false
-	}
-	d1 := a[1] - a[0]
-	prev := a[1]
-	for _, next := range a[2:] {
-		if next-prev != d1 {
-			return false
-		}
-		prev = next
 	}
 	return true
 }

--- a/lib/encoding/encoding_test.go
+++ b/lib/encoding/encoding_test.go
@@ -22,26 +22,6 @@ func TestIsConst(t *testing.T) {
 	f([]int64{1, 1, 2}, false)
 }
 
-func TestIsDeltaConst(t *testing.T) {
-	f := func(a []int64, okExpected bool) {
-		t.Helper()
-		ok := isDeltaConst(a)
-		if ok != okExpected {
-			t.Fatalf("unexpected isDeltaConst for a=%d; got %v; want %v", a, ok, okExpected)
-		}
-	}
-	f([]int64{}, false)
-	f([]int64{1}, false)
-	f([]int64{1, 2}, true)
-	f([]int64{1, 2, 3}, true)
-	f([]int64{3, 2, 1}, true)
-	f([]int64{3, 2, 1, 0, -1, -2}, true)
-	f([]int64{3, 2, 1, 0, -1, -2, 2}, false)
-	f([]int64{1, 1}, true)
-	f([]int64{1, 2, 1}, false)
-	f([]int64{1, 2, 4}, false)
-}
-
 func TestIsGauge(t *testing.T) {
 	f := func(a []int64, okExpected bool) {
 		t.Helper()

--- a/lib/encoding/is_delta_const.go
+++ b/lib/encoding/is_delta_const.go
@@ -1,0 +1,20 @@
+//go:build !amd64
+// +build !amd64
+
+package encoding
+
+// IsDeltaConst returns true if a contains counter with constant delta.
+func IsDeltaConst(a []int64) bool {
+	if len(a) < 2 {
+		return false
+	}
+	d1 := a[1] - a[0]
+	prev := a[1]
+	for _, next := range a[2:] {
+		if next-prev != d1 {
+			return false
+		}
+		prev = next
+	}
+	return true
+}

--- a/lib/encoding/is_delta_const_amd64.go
+++ b/lib/encoding/is_delta_const_amd64.go
@@ -1,0 +1,3 @@
+package encoding
+
+func IsDeltaConst(a []int64) bool

--- a/lib/encoding/is_delta_const_amd64.s
+++ b/lib/encoding/is_delta_const_amd64.s
@@ -1,0 +1,60 @@
+#include "textflag.h"
+
+TEXT ·IsDeltaConst(SB), NOSPLIT | NOFRAME, $0-25
+    // frame length:  0
+    // param length: 24 bytes
+    // return value: 1 bytes
+    MOVQ inPtr+0(FP), R8  // current
+    MOVQ inLen+8(FP), R9  // count
+    // check params
+    CMPQ R9, $2
+    JLT not_equal  // if count<2 then goto not_equal
+    // variables
+    MOVQ R9, AX
+    SHLQ $3, AX  // totalBytes = count<<3
+    ADDQ R8, AX  // end = current + totalBytes
+    MOVQ (R8), R12  // first_value = *current
+    MOVQ R12, BX
+    ADDQ $8, R8  // current += 8
+    SUBQ $1, R9  // count -= 1
+    MOVQ (R8), DX  // dx = second_value
+    SUBQ R12, DX  // delta = second_value - first_value
+    MOVQ R9, R10
+    ANDQ $-4, R10  // align_count = count & -4
+    LEAQ (R8)(R10*8), R11  // align_4_end = current + align_count*8
+    VPBROADCASTQ DX, Y0  // y0 = [delta,delta,delta,delta]
+align_4:
+    CMPQ R8, R11  // if current==align_4_end then goto label_align_4_end
+    JE align_4_end
+    VMOVDQU -8(R8), Y1  // load_u, 256 bit, 4 x int64
+    VMOVDQU (R8), Y2  // load_u, 256 bit, 4 x int64
+    ADDQ  $32, R8  // current += 32
+    VPSUBQ Y1, Y2, Y3  // y3 = y2 - y1
+    VPCMPEQQ Y3, Y0, Y4  // y4 = y3==y0
+    VMOVMSKPD Y4, R13  // move mask
+    CMPQ R13, $15  // if mask==15 then goto align_4
+    JE align_4
+    // not equal
+    MOVB $0, ret+24(FP)  // return 0
+    VZEROUPPER
+    RET
+align_4_end:
+    MOVQ -8(R8), BX  // bx = prev
+align_1:
+    CMPQ R8, AX
+    JEQ end  // if current==end then goto end
+    MOVQ (R8), R13 // r13 = *current
+    MOVQ R13, CX  // cx = *current
+    ADDQ $8, R8  // current += 8
+    SUBQ BX, R13  // delta = *current - prev
+    MOVQ CX, BX   // prev = *current
+    CMPQ DX ,R13
+    JEQ align_1
+not_equal:
+    MOVB $0, ret+24(FP)  // return 0
+    VZEROUPPER
+    RET
+end:
+    MOVB $1, ret+24(FP)  // return 1
+    VZEROUPPER
+    RET

--- a/lib/encoding/is_delta_const_test.go
+++ b/lib/encoding/is_delta_const_test.go
@@ -1,0 +1,199 @@
+package encoding
+
+import (
+	"testing"
+)
+
+// go test -timeout 30s -v -run ^TestIsDeltaConstFast$ github.com/VictoriaMetrics/VictoriaMetrics/lib/encoding
+func TestIsDeltaConstFast(t *testing.T) {
+	type args struct {
+		a []int64
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "7",
+			args: args{
+				a: []int64{1, 2, 3, 4, 5, 6},
+			},
+			want: true,
+		},
+		{
+			name: "6",
+			args: args{
+				a: []int64{1, 2, 3, 4, 5},
+			},
+			want: true,
+		},
+		{
+			name: "1",
+			args: args{
+				a: []int64{},
+			},
+			want: false,
+		},
+		{
+			name: "2",
+			args: args{
+				a: []int64{1},
+			},
+			want: false,
+		},
+		{
+			name: "3",
+			args: args{
+				a: []int64{1, 2},
+			},
+			want: true,
+		},
+		{
+			name: "4",
+			args: args{
+				a: []int64{1, 2, 3},
+			},
+			want: true,
+		},
+		{
+			name: "5",
+			args: args{
+				a: []int64{1, 2, 3, 4},
+			},
+			want: true,
+		},
+		{
+			name: "8",
+			args: args{
+				a: []int64{1, 2, 3, 4, 5, 6, 7},
+			},
+			want: true,
+		},
+		{
+			name: "9",
+			args: args{
+				a: []int64{1, 2, 3, 4, 5, 6, 7, 8},
+			},
+			want: true,
+		},
+		{
+			name: "10",
+			args: args{
+				a: []int64{1, 2, 3, 4, 5, 6, 7, 8, 9},
+			},
+			want: true,
+		},
+		{
+			name: "11",
+			args: args{
+				a: []int64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+			},
+			want: true,
+		},
+		{
+			name: "21",
+			args: args{
+				a: []int64{1, 2, 3, 3, 5, 6, 7, 8, 9, 10},
+			},
+			want: false,
+		},
+		{
+			name: "22",
+			args: args{
+				a: []int64{1, 2, 3, 4, 4, 6, 7, 8, 9, 10},
+			},
+			want: false,
+		},
+		{
+			name: "23",
+			args: args{
+				a: []int64{1, 2, 3, 4, 5, 5, 7, 8, 9, 10},
+			},
+			want: false,
+		},
+		{
+			name: "24",
+			args: args{
+				a: []int64{1, 2, 3, 4, 5, 6, 6, 8, 9, 10},
+			},
+			want: false,
+		},
+		{
+			name: "25",
+			args: args{
+				a: []int64{1, 2, 3, 4, 5, 6, 7, 7, 9, 10},
+			},
+			want: false,
+		},
+		{
+			name: "26",
+			args: args{
+				a: []int64{1, 2, 3, 4, 5, 6, 7, 8, 8, 10},
+			},
+			want: false,
+		},
+		{
+			name: "27",
+			args: args{
+				a: []int64{1, 2, 3, 4, 5, 6, 7, 8, 9, 9},
+			},
+			want: false,
+		},
+		{
+			name: "29",
+			args: args{
+				a: []int64{1, 2, 3, 3},
+			},
+			want: false,
+		},
+		{
+			name: "30",
+			args: args{
+				a: []int64{1, 2, 3, 4, 4},
+			},
+			want: false,
+		},
+		{
+			name: "31",
+			args: args{
+				a: []int64{3, 2, 1, 0, -1, -2, -3},
+			},
+			want: true,
+		},
+		{
+			name: "32",
+			args: args{
+				a: []int64{3, 2, 1, 0, -1, -1, -3},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsDeltaConst(tt.args.a); got != tt.want {
+				t.Errorf("IsDeltaConst() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsDeltaConst(t *testing.T) {
+	f := func(a []int64, okExpected bool) {
+		t.Helper()
+		ok := IsDeltaConst(a)
+		if ok != okExpected {
+			t.Fatalf("unexpected isDeltaConst for a=%d; got %v; want %v", a, ok, okExpected)
+		}
+	}
+	f([]int64{}, false)
+	f([]int64{1}, false)
+	f([]int64{1, 2}, true)
+	f([]int64{1, 2, 3}, true)
+	f([]int64{3, 2, 1}, true)
+	f([]int64{3, 2, 1, 0, -1, -2}, true)
+	f([]int64{3, 2, 1, 0, -1, -2, 2}, false)
+	f([]int64{1, 1}, true)
+	f([]int64{1, 2, 1}, false)
+	f([]int64{1, 2, 4}, false)
+}

--- a/lib/encoding/is_delta_const_timing_test.go
+++ b/lib/encoding/is_delta_const_timing_test.go
@@ -1,0 +1,69 @@
+package encoding
+
+import (
+	"math/rand"
+	"testing"
+)
+
+func getDeltaData(cnt int) []int64 {
+	arr := make([]int64, cnt)
+	seed := rand.Int63n(0x7f7f7f7f7f7f7f7f)
+	for i := 0; i < cnt; i++ {
+		arr[i] = seed + int64(i)
+	}
+	return arr
+}
+
+// go test -benchmem -run=^$ -bench ^Benchmark_is_delta_const$ github.com/VictoriaMetrics/VictoriaMetrics/lib/encoding
+// 6948.91 MB/s  // improve 31.8%
+//
+//4738.99 MB/s	// golang version,
+/*
+goos: linux
+goarch: amd64
+pkg: is_delta_const
+cpu: Intel(R) Xeon(R) Platinum 8260 CPU @ 2.40GHz
+Benchmark_is_delta_const
+Benchmark_is_delta_const-8           100          12071831 ns/op        6948.91 MB/s           0 B/op          0 allocs/op
+*/
+func Benchmark_is_delta_const(b *testing.B) {
+	cnt := 1024 * 1024 * 10
+	arr := getDeltaData(cnt)
+	b.SetBytes(int64(cnt * 8))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		ret := IsDeltaConst(arr)
+		if !ret {
+			b.Fatalf("ret=%v", ret)
+		}
+	}
+}
+
+// isDeltaConst returns true if a contains counter with constant delta.
+func isDeltaConst(a []int64) bool {
+	if len(a) < 2 {
+		return false
+	}
+	d1 := a[1] - a[0]
+	prev := a[1]
+	for _, next := range a[2:] {
+		if next-prev != d1 {
+			return false
+		}
+		prev = next
+	}
+	return true
+}
+
+func Benchmark_is_delta_const_slow(b *testing.B) {
+	cnt := 1024 * 1024 * 10
+	arr := getDeltaData(cnt)
+	b.SetBytes(int64(cnt * 8))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		ret := isDeltaConst(arr)
+		if !ret {
+			b.Fatalf("ret=%v", ret)
+		}
+	}
+}


### PR DESCRIPTION
### Describe Your Changes

Add avx2 version of  isDeltaConst().
31.8% faster then golang version.

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
