### PR TITLE
apptest: Add basic backup/restore integration test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -545,7 +545,7 @@ test-full:
 test-full-386:
 	GOEXPERIMENT=synctest GOARCH=386 go test -coverprofile=coverage.txt -covermode=atomic ./lib/... ./app/...
 
-integration-test: victoria-metrics vmagent vmalert vmauth vmctl
+integration-test: victoria-metrics vmagent vmalert vmauth vmctl vmbackup vmrestore
 	go test ./apptest/... -skip="^TestCluster.*"
 
 benchmark:

--- a/apptest/testcase.go
+++ b/apptest/testcase.go
@@ -189,6 +189,36 @@ func (tc *TestCase) MustStartVmauth(instance string, flags []string, configFileY
 	return app
 }
 
+// MustStartVmbackup is a test helper that starts an instance of vmbackup
+// and waits until the app exits. It fails the test if the app fails to start or
+// exits with non zero code.
+func (tc *TestCase) MustStartVmbackup(instance, storageDataPath, snapshotCreateURL, dst string) {
+	tc.t.Helper()
+
+	if err := StartVmbackup(instance, storageDataPath, snapshotCreateURL, dst); err != nil {
+		tc.t.Fatalf("vmbackup %q failed to start or exited with non-zero code: %v", instance, err)
+	}
+
+	// Do not add the process to the list of running apps using
+	// tc.addApp(instance, app), because the method blocks until the process
+	// exits.
+}
+
+// MustStartVmrestore is a test helper that starts an instance of vmrestore
+// and waits until the app exits. It fails the test if the app fails to start or
+// exits with non zero code.
+func (tc *TestCase) MustStartVmrestore(instance, src, storageDataPath string) {
+	tc.t.Helper()
+
+	if err := StartVmrestore(instance, src, storageDataPath); err != nil {
+		tc.t.Fatalf("vmrestore %q failed to start or exited with non-zero code: %v", instance, err)
+	}
+
+	// Do not add the process to the list of running apps using
+	// tc.addApp(instance, app), because the method blocks until the process
+	// exits.
+}
+
 // MustStartDefaultCluster starts a typical cluster configuration with default
 // flags.
 func (tc *TestCase) MustStartDefaultCluster() *Vmcluster {

--- a/apptest/tests/backup_restore_test.go
+++ b/apptest/tests/backup_restore_test.go
@@ -1,0 +1,188 @@
+package tests
+
+import (
+	"fmt"
+	"path/filepath"
+	"slices"
+	"testing"
+	"time"
+
+	at "github.com/VictoriaMetrics/VictoriaMetrics/apptest"
+)
+
+type testBackupRestoreOpts struct {
+	start              func() at.PrometheusWriteQuerier
+	stop               func()
+	storageDataPaths   []string
+	snapshotCreateURLs func(at.PrometheusWriteQuerier) []string
+}
+
+func TestSingleBackupRestore(t *testing.T) {
+	tc := at.NewTestCase(t)
+	defer tc.Stop()
+
+	storageDataPath := filepath.Join(tc.Dir(), "vmsingle")
+
+	opts := testBackupRestoreOpts{
+		start: func() at.PrometheusWriteQuerier {
+			return tc.MustStartVmsingle("vmsingle", []string{
+				"-storageDataPath=" + storageDataPath,
+				"-retentionPeriod=100y",
+				"-search.maxStalenessInterval=1m",
+			})
+		},
+		stop: func() {
+			tc.StopApp("vmsingle")
+		},
+		storageDataPaths: []string{
+			storageDataPath,
+		},
+		snapshotCreateURLs: func(sut at.PrometheusWriteQuerier) []string {
+			return []string{
+				sut.(*at.Vmsingle).SnapshotCreateURL(),
+			}
+		},
+	}
+
+	testBackupRestore(tc, opts)
+}
+
+func testBackupRestore(tc *at.TestCase, opts testBackupRestoreOpts) {
+	t := tc.T()
+
+	const msecPerMinute = 60 * 1000
+	genData := func(count int, prefix string, start int64) (recs []string, wantSeries []map[string]string, wantQueryResults []*at.QueryResult) {
+		recs = make([]string, count)
+		wantSeries = make([]map[string]string, count)
+		wantQueryResults = make([]*at.QueryResult, count)
+		for i := range count {
+			name := fmt.Sprintf("%s_%03d", prefix, i)
+			value := float64(i)
+			timestamp := start + int64(i)*msecPerMinute
+
+			recs[i] = fmt.Sprintf("%s %f %d", name, value, timestamp)
+			wantSeries[i] = map[string]string{"__name__": name}
+			wantQueryResults[i] = &at.QueryResult{
+				Metric:  map[string]string{"__name__": name},
+				Samples: []*at.Sample{{Timestamp: timestamp, Value: value}},
+			}
+		}
+		return recs, wantSeries, wantQueryResults
+	}
+
+	backupBaseDir, err := filepath.Abs(filepath.Join(tc.Dir(), "backups"))
+	if err != nil {
+		t.Fatalf("could not get absolute path for the backup base dir")
+	}
+
+	// assertSeries retrieves set of all metric names from the storage and
+	// compares it with the expected set.
+	assertSeries := func(app at.PrometheusQuerier, start, end int64, want []map[string]string) {
+		t.Helper()
+
+		tc.Assert(&at.AssertOptions{
+			Msg: "unexpected /api/v1/series response",
+			Got: func() any {
+				return app.PrometheusAPIV1Series(t, `{__name__=~".*"}`, at.QueryOpts{
+					Start: fmt.Sprintf("%d", start),
+					End:   fmt.Sprintf("%d", end),
+				}).Sort()
+			},
+			Want: &at.PrometheusAPIV1SeriesResponse{
+				Status: "success",
+				Data:   want,
+			},
+			FailNow: true,
+		})
+	}
+
+	// assertSeries retrieves all data from the storage and compares it with the
+	// expected result.
+	assertQueryResults := func(app at.PrometheusQuerier, start, end int64, want []*at.QueryResult) {
+		t.Helper()
+		tc.Assert(&at.AssertOptions{
+			Msg: "unexpected /api/v1/query_range response",
+			Got: func() any {
+				return app.PrometheusAPIV1QueryRange(t, `{__name__=~".*"}`, at.QueryOpts{
+					Start: fmt.Sprintf("%d", start),
+					End:   fmt.Sprintf("%d", end),
+					Step:  "60s",
+				})
+			},
+			Want: &at.PrometheusAPIV1QueryResponse{
+				Status: "success",
+				Data: &at.QueryData{
+					ResultType: "matrix",
+					Result:     want,
+				},
+			},
+			FailNow: true,
+			// The vmsingle with pt index seems to require more retries before
+			// the ingested data becomes available for querying.
+			Retries: 100,
+		})
+	}
+
+	// Use the same number of metrics and time range for all the data ingestions
+	// below.
+	const numMetrics = 1000
+	// With 1000 metrics (one per minute), the time range spans 2 months.
+	end := time.Date(2025, 3, 1, 10, 0, 0, 0, time.UTC).UnixMilli()
+	start := end - numMetrics*msecPerMinute
+
+	// Verify backup/restore:
+	//
+	// - Start vmsingle with empty storage data dir.
+	// - Ingest first batch or records (batch1) and ensure they can be queried.
+	// - Create batch1 backup
+	// - Ingest second batch of records (batch2) and ensure the queries return
+	//   (batch1 + batch2) data.
+	// - Stop vmsingle
+	// - Restore batch1 from backup
+	// - Start vmsingle
+	// - Ensure that the queries return batch1 data only.
+
+	sut := opts.start()
+
+	batch1Data, wantBatch1Series, wantBatch1QueryResults := genData(numMetrics, "batch1", start)
+	sut.PrometheusAPIV1ImportPrometheus(t, batch1Data, at.QueryOpts{})
+	sut.ForceFlush(t)
+	assertSeries(sut, start, end, wantBatch1Series)
+	assertQueryResults(sut, start, end, wantBatch1QueryResults)
+
+	createBackup := func(sut at.PrometheusWriteQuerier, name string) {
+		for i, storageDataPath := range opts.storageDataPaths {
+			replica := fmt.Sprintf("replica-%d", i)
+			instance := fmt.Sprintf("vmbackup-%s-%s", name, replica)
+			snapshotCreateURL := opts.snapshotCreateURLs(sut)[i]
+			backupPath := "fs://" + filepath.Join(backupBaseDir, name, replica)
+			tc.MustStartVmbackup(instance, storageDataPath, snapshotCreateURL, backupPath)
+		}
+	}
+	createBackup(sut, "batch1")
+
+	batch2Data, wantBatch2Series, wantBatch2QueryResults := genData(numMetrics, "batch2", start)
+	sut.PrometheusAPIV1ImportPrometheus(t, batch2Data, at.QueryOpts{})
+	sut.ForceFlush(t)
+	wantAllSeries := slices.Concat(wantBatch1Series, wantBatch2Series)
+	assertSeries(sut, start, end, wantAllSeries)
+	wantAllQueryResults := slices.Concat(wantBatch1QueryResults, wantBatch2QueryResults)
+	assertQueryResults(sut, start, end, wantAllQueryResults)
+	createBackup(sut, "batch2")
+
+	opts.stop()
+
+	restore := func(name string) {
+		for i, storageDataPath := range opts.storageDataPaths {
+			replica := fmt.Sprintf("replica-%d", i)
+			instance := fmt.Sprintf("vmrestore-%s-%s", name, replica)
+			backupPath := "fs://" + filepath.Join(backupBaseDir, name, replica)
+			tc.MustStartVmrestore(instance, backupPath, storageDataPath)
+		}
+	}
+	restore("batch1")
+
+	sut = opts.start()
+	assertSeries(sut, start, end, wantBatch1Series)
+	assertQueryResults(sut, start, end, wantBatch1QueryResults)
+}

--- a/apptest/vmbackup.go
+++ b/apptest/vmbackup.go
@@ -1,0 +1,13 @@
+package apptest
+
+// StartVmbackup starts an instance of vmbackup with the given flags and waits
+// until it exits.
+func StartVmbackup(instance, storageDataPath, snapshotCreateURL, dst string) error {
+	flags := []string{
+		"-storageDataPath=" + storageDataPath,
+		"-snapshot.createURL=" + snapshotCreateURL,
+		"-dst=" + dst,
+	}
+	_, _, err := startApp(instance, "../../bin/vmbackup", flags, &appOptions{wait: true})
+	return err
+}

--- a/apptest/vmrestore.go
+++ b/apptest/vmrestore.go
@@ -1,0 +1,12 @@
+package apptest
+
+// StartVmrestore starts an instance of vmrestore with the given flags and waits
+// until it exits.
+func StartVmrestore(instance, src, storageDataPath string) error {
+	flags := []string{
+		"-src=" + src,
+		"-storageDataPath=" + storageDataPath,
+	}
+	_, _, err := startApp(instance, "../../bin/vmrestore", flags, &appOptions{wait: true})
+	return err
+}

--- a/apptest/vmsingle.go
+++ b/apptest/vmsingle.go
@@ -363,8 +363,7 @@ func (app *Vmsingle) APIV1AdminStatusMetricNamesStatsReset(t *testing.T, opts Qu
 func (app *Vmsingle) SnapshotCreate(t *testing.T) *SnapshotCreateResponse {
 	t.Helper()
 
-	queryURL := fmt.Sprintf("http://%s/snapshot/create", app.httpListenAddr)
-	data, statusCode := app.cli.Post(t, queryURL, "", nil)
+	data, statusCode := app.cli.Post(t, app.SnapshotCreateURL(), "", nil)
 	if got, want := statusCode, http.StatusOK; got != want {
 		t.Fatalf("unexpected status code: got %d, want %d, resp text=%q", got, want, data)
 	}
@@ -375,6 +374,11 @@ func (app *Vmsingle) SnapshotCreate(t *testing.T) *SnapshotCreateResponse {
 	}
 
 	return &res
+}
+
+// SnapshotCreateURL returns the URL for creating snapshots.
+func (app *Vmsingle) SnapshotCreateURL() string {
+	return fmt.Sprintf("http://%s/snapshot/create", app.httpListenAddr)
 }
 
 // APIV1AdminTSDBSnapshot creates a database snapshot by sending a query to the
@@ -463,11 +467,6 @@ func (app *Vmsingle) SnapshotDeleteAll(t *testing.T) *SnapshotDeleteAllResponse 
 	}
 
 	return &res
-}
-
-// SnapshotCreateURL returns the URL for creating snapshots.
-func (app *Vmsingle) SnapshotCreateURL() string {
-	return fmt.Sprintf("http://%s/snapshot/create", app.httpListenAddr)
 }
 
 // APIV1StatusTSDB sends a query to a /prometheus/api/v1/status/tsdb

--- a/apptest/vmsingle.go
+++ b/apptest/vmsingle.go
@@ -465,6 +465,11 @@ func (app *Vmsingle) SnapshotDeleteAll(t *testing.T) *SnapshotDeleteAllResponse 
 	return &res
 }
 
+// SnapshotCreateURL returns the URL for creating snapshots.
+func (app *Vmsingle) SnapshotCreateURL() string {
+	return fmt.Sprintf("http://%s/snapshot/create", app.httpListenAddr)
+}
+
 // APIV1StatusTSDB sends a query to a /prometheus/api/v1/status/tsdb
 // //
 // See https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#tsdb-stats

--- a/apptest/vmstorage.go
+++ b/apptest/vmstorage.go
@@ -99,8 +99,7 @@ func (app *Vmstorage) ForceMerge(t *testing.T) {
 func (app *Vmstorage) SnapshotCreate(t *testing.T) *SnapshotCreateResponse {
 	t.Helper()
 
-	queryURL := fmt.Sprintf("http://%s/snapshot/create", app.httpListenAddr)
-	data, statusCode := app.cli.Post(t, queryURL, "", nil)
+	data, statusCode := app.cli.Post(t, app.SnapshotCreateURL(), "", nil)
 	if got, want := statusCode, http.StatusOK; got != want {
 		t.Fatalf("unexpected status code: got %d, want %d, resp text=%q", got, want, data)
 	}
@@ -111,6 +110,11 @@ func (app *Vmstorage) SnapshotCreate(t *testing.T) *SnapshotCreateResponse {
 	}
 
 	return &res
+}
+
+// SnapshotCreateURL returns the URL for creating snapshots.
+func (app *Vmstorage) SnapshotCreateURL() string {
+	return fmt.Sprintf("http://%s/snapshot/create", app.httpListenAddr)
 }
 
 // SnapshotList lists existing database snapshots by sending a query to the


### PR DESCRIPTION
### Describe Your Changes

This PR adds a basic backup/restore test for vmsingle and vmcluster. A more sophisticated was originally added to the partition index PR (#8134) and was aimed to test backup/restore when switching back and forth between legacy and partition index. During the code review it was decided that it would be good to have a separate test as well since legacy code will be removed in future and so will the test.

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
