### PR TITLE
lib/storage: properly optimise .+|^$ regex

### DIFF
--- a/docs/victoriametrics/changelog/CHANGELOG.md
+++ b/docs/victoriametrics/changelog/CHANGELOG.md
@@ -23,6 +23,7 @@ See also [LTS releases](https://docs.victoriametrics.com/victoriametrics/lts-rel
 * FEATURE: [vmalert](https://docs.victoriametrics.com/victoriametrics/vmalert/): add `datasource_type` query argument for `/api/v1/rules` and `/api/v1/alerts` endpoints to filter response by rule's datasource [type](https://docs.victoriametrics.com/victoriametrics/vmalert/#groups). See [#8537](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8537).
 
 * BUGFIX: [dashboards/vmagent](https://grafana.com/grafana/dashboards/12683) and [dashboards/vmalert](https://grafana.com/grafana/dashboards/14950): fix ad-hoc filters auto-complete and filtering on panels that use MetricsQL specific expressions. See [#8657](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8657). 
+* BUGFIX: [vmsingle](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/) and `vmstorage` in [VictoriaMetrics cluster](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/): properly return results for search requests with `.+|^$` regex filter expression. See [9290](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/9290) issue for details.
 
 ## [v1.120.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.120.0)
 

--- a/lib/storage/tag_filters.go
+++ b/lib/storage/tag_filters.go
@@ -772,10 +772,25 @@ func isDotStar(sre *syntax.Regexp) bool {
 	case syntax.OpCapture:
 		return isDotStar(sre.Sub[0])
 	case syntax.OpAlternate:
+		var (
+			hasDotPlus    bool
+			hasEmptyMatch bool
+		)
 		for _, reSub := range sre.Sub {
 			if isDotStar(reSub) {
 				return true
 			}
+			if !hasDotPlus {
+				hasDotPlus = isDotPlus(reSub)
+			}
+			if !hasEmptyMatch {
+				hasEmptyMatch = reSub.Op == syntax.OpEmptyMatch
+			}
+		}
+		// special case for .+|^$ expression
+		// it must be converted into .*
+		if hasDotPlus && hasEmptyMatch {
+			return true
 		}
 		return false
 	case syntax.OpStar:

--- a/lib/storage/tag_filters_test.go
+++ b/lib/storage/tag_filters_test.go
@@ -734,6 +734,8 @@ func TestGetRegexpFromCache(t *testing.T) {
 	f("(?i)foo.*bar", nil, []string{"foobar", "FooBAR", "FOOxxbaR"}, []string{"xfoobar", "foobarx", "xFOObarx"}, "")
 
 	f(".*", nil, []string{"", "a", "foo", "foobar"}, nil, "")
+	f(`.+|`, nil, []string{"", "a", "foo", "foobar"}, nil, "")
+	f(`.+||foo|bar`, nil, []string{"", "a", "foo", "foobar"}, nil, "")
 	f("foo|.*", nil, []string{"", "a", "foo", "foobar"}, nil, "")
 	f(".+", nil, []string{"a", "foo"}, []string{""}, "")
 	f("(.+)*(foo)?", nil, []string{"a", "foo", ""}, nil, "")


### PR DESCRIPTION
 Previously, regex `.*|^$` was optimised into `.+`. But in fact, it must
optimised into `.*`. Since this regex matches any non empty symbols and empty value. Which combines into any input.

 This commit adds a special case of isDotStar check, which covers this
expression.

Fixes https://github.com/VictoriaMetrics/VictoriaMetrics/issues/9290