### PR TITLE
apptest: update tests model by removing Prometheus prefix

### DIFF
--- a/apptest/testcase.go
+++ b/apptest/testcase.go
@@ -309,8 +309,8 @@ func (tc *TestCase) StopApp(instance string) {
 	}
 }
 
-// StopPrometheusWriteQuerier stop all apps that are a part of the pwq.
-func (tc *TestCase) StopPrometheusWriteQuerier(pwq WriteQuerier) {
+// StopWriteQuerier stop all apps that are a part of the pwq.
+func (tc *TestCase) StopWriteQuerier(pwq WriteQuerier) {
 	tc.t.Helper()
 	switch t := pwq.(type) {
 	case *Vmsingle:

--- a/apptest/testcase.go
+++ b/apptest/testcase.go
@@ -146,7 +146,7 @@ func (tc *TestCase) MustStartVmagent(instance string, flags []string, promScrape
 // Vmcluster represents a typical cluster setup: several vmstorage replicas, one
 // vminsert, and one vmselect.
 //
-// Both Vmsingle and Vmcluster implement the PrometheusWriteQuerier used in
+// Both Vmsingle and Vmcluster implement the WriteQuerier used in
 // business logic tests to abstract out the infrasture.
 //
 // This type is not suitable for infrastructure tests where custom cluster
@@ -310,7 +310,7 @@ func (tc *TestCase) StopApp(instance string) {
 }
 
 // StopPrometheusWriteQuerier stop all apps that are a part of the pwq.
-func (tc *TestCase) StopPrometheusWriteQuerier(pwq PrometheusWriteQuerier) {
+func (tc *TestCase) StopPrometheusWriteQuerier(pwq WriteQuerier) {
 	tc.t.Helper()
 	switch t := pwq.(type) {
 	case *Vmsingle:

--- a/apptest/tests/export_import_test.go
+++ b/apptest/tests/export_import_test.go
@@ -33,9 +33,9 @@ func TestClusterExportImportNative(t *testing.T) {
 
 // testExportImportNative test export and import in VictoriaMetrics’ native format.
 // see: https://docs.victoriametrics.com/#how-to-import-data-in-native-format
-func testExportImportNative(t *testing.T, sut at.PrometheusWriteQuerier) {
+func testExportImportNative(t *testing.T, sut at.WriteQuerier) {
 	// create test data
-	sut.PrometheusAPIV1ImportPrometheus(t, []string{
+	sut.APIV1ImportPrometheus(t, []string{
 		`native_export_import 10 1707123456700`, // 2024-02-05T08:57:36.700Z
 	}, at.QueryOpts{
 		ExtraLabels: []string{"el1=elv1", "el2=elv2"},
@@ -43,27 +43,27 @@ func testExportImportNative(t *testing.T, sut at.PrometheusWriteQuerier) {
 	sut.ForceFlush(t)
 
 	// export test data via native export API
-	exportResult := sut.PrometheusAPIV1ExportNative(t, "native_export_import", at.QueryOpts{
+	exportResult := sut.APIV1ExportNative(t, "native_export_import", at.QueryOpts{
 		Start: "2024-02-05T08:50:00.700Z",
 		End:   "2024-02-05T09:00:00.700Z",
 	})
 
 	// re-import test data via native import API
-	sut.PrometheusAPIV1ImportNative(t, exportResult, at.QueryOpts{})
+	sut.APIV1ImportNative(t, exportResult, at.QueryOpts{})
 	sut.ForceFlush(t)
 
 	// check query result
-	got := sut.PrometheusAPIV1QueryRange(t, "native_export_import", at.QueryOpts{
+	got := sut.APIV1QueryRange(t, "native_export_import", at.QueryOpts{
 		Start: "2024-02-05T08:57:36.700Z",
 		End:   "2024-02-05T08:57:36.700Z",
 		Step:  "60s",
 	})
 
 	cmpOptions := []cmp.Option{
-		cmpopts.IgnoreFields(at.PrometheusAPIV1QueryResponse{}, "Status", "Data.ResultType"),
+		cmpopts.IgnoreFields(at.APIV1QueryResponse{}, "Status", "Data.ResultType"),
 		cmpopts.EquateNaNs(),
 	}
-	want := at.NewPrometheusAPIV1QueryResponse(t, `{"data": {"result": [{"metric": {"__name__": "native_export_import", "el1": "elv1", "el2":"elv2"}, "values": []}]}}`)
+	want := at.NewAPIV1QueryResponse(t, `{"data": {"result": [{"metric": {"__name__": "native_export_import", "el1": "elv1", "el2":"elv2"}, "values": []}]}}`)
 	want.Data.Result[0].Samples = []*at.Sample{
 		at.NewSample(t, "2024-02-05T08:57:36.700Z", 10),
 	}

--- a/apptest/tests/ingestprotocols_test.go
+++ b/apptest/tests/ingestprotocols_test.go
@@ -22,7 +22,7 @@ func TestSingleIngestionProtocols(t *testing.T) {
 		wantMetrics []map[string]string
 		wantSamples []*at.Sample
 	}
-	f := func(sut at.PrometheusQuerier, opts *opts) {
+	f := func(sut at.APIQuerier, opts *opts) {
 		t.Helper()
 		wantResult := []*at.QueryResult{}
 		for idx, wm := range opts.wantMetrics {
@@ -35,16 +35,16 @@ func TestSingleIngestionProtocols(t *testing.T) {
 		tc.Assert(&at.AssertOptions{
 			Msg: "unexpected /export query response",
 			Got: func() any {
-				got := sut.PrometheusAPIV1Export(t, opts.query, at.QueryOpts{
+				got := sut.APIV1Export(t, opts.query, at.QueryOpts{
 					Start: "2024-02-05T08:50:00.700Z",
 					End:   "2024-02-05T09:00:00.700Z",
 				})
 				got.Sort()
 				return got
 			},
-			Want: &at.PrometheusAPIV1QueryResponse{Data: &at.QueryData{Result: wantResult}},
+			Want: &at.APIV1QueryResponse{Data: &at.QueryData{Result: wantResult}},
 			CmpOpts: []cmp.Option{
-				cmpopts.IgnoreFields(at.PrometheusAPIV1QueryResponse{}, "Status", "Data.ResultType"),
+				cmpopts.IgnoreFields(at.APIV1QueryResponse{}, "Status", "Data.ResultType"),
 			},
 		})
 	}
@@ -109,7 +109,7 @@ func TestSingleIngestionProtocols(t *testing.T) {
 	})
 
 	// CSV import
-	sut.PrometheusAPIV1ImportCSV(t, []string{
+	sut.APIV1ImportCSV(t, []string{
 		`GOOG,1.23,4.56,NYSE,1707123457`,
 		`MSFT,23,56,NASDAQ,1707123457`,
 	}, at.QueryOpts{
@@ -158,7 +158,7 @@ func TestSingleIngestionProtocols(t *testing.T) {
 	})
 
 	// prometheus text exposition format
-	sut.PrometheusAPIV1ImportPrometheus(t, []string{
+	sut.APIV1ImportPrometheus(t, []string{
 		`importprometheus_series 10 1707123456700`,                               // 2024-02-05T08:57:36.700Z
 		`importprometheus_series2{label="foo",label1="value1"} 20 1707123456800`, // 2024-02-05T08:57:36.800Z
 	}, at.QueryOpts{
@@ -227,7 +227,7 @@ func TestSingleIngestionProtocols(t *testing.T) {
 			},
 		},
 	}
-	sut.PrometheusAPIV1Write(t, pbData, at.QueryOpts{})
+	sut.APIV1Write(t, pbData, at.QueryOpts{})
 	sut.ForceFlush(t)
 	f(sut, &opts{
 		query: `{__name__=~"prometheusrw.+"}`,
@@ -282,22 +282,22 @@ func TestClusterIngestionProtocols(t *testing.T) {
 		tc.Assert(&at.AssertOptions{
 			Msg: "unexpected /export query response",
 			Got: func() any {
-				got := vmselect.PrometheusAPIV1Export(t, opts.query, at.QueryOpts{
+				got := vmselect.APIV1Export(t, opts.query, at.QueryOpts{
 					Start: "2024-02-05T08:50:00.700Z",
 					End:   "2024-02-05T09:00:00.700Z",
 				})
 				got.Sort()
 				return got
 			},
-			Want: &at.PrometheusAPIV1QueryResponse{Data: &at.QueryData{Result: wantResult}},
+			Want: &at.APIV1QueryResponse{Data: &at.QueryData{Result: wantResult}},
 			CmpOpts: []cmp.Option{
-				cmpopts.IgnoreFields(at.PrometheusAPIV1QueryResponse{}, "Status", "Data.ResultType"),
+				cmpopts.IgnoreFields(at.APIV1QueryResponse{}, "Status", "Data.ResultType"),
 			},
 		})
 	}
 
 	// prometheus text exposition format
-	vminsert.PrometheusAPIV1ImportPrometheus(t, []string{
+	vminsert.APIV1ImportPrometheus(t, []string{
 		`importprometheus_series 10 1707123456700`,                               // 2024-02-05T08:57:36.700Z
 		`importprometheus_series2{label="foo",label1="value1"} 20 1707123456800`, // 2024-02-05T08:57:36.800Z
 	}, at.QueryOpts{
@@ -358,7 +358,7 @@ func TestClusterIngestionProtocols(t *testing.T) {
 	})
 
 	// CSV import
-	vminsert.PrometheusAPIV1ImportCSV(t, []string{
+	vminsert.APIV1ImportCSV(t, []string{
 		`GOOG,1.23,4.56,NYSE,1707123457`, // 2024-02-05T08:57:37.000Z
 		`MSFT,23,56,NASDAQ,1707123457`,   // 2024-02-05T08:57:37.000Z
 	}, at.QueryOpts{
@@ -474,7 +474,7 @@ func TestClusterIngestionProtocols(t *testing.T) {
 			},
 		},
 	}
-	vminsert.PrometheusAPIV1Write(t, pbData, at.QueryOpts{})
+	vminsert.APIV1Write(t, pbData, at.QueryOpts{})
 	vmstorage.ForceFlush(t)
 	f(&opts{
 		query: `{__name__=~"prometheusrw.+"}`,

--- a/apptest/tests/maxingestionrate_test.go
+++ b/apptest/tests/maxingestionrate_test.go
@@ -16,7 +16,7 @@ func TestSingleMaxIngestionRateIncrementsMetric(t *testing.T) {
 	tc := apptest.NewTestCase(t)
 	defer tc.Stop()
 	sut := tc.MustStartVmsingle("vmsingle", []string{"-maxIngestionRate=1"})
-	sut.PrometheusAPIV1ImportPrometheus(t, testData, apptest.QueryOpts{})
+	sut.APIV1ImportPrometheus(t, testData, apptest.QueryOpts{})
 	if got := sut.GetMetric(t, "vm_max_ingestion_rate_limit_reached_total"); got <= 0 {
 		t.Fatalf("Unexpected vm_max_ingestion_rate_limit_reached_total: got %f, want >0", got)
 	}
@@ -26,7 +26,7 @@ func TestSingleMaxIngestionRateDoesNotIncrementMetric(t *testing.T) {
 	tc := apptest.NewTestCase(t)
 	defer tc.Stop()
 	sut := tc.MustStartVmsingle("vmsingle", []string{"-maxIngestionRate=15"})
-	sut.PrometheusAPIV1ImportPrometheus(t, testData, apptest.QueryOpts{})
+	sut.APIV1ImportPrometheus(t, testData, apptest.QueryOpts{})
 	if got, want := sut.GetMetric(t, "vm_max_ingestion_rate_limit_reached_total"), 0.0; got != want {
 		t.Fatalf("Unexpected vm_max_ingestion_rate_limit_reached_total: got %f, want >0", got)
 	}

--- a/apptest/tests/metric_names_stats_test.go
+++ b/apptest/tests/metric_names_stats_test.go
@@ -37,7 +37,7 @@ func TestSingleMetricNamesStats(t *testing.T) {
 	}
 	tsdbMetricNameEntryCmpOpts := cmpopts.IgnoreFields(apptest.TSDBStatusResponseMetricNameEntry{}, "LastRequestTimestamp")
 
-	sut.PrometheusAPIV1ImportPrometheus(t, dataSet, at.QueryOpts{})
+	sut.APIV1ImportPrometheus(t, dataSet, at.QueryOpts{})
 	sut.ForceFlush(t)
 
 	// verify ingest request correctly registered
@@ -55,7 +55,7 @@ func TestSingleMetricNamesStats(t *testing.T) {
 	}
 
 	// verify query request correctly registered
-	sut.PrometheusAPIV1Query(t, `{__name__!=""}`, at.QueryOpts{Time: ingestDateTime})
+	sut.APIV1Query(t, `{__name__!=""}`, at.QueryOpts{Time: ingestDateTime})
 	expected = apptest.MetricNamesStatsResponse{
 		Records: []at.MetricNamesStatsRecord{
 			{MetricName: largeMetricName, QueryRequestsCount: 1},
@@ -97,7 +97,7 @@ func TestSingleMetricNamesStats(t *testing.T) {
 	}
 
 	// perform query request for single metric and check counter increase
-	sut.PrometheusAPIV1Query(t, `metric_name_2`, at.QueryOpts{Time: ingestDateTime})
+	sut.APIV1Query(t, `metric_name_2`, at.QueryOpts{Time: ingestDateTime})
 	expected = apptest.MetricNamesStatsResponse{
 		Records: []at.MetricNamesStatsRecord{
 			{MetricName: largeMetricName, QueryRequestsCount: 1},
@@ -187,7 +187,7 @@ func TestClusterMetricNamesStats(t *testing.T) {
 	// ingest per tenant data and verify it with search
 	tenantIDs := []string{"1:1", "1:15", "15:15"}
 	for _, tenantID := range tenantIDs {
-		vminsert.PrometheusAPIV1ImportPrometheus(t, dataSet, apptest.QueryOpts{Tenant: tenantID})
+		vminsert.APIV1ImportPrometheus(t, dataSet, apptest.QueryOpts{Tenant: tenantID})
 		vmstorage1.ForceFlush(t)
 		vmstorage2.ForceFlush(t)
 
@@ -206,7 +206,7 @@ func TestClusterMetricNamesStats(t *testing.T) {
 		}
 
 		// verify query request registered correctly
-		vmselect.PrometheusAPIV1Query(t, `{__name__!=""}`, apptest.QueryOpts{
+		vmselect.APIV1Query(t, `{__name__!=""}`, apptest.QueryOpts{
 			Tenant: tenantID, Time: ingestDateTime,
 		})
 

--- a/apptest/tests/multilevel_test.go
+++ b/apptest/tests/multilevel_test.go
@@ -37,7 +37,7 @@ func TestClusterMultilevelSelect(t *testing.T) {
 
 	const numMetrics = 1000
 	records := make([]string, numMetrics)
-	want := &apptest.PrometheusAPIV1SeriesResponse{
+	want := &apptest.APIV1SeriesResponse{
 		Status:    "success",
 		IsPartial: false,
 		Data:      make([]map[string]string, numMetrics),
@@ -49,7 +49,7 @@ func TestClusterMultilevelSelect(t *testing.T) {
 	}
 	want.Sort()
 	qopts := apptest.QueryOpts{Tenant: "0"}
-	vminsert.PrometheusAPIV1ImportPrometheus(t, records, qopts)
+	vminsert.APIV1ImportPrometheus(t, records, qopts)
 	vmstorage.ForceFlush(t)
 
 	// Retrieve all time series and verify that both vmselect (L1) and
@@ -60,7 +60,7 @@ func TestClusterMultilevelSelect(t *testing.T) {
 		tc.Assert(&apptest.AssertOptions{
 			Msg: "unexpected /api/v1/series response",
 			Got: func() any {
-				res := app.PrometheusAPIV1Series(t, `{__name__=~".*"}`, qopts)
+				res := app.APIV1Series(t, `{__name__=~".*"}`, qopts)
 				res.Sort()
 				return res
 			},

--- a/apptest/tests/per_day_index_test.go
+++ b/apptest/tests/per_day_index_test.go
@@ -132,7 +132,7 @@ func testSearchWithDisabledPerDayIndex(tc *at.TestCase, start startSUTFunc) {
 
 	// Restart vmsingle with disabled per-day index, insert sample2, and confirm
 	// that both sample1 and sample2 is searchable.
-	tc.StopPrometheusWriteQuerier(sut)
+	tc.StopWriteQuerier(sut)
 	sut = start("without-per-day-index", true)
 	sample2 := []string{"metric2 222 1704067200000"} // 2024-01-01T00:00:00Z
 	sut.APIV1ImportPrometheus(t, sample2, at.QueryOpts{})
@@ -167,7 +167,7 @@ func testSearchWithDisabledPerDayIndex(tc *at.TestCase, start startSUTFunc) {
 	sample3 := []string{"metric1 333 1705708800000"} // 2024-01-20T00:00:00Z
 	sut.APIV1ImportPrometheus(t, sample3, at.QueryOpts{})
 	sut.ForceFlush(t)
-	tc.StopPrometheusWriteQuerier(sut)
+	tc.StopWriteQuerier(sut)
 	sut = start("with-per-day-index2", false)
 
 	// Time range is 1 day (Jan 1st) <= 40 days

--- a/apptest/tests/relabeling_test.go
+++ b/apptest/tests/relabeling_test.go
@@ -57,7 +57,7 @@ func TestSingleIngestionWithRelabeling(t *testing.T) {
 		wantMetrics []map[string]string
 		wantSamples []*at.Sample
 	}
-	f := func(sut at.PrometheusQuerier, opts *opts) {
+	f := func(sut at.APIQuerier, opts *opts) {
 		t.Helper()
 		wantResult := []*at.QueryResult{}
 		for idx, wm := range opts.wantMetrics {
@@ -70,19 +70,19 @@ func TestSingleIngestionWithRelabeling(t *testing.T) {
 		tc.Assert(&at.AssertOptions{
 			Msg: "unexpected /api/v1/query response",
 			Got: func() any {
-				return sut.PrometheusAPIV1Query(t, opts.query, at.QueryOpts{
+				return sut.APIV1Query(t, opts.query, at.QueryOpts{
 					Time: opts.qtime,
 					Step: opts.step,
 				})
 			},
-			Want: &at.PrometheusAPIV1QueryResponse{Data: &at.QueryData{Result: wantResult}},
+			Want: &at.APIV1QueryResponse{Data: &at.QueryData{Result: wantResult}},
 			CmpOpts: []cmp.Option{
-				cmpopts.IgnoreFields(at.PrometheusAPIV1QueryResponse{}, "Status", "Data.ResultType"),
+				cmpopts.IgnoreFields(at.APIV1QueryResponse{}, "Status", "Data.ResultType"),
 			},
 		})
 	}
 
-	sut.PrometheusAPIV1ImportPrometheus(t, []string{
+	sut.APIV1ImportPrometheus(t, []string{
 		`importprometheus_series{label="foo"} 10 1707123456700`, // 2024-02-05T08:57:36.700Z
 		`must_drop_series{label="foo"} 20 1707123456800`,        // 2024-02-05T08:57:36.800Z
 	}, at.QueryOpts{})
@@ -180,7 +180,7 @@ func TestSingleIngestionWithRelabeling(t *testing.T) {
 			},
 		},
 	}
-	sut.PrometheusAPIV1Write(t, pbData, at.QueryOpts{})
+	sut.APIV1Write(t, pbData, at.QueryOpts{})
 	sut.ForceFlush(t)
 	f(sut, &opts{
 		query: `{label="foo2"}[120ms]`,

--- a/apptest/tests/replication_test.go
+++ b/apptest/tests/replication_test.go
@@ -7,10 +7,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/VictoriaMetrics/VictoriaMetrics/apptest"
-	at "github.com/VictoriaMetrics/VictoriaMetrics/apptest"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+
+	"github.com/VictoriaMetrics/VictoriaMetrics/apptest"
+	at "github.com/VictoriaMetrics/VictoriaMetrics/apptest"
 )
 
 type clusterWithReplication struct {
@@ -94,7 +95,7 @@ func TestClusterReplication_DataIsWrittenSeveralTimes(t *testing.T) {
 	for i := range numRecs {
 		recs[i] = fmt.Sprintf("metric_%d %d", i, rand.IntN(1000))
 	}
-	c.vminsert.PrometheusAPIV1ImportPrometheus(t, recs, at.QueryOpts{})
+	c.vminsert.APIV1ImportPrometheus(t, recs, at.QueryOpts{})
 	tc.ForceFlush(c.vmstorages...)
 
 	// Verify that each storage node has metrics and that total metric count across
@@ -151,7 +152,7 @@ func TestClusterReplication_Deduplication(t *testing.T) {
 			ts = ts.Add(1 * time.Minute)
 		}
 	}
-	c.vminsert.PrometheusAPIV1ImportPrometheus(t, recs, at.QueryOpts{})
+	c.vminsert.APIV1ImportPrometheus(t, recs, at.QueryOpts{})
 	tc.ForceFlush(c.vmstorages...)
 
 	// Check /api/v1/series response.
@@ -164,12 +165,12 @@ func TestClusterReplication_Deduplication(t *testing.T) {
 		tc.Assert(&at.AssertOptions{
 			Msg: "unexpected /api/v1/series response",
 			Got: func() any {
-				return app.PrometheusAPIV1Series(t, `{__name__=~".*"}`, at.QueryOpts{
+				return app.APIV1Series(t, `{__name__=~".*"}`, at.QueryOpts{
 					Start: "2024-01-01T00:00:00Z",
 					End:   "2024-01-31T00:00:00Z",
 				}).Sort()
 			},
-			Want: &at.PrometheusAPIV1SeriesResponse{
+			Want: &at.APIV1SeriesResponse{
 				Status:    "success",
 				IsPartial: false,
 				Data: []map[string]string{
@@ -194,12 +195,12 @@ func TestClusterReplication_Deduplication(t *testing.T) {
 		tc.Assert(&at.AssertOptions{
 			Msg: "unexpected /api/v1/query response",
 			Got: func() any {
-				return app.PrometheusAPIV1Query(t, "metric_1", at.QueryOpts{
+				return app.APIV1Query(t, "metric_1", at.QueryOpts{
 					Time: "2024-01-01T00:05:00Z",
 					Step: "5m",
 				})
 			},
-			Want: &at.PrometheusAPIV1QueryResponse{
+			Want: &at.APIV1QueryResponse{
 				Status: "success",
 				Data: &at.QueryData{
 					ResultType: "vector",
@@ -236,12 +237,12 @@ func TestClusterReplication_Deduplication(t *testing.T) {
 		tc.Assert(&at.AssertOptions{
 			Msg: "unexpected /api/v1/query response",
 			Got: func() any {
-				return app.PrometheusAPIV1Query(t, "metric_1[5m]", at.QueryOpts{
+				return app.APIV1Query(t, "metric_1[5m]", at.QueryOpts{
 					Time: "2024-01-01T00:05:00Z",
 					Step: "5m",
 				})
 			},
-			Want: &at.PrometheusAPIV1QueryResponse{
+			Want: &at.APIV1QueryResponse{
 				Status: "success",
 				Data: &at.QueryData{
 					ResultType: "matrix",
@@ -273,13 +274,13 @@ func TestClusterReplication_Deduplication(t *testing.T) {
 		tc.Assert(&at.AssertOptions{
 			Msg: "unexpected /api/v1/query_range response",
 			Got: func() any {
-				return app.PrometheusAPIV1QueryRange(t, "metric_1", at.QueryOpts{
+				return app.APIV1QueryRange(t, "metric_1", at.QueryOpts{
 					Start: "2024-01-01T00:00:00Z",
 					End:   "2024-01-01T00:10:00Z",
 					Step:  "5m",
 				})
 			},
-			Want: &at.PrometheusAPIV1QueryResponse{
+			Want: &at.APIV1QueryResponse{
 				Status: "success",
 				Data: &at.QueryData{
 					ResultType: "matrix",
@@ -309,12 +310,12 @@ func TestClusterReplication_Deduplication(t *testing.T) {
 		tc.Assert(&at.AssertOptions{
 			Msg: "unexpected /api/v1/export response",
 			Got: func() any {
-				return app.PrometheusAPIV1Export(t, `{__name__="metric_1"}`, at.QueryOpts{
+				return app.APIV1Export(t, `{__name__="metric_1"}`, at.QueryOpts{
 					Start: "2024-01-01T00:00:00Z",
 					End:   "2024-01-01T00:03:00Z",
 				})
 			},
-			Want: &at.PrometheusAPIV1QueryResponse{
+			Want: &at.APIV1QueryResponse{
 				Status: "success",
 				Data: &at.QueryData{
 					ResultType: "matrix",
@@ -360,7 +361,7 @@ func TestClusterReplication_PartialResponse(t *testing.T) {
 	for i := range numRecs {
 		recs[i] = fmt.Sprintf("metric_%d %d", i, rand.IntN(1000))
 	}
-	c.vminsert.PrometheusAPIV1ImportPrometheus(t, recs, at.QueryOpts{})
+	c.vminsert.APIV1ImportPrometheus(t, recs, at.QueryOpts{})
 	tc.ForceFlush(c.vmstorages...)
 
 	// Verify partial vs full response.
@@ -370,14 +371,14 @@ func TestClusterReplication_PartialResponse(t *testing.T) {
 		tc.Assert(&at.AssertOptions{
 			Msg: "unexpected /api/v1/series response",
 			Got: func() any {
-				return app.PrometheusAPIV1Series(t, `{__name__=~".*"}`, at.QueryOpts{}).Sort()
+				return app.APIV1Series(t, `{__name__=~".*"}`, at.QueryOpts{}).Sort()
 			},
-			Want: &at.PrometheusAPIV1SeriesResponse{
+			Want: &at.APIV1SeriesResponse{
 				Status:    "success",
 				IsPartial: wantPartial,
 			},
 			CmpOpts: []cmp.Option{
-				cmpopts.IgnoreFields(apptest.PrometheusAPIV1SeriesResponse{}, "Data"),
+				cmpopts.IgnoreFields(apptest.APIV1SeriesResponse{}, "Data"),
 			},
 		})
 	}
@@ -437,7 +438,7 @@ func TestClusterReplication_SkipSlowReplicas(t *testing.T) {
 
 	const numRecs = 1000
 	recs := make([]string, numRecs)
-	wantSeries := &at.PrometheusAPIV1SeriesResponse{
+	wantSeries := &at.APIV1SeriesResponse{
 		Status: "success",
 		Data:   make([]map[string]string, numRecs),
 	}
@@ -447,7 +448,7 @@ func TestClusterReplication_SkipSlowReplicas(t *testing.T) {
 		wantSeries.Data[i] = map[string]string{"__name__": name}
 	}
 	wantSeries.Sort()
-	c.vminsert.PrometheusAPIV1ImportPrometheus(t, recs, at.QueryOpts{})
+	c.vminsert.APIV1ImportPrometheus(t, recs, at.QueryOpts{})
 	tc.ForceFlush(c.vmstorages...)
 
 	// Verify skipping slow replicas by counting the number of skipSlowReplicas
@@ -458,12 +459,12 @@ func TestClusterReplication_SkipSlowReplicas(t *testing.T) {
 		tc.Assert(&at.AssertOptions{
 			Msg: "unexpected /api/v1/series response",
 			Got: func() any {
-				return app.PrometheusAPIV1Series(t, `{__name__=~".*"}`, at.QueryOpts{}).Sort()
+				return app.APIV1Series(t, `{__name__=~".*"}`, at.QueryOpts{}).Sort()
 			},
 			Want: wantSeries,
 		})
 
-		res := app.PrometheusAPIV1Series(t, `{__name__=~".*"}`, at.QueryOpts{Trace: "1"})
+		res := app.APIV1Series(t, `{__name__=~".*"}`, at.QueryOpts{Trace: "1"})
 		got := res.Trace.Contains("cancel request because -search.skipSlowReplicas is set and every group returned the needed number of responses according to replicationFactor")
 		if got != want {
 			t.Errorf("unexpected number of skipSlowReplicas messages in request trace: got %d, want %d (full trace:\n%v)", got, want, res.Trace)
@@ -654,7 +655,7 @@ func TestClusterGroupReplication(t *testing.T) {
 		numRecs    = numMetrics * numSamples
 	)
 	var recs []string
-	wantSeries := &at.PrometheusAPIV1SeriesResponse{
+	wantSeries := &at.APIV1SeriesResponse{
 		Status: "success",
 		Data:   make([]map[string]string, numMetrics),
 	}
@@ -668,7 +669,7 @@ func TestClusterGroupReplication(t *testing.T) {
 		}
 	}
 	wantSeries.Sort()
-	c.vminsert.PrometheusAPIV1ImportPrometheus(t, recs, at.QueryOpts{})
+	c.vminsert.APIV1ImportPrometheus(t, recs, at.QueryOpts{})
 	c.forceFlush(tc)
 
 	opts := &testGroupReplicationOpts{
@@ -694,7 +695,7 @@ type testGroupReplicationOpts struct {
 	numGroups  int
 	numNodes   int
 	numRecs    int
-	wantSeries *at.PrometheusAPIV1SeriesResponse
+	wantSeries *at.APIV1SeriesResponse
 }
 
 // testGroupDataIsWrittenSeveralTimes checks that multiple
@@ -747,7 +748,7 @@ func testGroupDeduplication(tc *at.TestCase, opts *testGroupReplicationOpts) {
 		tc.Assert(&at.AssertOptions{
 			Msg: "unexpected /api/v1/series response",
 			Got: func() any {
-				return app.PrometheusAPIV1Series(t, `{__name__=~".*"}`, at.QueryOpts{
+				return app.APIV1Series(t, `{__name__=~".*"}`, at.QueryOpts{
 					Start: "2024-01-01T00:00:00Z",
 					End:   "2024-01-31T00:00:00Z",
 				}).Sort()
@@ -768,12 +769,12 @@ func testGroupDeduplication(tc *at.TestCase, opts *testGroupReplicationOpts) {
 		tc.Assert(&at.AssertOptions{
 			Msg: "unexpected /api/v1/query response",
 			Got: func() any {
-				return app.PrometheusAPIV1Query(t, "metric_1", at.QueryOpts{
+				return app.APIV1Query(t, "metric_1", at.QueryOpts{
 					Time: "2024-01-01T00:05:00Z",
 					Step: "5m",
 				})
 			},
-			Want: &at.PrometheusAPIV1QueryResponse{
+			Want: &at.APIV1QueryResponse{
 				Status: "success",
 				Data: &at.QueryData{
 					ResultType: "vector",
@@ -810,12 +811,12 @@ func testGroupDeduplication(tc *at.TestCase, opts *testGroupReplicationOpts) {
 		tc.Assert(&at.AssertOptions{
 			Msg: "unexpected /api/v1/query response",
 			Got: func() any {
-				return app.PrometheusAPIV1Query(t, "metric_1[5m]", at.QueryOpts{
+				return app.APIV1Query(t, "metric_1[5m]", at.QueryOpts{
 					Time: "2024-01-01T00:05:00Z",
 					Step: "5m",
 				})
 			},
-			Want: &at.PrometheusAPIV1QueryResponse{
+			Want: &at.APIV1QueryResponse{
 				Status: "success",
 				Data: &at.QueryData{
 					ResultType: "matrix",
@@ -847,13 +848,13 @@ func testGroupDeduplication(tc *at.TestCase, opts *testGroupReplicationOpts) {
 		tc.Assert(&at.AssertOptions{
 			Msg: "unexpected /api/v1/query_range response",
 			Got: func() any {
-				return app.PrometheusAPIV1QueryRange(t, "metric_1", at.QueryOpts{
+				return app.APIV1QueryRange(t, "metric_1", at.QueryOpts{
 					Start: "2024-01-01T00:00:00Z",
 					End:   "2024-01-01T00:10:00Z",
 					Step:  "5m",
 				})
 			},
-			Want: &at.PrometheusAPIV1QueryResponse{
+			Want: &at.APIV1QueryResponse{
 				Status: "success",
 				Data: &at.QueryData{
 					ResultType: "matrix",
@@ -883,12 +884,12 @@ func testGroupDeduplication(tc *at.TestCase, opts *testGroupReplicationOpts) {
 		tc.Assert(&at.AssertOptions{
 			Msg: "unexpected /api/v1/export response",
 			Got: func() any {
-				return app.PrometheusAPIV1Export(t, `{__name__="metric_1"}`, at.QueryOpts{
+				return app.APIV1Export(t, `{__name__="metric_1"}`, at.QueryOpts{
 					Start: "2024-01-01T00:00:00Z",
 					End:   "2024-01-01T00:03:00Z",
 				})
 			},
-			Want: &at.PrometheusAPIV1QueryResponse{
+			Want: &at.APIV1QueryResponse{
 				Status: "success",
 				Data: &at.QueryData{
 					ResultType: "matrix",
@@ -929,7 +930,7 @@ func testGroupSkipSlowReplicas(tc *at.TestCase, opts *testGroupReplicationOpts) 
 		tc.Assert(&at.AssertOptions{
 			Msg: "unexpected /api/v1/series response",
 			Got: func() any {
-				return app.PrometheusAPIV1Series(t, `{__name__=~".*"}`, at.QueryOpts{
+				return app.APIV1Series(t, `{__name__=~".*"}`, at.QueryOpts{
 					Start: "2024-01-01T00:00:00Z",
 					End:   "2024-01-31T00:00:00Z",
 				}).Sort()
@@ -937,7 +938,7 @@ func testGroupSkipSlowReplicas(tc *at.TestCase, opts *testGroupReplicationOpts) 
 			Want: opts.wantSeries,
 		})
 
-		res := app.PrometheusAPIV1Series(t, `{__name__=~".*"}`, at.QueryOpts{Trace: "1"})
+		res := app.APIV1Series(t, `{__name__=~".*"}`, at.QueryOpts{Trace: "1"})
 		got := res.Trace.Contains("cancel request because -search.skipSlowReplicas is set and every group returned the needed number of responses according to replicationFactor")
 		if got < wantMin || got > wantMax {
 			t.Errorf("unexpected number of skipSlowReplicas messages in request trace: got %d, %d <= want <= %d (full trace:\n%v)", got, wantMin, wantMax, res.Trace)
@@ -973,7 +974,7 @@ func testGroupSkipSlowReplicas(tc *at.TestCase, opts *testGroupReplicationOpts) 
 
 	// The data is replicated across N groups of M nodes. Replication factor is
 	// globalRF. There is no replication across the nodes within each group or
-	//it is unknown it there is one.
+	// it is unknown it there is one.
 	//
 	// Max number of nodes to skip is M*(globalRF-1). This corresponds to the
 	// case when N-globalRF+1 groups have received the response from all of
@@ -1020,17 +1021,17 @@ func testGroupPartialResponse(tc *at.TestCase, opts *testGroupReplicationOpts) {
 		tc.Assert(&at.AssertOptions{
 			Msg: "unexpected /api/v1/series response",
 			Got: func() any {
-				return app.PrometheusAPIV1Series(t, `{__name__=~".*"}`, at.QueryOpts{
+				return app.APIV1Series(t, `{__name__=~".*"}`, at.QueryOpts{
 					Start: "2024-01-01T00:00:00Z",
 					End:   "2024-01-31T00:00:00Z",
 				}).Sort()
 			},
-			Want: &at.PrometheusAPIV1SeriesResponse{
+			Want: &at.APIV1SeriesResponse{
 				Status:    "success",
 				IsPartial: wantPartial,
 			},
 			CmpOpts: []cmp.Option{
-				cmpopts.IgnoreFields(apptest.PrometheusAPIV1SeriesResponse{}, "Data"),
+				cmpopts.IgnoreFields(apptest.APIV1SeriesResponse{}, "Data"),
 			},
 		})
 	}
@@ -1128,10 +1129,10 @@ func TestClusterReplication_PartialResponseMultitenant(t *testing.T) {
 		recs[i] = fmt.Sprintf("metric_%d %d", i, rand.IntN(1000))
 	}
 
-	c.vminsert.PrometheusAPIV1ImportPrometheus(t, recs, at.QueryOpts{
+	c.vminsert.APIV1ImportPrometheus(t, recs, at.QueryOpts{
 		Tenant: "0",
 	})
-	c.vminsert.PrometheusAPIV1ImportPrometheus(t, recs, at.QueryOpts{
+	c.vminsert.APIV1ImportPrometheus(t, recs, at.QueryOpts{
 		Tenant: "1",
 	})
 	tc.ForceFlush(c.vmstorages...)
@@ -1144,14 +1145,14 @@ func TestClusterReplication_PartialResponseMultitenant(t *testing.T) {
 			Msg: "unexpected /api/v1/query response",
 			Got: func() any {
 				qo := at.QueryOpts{Tenant: "multitenant", Trace: "1"}
-				return app.PrometheusAPIV1Query(t, `{__name__=~"metric_.*"}`, qo)
+				return app.APIV1Query(t, `{__name__=~"metric_.*"}`, qo)
 			},
-			Want: &at.PrometheusAPIV1QueryResponse{
+			Want: &at.APIV1QueryResponse{
 				Status:    "success",
 				IsPartial: wantPartial,
 			},
 			CmpOpts: []cmp.Option{
-				cmpopts.IgnoreFields(apptest.PrometheusAPIV1QueryResponse{}, "Data"),
+				cmpopts.IgnoreFields(apptest.APIV1QueryResponse{}, "Data"),
 			},
 		})
 	}

--- a/apptest/tests/rollup_result_cache_test.go
+++ b/apptest/tests/rollup_result_cache_test.go
@@ -13,7 +13,7 @@ import (
 func TestClusterRollupResultCache(t *testing.T) {
 	os.RemoveAll(t.Name())
 
-	cmpOpt := cmpopts.IgnoreFields(apptest.PrometheusAPIV1QueryResponse{}, "Status", "Data.ResultType")
+	cmpOpt := cmpopts.IgnoreFields(apptest.APIV1QueryResponse{}, "Status", "Data.ResultType")
 
 	tc := apptest.NewTestCase(t)
 	defer tc.Stop()
@@ -34,10 +34,10 @@ func TestClusterRollupResultCache(t *testing.T) {
 		`foo_bar{vm_account_id="5",vm_project_id="15"} 3.00 1652169720000`, // 2022-05-10T08:02:00Z
 	}
 
-	vminsert.PrometheusAPIV1ImportPrometheus(t, tenantLabelsSamples, apptest.QueryOpts{Tenant: "multitenant"})
+	vminsert.APIV1ImportPrometheus(t, tenantLabelsSamples, apptest.QueryOpts{Tenant: "multitenant"})
 	vmstorage.ForceFlush(t)
 
-	want := apptest.NewPrometheusAPIV1QueryResponse(t,
+	want := apptest.NewAPIV1QueryResponse(t,
 		`{"data":
 	   {"result":[
 	        {"metric":{"__name__":"foo_bar","vm_account_id":"5","vm_project_id": "0"},"values":[[1652169720,"1"],[1652169780,"1"]]},
@@ -47,7 +47,7 @@ func TestClusterRollupResultCache(t *testing.T) {
 	}`,
 	)
 
-	got := vmselect.PrometheusAPIV1QueryRange(t, `foo_bar{}`, apptest.QueryOpts{
+	got := vmselect.APIV1QueryRange(t, `foo_bar{}`, apptest.QueryOpts{
 		Tenant:       "multitenant",
 		Start:        "2022-05-10T07:59:00.000Z",
 		End:          "2022-05-10T08:05:00.000Z",
@@ -58,13 +58,13 @@ func TestClusterRollupResultCache(t *testing.T) {
 		t.Errorf("unexpected response (-want, +got):\n%s", diff)
 	}
 
-	want = apptest.NewPrometheusAPIV1QueryResponse(t,
+	want = apptest.NewAPIV1QueryResponse(t,
 		`{"data":
 	   {"result":[]}
 	}`,
 	)
 
-	got = vmselect.PrometheusAPIV1QueryRange(t, `foo_bar{}`, apptest.QueryOpts{
+	got = vmselect.APIV1QueryRange(t, `foo_bar{}`, apptest.QueryOpts{
 		Tenant:       "multitenant",
 		Start:        "2022-05-10T07:59:00.000Z",
 		End:          "2022-05-10T08:05:00.000Z",

--- a/apptest/tests/sharding_test.go
+++ b/apptest/tests/sharding_test.go
@@ -38,7 +38,7 @@ func TestClusterVminsertShardsDataVmselectBuildsFullResultFromShards(t *testing.
 
 	const numMetrics = 1000
 	records := make([]string, numMetrics)
-	want := &apptest.PrometheusAPIV1SeriesResponse{
+	want := &apptest.APIV1SeriesResponse{
 		Status:    "success",
 		IsPartial: false,
 		Data:      make([]map[string]string, numMetrics),
@@ -49,7 +49,7 @@ func TestClusterVminsertShardsDataVmselectBuildsFullResultFromShards(t *testing.
 		want.Data[i] = map[string]string{"__name__": name}
 	}
 	want.Sort()
-	vminsert.PrometheusAPIV1ImportPrometheus(t, records, apptest.QueryOpts{})
+	vminsert.APIV1ImportPrometheus(t, records, apptest.QueryOpts{})
 	vmstorage1.ForceFlush(t)
 	vmstorage2.ForceFlush(t)
 
@@ -74,7 +74,7 @@ func TestClusterVminsertShardsDataVmselectBuildsFullResultFromShards(t *testing.
 	tc.Assert(&apptest.AssertOptions{
 		Msg: "unexpected /api/v1/series response",
 		Got: func() any {
-			res := vmselect.PrometheusAPIV1Series(t, `{__name__=~".*"}`, apptest.QueryOpts{})
+			res := vmselect.APIV1Series(t, `{__name__=~".*"}`, apptest.QueryOpts{})
 			res.Sort()
 			return res
 		},

--- a/apptest/tests/snapshot_test.go
+++ b/apptest/tests/snapshot_test.go
@@ -28,7 +28,7 @@ func TestSingleSnapshots_CreateListDelete(t *testing.T) {
 	for i := range numSamples {
 		samples[i] = fmt.Sprintf("metric_%03d %d", i, i)
 	}
-	sut.PrometheusAPIV1ImportPrometheus(t, samples, at.QueryOpts{})
+	sut.APIV1ImportPrometheus(t, samples, at.QueryOpts{})
 	sut.ForceFlush(t)
 
 	// Create several snapshots using VictoriaMetrics and Prometheus endpoints.
@@ -113,7 +113,7 @@ func TestClusterSnapshots_CreateListDelete(t *testing.T) {
 	for i := range numSamples {
 		samples[i] = fmt.Sprintf("metric_%03d %d", i, i)
 	}
-	sut.PrometheusAPIV1ImportPrometheus(t, samples, at.QueryOpts{})
+	sut.APIV1ImportPrometheus(t, samples, at.QueryOpts{})
 	sut.ForceFlush(t)
 
 	// Create several snapshots for both vmstorage replicas using

--- a/apptest/tests/vmagent_remotewrite_test.go
+++ b/apptest/tests/vmagent_remotewrite_test.go
@@ -45,12 +45,12 @@ func TestSingleVMAgentReloadConfigs(t *testing.T) {
 	tc.Assert(&at.AssertOptions{
 		Msg: `unexpected metrics stored on vmagent remote write`,
 		Got: func() any {
-			return vmsingle.PrometheusAPIV1Series(t, `{__name__="foo_bar"}`, at.QueryOpts{
+			return vmsingle.APIV1Series(t, `{__name__="foo_bar"}`, at.QueryOpts{
 				Start: "2022-05-10T00:00:00Z",
 				End:   "2022-05-10T23:59:59Z",
 			}).Sort()
 		},
-		Want: &at.PrometheusAPIV1SeriesResponse{
+		Want: &at.APIV1SeriesResponse{
 			Status: "success",
 			Data:   []map[string]string{{"__name__": "foo_bar", "label1": "value1"}},
 		},
@@ -76,12 +76,12 @@ func TestSingleVMAgentReloadConfigs(t *testing.T) {
 	tc.Assert(&at.AssertOptions{
 		Msg: `unexpected metrics stored on vmagent remote write`,
 		Got: func() any {
-			return vmsingle.PrometheusAPIV1Series(t, `{__name__="bar_foo"}`, at.QueryOpts{
+			return vmsingle.APIV1Series(t, `{__name__="bar_foo"}`, at.QueryOpts{
 				Start: "2022-05-10T00:00:00Z",
 				End:   "2022-05-10T23:59:59Z",
 			}).Sort()
 		},
-		Want: &at.PrometheusAPIV1SeriesResponse{
+		Want: &at.APIV1SeriesResponse{
 			Status: "success",
 			Data:   []map[string]string{{"__name__": "bar_foo", "label1": "value2"}},
 		},
@@ -122,12 +122,12 @@ func testSingleVMAgentRemoteWrite(t *testing.T, forcePromProto bool) {
 	tc.Assert(&at.AssertOptions{
 		Msg: `unexpected metrics stored on vmagent remote write`,
 		Got: func() any {
-			return vmsingle.PrometheusAPIV1Series(t, `{__name__="foo_bar"}`, at.QueryOpts{
+			return vmsingle.APIV1Series(t, `{__name__="foo_bar"}`, at.QueryOpts{
 				Start: "2022-05-10T00:00:00Z",
 				End:   "2022-05-10T23:59:59Z",
 			}).Sort()
 		},
-		Want: &at.PrometheusAPIV1SeriesResponse{
+		Want: &at.APIV1SeriesResponse{
 			Status: "success",
 			Data:   []map[string]string{{"__name__": "foo_bar"}},
 		},

--- a/apptest/tests/vmctl_prometheus_migration_test.go
+++ b/apptest/tests/vmctl_prometheus_migration_test.go
@@ -55,19 +55,19 @@ func TestClusterVmctlPrometheusProtocol(t *testing.T) {
 	testPrometheusProtocol(tc, cluster, vmctlFlags)
 }
 
-func testPrometheusProtocol(tc *apptest.TestCase, sut apptest.PrometheusWriteQuerier, vmctlFlags []string) {
+func testPrometheusProtocol(tc *apptest.TestCase, sut apptest.WriteQuerier, vmctlFlags []string) {
 	t := tc.T()
 	t.Helper()
 
-	cmpOpt := cmpopts.IgnoreFields(apptest.PrometheusAPIV1QueryResponse{}, "Status", "Data.ResultType")
+	cmpOpt := cmpopts.IgnoreFields(apptest.APIV1QueryResponse{}, "Status", "Data.ResultType")
 
 	// test for empty data request
-	got := sut.PrometheusAPIV1Query(t, `{__name__=~".*"}`, apptest.QueryOpts{
+	got := sut.APIV1Query(t, `{__name__=~".*"}`, apptest.QueryOpts{
 		Step: "5m",
 		Time: "2025-06-02T17:14:00Z",
 	})
 
-	want := apptest.NewPrometheusAPIV1QueryResponse(t, `{"data":{"result":[]}}`)
+	want := apptest.NewAPIV1QueryResponse(t, `{"data":{"result":[]}}`)
 	if diff := cmp.Diff(want, got, cmpOpt); diff != "" {
 		t.Errorf("unexpected response (-want, +got):\n%s", diff)
 	}
@@ -88,7 +88,7 @@ func testPrometheusProtocol(tc *apptest.TestCase, sut apptest.PrometheusWriteQue
 		t.Fatalf("cannot read expected series response file: %s", err)
 	}
 
-	var wantResponse apptest.PrometheusAPIV1QueryResponse
+	var wantResponse apptest.APIV1QueryResponse
 	if err := json.Unmarshal(bytes, &wantResponse); err != nil {
 		t.Fatalf("cannot unmarshal expected series response file: %s", err)
 	}
@@ -99,7 +99,7 @@ func testPrometheusProtocol(tc *apptest.TestCase, sut apptest.PrometheusWriteQue
 		Retries: 300,
 		Msg:     `unexpected metrics stored on vmsingle via the prometheus protocol`,
 		Got: func() any {
-			expected := sut.PrometheusAPIV1Export(t, `{__name__="vm_log_messages_total", location=~"VictoriaMetrics/lib/ingestserver/opentsdb/server.go:(48|59)"}`, apptest.QueryOpts{
+			expected := sut.APIV1Export(t, `{__name__="vm_log_messages_total", location=~"VictoriaMetrics/lib/ingestserver/opentsdb/server.go:(48|59)"}`, apptest.QueryOpts{
 				Start: "2025-06-02T00:00:00Z",
 				End:   "2025-06-02T23:59:59Z",
 			})
@@ -108,7 +108,7 @@ func testPrometheusProtocol(tc *apptest.TestCase, sut apptest.PrometheusWriteQue
 		},
 		Want: wantResponse.Data.Result,
 		CmpOpts: []cmp.Option{
-			cmpopts.IgnoreFields(apptest.PrometheusAPIV1QueryResponse{}, "Status", "Data.ResultType"),
+			cmpopts.IgnoreFields(apptest.APIV1QueryResponse{}, "Status", "Data.ResultType"),
 		},
 	})
 }

--- a/apptest/tests/vmctl_remote_read_mogration_test.go
+++ b/apptest/tests/vmctl_remote_read_mogration_test.go
@@ -75,7 +75,7 @@ func TestClusterVmctlRemoteReadProtocol(t *testing.T) {
 	testRemoteReadProtocol(tc, clusterDst, newRemoteReadServer, vmctlFlags)
 }
 
-func testRemoteReadProtocol(tc *at.TestCase, sut at.PrometheusWriteQuerier, newRemoteReadServer func(t *testing.T) *RemoteReadServer, vmctlFlags []string) {
+func testRemoteReadProtocol(tc *at.TestCase, sut at.WriteQuerier, newRemoteReadServer func(t *testing.T) *RemoteReadServer, vmctlFlags []string) {
 	t := tc.T()
 	t.Helper()
 
@@ -84,14 +84,14 @@ func testRemoteReadProtocol(tc *at.TestCase, sut at.PrometheusWriteQuerier, newR
 
 	expectedResult := transformSeriesToQueryResult(rrs.storage.store)
 
-	cmpOpt := cmpopts.IgnoreFields(at.PrometheusAPIV1QueryResponse{}, "Status", "Data.ResultType")
+	cmpOpt := cmpopts.IgnoreFields(at.APIV1QueryResponse{}, "Status", "Data.ResultType")
 	// test for empty data request
-	got := sut.PrometheusAPIV1Query(t, `{__name__=~".*"}`, at.QueryOpts{
+	got := sut.APIV1Query(t, `{__name__=~".*"}`, at.QueryOpts{
 		Step: "5m",
 		Time: "2025-06-02T17:14:00Z",
 	})
 
-	want := at.NewPrometheusAPIV1QueryResponse(t, `{"data":{"result":[]}}`)
+	want := at.NewAPIV1QueryResponse(t, `{"data":{"result":[]}}`)
 	if diff := cmp.Diff(want, got, cmpOpt); diff != "" {
 		t.Errorf("unexpected response (-want, +got):\n%s", diff)
 	}
@@ -106,7 +106,7 @@ func testRemoteReadProtocol(tc *at.TestCase, sut at.PrometheusWriteQuerier, newR
 		Retries: 300,
 		Msg:     `unexpected metrics stored on vmsingle via the prometheus protocol`,
 		Got: func() any {
-			expected := sut.PrometheusAPIV1Export(t, `{__name__=~".*"}`, at.QueryOpts{
+			expected := sut.APIV1Export(t, `{__name__=~".*"}`, at.QueryOpts{
 				Start: "2025-06-11T15:31:10Z",
 				End:   "2025-06-11T15:32:20Z",
 			})
@@ -115,7 +115,7 @@ func testRemoteReadProtocol(tc *at.TestCase, sut at.PrometheusWriteQuerier, newR
 		},
 		Want: expectedResult,
 		CmpOpts: []cmp.Option{
-			cmpopts.IgnoreFields(at.PrometheusAPIV1QueryResponse{}, "Status", "Data.ResultType"),
+			cmpopts.IgnoreFields(at.APIV1QueryResponse{}, "Status", "Data.ResultType"),
 		},
 	})
 }

--- a/apptest/vminsert.go
+++ b/apptest/vminsert.go
@@ -127,12 +127,12 @@ func (app *Vminsert) GraphiteWrite(t *testing.T, records []string, _ QueryOpts) 
 	app.cli.Write(t, app.graphiteListenAddr, records)
 }
 
-// PrometheusAPIV1ImportCSV is a test helper function that inserts a collection
+// APIV1ImportCSV is a test helper function that inserts a collection
 // of records in CSV format for the given tenant by sending an HTTP POST
 // request to prometheus/api/v1/import/csv vminsert endpoint.
 //
 // See https://docs.victoriametrics.com/cluster-victoriametrics/#url-format
-func (app *Vminsert) PrometheusAPIV1ImportCSV(t *testing.T, records []string, opts QueryOpts) {
+func (app *Vminsert) APIV1ImportCSV(t *testing.T, records []string, opts QueryOpts) {
 	t.Helper()
 
 	url := fmt.Sprintf("http://%s/insert/%s/prometheus/api/v1/import/csv", app.httpListenAddr, opts.getTenant())
@@ -150,12 +150,12 @@ func (app *Vminsert) PrometheusAPIV1ImportCSV(t *testing.T, records []string, op
 	})
 }
 
-// PrometheusAPIV1ImportNative is a test helper function that inserts a collection
+// APIV1ImportNative is a test helper function that inserts a collection
 // of records in Native format for the given tenant by sending an HTTP POST
 // request to prometheus/api/v1/import/native vminsert endpoint.
 //
 // See https://docs.victoriametrics.com/cluster-victoriametrics/#url-format
-func (app *Vminsert) PrometheusAPIV1ImportNative(t *testing.T, data []byte, opts QueryOpts) {
+func (app *Vminsert) APIV1ImportNative(t *testing.T, data []byte, opts QueryOpts) {
 	t.Helper()
 
 	url := fmt.Sprintf("http://%s/insert/%s/prometheus/api/v1/import/native", app.httpListenAddr, opts.getTenant())
@@ -195,10 +195,10 @@ func (app *Vminsert) OpenTSDBAPIPut(t *testing.T, records []string, opts QueryOp
 	})
 }
 
-// PrometheusAPIV1Write is a test helper function that inserts a
+// APIV1Write is a test helper function that inserts a
 // collection of records in Prometheus remote-write format by sending a HTTP
 // POST request to /prometheus/api/v1/write vminsert endpoint.
-func (app *Vminsert) PrometheusAPIV1Write(t *testing.T, records []pb.TimeSeries, opts QueryOpts) {
+func (app *Vminsert) APIV1Write(t *testing.T, records []pb.TimeSeries, opts QueryOpts) {
 	t.Helper()
 
 	url := fmt.Sprintf("http://%s/insert/%s/prometheus/api/v1/write", app.httpListenAddr, opts.getTenant())
@@ -212,13 +212,13 @@ func (app *Vminsert) PrometheusAPIV1Write(t *testing.T, records []pb.TimeSeries,
 	})
 }
 
-// PrometheusAPIV1ImportPrometheus is a test helper function that inserts a
+// APIV1ImportPrometheus is a test helper function that inserts a
 // collection of records in Prometheus text exposition format for the given
 // tenant by sending a HTTP POST request to
 // /prometheus/api/v1/import/prometheus vminsert endpoint.
 //
 // See https://docs.victoriametrics.com/victoriametrics/url-examples/#apiv1importprometheus
-func (app *Vminsert) PrometheusAPIV1ImportPrometheus(t *testing.T, records []string, opts QueryOpts) {
+func (app *Vminsert) APIV1ImportPrometheus(t *testing.T, records []string, opts QueryOpts) {
 	t.Helper()
 
 	url := fmt.Sprintf("http://%s/insert/%s/prometheus/api/v1/import/prometheus", app.httpListenAddr, opts.getTenant())

--- a/apptest/vmselect.go
+++ b/apptest/vmselect.go
@@ -61,12 +61,12 @@ func (app *Vmselect) HTTPAddr() string {
 	return app.httpListenAddr
 }
 
-// PrometheusAPIV1Export is a test helper function that performs the export of
+// APIV1Export is a test helper function that performs the export of
 // raw samples in JSON line format by sending a HTTP POST request to
 // /prometheus/api/v1/export vmselect endpoint.
 //
 // See https://docs.victoriametrics.com/victoriametrics/url-examples/#apiv1export
-func (app *Vmselect) PrometheusAPIV1Export(t *testing.T, query string, opts QueryOpts) *PrometheusAPIV1QueryResponse {
+func (app *Vmselect) APIV1Export(t *testing.T, query string, opts QueryOpts) *APIV1QueryResponse {
 	t.Helper()
 
 	exportURL := fmt.Sprintf("http://%s/select/%s/prometheus/api/v1/export", app.httpListenAddr, opts.getTenant())
@@ -74,15 +74,15 @@ func (app *Vmselect) PrometheusAPIV1Export(t *testing.T, query string, opts Quer
 	values.Add("match[]", query)
 	values.Add("format", "promapi")
 	res, _ := app.cli.PostForm(t, exportURL, values)
-	return NewPrometheusAPIV1QueryResponse(t, res)
+	return NewAPIV1QueryResponse(t, res)
 }
 
-// PrometheusAPIV1ExportNative is a test helper function that performs the export of
+// APIV1ExportNative is a test helper function that performs the export of
 // raw samples in native binary format by sending an HTTP POST request to
 // /prometheus/api/v1/export/native vmselect endpoint.
 //
 // See https://docs.victoriametrics.com/victoriametrics/url-examples/#apiv1exportnative
-func (app *Vmselect) PrometheusAPIV1ExportNative(t *testing.T, query string, opts QueryOpts) []byte {
+func (app *Vmselect) APIV1ExportNative(t *testing.T, query string, opts QueryOpts) []byte {
 	t.Helper()
 
 	exportURL := fmt.Sprintf("http://%s/select/%s/prometheus/api/v1/export/native", app.httpListenAddr, opts.getTenant())
@@ -93,12 +93,12 @@ func (app *Vmselect) PrometheusAPIV1ExportNative(t *testing.T, query string, opt
 	return []byte(res)
 }
 
-// PrometheusAPIV1Query is a test helper function that performs PromQL/MetricsQL
+// APIV1Query is a test helper function that performs PromQL/MetricsQL
 // instant query by sending a HTTP POST request to /prometheus/api/v1/query
 // vmselect endpoint.
 //
 // See https://docs.victoriametrics.com/victoriametrics/url-examples/#apiv1query
-func (app *Vmselect) PrometheusAPIV1Query(t *testing.T, query string, opts QueryOpts) *PrometheusAPIV1QueryResponse {
+func (app *Vmselect) APIV1Query(t *testing.T, query string, opts QueryOpts) *APIV1QueryResponse {
 	t.Helper()
 
 	queryURL := fmt.Sprintf("http://%s/select/%s/prometheus/api/v1/query", app.httpListenAddr, opts.getTenant())
@@ -106,15 +106,15 @@ func (app *Vmselect) PrometheusAPIV1Query(t *testing.T, query string, opts Query
 	values.Add("query", query)
 
 	res, _ := app.cli.PostForm(t, queryURL, values)
-	return NewPrometheusAPIV1QueryResponse(t, res)
+	return NewAPIV1QueryResponse(t, res)
 }
 
-// PrometheusAPIV1QueryRange is a test helper function that performs
+// APIV1QueryRange is a test helper function that performs
 // PromQL/MetricsQL range query by sending a HTTP POST request to
 // /prometheus/api/v1/query_range vmselect endpoint.
 //
 // See https://docs.victoriametrics.com/victoriametrics/url-examples/#apiv1query_range
-func (app *Vmselect) PrometheusAPIV1QueryRange(t *testing.T, query string, opts QueryOpts) *PrometheusAPIV1QueryResponse {
+func (app *Vmselect) APIV1QueryRange(t *testing.T, query string, opts QueryOpts) *APIV1QueryResponse {
 	t.Helper()
 
 	queryURL := fmt.Sprintf("http://%s/select/%s/prometheus/api/v1/query_range", app.httpListenAddr, opts.getTenant())
@@ -122,14 +122,14 @@ func (app *Vmselect) PrometheusAPIV1QueryRange(t *testing.T, query string, opts 
 	values.Add("query", query)
 
 	res, _ := app.cli.PostForm(t, queryURL, values)
-	return NewPrometheusAPIV1QueryResponse(t, res)
+	return NewAPIV1QueryResponse(t, res)
 }
 
-// PrometheusAPIV1Series sends a query to a /prometheus/api/v1/series endpoint
+// APIV1Series sends a query to a /prometheus/api/v1/series endpoint
 // and returns the list of time series that match the query.
 //
 // See https://docs.victoriametrics.com/victoriametrics/url-examples/#apiv1series
-func (app *Vmselect) PrometheusAPIV1Series(t *testing.T, matchQuery string, opts QueryOpts) *PrometheusAPIV1SeriesResponse {
+func (app *Vmselect) APIV1Series(t *testing.T, matchQuery string, opts QueryOpts) *APIV1SeriesResponse {
 	t.Helper()
 
 	seriesURL := fmt.Sprintf("http://%s/select/%s/prometheus/api/v1/series", app.httpListenAddr, opts.getTenant())
@@ -137,7 +137,7 @@ func (app *Vmselect) PrometheusAPIV1Series(t *testing.T, matchQuery string, opts
 	values.Add("match[]", matchQuery)
 
 	res, _ := app.cli.PostForm(t, seriesURL, values)
-	return NewPrometheusAPIV1SeriesResponse(t, res)
+	return NewAPIV1SeriesResponse(t, res)
 }
 
 // DeleteSeries sends a query to a /prometheus/api/v1/admin/tsdb/delete_series

--- a/apptest/vmsingle.go
+++ b/apptest/vmsingle.go
@@ -143,12 +143,12 @@ func (app *Vmsingle) GraphiteWrite(t *testing.T, records []string, _ QueryOpts) 
 	app.cli.Write(t, app.graphiteWriteAddr, records)
 }
 
-// PrometheusAPIV1ImportCSV is a test helper function that inserts a collection
+// APIV1ImportCSV is a test helper function that inserts a collection
 // of records in CSV format for the given tenant by sending an HTTP POST
 // request to /api/v1/import/csv vmsingle endpoint.
 //
 // See https://docs.victoriametrics.com/single-server-victoriametrics/#how-to-import-csv-data
-func (app *Vmsingle) PrometheusAPIV1ImportCSV(t *testing.T, records []string, opts QueryOpts) {
+func (app *Vmsingle) APIV1ImportCSV(t *testing.T, records []string, opts QueryOpts) {
 	t.Helper()
 
 	url := fmt.Sprintf("http://%s/api/v1/import/csv", app.httpListenAddr)
@@ -164,12 +164,12 @@ func (app *Vmsingle) PrometheusAPIV1ImportCSV(t *testing.T, records []string, op
 	}
 }
 
-// PrometheusAPIV1ImportNative is a test helper function that inserts a collection
+// APIV1ImportNative is a test helper function that inserts a collection
 // of records in native format for the given tenant by sending an HTTP POST
 // request to /api/v1/import/native vmsingle endpoint.
 //
 // See https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#how-to-import-data-in-native-format
-func (app *Vmsingle) PrometheusAPIV1ImportNative(t *testing.T, data []byte, opts QueryOpts) {
+func (app *Vmsingle) APIV1ImportNative(t *testing.T, data []byte, opts QueryOpts) {
 	t.Helper()
 
 	url := fmt.Sprintf("http://%s/api/v1/import/native", app.httpListenAddr)
@@ -206,10 +206,10 @@ func (app *Vmsingle) OpenTSDBAPIPut(t *testing.T, records []string, opts QueryOp
 	}
 }
 
-// PrometheusAPIV1Write is a test helper function that inserts a
+// APIV1Write is a test helper function that inserts a
 // collection of records in Prometheus remote-write format by sending a HTTP
 // POST request to /prometheus/api/v1/write vmsingle endpoint.
-func (app *Vmsingle) PrometheusAPIV1Write(t *testing.T, records []pb.TimeSeries, _ QueryOpts) {
+func (app *Vmsingle) APIV1Write(t *testing.T, records []pb.TimeSeries, _ QueryOpts) {
 	t.Helper()
 
 	wr := pb.WriteRequest{Timeseries: records}
@@ -220,12 +220,12 @@ func (app *Vmsingle) PrometheusAPIV1Write(t *testing.T, records []pb.TimeSeries,
 	}
 }
 
-// PrometheusAPIV1ImportPrometheus is a test helper function that inserts a
+// APIV1ImportPrometheus is a test helper function that inserts a
 // collection of records in Prometheus text exposition format by sending a HTTP
 // POST request to /prometheus/api/v1/import/prometheus vmsingle endpoint.
 //
 // See https://docs.victoriametrics.com/victoriametrics/url-examples/#apiv1importprometheus
-func (app *Vmsingle) PrometheusAPIV1ImportPrometheus(t *testing.T, records []string, opts QueryOpts) {
+func (app *Vmsingle) APIV1ImportPrometheus(t *testing.T, records []string, opts QueryOpts) {
 	t.Helper()
 
 	// add extra label
@@ -243,27 +243,27 @@ func (app *Vmsingle) PrometheusAPIV1ImportPrometheus(t *testing.T, records []str
 	}
 }
 
-// PrometheusAPIV1Export is a test helper function that performs the export of
+// APIV1Export is a test helper function that performs the export of
 // raw samples in JSON line format by sending a HTTP POST request to
 // /prometheus/api/v1/export vmsingle endpoint.
 //
 // See https://docs.victoriametrics.com/victoriametrics/url-examples/#apiv1export
-func (app *Vmsingle) PrometheusAPIV1Export(t *testing.T, query string, opts QueryOpts) *PrometheusAPIV1QueryResponse {
+func (app *Vmsingle) APIV1Export(t *testing.T, query string, opts QueryOpts) *APIV1QueryResponse {
 	t.Helper()
 	values := opts.asURLValues()
 	values.Add("match[]", query)
 	values.Add("format", "promapi")
 
 	res, _ := app.cli.PostForm(t, app.prometheusAPIV1ExportURL, values)
-	return NewPrometheusAPIV1QueryResponse(t, res)
+	return NewAPIV1QueryResponse(t, res)
 }
 
-// PrometheusAPIV1ExportNative is a test helper function that performs the export of
+// APIV1ExportNative is a test helper function that performs the export of
 // raw samples in native binary format by sending an HTTP POST request to
 // /prometheus/api/v1/export/native vmselect endpoint.
 //
 // See https://docs.victoriametrics.com/victoriametrics/url-examples/#apiv1exportnative
-func (app *Vmsingle) PrometheusAPIV1ExportNative(t *testing.T, query string, opts QueryOpts) []byte {
+func (app *Vmsingle) APIV1ExportNative(t *testing.T, query string, opts QueryOpts) []byte {
 	t.Helper()
 
 	t.Helper()
@@ -275,47 +275,47 @@ func (app *Vmsingle) PrometheusAPIV1ExportNative(t *testing.T, query string, opt
 	return []byte(res)
 }
 
-// PrometheusAPIV1Query is a test helper function that performs PromQL/MetricsQL
+// APIV1Query is a test helper function that performs PromQL/MetricsQL
 // instant query by sending a HTTP POST request to /prometheus/api/v1/query
 // vmsingle endpoint.
 //
 // See https://docs.victoriametrics.com/victoriametrics/url-examples/#apiv1query
-func (app *Vmsingle) PrometheusAPIV1Query(t *testing.T, query string, opts QueryOpts) *PrometheusAPIV1QueryResponse {
+func (app *Vmsingle) APIV1Query(t *testing.T, query string, opts QueryOpts) *APIV1QueryResponse {
 	t.Helper()
 
 	values := opts.asURLValues()
 	values.Add("query", query)
 	res, _ := app.cli.PostForm(t, app.prometheusAPIV1QueryURL, values)
-	return NewPrometheusAPIV1QueryResponse(t, res)
+	return NewAPIV1QueryResponse(t, res)
 }
 
-// PrometheusAPIV1QueryRange is a test helper function that performs
+// APIV1QueryRange is a test helper function that performs
 // PromQL/MetricsQL range query by sending a HTTP POST request to
 // /prometheus/api/v1/query_range vmsingle endpoint.
 //
 // See https://docs.victoriametrics.com/victoriametrics/url-examples/#apiv1query_range
-func (app *Vmsingle) PrometheusAPIV1QueryRange(t *testing.T, query string, opts QueryOpts) *PrometheusAPIV1QueryResponse {
+func (app *Vmsingle) APIV1QueryRange(t *testing.T, query string, opts QueryOpts) *APIV1QueryResponse {
 	t.Helper()
 
 	values := opts.asURLValues()
 	values.Add("query", query)
 
 	res, _ := app.cli.PostForm(t, app.prometheusAPIV1QueryRangeURL, values)
-	return NewPrometheusAPIV1QueryResponse(t, res)
+	return NewAPIV1QueryResponse(t, res)
 }
 
-// PrometheusAPIV1Series sends a query to a /prometheus/api/v1/series endpoint
+// APIV1Series sends a query to a /prometheus/api/v1/series endpoint
 // and returns the list of time series that match the query.
 //
 // See https://docs.victoriametrics.com/victoriametrics/url-examples/#apiv1series
-func (app *Vmsingle) PrometheusAPIV1Series(t *testing.T, matchQuery string, opts QueryOpts) *PrometheusAPIV1SeriesResponse {
+func (app *Vmsingle) APIV1Series(t *testing.T, matchQuery string, opts QueryOpts) *APIV1SeriesResponse {
 	t.Helper()
 
 	values := opts.asURLValues()
 	values.Add("match[]", matchQuery)
 
 	res, _ := app.cli.PostForm(t, app.prometheusAPIV1SeriesURL, values)
-	return NewPrometheusAPIV1SeriesResponse(t, res)
+	return NewAPIV1SeriesResponse(t, res)
 }
 
 // APIV1StatusMetricNamesStats sends a query to a /api/v1/status/metric_names_stats endpoint


### PR DESCRIPTION
### Describe Your Changes

Updated integration tests model by removing the `Prometheus` prefix from the interfaces, methods, and structs to make it consistent with the API naming.
We discussed those changes with @rtm0 . 

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
