### PR TITLE
lib/logstorage: clarify comment on writeBlockResultFunc usage constraints

### DIFF
--- a/lib/logstorage/storage_search.go
+++ b/lib/logstorage/storage_search.go
@@ -64,7 +64,8 @@ type searchOptions struct {
 
 // WriteDataBlockFunc must process the db.
 //
-// WriteDataBlockFunc cannot hold references to db after returning.
+// WriteDataBlockFunc cannot hold references to db or any of its fields after the function returns.
+// If you need BlockColumn names or values after the function returns, copy them using strings.Clone.
 type WriteDataBlockFunc func(workerID uint, db *DataBlock)
 
 func (f WriteDataBlockFunc) newBlockResultWriter() writeBlockResultFunc {


### PR DESCRIPTION
### Describe Your Changes

The `DataBlock` contains structs with string fields, and while the original comment mentioned not holding references to `br`, it wasn't immediately clear that this also applies to fields like strings within the data.

This change clarifies that the `writeBlockResultFunc` must not retain references to any part of `br`, including its fields. This makes it explicit that even seemingly safe types like strings must be copied if needed.

### Checklist

The following checks are **mandatory**:

- [ ] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
