### PR TITLE
app/vmselect/promql: respect window interval for rollup functions when removing resets

### DIFF
--- a/apptest/tests/special_query_regression_test.go
+++ b/apptest/tests/special_query_regression_test.go
@@ -41,6 +41,7 @@ func testSpecialQueryRegression(tc *at.TestCase, sut at.PrometheusWriteQuerier) 
 	testDuplicateLabel(tc, sut)
 	testTooBigLookbehindWindow(tc, sut)
 	testMatchSeries(tc, sut)
+	testNegativeIncrease(tc, sut)
 
 	// graphite
 	testComparisonNotInfNotNan(tc, sut)
@@ -229,6 +230,53 @@ func testMatchSeries(tc *at.TestCase, sut at.PrometheusWriteQuerier) {
 				{"__name__": "GenBearTemp", "db": "TenMinute", "Park": "2", "TurbineType": "V112"},
 				{"__name__": "GenBearTemp", "db": "TenMinute", "Park": "3", "TurbineType": "V112"},
 				{"__name__": "GenBearTemp", "db": "TenMinute", "Park": "4", "TurbineType": "V112"},
+			},
+		},
+	})
+}
+
+func testNegativeIncrease(tc *at.TestCase, sut at.PrometheusWriteQuerier) {
+	t := tc.T()
+
+	// negative increase when user overrides staleness interval
+	// https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8935#issuecomment-2978728661
+	sut.PrometheusAPIV1ImportPrometheus(t, []string{
+		`foo 108 1750109243514`, // 2025-06-16 21:27:23:514
+		`foo 108 1750109258514`, // 2025-06-16 21:27:38:514
+		// gap 75s
+		`foo 1 1750109333514`, // 2025-06-16 21:28:53:514
+		`foo 1 1750109348514`, // 2025-06-16 21:29:08:514
+	}, at.QueryOpts{})
+	sut.ForceFlush(t)
+
+	tc.Assert(&at.AssertOptions{
+		Msg:        "regression for https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8935#issuecomment-2978728661",
+		DoNotRetry: true,
+		Got: func() any {
+			return sut.PrometheusAPIV1QueryRange(t, `increase(foo[1m])`, at.QueryOpts{
+				Start:       "2025-06-16T21:28:40.700Z",
+				End:         "2025-06-16T21:29:30.700Z",
+				Step:        "9s",
+				MaxLookback: "65s",
+			})
+		},
+		Want: &at.PrometheusAPIV1QueryResponse{
+			Status: "success",
+			Data: &at.QueryData{
+				ResultType: "matrix",
+				Result: []*at.QueryResult{
+					{
+						Metric: map[string]string{},
+						Samples: []*at.Sample{
+							at.NewSample(t, "2025-06-16T21:28:40.700Z", 0),
+							at.NewSample(t, "2025-06-16T21:28:49.700Z", 0),
+							at.NewSample(t, "2025-06-16T21:28:58.700Z", 1),
+							at.NewSample(t, "2025-06-16T21:29:07.700Z", 1),
+							at.NewSample(t, "2025-06-16T21:29:16.700Z", 0),
+							at.NewSample(t, "2025-06-16T21:29:25.700Z", 0),
+						},
+					},
+				},
 			},
 		},
 	})

--- a/docs/victoriametrics/changelog/CHANGELOG.md
+++ b/docs/victoriametrics/changelog/CHANGELOG.md
@@ -30,6 +30,7 @@ See also [LTS releases](https://docs.victoriametrics.com/victoriametrics/lts-rel
 * BUGFIX: [vmalert](https://docs.victoriametrics.com/victoriametrics/vmalert/): fix exposition of duplicated metrics for dynamically discovered notifiers via Consul and DNS. See [#9260](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/9260).
 * BUGFIX: [vmui](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#vmui): fix errors in console about loading of `manifest.json` when accessing UI through vmauth with Basic Auth enabled.
 * BUGFIX: [vmsingle](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/) and `vmstorage` in [VictoriaMetrics cluster](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/): properly return results for search requests with `.+|^$` regex filter expression. See [9290](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/9290) issue for details.
+* BUGFIX: [MetricsQL](https://docs.victoriametrics.com/victoriametrics/metricsql/): fix negative increase result when `-search.maxLookback` or `-search.maxStalenessInterval` are set and data contains gap. See [#8935 (comment)](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8935#issuecomment-2978728661).
 
 ## [v1.120.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.120.0)
 


### PR DESCRIPTION
removeCounterResets was operating only using stalenessInterval (when set by user) and didn't account for user-specified [window] in rollup functions. Since in rollup functions MetricsQL could look behind for up to [window] interval - it can capture those datapoints that weren't accounted in removeCounterResets. With this change, we remove resets on stalenessInterval+window interval to avoid this corner case.

Fixes https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8935#issuecomment-2978728661

### Describe Your Changes

Please provide a brief description of the changes you made. Be as specific as possible to help others understand the purpose and impact of your modifications.

### Checklist

The following checks are **mandatory**:

- [ ] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
