### PR TITLE
app/vlinsert/journald: fix stream parsing and -maxConcurrentInserts

### DIFF
--- a/app/vlinsert/journald/journald.go
+++ b/app/vlinsert/journald/journald.go
@@ -174,7 +174,6 @@ func processStreamInternal(streamName string, r io.Reader, lmp insertutil.LogMes
 
 	for {
 		err := readJournaldLogEntry(streamName, lr, lmp, cp)
-		wcr.DecConcurrency()
 		if err != nil {
 			if errors.Is(err, io.EOF) {
 				return nil
@@ -296,7 +295,7 @@ func readJournaldLogEntry(streamName string, lr *insertutil.LineReader, lmp inse
 				fb.value = append(fb.value, lr.Line...)
 				fb.value = append(fb.value, '\n')
 			}
-			value = bytesutil.ToUnsafeString(fb.value[8 : len(fb.value)-1])
+			value = bytesutil.ToUnsafeString(fb.value[8 : 8+size])
 			if uint64(len(value)) != size {
 				return fmt.Errorf("unexpected %q value size; got %d bytes; want %d bytes; value: %q", fb.name, len(value), size, value)
 			}


### PR DESCRIPTION
### Describe Your Changes

This commit (63dccea9324037aad110cb6b7da023f0bd6a3e84) is broken. It breaks both line parsing and -maxConcurrentInserts . This PR fixes both.

Before:
```
2025-06-19T03:23:55.137Z        warn    app/vlinsert/journald/journald.go:148   remoteAddr: "127.0.0.1:62656"; requestURI: /insert/journald/upload; cannot read journald protocol data: remoteAddr="127.0.0.1:62656", requestURI="/insert/journald/upload": unexpected "_SELINUX_CONTEXT" value size; got 10 bytes; want 11 bytes; value: "unconfined"
```
with -maxConcurrentInserts=1
<img width="1800" alt="Screenshot 2025-06-19 at 05 40 31" src="https://github.com/user-attachments/assets/a2aee2c9-4d15-4278-b46f-9873789a4f7a" />

After:

<img width="1800" alt="Screenshot 2025-06-19 at 05 41 33" src="https://github.com/user-attachments/assets/d962470a-3cd8-4e53-ac73-d8a434006184" />



### Checklist

The following checks are **mandatory**:

- [ ] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
