### PR TITLE
deployment/docker/victorialogs: Fix container name to fluentbit-oltp

### DIFF
--- a/deployment/docker/victorialogs/fluentbit/otlp/compose.yml
+++ b/deployment/docker/victorialogs/fluentbit/otlp/compose.yml
@@ -1,3 +1,3 @@
 include:
  - ../compose-base.yml
-name: fluentbit-loki
+name: fluentbit-oltp


### PR DESCRIPTION
### Describe Your Changes

The container name for oltp has the same name as the loki container.  Fixed.

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
