### PR TITLE
issue-7599: implement conversion legacy global idb <-> partitioned idb

### DIFF
--- a/lib/storage/filenames.go
+++ b/lib/storage/filenames.go
@@ -8,8 +8,9 @@ const (
 	partsFilename      = "parts.json"
 	metadataFilename   = "metadata.json"
 
-	appliedRetentionFilename    = "appliedRetention.txt"
-	resetCacheOnStartupFilename = "reset_cache_on_startup"
+	appliedRetentionFilename      = "appliedRetention.txt"
+	resetCacheOnStartupFilename   = "reset_cache_on_startup"
+	migrateIndexOnStartupFilename = "migrate_index_on_startup"
 )
 
 const (

--- a/lib/storage/index_db_legacy.go
+++ b/lib/storage/index_db_legacy.go
@@ -1,13 +1,11 @@
 package storage
 
 import (
-	"fmt"
 	"math"
 	"path/filepath"
 	"strconv"
 	"sync/atomic"
 
-	"github.com/VictoriaMetrics/VictoriaMetrics/lib/encoding"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/logger"
 )
 
@@ -32,45 +30,11 @@ func mustOpenLegacyIndexDBReadOnly(path string, s *Storage) *indexDB {
 	return mustOpenIndexDB(id, tr, name, path, s, &alwaysReadOnly)
 }
 
-// appendTo scans through all index db items and appends them to the given dstIdbs:
-//   - global index items go to all dstIdbs.
-//   - per-day - only to dstIdbs covering this particular day.
-func (db *indexDB) appendTo(dstIdbs []*indexDB) error {
-	// FIXME: measure/optimize performance if this function is used for real indexDBs
-	is := db.getIndexSearch(noDeadline)
-	defer db.putIndexSearch(is)
-
-	ts := is.ts
-	ts.Seek(nil)
-	for ts.NextItem() {
-		item := ts.Item
-		switch item[0] {
-		case nsPrefixDateToMetricID, nsPrefixDateTagToMetricIDs, nsPrefixDateMetricNameToTSID:
-			date := encoding.UnmarshalUint64(item[1:])
-			for _, dstIdb := range dstIdbs {
-				minDate, maxDate := dstIdb.tr.DateRange()
-				if minDate <= date && maxDate >= date {
-					dstIdb.tb.AddItems([][]byte{item})
-				}
-			}
-
-		default:
-			for _, dstIdb := range dstIdbs {
-				dstIdb.tb.AddItems([][]byte{item})
-			}
-		}
-	}
-
-	if err := ts.Error(); err != nil {
-		return fmt.Errorf("could not append indexDB %q: %w", db.name, err)
-	}
-
-	// FIXME: ugly, but we need to reload all added deleted metric IDs
+// mustAppendSnapshotTo takes snapshot of current idb and add hardlinks to all parts to dstIdbs.
+func (db *indexDB) mustAppendSnapshotTo(dstIdbs []*indexDB) {
 	for _, dstIdb := range dstIdbs {
-		dstIdb.tb.DebugFlush()
+		db.tb.MustAppendSnapshotTo(dstIdb.tb)
 		dstIdb.loadDeletedMetricIDs()
 		dstIdb.invalidateTagFiltersCache()
 	}
-
-	return nil
 }

--- a/lib/storage/index_db_legacy.go
+++ b/lib/storage/index_db_legacy.go
@@ -1,11 +1,13 @@
 package storage
 
 import (
+	"fmt"
 	"math"
 	"path/filepath"
 	"strconv"
 	"sync/atomic"
 
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/encoding"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/logger"
 )
 
@@ -28,4 +30,47 @@ func mustOpenLegacyIndexDBReadOnly(path string, s *Storage) *indexDB {
 	var alwaysReadOnly atomic.Bool
 	alwaysReadOnly.Store(true)
 	return mustOpenIndexDB(id, tr, name, path, s, &alwaysReadOnly)
+}
+
+// appendTo scans through all index db items and appends them to the given dstIdbs:
+//   - global index items go to all dstIdbs.
+//   - per-day - only to dstIdbs covering this particular day.
+func (db *indexDB) appendTo(dstIdbs []*indexDB) error {
+	// FIXME: measure/optimize performance if this function is used for real indexDBs
+	is := db.getIndexSearch(noDeadline)
+	defer db.putIndexSearch(is)
+
+	ts := is.ts
+	ts.Seek(nil)
+	for ts.NextItem() {
+		item := ts.Item
+		switch item[0] {
+		case nsPrefixDateToMetricID, nsPrefixDateTagToMetricIDs, nsPrefixDateMetricNameToTSID:
+			date := encoding.UnmarshalUint64(item[1:])
+			for _, dstIdb := range dstIdbs {
+				minDate, maxDate := dstIdb.tr.DateRange()
+				if minDate <= date && maxDate >= date {
+					dstIdb.tb.AddItems([][]byte{item})
+				}
+			}
+
+		default:
+			for _, dstIdb := range dstIdbs {
+				dstIdb.tb.AddItems([][]byte{item})
+			}
+		}
+	}
+
+	if err := ts.Error(); err != nil {
+		return fmt.Errorf("could not append indexDB %q: %w", db.name, err)
+	}
+
+	// FIXME: ugly, but we need to reload all added deleted metric IDs
+	for _, dstIdb := range dstIdbs {
+		dstIdb.tb.DebugFlush()
+		dstIdb.loadDeletedMetricIDs()
+		dstIdb.invalidateTagFiltersCache()
+	}
+
+	return nil
 }

--- a/lib/storage/storage.go
+++ b/lib/storage/storage.go
@@ -278,6 +278,12 @@ func MustOpenStorage(path string, opts OpenOptions) *Storage {
 	tb := mustOpenTable(tablePath, s)
 	s.tb = tb
 
+	// Migrate legacy indexes if needed once the storage is initialized.
+	if path := filepath.Join(legacyIDBPath, migrateIndexOnStartupFilename); fs.IsPathExist(path) {
+		s.migrateLegacyIndexes()
+		fs.MustRemoveAll(path)
+	}
+
 	// Load nextDayMetricIDs cache after the data table is opened since it
 	// requires the table to operate properly.
 	// Load prevHourMetricIDs, currHourMetricIDs, and nextDayMetricIDs caches

--- a/lib/storage/storage_legacy.go
+++ b/lib/storage/storage_legacy.go
@@ -1,6 +1,11 @@
 package storage
 
-import "time"
+import (
+	"math"
+	"time"
+
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/logger"
+)
 
 func (s *Storage) hasLegacyIndexDBs() bool {
 	return s.legacyIDBPrev.Load() != nil || s.legacyIDBCurr.Load() != nil
@@ -45,4 +50,28 @@ func (s *Storage) legacyMustRotateIndexDB(currentTime time.Time) {
 	// Update nextRotationTimestamp
 	nextRotationTimestamp := currentTime.Unix() + s.retentionMsecs/1000
 	s.legacyNextRotationTimestamp.Store(nextRotationTimestamp)
+}
+
+// migrateLegacyIndexes will create hardlinks to the legacy IndexDB parts and add them to all current partitioned IndexDBs
+func (s *Storage) migrateLegacyIndexes() {
+	idbs := s.tb.GetIndexDBs(TimeRange{MinTimestamp: 0, MaxTimestamp: math.MaxInt64})
+	defer s.tb.PutIndexDBs(idbs)
+
+	idbsNames := make([]string, 0, len(idbs))
+	for _, idb := range idbs {
+		idbsNames = append(idbsNames, idb.name)
+	}
+
+	for {
+		idbPrev := s.legacyIDBPrev.Load()
+		if idbPrev == nil {
+			break
+		}
+
+		logger.Infof("Migrating legacy indexDB %s to partitioned indexes %v", idbPrev.name, idbsNames)
+		idbPrev.mustAppendSnapshotTo(idbs)
+		s.legacyMustRotateIndexDB(time.Now())
+	}
+
+	s.legacyDeletedMetricIDs = nil
 }

--- a/lib/storage/storage_legacy_test.go
+++ b/lib/storage/storage_legacy_test.go
@@ -864,10 +864,7 @@ func testStorageConvertToLegacy(t *testing.T) {
 	})
 
 	for _, idb := range idbs {
-		err := idb.appendTo([]*indexDB{legacyIDBCurr})
-		if err != nil {
-			t.Fatalf("could not convert indexDBs to legacy: %v", err)
-		}
+		idb.mustAppendSnapshotTo([]*indexDB{legacyIDBCurr})
 	}
 
 	s.tb.PutIndexDBs(idbs)

--- a/lib/storage/time.go
+++ b/lib/storage/time.go
@@ -110,6 +110,12 @@ func (tr *TimeRange) overlapsWith(v TimeRange) bool {
 	return tr.MinTimestamp <= v.MaxTimestamp && tr.MaxTimestamp >= v.MinTimestamp
 }
 
+// overlapsWith returns true if the time range contains given day.
+func (tr *TimeRange) hasDay(date uint64) bool {
+	ts := int64(date) * msecPerDay
+	return tr.MinTimestamp <= ts && tr.MaxTimestamp >= ts
+}
+
 const msecPerDay = 24 * 3600 * 1000
 
 const msecPerHour = 3600 * 1000


### PR DESCRIPTION
### Describe Your Changes

Conversion could be used in 3 scenarios:
1) Tests (only global/only partitioned/mixed indexes). The current conversion code doesn't cover all cases (e.g. deleted metric ids) and is too slow to run on real indexes.
2) As opt-in migration to get rid of the legacy index earlier (for those who don't want to wait 2*retention periods) in order to
   - save disk
   - reduce the chances of compatibility bugs in the future
3) Mandatory conversion before final deletion of compatibility code, since we have no control over when clients upgraded to the partitioned version of the index and their settings for the retention period.  

I intentionally write the most basic version of the conversion to show the idea.  If you are ok with usages 2 & 3, we could add some benchmarks and optimize the code. 

### Checklist

The following checks are **mandatory**:

- [ ] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
