### PR TITLE
lib/logstorage: properly iterate over ForEachRow

### DIFF
--- a/lib/logstorage/log_rows.go
+++ b/lib/logstorage/log_rows.go
@@ -238,6 +238,9 @@ func (lr *LogRows) ForEachRow(callback func(streamHash uint64, r *InsertRow)) {
 
 		callback(streamHash, r)
 	}
+	// remove reference to logRows fields
+	// since reset of r can modify actual LogRows
+	r.Fields = nil
 	PutInsertRow(r)
 }
 


### PR DESCRIPTION
 Previously, ForEachRow always reset last row fields after iteration.
It makes impossible concurrent iteration with forEachRow, since ForEachRow performed hidden mutation of LogRows.

 This commit resolves this issue by removal of fields reference.

Related to https://github.com/VictoriaMetrics/VictoriaMetrics/issues/9076