### PR TITLE
deployment/docker/victorialogs: fixed journald ignore filters in example

### DIFF
--- a/deployment/docker/victorialogs/compose-base.yml
+++ b/deployment/docker/victorialogs/compose-base.yml
@@ -8,7 +8,7 @@ services:
       - -syslog.listenAddr.tcp=0.0.0.0:8094
       - -datadog.streamFields=service,hostname,ddsource
       - -journald.streamFields=_HOSTNAME,_SYSTEMD_UNIT,_PID
-      - -journald.ignoreFields=MESSAGE_ID,INVOCATION_ID,USER_INVOCATION_ID,
+      - -journald.ignoreFields=MESSAGE_ID,INVOCATION_ID,USER_INVOCATION_ID
       - -journald.ignoreFields=_BOOT_ID,_MACHINE_ID,_SYSTEMD_INVOCATION_ID,_STREAM_ID,_UID
     deploy:
       replicas: 0


### PR DESCRIPTION
### Describe Your Changes

removed trailing comma in ignoreFields, which led to _msg field removal, since it is converted to empty string before filtering

### Checklist

The following checks are **mandatory**:

- [ ] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
