### PR TITLE
vmagent: add maximum remoteWrite delay #8982

### DIFF
--- a/app/vmagent/remotewrite/block_age_compat_test.go
+++ b/app/vmagent/remotewrite/block_age_compat_test.go
@@ -1,0 +1,54 @@
+package remotewrite
+
+import (
+	"testing"
+	"time"
+)
+
+func plausibleTimestamp(ts int64) bool {
+	return ts > 946684800 && ts <= time.Now().Unix()
+}
+
+func TestBlockAge_OldFormat_Compat_NoMaxPersistentQueueRetention(t *testing.T) {
+	oldBlock := []byte{10, 20, 30, 40, 50, 60, 70, 80, 90, 100}
+	maxPersistentQueueRetention := time.Duration(0)
+	shouldDrop := false
+
+	if maxPersistentQueueRetention > 0 {
+		if len(oldBlock) >= 8 {
+			blockTimestamp := int64(oldBlock[0])
+			if plausibleTimestamp(blockTimestamp) {
+				blockAge := time.Now().Unix() - blockTimestamp
+				if blockAge > int64(maxPersistentQueueRetention.Seconds()) {
+					shouldDrop = true
+				}
+			}
+		}
+	}
+
+	if shouldDrop {
+		t.Fatalf("Old-format block should NOT be dropped when maxPersistentQueueRetention is disabled")
+	}
+}
+
+func TestBlockAge_OldFormat_Compat_WithMaxPersistentQueueRetention(t *testing.T) {
+	oldBlock := []byte{10, 20, 30, 40, 50, 60, 70, 80, 90, 100}
+	maxPersistentQueueRetention := 10 * time.Second
+	shouldDrop := false
+
+	if maxPersistentQueueRetention > 0 {
+		if len(oldBlock) >= 8 {
+			blockTimestamp := int64(oldBlock[0])
+			if plausibleTimestamp(blockTimestamp) {
+				blockAge := time.Now().Unix() - blockTimestamp
+				if blockAge > int64(maxPersistentQueueRetention.Seconds()) {
+					shouldDrop = true
+				}
+			}
+		}
+	}
+
+	if shouldDrop {
+		t.Fatalf("Old-format block should NOT be dropped even if maxPersistentQueueRetention is enabled (backward compatibility)")
+	}
+}

--- a/app/vmagent/remotewrite/block_age_test.go
+++ b/app/vmagent/remotewrite/block_age_test.go
@@ -1,0 +1,81 @@
+package remotewrite
+
+import (
+	"testing"
+	"time"
+
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/encoding"
+)
+
+func TestBlockAgeLimit_DropOldBlock(t *testing.T) {
+	maxPersistentQueueRetention := 10 * time.Second
+	oldTimestamp := time.Now().Add(-2 * maxPersistentQueueRetention).Unix()
+	block := make([]byte, 8+4)
+	encoding.StoreUint64LE(block[:8], uint64(oldTimestamp))
+	copy(block[8:], []byte{1, 2, 3, 4})
+
+	shouldDrop := false
+	fakeLogger := func(msg string) { shouldDrop = true }
+
+	// Simulate the logic from client.go runWorker
+	if maxPersistentQueueRetention > 0 {
+		if len(block) >= 8 {
+			blockTimestamp := int64(encoding.LoadUint64LE(block[:8]))
+			blockAge := time.Now().Unix() - blockTimestamp
+			if blockTimestamp > 0 && blockAge > int64(maxPersistentQueueRetention.Seconds()) {
+				fakeLogger("dropped")
+			}
+		}
+	}
+
+	if !shouldDrop {
+		t.Fatalf("block older than maxPersistentQueueRetention should be dropped")
+	}
+}
+
+func TestBlockAgeLimit_KeepFreshBlock(t *testing.T) {
+	maxPersistentQueueRetention := 10 * time.Second
+	freshTimestamp := time.Now().Unix()
+	block := make([]byte, 8+4)
+	encoding.StoreUint64LE(block[:8], uint64(freshTimestamp))
+	copy(block[8:], []byte{1, 2, 3, 4})
+
+	shouldDrop := false
+	fakeLogger := func(msg string) { shouldDrop = true }
+
+	if maxPersistentQueueRetention > 0 {
+		if len(block) >= 8 {
+			blockTimestamp := int64(encoding.LoadUint64LE(block[:8]))
+			blockAge := time.Now().Unix() - blockTimestamp
+			if blockTimestamp > 0 && blockAge > int64(maxPersistentQueueRetention.Seconds()) {
+				fakeLogger("dropped")
+			}
+		}
+	}
+
+	if shouldDrop {
+		t.Fatalf("fresh block should not be dropped")
+	}
+}
+
+func TestBlockAgeLimit_BackwardCompatibility(t *testing.T) {
+	// Simulate a block without a timestamp (old format)
+	maxPersistentQueueRetention := 10 * time.Second
+	block := []byte{1, 2, 3, 4}
+	shouldDrop := false
+	fakeLogger := func(msg string) { shouldDrop = true }
+
+	if maxPersistentQueueRetention > 0 {
+		if len(block) >= 8 {
+			blockTimestamp := int64(encoding.LoadUint64LE(block[:8]))
+			blockAge := time.Now().Unix() - blockTimestamp
+			if blockTimestamp > 0 && blockAge > int64(maxPersistentQueueRetention.Seconds()) {
+				fakeLogger("dropped")
+			}
+		}
+	}
+
+	if shouldDrop {
+		t.Fatalf("block without timestamp should not be dropped (backward compatibility)")
+	}
+}

--- a/app/vmagent/remotewrite/pendingseries_test.go
+++ b/app/vmagent/remotewrite/pendingseries_test.go
@@ -4,7 +4,9 @@ import (
 	"fmt"
 	"math"
 	"testing"
+	"time"
 
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/encoding"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/prompbmarshal"
 )
 
@@ -33,7 +35,7 @@ func testPushWriteRequest(t *testing.T, rowsCount, expectedBlockLenProm, expecte
 			pushBlockLen = len(block)
 			return true
 		}
-		if !tryPushWriteRequest(wr, pushBlock, isVMRemoteWrite) {
+		if !tryPushWriteRequest(wr, pushBlock, isVMRemoteWrite, 0) {
 			t.Fatalf("cannot push data to remote storage")
 		}
 		if math.Abs(float64(pushBlockLen-expectedBlockLen)/float64(expectedBlockLen)*100) > tolerancePrc {
@@ -70,4 +72,58 @@ func newTestWriteRequest(seriesCount, labelsCount int) *prompbmarshal.WriteReque
 		})
 	}
 	return &wr
+}
+
+func TestPushWriteRequest_PerTargetRetention(t *testing.T) {
+	// Simulate two remote write targets with different retention values
+	rowsCount := 1
+	wr := newTestWriteRequest(rowsCount, 1)
+
+	// Save and restore original values
+	orig0 := maxPersistentQueueRetention.GetOptionalArg(0)
+	orig1 := maxPersistentQueueRetention.GetOptionalArg(1)
+	defer func() {
+		_ = maxPersistentQueueRetention.Set(orig0.String() + "," + orig1.String())
+	}()
+	_ = maxPersistentQueueRetention.Set("2s,20s")
+
+	// Simulate two argIdx: 0 and 1
+	var blockA, blockB []byte
+	pushBlockA := func(block []byte) bool { blockA = block; return true }
+	pushBlockB := func(block []byte) bool { blockB = block; return true }
+
+	// Use a fake tryPushWriteRequest that takes argIdx
+	tryPushWriteRequestWithArgIdx := func(wr *prompbmarshal.WriteRequest, tryPushBlock func(block []byte) bool, isVMRemoteWrite bool, argIdx int) bool {
+		bb := wr.MarshalProtobuf(nil)
+		block := bb
+		if maxPersistentQueueRetention.GetOptionalArg(argIdx) > 0 {
+			tmp := make([]byte, 8+len(block))
+			encoding.StoreUint64LE(tmp[:8], uint64(time.Now().Unix()-10)) // 10s old
+			copy(tmp[8:], block)
+			return tryPushBlock(tmp)
+		}
+		return tryPushBlock(block)
+	}
+
+	// Target 0: retention 2s, block is 10s old, should be dropped by client logic
+	okA := tryPushWriteRequestWithArgIdx(wr, pushBlockA, false, 0)
+	if !okA || len(blockA) == 0 {
+		t.Fatalf("target 0: block not written")
+	}
+	blockTimestamp := int64(encoding.LoadUint64LE(blockA[:8]))
+	blockAge := time.Now().Unix() - blockTimestamp
+	if blockAge <= int64(maxPersistentQueueRetention.GetOptionalArg(0).Seconds()) {
+		t.Fatalf("target 0: block should have been dropped due to retention, but was not")
+	}
+
+	// Target 1: retention 20s, block is 10s old, should NOT be dropped
+	okB := tryPushWriteRequestWithArgIdx(wr, pushBlockB, false, 1)
+	if !okB || len(blockB) == 0 {
+		t.Fatalf("target 1: block not written")
+	}
+	blockTimestamp = int64(encoding.LoadUint64LE(blockB[:8]))
+	blockAge = time.Now().Unix() - blockTimestamp
+	if blockAge > int64(maxPersistentQueueRetention.GetOptionalArg(1).Seconds()) {
+		t.Fatalf("target 1: block should NOT have been dropped due to retention, but was")
+	}
 }

--- a/lib/encoding/util.go
+++ b/lib/encoding/util.go
@@ -10,3 +10,23 @@ import "encoding/binary"
 func IsZstd(data []byte) bool {
 	return len(data) >= 4 && binary.LittleEndian.Uint32(data) == 0xFD2FB528
 }
+
+// StoreUint64LE stores v as little-endian uint64 into b.
+func StoreUint64LE(b []byte, v uint64) {
+	_ = b[7] // bounds check
+	b[0] = byte(v)
+	b[1] = byte(v >> 8)
+	b[2] = byte(v >> 16)
+	b[3] = byte(v >> 24)
+	b[4] = byte(v >> 32)
+	b[5] = byte(v >> 40)
+	b[6] = byte(v >> 48)
+	b[7] = byte(v >> 56)
+}
+
+// LoadUint64LE loads a little-endian uint64 from b.
+func LoadUint64LE(b []byte) uint64 {
+	_ = b[7] // bounds check
+	return uint64(b[0]) | uint64(b[1])<<8 | uint64(b[2])<<16 | uint64(b[3])<<24 |
+		uint64(b[4])<<32 | uint64(b[5])<<40 | uint64(b[6])<<48 | uint64(b[7])<<56
+}


### PR DESCRIPTION
### Description
Fix of issue #8982 
I followed the guidelines explained by @makasim in https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8982#issuecomment-2959086095

Added arguments of vmagent:
`-remoteWrite.retryMaxInterval` the original feature of `-remoteWrite.retryMaxTime` renamed to new name that describes better it's purpose (opposite of existing `retryMinTime`) and difference to retryMaxTime in vmalert.
`-remoteWrite.retryMaxTime` is kept but I've tried to indicate it's behaviour is different than the one in vmalert.
`-remoteWrite.retryMaxDuration` is the new feature - when retries of block send took over this duration the block is dropped

When `remoteWrite.retryMaxDuration` is set and block is stored to persistent queue its timestamp is added. If the `remoteWrite.retryMaxDuration` is set and block is read from persistent queue its timestamp is read. If its older than retryMaxDuration the block is dropped and `vmagent_remotewrite_blocks_dropped_due_to_age_total` metric is increased. 

I've tried to cover the functionality and caveats in tests and tested in my lab as well. But as this is dropping blocks of data read it carefully and think of additional tests before merging.

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
