### PR TITLE
victorialogs/docs: fix invalid stats example in "Comments" section

### DIFF
--- a/docs/victorialogs/LogsQL.md
+++ b/docs/victorialogs/LogsQL.md
@@ -4136,10 +4136,10 @@ LogsQL query may contain comments at any place. The comment starts with `#` and 
 Example query with comments:
 
 ```logsql
-error                       # find logs with `error` word
-  | stats by (_stream) logs # then count the number of logs per `_stream` label
-  | sort by (logs) desc     # then sort by the found logs in descending order
-  | limit 5                 # and show top 5 streams with the biggest number of logs
+error                               # find logs with `error` word
+  | stats by (_stream) count() logs # then count the number of logs per `_stream` label
+  | sort by (logs) desc             # then sort by the found logs in descending order
+  | limit 5                         # and show top 5 streams with the biggest number of logs
 ```
 
 ## Numeric values


### PR DESCRIPTION
### Describe Your Changes

The example in the VictoriaLogs docs (Comments section) is currently missing an aggregate function in the `stats` pipe:

```logsql
error                       # find logs with `error` word
  | stats by (_stream) logs # then count the number of logs per `_stream` label
  | sort by (logs) desc     # then sort by the found logs in descending order
  | limit 5                 # and show top 5 streams with the biggest number of logs
```

However, `stats by (_stream) logs` is invalid syntax - `logs` is interpreted as a function name, which causes a parsing error.

This fix replaces it with a valid version using `count()`:

```logsql
| stats by (_stream) count() as logs
```

Without `count()`, the query fails with:

```
 cannot parse 'stats' pipe: unknown stats func "logs"
```

