### PR TITLE
VictoriaLogs: add message processor metrics

### DIFF
--- a/app/vlinsert/insertutil/common_params.go
+++ b/app/vlinsert/insertutil/common_params.go
@@ -292,10 +292,11 @@ func (lmp *logMessageProcessor) AddInsertRow(r *logstorage.InsertRow) {
 
 // flushLocked must be called under locked lmp.mu.
 func (lmp *logMessageProcessor) flushLocked() {
-	lmp.lastFlushTime = time.Now()
+	start := time.Now()
+	lmp.lastFlushTime = start
 	logRowsStorage.MustAddRows(lmp.lr)
 	lmp.lr.ResetKeepSettings()
-	lmp.flushDuration.UpdateDuration(lmp.lastFlushTime)
+	lmp.flushDuration.UpdateDuration(start)
 }
 
 // MustClose flushes the remaining data to the underlying storage and closes lmp.


### PR DESCRIPTION
Add metrics to track the behavior of the message processor:

- `vl_insert_processors_count` tracks the current number of active log message processors.
- `vl_insert_flush_duration_seconds{type="protocol"}` measures the time taken to flush log data from recently parsed logs to the underlying storage system (in-memory buffering, remote storage nodes, or local storage).

Related issue: https://github.com/VictoriaMetrics/VictoriaMetrics/issues/9320