### PR TITLE
lib/mergeset: misuse of unsafe.Pointer

### DIFF
--- a/lib/mergeset/encoding.go
+++ b/lib/mergeset/encoding.go
@@ -29,7 +29,7 @@ type Item struct {
 // The returned bytes representation belongs to data.
 func (it Item) Bytes(data []byte) []byte {
 	n := int(it.End - it.Start)
-	return unsafe.Slice((*byte)(unsafe.Pointer(uintptr(unsafe.Pointer(unsafe.SliceData(data)))+uintptr(it.Start))), n)
+	return unsafe.Slice(unsafe.SliceData(data[it.Start:]), n)
 }
 
 // String returns string representation of it obtained from data.
@@ -37,7 +37,7 @@ func (it Item) Bytes(data []byte) []byte {
 // The returned string representation belongs to data.
 func (it Item) String(data []byte) string {
 	n := int(it.End - it.Start)
-	return unsafe.String((*byte)(unsafe.Pointer(uintptr(unsafe.Pointer(unsafe.SliceData(data)))+uintptr(it.Start))), n)
+	return unsafe.String(unsafe.SliceData(data[it.Start:]), n)
 }
 
 func (ib *inmemoryBlock) Len() int {

--- a/lib/mergeset/encoding.go
+++ b/lib/mergeset/encoding.go
@@ -29,7 +29,7 @@ type Item struct {
 // The returned bytes representation belongs to data.
 func (it Item) Bytes(data []byte) []byte {
 	n := int(it.End - it.Start)
-	return unsafe.Slice(unsafe.SliceData(data[it.Start:]), n)
+	return unsafe.Slice((*byte)(unsafe.Add(unsafe.Pointer(unsafe.SliceData(data)), it.Start)), n)
 }
 
 // String returns string representation of it obtained from data.
@@ -37,7 +37,7 @@ func (it Item) Bytes(data []byte) []byte {
 // The returned string representation belongs to data.
 func (it Item) String(data []byte) string {
 	n := int(it.End - it.Start)
-	return unsafe.String(unsafe.SliceData(data[it.Start:]), n)
+	return unsafe.String((*byte)(unsafe.Add(unsafe.Pointer(unsafe.SliceData(data)), it.Start)), n)
 }
 
 func (ib *inmemoryBlock) Len() int {

--- a/lib/mergeset/encoding.go
+++ b/lib/mergeset/encoding.go
@@ -28,7 +28,10 @@ type Item struct {
 //
 // The returned bytes representation belongs to data.
 func (it Item) Bytes(data []byte) []byte {
-	n := int(it.End - it.Start)
+	n := it.End - it.Start
+	if n == 0 {
+		return nil
+	}
 	return unsafe.Slice((*byte)(unsafe.Add(unsafe.Pointer(unsafe.SliceData(data)), it.Start)), n)
 }
 
@@ -36,7 +39,10 @@ func (it Item) Bytes(data []byte) []byte {
 //
 // The returned string representation belongs to data.
 func (it Item) String(data []byte) string {
-	n := int(it.End - it.Start)
+	n := it.End - it.Start
+	if n == 0 {
+		return ""
+	}
 	return unsafe.String((*byte)(unsafe.Add(unsafe.Pointer(unsafe.SliceData(data)), it.Start)), n)
 }
 


### PR DESCRIPTION
### Describe Your Changes

It appears the `lib/mergeset.Item` violates the 3rd rule https://pkg.go.dev/unsafe#Pointer

> (3) Conversion of a Pointer to a uintptr and back, with arithmetic.
> 
> Unlike in C, it is not valid to advance a pointer just beyond the end of its original allocation:
> ```
> // INVALID: end points outside allocated space.
> b := make([]byte, n)`
> end = unsafe.Pointer(uintptr(unsafe.Pointer(&b[0])) + uintptr(n))
> ```


`CGO_ENABLED=0 go test -trimpath -gcflags=all=-d=checkptr -run TestTableAddItemsSerial`
```
fatal error: checkptr: pointer arithmetic result points to invalid allocation

goroutine 42 gp=0x14000082e00 m=6 mp=0x14000080808 [running]:
runtime.throw({0x100278d2a?, 0x100031a90?})
        runtime/panic.go:1101 +0x38 fp=0x14000987d00 sp=0x14000987cd0 pc=0x100097268
runtime.checkptrArithmetic(0x10067c5c0?, {0x14000987d90, 0x1, 0x14000996a80?})
        runtime/checkptr.go:69 +0xa8 fp=0x14000987d30 sp=0x14000987d00 pc=0x100031b78
github.com/VictoriaMetrics/VictoriaMetrics/lib/mergeset.Item.String(...)
        github.com/VictoriaMetrics/VictoriaMetrics/lib/mergeset/encoding.go:40
github.com/VictoriaMetrics/VictoriaMetrics/lib/mergeset.(*inmemoryBlock).Less(0x0?, 0x1000a4780?, 0x320?)
        github.com/VictoriaMetrics/VictoriaMetrics/lib/mergeset/encoding.go:55 +0xa8 fp=0x14000987da0 sp=0x14000987d30 pc=0x10021a098
sort.IsSorted({0x1003bf308, 0x140005a3880})
        sort/sort.go:111 +0x58 fp=0x14000987dd0 sp=0x14000987da0 pc=0x1001211f8
github.com/VictoriaMetrics/VictoriaMetrics/lib/mergeset.(*inmemoryBlock).isSorted(...)
        github.com/VictoriaMetrics/VictoriaMetrics/lib/mergeset/encoding.go:207
github.com/VictoriaMetrics/VictoriaMetrics/lib/mergeset.(*inmemoryBlock).SortItems(0x140005a3880)
        github.com/VictoriaMetrics/VictoriaMetrics/lib/mergeset/encoding.go:82 +0x2c fp=0x14000987df0 sp=0x14000987dd0 pc=0x10021a1ec
github.com/VictoriaMetrics/VictoriaMetrics/lib/mergeset.(*blockStreamReader).MustInitFromInmemoryBlock(0x140005a3880, 0x140000a89b0)
        github.com/VictoriaMetrics/VictoriaMetrics/lib/mergeset/block_stream_reader.go:110 +0x208 fp=0x14000987e60 sp=0x14000987df0 pc=0x100218228
github.com/VictoriaMetrics/VictoriaMetrics/lib/mergeset.(*Table).createInmemoryPart(0x1400014e3c0, {0x1400094c1e8, 0xf, 0x10020b910?})
        github.com/VictoriaMetrics/VictoriaMetrics/lib/mergeset/table.go:1006 +0xc0 fp=0x14000987f10 sp=0x14000987e60 pc=0x100228030
github.com/VictoriaMetrics/VictoriaMetrics/lib/mergeset.(*Table).flushBlocksToInmemoryParts.func1({0x1400094c1e8, 0xf, 0x0?})
        github.com/VictoriaMetrics/VictoriaMetrics/lib/mergeset/table.go:866 +0x78 fp=0x14000987fa0 sp=0x14000987f10 pc=0x100227338
github.com/VictoriaMetrics/VictoriaMetrics/lib/mergeset.(*Table).flushBlocksToInmemoryParts.gowrap1()
        github.com/VictoriaMetrics/VictoriaMetrics/lib/mergeset/table.go:875 +0x38 fp=0x14000987fd0 sp=0x14000987fa0 pc=0x100227288
runtime.goexit({})
        runtime/asm_arm64.s:1223 +0x4 fp=0x14000987fd0 sp=0x14000987fd0 pc=0x10009ee34
created by github.com/VictoriaMetrics/VictoriaMetrics/lib/mergeset.(*Table).flushBlocksToInmemoryParts in goroutine 14
        github.com/VictoriaMetrics/VictoriaMetrics/lib/mergeset/table.go:860 +0x140
```

`go version go1.24.4 darwin/arm64`


### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
