### PR TITLE
app/vmui/logs: improve usability of the live tailing tab

### DIFF
--- a/app/vmui/packages/vmui/src/components/LogsConfigurators/GroupLogsConfigurators/GroupLogsConfigurators.tsx
+++ b/app/vmui/packages/vmui/src/components/LogsConfigurators/GroupLogsConfigurators/GroupLogsConfigurators.tsx
@@ -19,8 +19,8 @@ import {
   LOGS_URL_PARAMS,
   WITHOUT_GROUPING
 } from "../../../constants/logs";
-import { getFromStorage, saveToStorage } from "../../../utils/storage";
 import LogParsingSwitches from "../../Configurators/LogsSettings/LogParsingSwitches";
+import { useLocalStorageBoolean } from "../../../hooks/useLocalStorageBoolean";
 
 const {
   GROUP_BY,
@@ -48,7 +48,7 @@ const GroupLogsConfigurators: FC<Props> = ({ logs }) => {
   const [dateFormat, setDateFormat] = useState(searchParams.get(DATE_FORMAT) || LOGS_DATE_FORMAT);
   const [errorFormat, setErrorFormat] = useState("");
 
-  const [disabledHovers, setDisabledHovers] = useState(!!getFromStorage("LOGS_DISABLED_HOVERS"));
+  const [disabledHovers, handleSetDisabledHovers] = useLocalStorageBoolean("LOGS_DISABLED_HOVERS");
 
   const isGroupChanged = groupBy !== LOGS_GROUP_BY;
   const isDisplayFieldsChanged = displayFields.length !== 1 || displayFields[0] !== LOGS_DISPLAY_FIELDS;
@@ -115,11 +115,6 @@ const GroupLogsConfigurators: FC<Props> = ({ logs }) => {
     }
     setSearchParams(searchParams);
     handleClose();
-  };
-
-  const handleSetDisabledHovers = (value: boolean) => {
-    setDisabledHovers(value);
-    saveToStorage("LOGS_DISABLED_HOVERS", value);
   };
 
   const tooltipContent = () => {

--- a/app/vmui/packages/vmui/src/components/Main/Icons/index.tsx
+++ b/app/vmui/packages/vmui/src/components/Main/Icons/index.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { getCssVariable } from "../../../utils/theme";
 
 export const LogoIcon = () => (
@@ -641,5 +640,19 @@ export const PauseIcon = () => (
     fill="currentColor"
   >
     <path d="M6 19h4V5H6v14zm8-14v14h4V5h-4z" />
+  </svg>
+);
+
+export const ScrollToTopIcon = () => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="currentColor"
+  >
+    <path
+      d="M8 12l4-4 4 4m-4-4v12"
+      strokeWidth="2"
+      stroke="currentColor"
+      fill="none"
+    />
   </svg>
 );

--- a/app/vmui/packages/vmui/src/components/ScrollToTopButton/ScrollToTopButton.tsx
+++ b/app/vmui/packages/vmui/src/components/ScrollToTopButton/ScrollToTopButton.tsx
@@ -1,0 +1,59 @@
+import { FC, useEffect, useState } from "preact/compat";
+import Button from "../Main/Button/Button";
+import Tooltip from "../Main/Tooltip/Tooltip";
+import { ScrollToTopIcon } from "../Main/Icons";
+import classNames from "classnames";
+import "./style.scss";
+import { useCallback } from "react";
+
+interface ScrollToTopButtonProps {
+  className?: string;
+}
+
+const ScrollToTopButton: FC<ScrollToTopButtonProps> = ({ className }) => {
+  const [isVisible, setIsVisible] = useState(false);
+
+  const checkScrollPosition = () => {
+    const scrollPosition = window.pageYOffset || document.documentElement.scrollTop;
+    const visibleHeightThreshold = window.innerHeight;
+
+    setIsVisible(scrollPosition > visibleHeightThreshold);
+  };
+
+  const scrollToTop = useCallback(() => {
+    window.scrollTo({
+      top: 0,
+      behavior: "smooth"
+    });
+  }, []);
+
+  useEffect(() => {
+    window.addEventListener("scroll", checkScrollPosition);
+    checkScrollPosition();
+    
+    return () => {
+      window.removeEventListener("scroll", checkScrollPosition);
+    };
+  }, []);
+
+  return (
+    <div
+      className={classNames({
+        "vm-scroll-to-top-button": true,
+        "vm-scroll-to-top-button_visible": isVisible
+      }, className)}
+    >
+      <Tooltip title="Scroll to top">
+        <Button
+          variant="contained"
+          color="primary"
+          onClick={scrollToTop}
+          ariaLabel="Scroll to top"
+          startIcon={<ScrollToTopIcon />}
+        />
+      </Tooltip>
+    </div>
+  );
+};
+
+export default ScrollToTopButton;

--- a/app/vmui/packages/vmui/src/components/ScrollToTopButton/style.scss
+++ b/app/vmui/packages/vmui/src/components/ScrollToTopButton/style.scss
@@ -1,0 +1,26 @@
+@use "src/styles/variables" as *;
+
+.vm-scroll-to-top-button {
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  z-index: 4;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.3s, visibility 0.3s;
+
+  &_visible {
+    opacity: 1;
+    visibility: visible;
+  }
+
+  .vm-button {
+    border-radius: 50%;
+    width: 40px;
+    height: 40px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.2);
+  }
+}

--- a/app/vmui/packages/vmui/src/hooks/useLocalStorageBoolean.test.ts
+++ b/app/vmui/packages/vmui/src/hooks/useLocalStorageBoolean.test.ts
@@ -1,0 +1,70 @@
+import { act, renderHook } from "@testing-library/preact";
+import { useLocalStorageBoolean } from "./useLocalStorageBoolean";
+import * as storageUtils from "../utils/storage";
+import { Mock } from "vitest";
+import { StorageKeys } from "../utils/storage";
+
+vi.mock("../utils/storage");
+
+const testStorageKey = "TEST_STORAGE_KEY" as StorageKeys;
+
+describe("useLocalStorageBoolean", () => {
+  const { getFromStorage, saveToStorage } = storageUtils;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("initializes with the value from localStorage", () => {
+    const mockGetFromStorage = getFromStorage as Mock;
+    mockGetFromStorage.mockReturnValueOnce(true);
+
+    const { result } = renderHook(() => useLocalStorageBoolean(testStorageKey));
+
+    expect(result.current[0]).toBe(true);
+    expect(getFromStorage).toHaveBeenCalledWith(testStorageKey);
+  });
+
+  it("updates localStorage and state when setter is called", () => {
+    const mockGetFromStorage = getFromStorage as Mock;
+    mockGetFromStorage.mockReturnValueOnce(false);
+
+    const { result } = renderHook(() => useLocalStorageBoolean(testStorageKey));
+
+    act(() => {
+      result.current[1](true);
+    });
+
+    expect(saveToStorage).toHaveBeenCalledWith(testStorageKey, true);
+    expect(result.current[0]).toBe(false);
+  });
+
+  it("reacts to changes in localStorage by storage events", () => {
+    const mockGetFromStorage = getFromStorage as Mock;
+    mockGetFromStorage.mockReturnValueOnce(false);
+
+    const { result } = renderHook(() => useLocalStorageBoolean(testStorageKey));
+
+    // Simulate a storage event
+    act(() => {
+      mockGetFromStorage.mockReturnValueOnce(true);
+      window.dispatchEvent(new StorageEvent("storage", { key: testStorageKey, newValue: "true" }));
+    });
+
+    expect(result.current[0]).toBe(true);
+  });
+
+  it("does not update state if the localStorage value remains the same", () => {
+    const mockGetFromStorage = getFromStorage as Mock;
+    mockGetFromStorage.mockReturnValueOnce(false);
+
+    const { result } = renderHook(() => useLocalStorageBoolean(testStorageKey));
+
+    act(() => {
+      mockGetFromStorage.mockReturnValueOnce(false);
+      window.dispatchEvent(new StorageEvent("storage", { key: testStorageKey, newValue: "false" }));
+    });
+
+    expect(result.current[0]).toBe(false);
+  });
+});

--- a/app/vmui/packages/vmui/src/hooks/useLocalStorageBoolean.ts
+++ b/app/vmui/packages/vmui/src/hooks/useLocalStorageBoolean.ts
@@ -1,0 +1,31 @@
+import { useMemo, useState } from "preact/compat";
+import { getFromStorage, saveToStorage, StorageKeys } from "../utils/storage";
+import useEventListener from "./useEventListener";
+import { useCallback } from "react";
+
+/**
+ * A custom hook that synchronizes a boolean state with a value stored in localStorage.
+ *
+ * @param {StorageKeys} key - The key used to access the corresponding value in localStorage.
+ * @returns {[boolean, function]} A tuple containing the current boolean value from localStorage and a setter function to update the value in localStorage.
+ *
+ * The hook listens to the "storage" event to automatically update the state when the localStorage value changes.
+ */
+export const useLocalStorageBoolean = (key: StorageKeys): [boolean, (value: boolean) => void] => {
+  const [value, setValue] = useState(!!getFromStorage(key));
+
+  const handleUpdateStorage = useCallback(() => {
+    const newValue = !!getFromStorage(key);
+    if (newValue !== value) {
+      setValue(newValue);
+    }
+  }, [key, value]);
+
+  const setNewValue = useCallback((newValue: boolean) => {
+    saveToStorage(key, newValue);
+  }, [key]);
+
+  useEventListener("storage", handleUpdateStorage);
+
+  return useMemo(() => [value, setNewValue], [value, setNewValue]);
+};

--- a/app/vmui/packages/vmui/src/pages/ExploreLogs/ExploreLogsBody/views/LiveTailingView/LiveTailingSettings.tsx
+++ b/app/vmui/packages/vmui/src/pages/ExploreLogs/ExploreLogsBody/views/LiveTailingView/LiveTailingSettings.tsx
@@ -19,8 +19,8 @@ interface LiveTailingSettingsProps {
   handleResumeLiveTailing: () => void;
   pauseLiveTailing: () => void;
   clearLogs: () => void;
-  isCompactTailingNumber: boolean;
-  handleSetCompactTailing: (value: boolean) => void;
+  isRawJsonView: boolean;
+  onRawJsonViewChange: (value: boolean) => void;
 }
 
 const LiveTailingSettings: FC<LiveTailingSettingsProps> = ({
@@ -32,8 +32,8 @@ const LiveTailingSettings: FC<LiveTailingSettingsProps> = ({
   handleResumeLiveTailing,
   pauseLiveTailing,
   clearLogs,
-  isCompactTailingNumber,
-  handleSetCompactTailing
+  isRawJsonView,
+  onRawJsonViewChange
 }) => {
   const settingButtonRef = useRef<HTMLDivElement>(null);
   const { value: isSettingsOpen, setFalse: closeSettings, setTrue: openSettings } = useBoolean(false);
@@ -106,12 +106,12 @@ const LiveTailingSettings: FC<LiveTailingSettingsProps> = ({
           <div className="vm-live-tailing-view__settings-modal">
             <div className={"vm-live-tailing-view__settings-modal-item"}>
               <Switch
-                label={"Expandable Properties View"}
-                value={isCompactTailingNumber}
-                onChange={handleSetCompactTailing}
+                label={"Raw JSON View"}
+                value={isRawJsonView}
+                onChange={onRawJsonViewChange}
               />
               <span className="vm-group-logs-configurator-item__info">
-                Switches log display to expandable properties view with additional visualization settings. Please note: when processing large volumes of data, it may increase system response time.
+                When this option is enabled, logs will be displayed in raw JSON format. This improves performance and uses less CPU and memory.
               </span>
             </div>
           </div>

--- a/app/vmui/packages/vmui/src/pages/ExploreLogs/ExploreLogsBody/views/LiveTailingView/LiveTailingView.tsx
+++ b/app/vmui/packages/vmui/src/pages/ExploreLogs/ExploreLogsBody/views/LiveTailingView/LiveTailingView.tsx
@@ -12,11 +12,13 @@ import GroupLogsItem from "../../../GroupLogs/GroupLogsItem";
 import LiveTailingSettings from "./LiveTailingSettings";
 import Alert from "../../../../../components/Main/Alert/Alert";
 import { isDecreasing } from "../../../../../utils/array";
+import { useLocalStorageBoolean } from "../../../../../hooks/useLocalStorageBoolean";
+import ScrollToTopButton from "../../../../../components/ScrollToTopButton/ScrollToTopButton";
 
 const SCROLL_THRESHOLD = 100;
 const scrollToBottom = () => window.scrollTo({
   top: document.documentElement.scrollHeight,
-  behavior: "instant"
+  behavior: "smooth"
 });
 const throttledScrollToBottom = throttle(scrollToBottom, 200);
 
@@ -28,8 +30,7 @@ const LiveTailingView: FC<ViewProps> = ({ settingsRef }) => {
   const { setSearchParamsFromKeys } = useSearchParamsFromObject();
   const [rowsPerPage, setRowsPerPage] = useStateSearchParams(100, "rows_per_page");
   const [query, _setQuery] = useStateSearchParams("*", "query");
-  const [isCompactTailingStr] = useStateSearchParams(0, "compact_tailing");
-  const isCompactTailingNumber = Boolean(Number(isCompactTailingStr));
+  const [isRawJsonView, setIsRawJsonView] = useLocalStorageBoolean("RAW_JSON_LIVE_VIEW");
   const {
     logs,
     isPaused,
@@ -53,10 +54,6 @@ const LiveTailingView: FC<ViewProps> = ({ settingsRef }) => {
   const handleSetRowsPerPage = useCallback((limit: number) => {
     setSearchParamsFromKeys({ rows_per_page: limit });
   }, [setRowsPerPage, setSearchParamsFromKeys]);
-
-  const handleSetCompactTailing = useCallback((value: boolean) => {
-    setSearchParamsFromKeys({ compact_tailing: Number(value) });
-  }, [setSearchParamsFromKeys]);
 
   useEffect(() => {
     startLiveTailing();
@@ -111,9 +108,10 @@ const LiveTailingView: FC<ViewProps> = ({ settingsRef }) => {
         handleResumeLiveTailing={handleResumeLiveTailing}
         pauseLiveTailing={pauseLiveTailing}
         clearLogs={clearLogs}
-        isCompactTailingNumber={isCompactTailingNumber}
-        handleSetCompactTailing={handleSetCompactTailing}
+        isRawJsonView={isRawJsonView}
+        onRawJsonViewChange={setIsRawJsonView}
       />
+      <ScrollToTopButton />
       <div
         ref={containerRef}
         className="vm-live-tailing-view__container"
@@ -122,28 +120,31 @@ const LiveTailingView: FC<ViewProps> = ({ settingsRef }) => {
           ? (<div className="vm-live-tailing-view__empty">Waiting for logs...</div>)
           : (<div className="vm-live-tailing-view__logs">
             {logs.map(({ _log_id, ...log }, idx) =>
-              isCompactTailingNumber
-                ? (
-                  <GroupLogsItem
-                    key={_log_id}
-                    log={log}
-                    onItemClick={pauseLiveTailing}
-                    hideGroupButton={true}
-                    displayFields={displayFields}
-                  />
-                ) : (
-                  <pre
-                    key={idx}
-                    className="vm-live-tailing-view__log-row"
-                  >
-                    {JSON.stringify(log)}
-                  </pre>
-                )
+              isRawJsonView ? (
+                <pre
+                  key={idx}
+                  className="vm-live-tailing-view__log-row"
+                  onMouseDown={pauseLiveTailing}
+                >
+                  {JSON.stringify(log)}
+                </pre>
+              ) : (
+                <GroupLogsItem
+                  key={_log_id}
+                  log={log}
+                  onItemClick={pauseLiveTailing}
+                  hideGroupButton={true}
+                  displayFields={displayFields}
+                />
+              )
             )}
           </div>
           )}
       </div>
-      {isLimitedLogsPerUpdate && (<Alert variant="warning">Too many logs per second detected. Large volumes of log data are difficult to process and may impact performance. We recommend adding filters to your query for better analysis and system performance.</Alert>)}
+      {isLimitedLogsPerUpdate && (
+        <Alert variant="warning">Too many logs per second detected. Large volumes of log data are difficult to process
+          and may impact performance. We recommend adding filters to your query for better analysis and system
+          performance.</Alert>)}
     </>
   );
 };

--- a/app/vmui/packages/vmui/src/pages/ExploreLogs/ExploreLogsBody/views/LiveTailingView/style.scss
+++ b/app/vmui/packages/vmui/src/pages/ExploreLogs/ExploreLogsBody/views/LiveTailingView/style.scss
@@ -34,9 +34,10 @@
     width: 100%;
     height: 100%;
     overflow: auto;
-    min-height: 200px;
+    min-height: calc(100vh - 120px);
     font-family: $font-family-monospace;
     padding-bottom: $padding-medium;
+    transition: min-height 0.3s ease;
   }
 
   &__empty {

--- a/app/vmui/packages/vmui/src/pages/ExploreLogs/ExploreLogsBody/views/LiveTailingView/useLiveTailingLogs.ts
+++ b/app/vmui/packages/vmui/src/pages/ExploreLogs/ExploreLogsBody/views/LiveTailingView/useLiveTailingLogs.ts
@@ -4,19 +4,8 @@ import { Logs } from "../../../../../api/types";
 import { useAppState } from "../../../../../state/common/StateContext";
 import useBoolean from "../../../../../hooks/useBoolean";
 import { useTenant } from "../../../../../hooks/useTenant";
+import { LogFlowAnalyzer } from "./utils";
 
-/**
- * Defines the maximum number of consecutive times logs can be fetched above the threshold
- * before showing a warning notification, and vice versa:
- * - If logs are fetched above a threshold this many times in a row -> show warning
- * - If warning is shown, it won't disappear until logs are fetched below a threshold
- *   this many times in a row
- *
- * This threshold helps optimize log display performance when dealing with large volumes of logs.
- * If the threshold is consistently exceeded, users will be prompted to add filters to their query
- * for better system performance and more focused log analysis.
- */
-const MAX_ATTEMPTS_FETCH_LOGS_PER_SECOND = 5;
 /**
  * Defines the log's threshold, after which will be shown a warning notification
  */
@@ -64,31 +53,6 @@ const createStreamProcessor = (
   };
 };
 
-const updateLimitModeTracking = (
-  linesCount: number,
-  attemptsFetchLimitRef: React.MutableRefObject<number>,
-  attemptsFetchLowRef: React.MutableRefObject<number>,
-  isLimitedLogsPerUpdate: boolean,
-) => {
-  if (linesCount > LOGS_THRESHOLD) {
-    attemptsFetchLimitRef.current++;
-    attemptsFetchLowRef.current = 0;
-  } else {
-    attemptsFetchLowRef.current++;
-    attemptsFetchLimitRef.current = 0;
-  }
-
-  if (attemptsFetchLimitRef.current > MAX_ATTEMPTS_FETCH_LOGS_PER_SECOND) {
-    return true;
-  }
-
-  if (attemptsFetchLowRef.current > MAX_ATTEMPTS_FETCH_LOGS_PER_SECOND) {
-    return false;
-  }
-
-  return isLimitedLogsPerUpdate;
-};
-
 const parseLogLines = (lines: string[], counterRef: React.MutableRefObject<bigint>): Logs[] => {
   return lines
     .map(line => {
@@ -108,27 +72,22 @@ interface ProcessBufferedLogsParams {
   lines: string[];
   limit: number;
   counterRef: React.MutableRefObject<bigint>;
-  attemptsFetchLimitRef: React.MutableRefObject<number>;
-  attemptsFetchLowRef: React.MutableRefObject<number>;
   setIsLimitedLogsPerUpdate: (isLimited: boolean) => void;
   setLogs: React.Dispatch<React.SetStateAction<Logs[]>>;
   bufferLinesRef: React.MutableRefObject<string[]>;
-  isLimitedLogsPerUpdate: boolean;
+  logFlowAnalyzerRef?: React.MutableRefObject<LogFlowAnalyzer>;
 }
 
 const processBufferedLogs = ({
   lines,
   limit,
   counterRef,
-  attemptsFetchLimitRef,
-  attemptsFetchLowRef,
   setIsLimitedLogsPerUpdate,
   setLogs,
   bufferLinesRef,
-  isLimitedLogsPerUpdate
+  logFlowAnalyzerRef
 }: ProcessBufferedLogsParams) => {
-
-  const isLimitLogsMode = updateLimitModeTracking(lines.length, attemptsFetchLimitRef, attemptsFetchLowRef, isLimitedLogsPerUpdate);
+  const isLimitLogsMode = logFlowAnalyzerRef?.current?.update(lines.length) === "high";
   const limitedLines = isLimitLogsMode && lines.length > LOGS_THRESHOLD ? lines.slice(-LOGS_THRESHOLD) : lines;
   const newLogs = parseLogLines(limitedLines, counterRef);
 
@@ -155,8 +114,7 @@ export const useLiveTailingLogs = (query: string, limit: number) => {
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const bufferRef = useRef<string>("");
   const bufferLinesRef = useRef<string[]>([]);
-  const attemptsFetchLimitLogsPerSecondCountRef = useRef<number>(0);
-  const attemptsFetchLowLogsPerSecondCountRef = useRef<number>(0);
+  const logFlowAnalyzerRef = useRef(new LogFlowAnalyzer());
 
   const stopLiveTailing = useCallback(() => {
     if (readerRef.current) {
@@ -239,12 +197,10 @@ export const useLiveTailingLogs = (query: string, limit: number) => {
         lines,
         limit,
         counterRef,
-        attemptsFetchLimitRef: attemptsFetchLimitLogsPerSecondCountRef,
-        attemptsFetchLowRef: attemptsFetchLowLogsPerSecondCountRef,
         setIsLimitedLogsPerUpdate,
-        isLimitedLogsPerUpdate,
         setLogs,
-        bufferLinesRef
+        bufferLinesRef,
+        logFlowAnalyzerRef
       });
     }, PROCESSING_INTERVAL_MS);
 

--- a/app/vmui/packages/vmui/src/pages/ExploreLogs/ExploreLogsBody/views/LiveTailingView/utils.ts
+++ b/app/vmui/packages/vmui/src/pages/ExploreLogs/ExploreLogsBody/views/LiveTailingView/utils.ts
@@ -1,0 +1,45 @@
+export class LogFlowAnalyzer {
+  private threshold: number;
+  private windowSize: number;
+  private minHighCount: number;
+  private minNormalCount: number;
+  private window: number[];
+  private state: "normal" | "high";
+
+  /**
+   * @param {number} threshold - The threshold value used for state evaluation. Defaults to 200.
+   * @param {number} windowSize - The size of the window used for tracking data. Defaults to 10.
+   * @param {number} minHighCount - The minimum number of high occurrences needed for state transition. Defaults to 6.
+   * @param {number} minNormalCount - The minimum number of normal occurrences needed for state reset. Defaults to 2.
+   * @return {void}
+   */
+  constructor(threshold: number = 200, windowSize: number = 10, minHighCount: number = 6, minNormalCount: number = 2) {
+    this.threshold = threshold;
+    this.windowSize = windowSize;
+    this.minHighCount = minHighCount;
+    this.minNormalCount = minNormalCount;
+    this.window = [];
+    this.state = "normal";
+  }
+
+  update(logCount: number): "normal" | "high" {
+    this.window.push(logCount);
+    if (this.window.length > this.windowSize) {
+      this.window.shift();
+    }
+
+    const highCount = this.window.filter((x) => x > this.threshold).length;
+
+    if (this.state === "normal") {
+      if (highCount >= this.minHighCount) {
+        this.state = "high";
+      }
+    } else if (this.state === "high") {
+      if (highCount < this.minNormalCount) {
+        this.state = "normal";
+      }
+    }
+
+    return this.state;
+  }
+}

--- a/app/vmui/packages/vmui/src/pages/ExploreLogs/GroupLogs/GroupLogsFields.tsx
+++ b/app/vmui/packages/vmui/src/pages/ExploreLogs/GroupLogs/GroupLogsFields.tsx
@@ -1,10 +1,9 @@
-import React, { FC, useMemo, useState } from "preact/compat";
+import { FC, useMemo } from "preact/compat";
 import { Logs } from "../../../api/types";
 import "./style.scss";
 import classNames from "classnames";
 import GroupLogsFieldRow from "./GroupLogsFieldRow";
-import useEventListener from "../../../hooks/useEventListener";
-import { getFromStorage } from "../../../utils/storage";
+import { useLocalStorageBoolean } from "../../../hooks/useLocalStorageBoolean";
 
 interface Props {
   log: Logs;
@@ -17,16 +16,7 @@ const GroupLogsFields: FC<Props> = ({ log, hideGroupButton }) => {
       .sort(([aKey], [bKey]) => aKey.localeCompare(bKey));
   }, [log]);
 
-  const [disabledHovers, setDisabledHovers] = useState(!!getFromStorage("LOGS_DISABLED_HOVERS"));
-
-  const handleUpdateStage = () => {
-    const newValDisabledHovers = !!getFromStorage("LOGS_DISABLED_HOVERS");
-    if (newValDisabledHovers !== disabledHovers) {
-      setDisabledHovers(newValDisabledHovers);
-    }
-  };
-
-  useEventListener("storage", handleUpdateStage);
+  const [disabledHovers] = useLocalStorageBoolean("LOGS_DISABLED_HOVERS");
 
   return (
     <div

--- a/app/vmui/packages/vmui/src/pages/ExploreLogs/GroupLogs/GroupLogsItem.tsx
+++ b/app/vmui/packages/vmui/src/pages/ExploreLogs/GroupLogs/GroupLogsItem.tsx
@@ -1,8 +1,8 @@
-import React, { FC, memo, useMemo, useState } from "preact/compat";
+import React, { FC, memo, useMemo } from "preact/compat";
 import { Logs } from "../../../api/types";
 import "./style.scss";
 import useBoolean from "../../../hooks/useBoolean";
-import { ArrowDownIcon } from "../../../components/Main/Icons";
+import { ArrowDownIcon, CopyIcon } from "../../../components/Main/Icons";
 import classNames from "classnames";
 import { useLogsState } from "../../../state/logsPanel/LogsStateContext";
 import dayjs from "dayjs";
@@ -10,10 +10,13 @@ import { useTimeState } from "../../../state/time/TimeStateContext";
 import { marked } from "marked";
 import { useSearchParams } from "react-router-dom";
 import { LOGS_DATE_FORMAT, LOGS_URL_PARAMS } from "../../../constants/logs";
-import useEventListener from "../../../hooks/useEventListener";
-import { getFromStorage } from "../../../utils/storage";
 import { parseAnsiToHtml } from "../../../utils/ansiParser";
 import GroupLogsFields from "./GroupLogsFields";
+import { useLocalStorageBoolean } from "../../../hooks/useLocalStorageBoolean";
+import Button from "../../../components/Main/Button/Button";
+import Tooltip from "../../../components/Main/Tooltip/Tooltip";
+import { useCallback, useEffect, useState } from "react";
+import useCopyToClipboard from "../../../hooks/useCopyToClipboard";
 
 interface Props {
   log: Logs;
@@ -27,6 +30,8 @@ const GroupLogsItem: FC<Props> = ({ log, displayFields = ["_msg"], onItemClick, 
     value: isOpenFields,
     toggle: toggleOpenFields,
   } = useBoolean(false);
+  const [copied, setCopied] = useState<boolean>(false);
+  const copyToClipboard = useCopyToClipboard();
 
   const [searchParams] = useSearchParams();
   const { markdownParsing, ansiParsing } = useLogsState();
@@ -68,21 +73,29 @@ const GroupLogsItem: FC<Props> = ({ log, displayFields = ["_msg"], onItemClick, 
     return values;
   }, [log, hasFields, displayFields, ansiParsing]);
 
-  const [disabledHovers, setDisabledHovers] = useState(!!getFromStorage("LOGS_DISABLED_HOVERS"));
-
-  const handleUpdateStage = () => {
-    const newValDisabledHovers = !!getFromStorage("LOGS_DISABLED_HOVERS");
-    if (newValDisabledHovers !== disabledHovers) {
-      setDisabledHovers(newValDisabledHovers);
-    }
-  };
+  const [disabledHovers] = useLocalStorageBoolean("LOGS_DISABLED_HOVERS");
 
   const handleClick = () => {
     toggleOpenFields();
     onItemClick?.(log);
   };
 
-  useEventListener("storage", handleUpdateStage);
+  const handleCopy = useCallback(async (e: Event) => {
+    e.stopPropagation();
+    if (copied) return;
+    try {
+      await copyToClipboard(JSON.stringify(log, null, 2));
+      setCopied(true);
+    } catch (e) {
+      console.error(e);
+    }
+  }, [copied, copyToClipboard]);
+
+  useEffect(() => {
+    if (copied === null) return;
+    const timeout = setTimeout(() => setCopied(false), 2000);
+    return () => clearTimeout(timeout);
+  }, [copied]);
 
   return (
     <div className="vm-group-logs-row">
@@ -93,6 +106,17 @@ const GroupLogsItem: FC<Props> = ({ log, displayFields = ["_msg"], onItemClick, 
         })}
         onClick={handleClick}
       >
+        <Tooltip title={copied ? "Copied" : "Copy to clipboard"}>
+          <Button
+            className="vm-group-logs-row-content__copy-row"
+            variant="text"
+            color="gray"
+            size="small"
+            startIcon={<CopyIcon/>}
+            onClick={handleCopy}
+            ariaLabel="copy to clipboard"
+          />
+        </Tooltip>
         {hasFields && (
           <div
             className={classNames({

--- a/app/vmui/packages/vmui/src/pages/ExploreLogs/GroupLogs/style.scss
+++ b/app/vmui/packages/vmui/src/pages/ExploreLogs/GroupLogs/style.scss
@@ -132,7 +132,7 @@ $font-size-logs: var(--font-size-logs, $font-size-small);
 
     &-content {
       display: flex;
-      padding: 2px 0;
+      padding: 2px 24px 2px 0;
       cursor: pointer;
 
       &_interactive {
@@ -140,8 +140,23 @@ $font-size-logs: var(--font-size-logs, $font-size-small);
         will-change: background-color;
       }
 
+      &__copy-row {
+        position: absolute;
+        top: 0;
+        right: 0;
+        z-index: 1;
+        visibility: hidden;
+
+        &.vm-button {
+          padding: 2px;
+        }
+      }
+
       &_interactive:hover {
         background-color: $color-hover-black;
+        .vm-group-logs-row-content__copy-row {
+          visibility: visible;
+        }
       }
 
       &__arrow {

--- a/app/vmui/packages/vmui/src/utils/storage.ts
+++ b/app/vmui/packages/vmui/src/utils/storage.ts
@@ -19,6 +19,7 @@ export type StorageKeys = "AUTOCOMPLETE"
   | "LOGS_QUERY_HISTORY"
   | "METRICS_QUERY_HISTORY"
   | "SERVER_URL"
+  | "RAW_JSON_LIVE_VIEW"
   | DeprecatedStorageKeys;
 
 


### PR DESCRIPTION
### Describe Your Changes

Related issue: #9130 

 - add `ScrollToTopButton` component for better navigation UX and integrate it into Live Tailing view;
 
<img width="1293" alt="image" src="https://github.com/user-attachments/assets/98a96ac8-fe2b-43fa-a470-a51f68df2e01" />

 - replace log throttling logic with the new `LogFlowAnalyzer` utility for enhanced performance state tracking;
 - enhance `GroupLogsItem` with a copy-to-clipboard feature, which allows to copy only one log object; 
 
<img width="1268" alt="image" src="https://github.com/user-attachments/assets/c42ad5e1-0d02-456e-b231-d42064f48eb4" />

 - update styles for better responsiveness and aesthetics;
 - change raw json view into expandable view in the live tailing tab by default and keep the value of this setting in the local storage, it became possible thanks to [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/9130#9083).
  
<img width="554" alt="image" src="https://github.com/user-attachments/assets/6bcda0f1-dd2f-4608-8e0d-f9c0bc6efac3" />



Short demo: 

https://github.com/user-attachments/assets/351133a7-f3ef-41ad-b23d-cc12f030a357


### Checklist

The following checks are **mandatory**:

- [ ] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
