### PR TITLE
app/logstorage: optimize pipes after appending limit pipe

### DIFF
--- a/lib/logstorage/parser.go
+++ b/lib/logstorage/parser.go
@@ -587,6 +587,7 @@ func (q *Query) AddPipeLimit(n uint64) {
 	q.pipes = append(q.pipes, &pipeLimit{
 		limit: n,
 	})
+	q.optimize()
 }
 
 // optimize applies various optimations to q.


### PR DESCRIPTION
### Describe Your Changes

This PR adds a call to optimize pipes after the `limit` pipe has been appended.

Related: #9200

While this approach is not ideal, since it forces us to re-optimize all pipes, but it is simpler.

An alternative would be to reapply only the relevant optimizations specifically for this case, something like:

```go
func (q *Query) AddPipeLimit(n uint64) {
	if len(q.pipes) > 0 {
		ps, ok := q.pipes[len(q.pipes)-1].(*pipeSort)
		if ok {
			if ps.limit == 0 || n < ps.limit {
				ps.limit = n
			}
			return
		}
		pu, ok := q.pipes[len(q.pipes)-1].(*pipeUniq)
		if ok {
			if pu.limit == 0 || n < pu.limit {
				pu.limit = n
			}
			return
		}
	}
	q.pipes = append(q.pipes, &pipeLimit{
		limit: n,
	})
}
```

### Checklist

The following checks are **mandatory**:

- [X] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
