### PR TITLE
app/vmauth: fix duplicate slashes in merged URLs

### DIFF
--- a/app/vmauth/target_url.go
+++ b/app/vmauth/target_url.go
@@ -11,10 +11,12 @@ import (
 func mergeURLs(uiURL, requestURI *url.URL, dropSrcPathPrefixParts int) *url.URL {
 	targetURL := *uiURL
 	srcPath := dropPrefixParts(requestURI.Path, dropSrcPathPrefixParts)
-	if strings.HasPrefix(srcPath, "/") {
-		targetURL.Path = strings.TrimSuffix(targetURL.Path, "/")
+	// Collapse duplicate slashes at the boundary between targetURL.Path and srcPath
+	if targetURL.Path == "" {
+		targetURL.Path = srcPath
+	} else if srcPath != "" {
+		targetURL.Path = strings.TrimRight(targetURL.Path, "/") + "/" + strings.TrimLeft(srcPath, "/")
 	}
-	targetURL.Path += srcPath
 	requestParams := requestURI.Query()
 	// fast path
 	if len(requestParams) == 0 {


### PR DESCRIPTION
app/vmauth: fix duplicate slashes in merged URLs

### Problem
When merging a configured url_prefix with an incoming request path, duplicate slashes could appear at the boundary between the two paths. This issue occurs in the `mergeURLs` function in `app/vmauth/target_url.go` when concatenating paths.

### Solution
The fix properly handles path concatenation by:
1. Trimming slashes from both the target URL path and source path before merging
2. Ensuring proper slash handling at the boundary between paths
3. Maintaining a single slash between path components


### Checklist
- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist)

Fixes #9096