### PR TITLE
docs/anomaly-detection: mark import_json_path as deprecated

### DIFF
--- a/docs/anomaly-detection/components/writer.md
+++ b/docs/anomaly-detection/components/writer.md
@@ -126,7 +126,7 @@ Metrics to save the output (in metric names or labels). Must have `__name__` key
             </td>
             <td>
 
-`/api/v1/import`
+`/api/v1/import`{{% deprecated_from "v1.19.2" anomaly %}}
             </td>
             <td>
 


### PR DESCRIPTION
### Describe Your Changes

as noticed @f41gh7 in [operator PR](https://github.com/VictoriaMetrics/operator/pull/1427#discussion_r2164171944)
vm writer `import_json_path` became deprecated starting [v1.19.2](https://github.com/VictoriaMetrics/vmanomaly/commit/cc2cd0e084a9e431d0f5ea1b82ed33123cff9547). Adding this information to docs

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
