### PR TITLE
app/vlinsert/journald: fixed binary value parsing

### DIFF
--- a/app/vlinsert/journald/journald.go
+++ b/app/vlinsert/journald/journald.go
@@ -282,7 +282,6 @@ func readJournaldLogEntry(streamName string, lr *insertutil.LineReader, lmp inse
 					return fmt.Errorf("unexpected end of stream while reading value size")
 				}
 				fb.value = append(fb.value, lr.Line...)
-				fb.value = append(fb.value, '\n')
 			}
 			size := binary.LittleEndian.Uint64(fb.value[:8])
 


### PR DESCRIPTION
### Describe Your Changes

do not append `\n` while extracting journald entry size

### Checklist

The following checks are **mandatory**:

- [ ] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
