### PR TITLE
lib/netutil/netutil: fix strings index check

### DIFF
--- a/lib/netutil/netutil.go
+++ b/lib/netutil/netutil.go
@@ -80,7 +80,7 @@ func IsErrMissingPort(err error) bool {
 // It returns the normalized address in the form "host:port".
 // It is expected that addr is in the form "host" or "host:port".
 func NormalizeAddr(addr string, defaultPort int) (string, error) {
-	if strings.Index(addr, "/") > 0 {
+	if strings.Index(addr, "/") > -1 {
 		return "", fmt.Errorf("invalid address %q; expected format: host:port", addr)
 	}
 

--- a/lib/netutil/netutil.go
+++ b/lib/netutil/netutil.go
@@ -80,7 +80,7 @@ func IsErrMissingPort(err error) bool {
 // It returns the normalized address in the form "host:port".
 // It is expected that addr is in the form "host" or "host:port".
 func NormalizeAddr(addr string, defaultPort int) (string, error) {
-	if strings.Index(addr, "/") > -1 {
+	if strings.Contains(addr, "/") {
 		return "", fmt.Errorf("invalid address %q; expected format: host:port", addr)
 	}
 

--- a/lib/netutil/netutil_test.go
+++ b/lib/netutil/netutil_test.go
@@ -65,4 +65,5 @@ func TestNormalizeAddrError(t *testing.T) {
 	f("http://127.0.0.1:80")
 	f("http://vmstorage-0.svc.cluster.local.")
 	f("http://vmstorage-0.svc.cluster.local.:80")
+	f("/vmstorage-0.svc.cluster.local.:80")
 }


### PR DESCRIPTION


### Describe Your Changes

Properly check index returned by `strings.Index`, previously it was ignoring a case where "/" would be at the beginning of the string.

This is a follow-up for 00712b18
