### PR TITLE
lib/mergeset: check invariant

### DIFF
--- a/lib/mergeset/part.go
+++ b/lib/mergeset/part.go
@@ -1,6 +1,7 @@
 package mergeset
 
 import (
+	"fmt"
 	"path/filepath"
 	"sync"
 	"unsafe"
@@ -127,6 +128,26 @@ func newPart(ph *partHeader, path string, size uint64, metaindexReader filestrea
 
 	p.ph.CopyFrom(ph)
 	return &p
+}
+
+func (p *part) validateOrder() {
+	ps := partSearch{}
+	ps.Init(p, true)
+
+	for i := range 256 {
+		ps.Seek([]byte{byte(i)})
+		hasNext := ps.NextItem()
+		if hasNext {
+			item := ps.Item
+			if item[0] < byte(i) {
+				panic(fmt.Sprintf("BUG: search for part %s returns item with first byte (%d) < i (%d), which is not expected", p.path, item[0], i))
+			}
+		}
+
+		if ps.Error() != nil {
+			panic(fmt.Sprintf("BUG: cannot validate order for part %q: %s", p.path, ps.Error()))
+		}
+	}
 }
 
 func (p *part) MustClose() {

--- a/lib/mergeset/table.go
+++ b/lib/mergeset/table.go
@@ -1256,6 +1256,10 @@ func (tb *Table) mergeParts(pws []*partWrapper, stopCh <-chan struct{}, isFinal 
 	dstBlocksCount := pDst.ph.blocksCount
 	dstSize := pDst.size
 
+	if isInTest {
+		pwNew.p.validateOrder()
+	}
+
 	tb.swapSrcWithDstParts(pws, pwNew, dstPartType)
 
 	d := time.Since(startTime)


### PR DESCRIPTION
### Describe Your Changes

Not sure if this could happen in real life, but it is possible to write a block with only one item to `lib/mergeset` (there is even a test in VM codebase for that – `TestTableAddItemsConcurrentStress`). The issue here is that a one-item block has 0 `itemsBlockSize` and therefore 2 blocks in the same part could have equal `itemsBlockOffset`, which breaks [a key](https://github.com/VictoriaMetrics/VictoriaMetrics/blob/e9f86af7f56274865337bfee6b80ce77f62d23bb/lib/mergeset/part_search.go#L310) for the block cache 
```
	ibKey := blockcache.Key{
		Part:   ps.p,
		Offset: bh.itemsBlockOffset,
	}
```  

A simple check in PR shows that – `TestTableAddItemsConcurrentStress` fails. I think it should either be prohibited to add these items or handled correctly (e.g. do not cache these items). 
If cache is [ignored](https://github.com/VictoriaMetrics/VictoriaMetrics/blob/e9f86af7f56274865337bfee6b80ce77f62d23bb/lib/mergeset/part_search.go#L315) (always fetch from disk), the test passes. 

### Checklist

The following checks are **mandatory**:

- [ ] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
