### PR TITLE
.github/workflows: allow codecov to report without failing CI build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -91,7 +91,6 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           files: ./coverage.txt
-          fail_ci_if_error: false
 
   integration-test:
     name: integration-test

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,9 @@
+# see https://docs.codecov.com/docs/common-recipe-list#set-non-blocking-status-checks
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true


### PR DESCRIPTION
### Describe Your Changes

The `fail_ci_if_error` flag only affects the upload step and does not control
Codecov's status checks (e.g., codecov/patch, codecov/project). My prior tests
did not surface this behavior.

Switched to 'informational' mode per Codecov docs to avoid blocking CI. See:
https://docs.codecov.com/docs/common-recipe-list#set-non-blocking-status-checks

Follow up on 
https://github.com/VictoriaMetrics/VictoriaMetrics/pull/9139, https://github.com/VictoriaMetrics/VictoriaMetrics/pull/9139/commits/52022e482c3acf455ef5ce24cfadb888d484b1cb
### Checklist

The following checks are **mandatory**:

- [ ] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
