### PR TITLE
app/vmalert: data race in TestReply

### DIFF
--- a/app/vmalert/replay_test.go
+++ b/app/vmalert/replay_test.go
@@ -32,9 +32,6 @@ func (fr *fakeReplayQuerier) QueryRange(_ context.Context, q string, from, to ti
 		return res, fmt.Errorf("unexpected time range received: %q", key)
 	}
 	delete(dps, key)
-	if len(fr.registry[q]) < 1 {
-		delete(fr.registry, q)
-	}
 	return res, nil
 }
 
@@ -58,6 +55,11 @@ func TestReplay(t *testing.T) {
 		*replayMaxDatapoints = maxDP
 		if err := replay(cfg, qb, rwb); err != nil {
 			t.Fatalf("replay failed: %s", err)
+		}
+		for q := range qb.registry {
+			if len(qb.registry[q]) < 1 {
+				delete(qb.registry, q)
+			}
 		}
 		if len(qb.registry) > 0 {
 			t.Fatalf("not all requests were sent: %#v", qb.registry)


### PR DESCRIPTION
### Describe Your Changes

It appears that #9214 introduced a data race by adding a group with non-default concurrency

`CGO_ENABLED=1 go test -trimpath -run TestReplay -race`
```
WARNING: DATA RACE
Write at 0x00c000396660 by goroutine 32:
  runtime.mapassign_faststr()
      internal/runtime/maps/runtime_faststr_swiss.go:263 +0x4ac
  github.com/VictoriaMetrics/VictoriaMetrics/app/vmalert.(*fakeReplayQuerier).QueryRange()
      github.com/VictoriaMetrics/VictoriaMetrics/app/vmalert/replay_test.go:36 +0x224
  github.com/VictoriaMetrics/VictoriaMetrics/app/vmalert/rule.(*AlertingRule).execRange()
      github.com/VictoriaMetrics/VictoriaMetrics/app/vmalert/rule/alerting.go:332 +0xc8
  github.com/VictoriaMetrics/VictoriaMetrics/app/vmalert/rule.replayRule()
      github.com/VictoriaMetrics/VictoriaMetrics/app/vmalert/rule/rule.go:156 +0x124
  github.com/VictoriaMetrics/VictoriaMetrics/app/vmalert/rule.replayRuleRange()
      github.com/VictoriaMetrics/VictoriaMetrics/app/vmalert/rule/group.go:593 +0x164
  github.com/VictoriaMetrics/VictoriaMetrics/app/vmalert/rule.(*Group).Replay.func1()
      github.com/VictoriaMetrics/VictoriaMetrics/app/vmalert/rule/group.go:568 +0x128
  github.com/VictoriaMetrics/VictoriaMetrics/app/vmalert/rule.(*Group).Replay.gowrap1()
      github.com/VictoriaMetrics/VictoriaMetrics/app/vmalert/rule/group.go:571 +0xb8

Previous read at 0x00c000396660 by goroutine 31:
  runtime.mapaccess1_faststr()
      internal/runtime/maps/runtime_faststr_swiss.go:103 +0x28c
  github.com/VictoriaMetrics/VictoriaMetrics/app/vmalert.(*fakeReplayQuerier).QueryRange()
      github.com/VictoriaMetrics/VictoriaMetrics/app/vmalert/replay_test.go:26 +0x158
  github.com/VictoriaMetrics/VictoriaMetrics/app/vmalert/rule.(*AlertingRule).execRange()
      github.com/VictoriaMetrics/VictoriaMetrics/app/vmalert/rule/alerting.go:332 +0xc8
  github.com/VictoriaMetrics/VictoriaMetrics/app/vmalert/rule.replayRule()
      github.com/VictoriaMetrics/VictoriaMetrics/app/vmalert/rule/rule.go:156 +0x124
  github.com/VictoriaMetrics/VictoriaMetrics/app/vmalert/rule.replayRuleRange()
      github.com/VictoriaMetrics/VictoriaMetrics/app/vmalert/rule/group.go:593 +0x164
  github.com/VictoriaMetrics/VictoriaMetrics/app/vmalert/rule.(*Group).Replay.func1()
      github.com/VictoriaMetrics/VictoriaMetrics/app/vmalert/rule/group.go:568 +0x128
  github.com/VictoriaMetrics/VictoriaMetrics/app/vmalert/rule.(*Group).Replay.gowrap1()
      github.com/VictoriaMetrics/VictoriaMetrics/app/vmalert/rule/group.go:571 +0xb8

Goroutine 32 (running) created at:
  github.com/VictoriaMetrics/VictoriaMetrics/app/vmalert/rule.(*Group).Replay()
      github.com/VictoriaMetrics/VictoriaMetrics/app/vmalert/rule/group.go:566 +0x58c
  github.com/VictoriaMetrics/VictoriaMetrics/app/vmalert.replay()
      github.com/VictoriaMetrics/VictoriaMetrics/app/vmalert/replay.go:75 +0xa28
  github.com/VictoriaMetrics/VictoriaMetrics/app/vmalert.TestReplay.func1()
      github.com/VictoriaMetrics/VictoriaMetrics/app/vmalert/replay_test.go:59 +0x388
  github.com/VictoriaMetrics/VictoriaMetrics/app/vmalert.TestReplay()
      github.com/VictoriaMetrics/VictoriaMetrics/app/vmalert/replay_test.go:142 +0x11f8
  testing.tRunner()
      testing/testing.go:1792 +0x180
  testing.(*T).Run.gowrap1()
      testing/testing.go:1851 +0x40

Goroutine 31 (finished) created at:
  github.com/VictoriaMetrics/VictoriaMetrics/app/vmalert/rule.(*Group).Replay()
      github.com/VictoriaMetrics/VictoriaMetrics/app/vmalert/rule/group.go:566 +0x58c
  github.com/VictoriaMetrics/VictoriaMetrics/app/vmalert.replay()
      github.com/VictoriaMetrics/VictoriaMetrics/app/vmalert/replay.go:75 +0xa28
  github.com/VictoriaMetrics/VictoriaMetrics/app/vmalert.TestReplay.func1()
      github.com/VictoriaMetrics/VictoriaMetrics/app/vmalert/replay_test.go:59 +0x388
  github.com/VictoriaMetrics/VictoriaMetrics/app/vmalert.TestReplay()
      github.com/VictoriaMetrics/VictoriaMetrics/app/vmalert/replay_test.go:142 +0x11f8
  testing.tRunner()
      testing/testing.go:1792 +0x180
  testing.(*T).Run.gowrap1()
      testing/testing.go:1851 +0x40
```
`go version go1.24.4 darwin/arm64`

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
