### PR TITLE
.github/workflows: allow codecov to report without failing CI build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -91,6 +91,7 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           files: ./coverage.txt
+          fail_ci_if_error: false
 
   integration-test:
     name: integration-test


### PR DESCRIPTION
### Describe Your Changes

Currently, some PRs have a failed CI due to low code coverage reported by Codecov. However, the team typically ignore this and relies on other quality indicators such as thorough code reviews.

This change configures Codecov to continue posting coverage reports without marking the build as failed.

It also helps reduce confusion for external contributors, who might otherwise feel pressured to add unnecessary tests just to satisfy Codecov requirements (for example https://github.com/VictoriaMetrics/VictoriaMetrics/pull/9002#discussion_r2111651046).

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
