### PR TITLE
Add avx2 version for IsInt64ArraySorted()

### DIFF
--- a/lib/encoding/is_sorted.go
+++ b/lib/encoding/is_sorted.go
@@ -1,0 +1,13 @@
+//go:build !amd64
+// +build !amd64
+
+package encoding
+
+func IsInt64ArraySorted(a []int64) bool {
+	for i := range a {
+		if i > 0 && a[i] < a[i-1] {
+			return false
+		}
+	}
+	return true
+}

--- a/lib/encoding/is_sorted_amd64.go
+++ b/lib/encoding/is_sorted_amd64.go
@@ -1,0 +1,3 @@
+package encoding
+
+func IsInt64ArraySorted(a []int64) bool

--- a/lib/encoding/is_sorted_amd64.s
+++ b/lib/encoding/is_sorted_amd64.s
@@ -1,0 +1,53 @@
+#include "textflag.h"
+
+TEXT ·IsInt64ArraySorted(SB), NOSPLIT | NOFRAME, $0-25
+    // frame length:  0
+    // param length: 24 bytes
+    // return value length: 1 bytes
+    MOVQ inPtr+0(FP), R8  // current
+    MOVQ inLen+8(FP), R9  // count
+    // check params
+    CMPQ R9, $2
+    JLT sorted  // if count<2 then goto sorted
+    // variables
+    MOVQ R9, AX
+    SHLQ $3, AX  // totalBytes = count<<3
+    ADDQ R8, AX  // end = current + totalBytes
+    ADDQ $8, R8  // current += 8
+    SUBQ $1, R9  // count -= 1
+    MOVQ R9, R10
+    ANDQ $-4, R10  // align_count = count & -4
+    LEAQ (R8)(R10*8), R11  // align_4_end = current + align_count*8
+align_4:
+    CMPQ R8, R11  // if current==align_4_end then goto label_align_4_end
+    JE align_4_end
+    VMOVDQU -8(R8), Y1  // load_u, 256 bit, 4 x int64
+    VMOVDQU (R8), Y2  // load_u, 256 bit, 4 x int64
+    ADDQ  $32, R8  // current += 32
+    VPCMPGTQ Y2, Y1, Y3  // y3 = y1 > y2
+    VMOVMSKPD Y3, R13  // move mask
+    CMPQ R13, $0  // if mask==0 then goto align_4
+    JE align_4
+    // not sorted
+    MOVB $0, ret+24(FP)  // return 0
+    VZEROUPPER
+    RET
+align_4_end:
+    MOVQ -8(R8), BX  // bx = prev
+align_1:
+    CMPQ R8, AX
+    JEQ sorted  // if current==end then goto end
+    MOVQ (R8), R13 // r13 = *current
+    ADDQ $8, R8  // current += 8
+    MOVQ BX, R10  // r10 = prev
+    MOVQ R13, BX   // prev = *current
+    CMPQ R13, R10  // if *current>=prev then goto align_1
+    JGE align_1
+not_sorted:
+    MOVB $0, ret+24(FP)  // return 0
+    VZEROUPPER
+    RET
+sorted:
+    MOVB $1, ret+24(FP)  // return 1
+    VZEROUPPER
+    RET

--- a/lib/encoding/is_sorted_test.go
+++ b/lib/encoding/is_sorted_test.go
@@ -1,0 +1,27 @@
+package encoding
+
+import (
+	"testing"
+)
+
+func TestIsInt64ArraySorted(t *testing.T) {
+	f := func(a []int64, expect bool) {
+		if IsInt64ArraySorted(a) != expect {
+			t.Errorf("%+v should be %v", a, expect)
+		}
+	}
+	f([]int64{1, 2, 3, 4, 6, 7, 8, 9, 9}, true)
+	f([]int64{}, true)
+	f([]int64{1}, true)
+	f([]int64{1, 2}, true)
+	f([]int64{1, 3}, true)
+	f([]int64{1, 2, 3, 4}, true)
+	f([]int64{1, 2, 3, 4, 5}, true)
+	f([]int64{1, 2, 3, 4, 6}, true)
+	f([]int64{1, 2, 3, 4, 6, 7, 8}, true)
+	f([]int64{1, 2, 3, 4, 6, 7, 8, 9}, true)
+
+	f([]int64{1, 2, 3, 4, 6, 7, 8, 9, 9, 8}, false)
+	f([]int64{-4, -3, -2, -1, 0, 1, 2, 3, 4, 6, 7, 8, 9, 9}, true)
+	f([]int64{-4, -3, -2, -1, 0, 1, 0, 2, 3, 4, 6, 7, 8, 9, 9}, false)
+}

--- a/lib/encoding/is_sorted_timing_test.go
+++ b/lib/encoding/is_sorted_timing_test.go
@@ -1,0 +1,75 @@
+package encoding
+
+import (
+	"math/rand"
+	"testing"
+)
+
+func isSortedSlow(a []int64) bool {
+	for i := range a {
+		if i > 0 && a[i] < a[i-1] {
+			return false
+		}
+	}
+	return true
+}
+
+func getDeltaData(cnt int) []int64 {
+	arr := make([]int64, cnt)
+	seed := rand.Int63n(0x7f7f7f7f7f7f7f7f)
+	for i := 0; i < cnt; i++ {
+		arr[i] = seed + int64(i)
+	}
+	return arr
+}
+
+/*
+go test -benchmem -run=^$ -bench ^BenchmarkIsInt64ArraySorted$ github.com/VictoriaMetrics/VictoriaMetrics/lib/encoding
+
+goos: linux
+goarch: amd64
+pkg: github.com/VictoriaMetrics/VictoriaMetrics/lib/encoding
+cpu: Intel(R) Xeon(R) Platinum 8260 CPU @ 2.40GHz
+=== RUN   BenchmarkIsInt64ArraySorted
+BenchmarkIsInt64ArraySorted
+BenchmarkIsInt64ArraySorted-8                100          11406021 ns/op        7354.54 MB/s           0 B/op          0 allocs/op
+
+golang version: 5134.81 MB/s
+30.18% faster
+*/
+func BenchmarkIsInt64ArraySorted(b *testing.B) {
+	cnt := 1024 * 1024 * 10
+	arr := getDeltaData(cnt)
+	b.SetBytes(int64(cnt * 8))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		ret := IsInt64ArraySorted(arr)
+		if !ret {
+			b.Fatalf("ret=%v", ret)
+		}
+	}
+}
+
+/*
+go test -benchmem -run=^$ -bench ^Benchmark_is_sorted_slow$ github.com/VictoriaMetrics/VictoriaMetrics/lib/encoding
+
+goos: linux
+goarch: amd64
+pkg: github.com/VictoriaMetrics/VictoriaMetrics/lib/encoding
+cpu: Intel(R) Xeon(R) Platinum 8260 CPU @ 2.40GHz
+=== RUN   Benchmark_is_sorted_slow
+Benchmark_is_sorted_slow
+Benchmark_is_sorted_slow-8            82          16336747 ns/op        5134.81 MB/s           0 B/op          0 allocs/op
+*/
+func Benchmark_is_sorted_slow(b *testing.B) {
+	cnt := 1024 * 1024 * 10
+	arr := getDeltaData(cnt)
+	b.SetBytes(int64(cnt * 8))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		ret := isSortedSlow(arr)
+		if !ret {
+			b.Fatalf("ret=%v", ret)
+		}
+	}
+}

--- a/lib/logstorage/block.go
+++ b/lib/logstorage/block.go
@@ -196,10 +196,12 @@ func (c *column) mustWriteTo(ch *columnHeader, sw *streamWriters) {
 func (b *block) assertValid() {
 	// Check that timestamps are in ascending order
 	timestamps := b.timestamps
-	for i := 1; i < len(timestamps); i++ {
-		if timestamps[i-1] > timestamps[i] {
-			logger.Panicf("BUG: log entries must be sorted by timestamp; got the previous entry with bigger timestamp %d than the current entry with timestamp %d",
-				timestamps[i-1], timestamps[i])
+	if !encoding.IsInt64ArraySorted(timestamps) {
+		for i := 1; i < len(timestamps); i++ {
+			if timestamps[i-1] > timestamps[i] {
+				logger.Panicf("BUG: log entries must be sorted by timestamp; got the previous entry with bigger timestamp %d than the current entry with timestamp %d",
+					timestamps[i-1], timestamps[i])
+			}
 		}
 	}
 
@@ -360,10 +362,12 @@ func canStoreInConstColumn(rows [][]Field, colIdx int) bool {
 }
 
 func assertTimestampsSorted(timestamps []int64) {
-	for i := range timestamps {
-		if i > 0 && timestamps[i-1] > timestamps[i] {
-			logger.Panicf("BUG: log entries must be sorted by timestamp; got the previous entry with bigger timestamp %d than the current entry with timestamp %d",
-				timestamps[i-1], timestamps[i])
+	if !encoding.IsInt64ArraySorted(timestamps) {
+		for i := range timestamps {
+			if i > 0 && timestamps[i-1] > timestamps[i] {
+				logger.Panicf("BUG: log entries must be sorted by timestamp; got the previous entry with bigger timestamp %d than the current entry with timestamp %d",
+					timestamps[i-1], timestamps[i])
+			}
 		}
 	}
 }


### PR DESCRIPTION
### Describe Your Changes

Add avx2 version for IsInt64ArraySorted().
30.18% faster then golang version.

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
