### PR TITLE
app/vmui/vlogs: improve autocomplete usability

### DIFF
--- a/app/vmui/packages/vmui/src/components/Configurators/AdditionalSettings/AdditionalSettings.tsx
+++ b/app/vmui/packages/vmui/src/components/Configurators/AdditionalSettings/AdditionalSettings.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useRef } from "preact/compat";
+import { FC, useRef } from "preact/compat";
 import { useCustomPanelDispatch, useCustomPanelState } from "../../../state/customPanel/CustomPanelStateContext";
 import { useQueryDispatch, useQueryState } from "../../../state/query/QueryStateContext";
 import "./style.scss";
@@ -9,10 +9,10 @@ import { TuneIcon } from "../../Main/Icons";
 import Button from "../../Main/Button/Button";
 import classNames from "classnames";
 import useBoolean from "../../../hooks/useBoolean";
-import useEventListener from "../../../hooks/useEventListener";
 import Tooltip from "../../Main/Tooltip/Tooltip";
 import { AUTOCOMPLETE_QUICK_KEY } from "../../Main/ShortcutKeys/constants/keyList";
 import { QueryConfiguratorProps } from "../../../pages/CustomPanel/QueryConfigurator/QueryConfigurator";
+import { useQuickAutocomplete } from "../../../hooks/useQuickAutocomplete";
 
 type Props = Pick<QueryConfiguratorProps, "hideButtons">;
 
@@ -22,6 +22,7 @@ const AdditionalSettingsControls: FC<Props & {isMobile?: boolean}> = ({ isMobile
 
   const { nocache, isTracingEnabled, reduceMemUsage } = useCustomPanelState();
   const customPanelDispatch = useCustomPanelDispatch();
+  useQuickAutocomplete();
 
   const onChangeCache = () => {
     customPanelDispatch({ type: "TOGGLE_NO_CACHE" });
@@ -38,21 +39,6 @@ const AdditionalSettingsControls: FC<Props & {isMobile?: boolean}> = ({ isMobile
   const onChangeAutocomplete = () => {
     queryDispatch({ type: "TOGGLE_AUTOCOMPLETE" });
   };
-
-  const onChangeQuickAutocomplete = () => {
-    queryDispatch({ type: "SET_AUTOCOMPLETE_QUICK", payload: true });
-  };
-
-  const handleKeyDown = (e: KeyboardEvent) => {
-    /** @see AUTOCOMPLETE_QUICK_KEY */
-    const { code, ctrlKey, altKey } = e;
-    if (code === "Space" && (ctrlKey || altKey)) {
-      e.preventDefault();
-      onChangeQuickAutocomplete();
-    }
-  };
-
-  useEventListener("keydown", handleKeyDown);
 
   return (
     <div

--- a/app/vmui/packages/vmui/src/components/Configurators/QueryEditor/LogsQL/LogsQueryEditorAutocomplete.tsx
+++ b/app/vmui/packages/vmui/src/components/Configurators/QueryEditor/LogsQL/LogsQueryEditorAutocomplete.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useCallback, useEffect, useMemo, useState } from "preact/compat";
+import { FC, useCallback, useEffect, useMemo, useState } from "preact/compat";
 import Autocomplete, { AutocompleteOptions } from "../../../Main/Autocomplete/Autocomplete";
 import { AUTOCOMPLETE_LIMITS } from "../../../../constants/queryAutocomplete";
 import { QueryEditorAutocompleteProps } from "../QueryEditor";
@@ -13,7 +13,8 @@ const LogsQueryEditorAutocomplete: FC<QueryEditorAutocompleteProps> = ({
   caretPosition,
   hasHelperText,
   onSelect,
-  onFoundOptions
+  onFoundOptions,
+  isOpen
 }) => {
   const [offsetPos, setOffsetPos] = useState({ top: 0, left: 0 });
 
@@ -41,7 +42,7 @@ const LogsQueryEditorAutocomplete: FC<QueryEditorAutocompleteProps> = ({
       query: value,
       ...getContextData(part, cursorStartPosition)
     };
-  }, [logicalParts, caretPosition]);
+  }, [logicalParts, caretPosition, value]);
 
   const { fieldNames, fieldValues, loading } = useFetchLogsQLOptions(contextData);
 
@@ -141,6 +142,10 @@ const LogsQueryEditorAutocomplete: FC<QueryEditorAutocompleteProps> = ({
     span.remove();
     marker.remove();
   }, [anchorEl, caretPosition, hasHelperText, fullValue]);
+
+  if (!isOpen) {
+    return;
+  }
 
   return (
     <>

--- a/app/vmui/packages/vmui/src/components/Configurators/QueryEditor/LogsQL/parser.ts
+++ b/app/vmui/packages/vmui/src/components/Configurators/QueryEditor/LogsQL/parser.ts
@@ -107,7 +107,7 @@ export const getContextData = (part: LogicalPart, cursorPos: number): ContextDat
     contextType: ContextType.Unknown,
   };
 
-  // Determine context type based on logical part type
+  // Determine a context type based on a logical part type
   determineContextType(part, valueBeforeCursor, valueAfterCursor, metaData);
 
   // Clean up quotes in valueContext
@@ -131,7 +131,7 @@ const handleFilterValue = (valueBeforeCursor: string, metaData: ContextData): vo
   const [filterName, ...filterValue] = valueBeforeCursor.split(":");
   metaData.contextType = ContextType.FilterValue;
   metaData.filterName = filterName;
-  const enhanceOperators = ["=", "-", "!", "~", "<", ">", "<=", ">="] as const;
+  const enhanceOperators = ["=", "-", "!"] as const;
   const enhanceOperator = enhanceOperators.find(op => op === filterValue[0]);
   if (enhanceOperator) {
     metaData.valueContext = filterValue.slice(1).join(":");
@@ -142,7 +142,7 @@ const handleFilterValue = (valueBeforeCursor: string, metaData: ContextData): vo
   }
 };
 
-/** Function to determine context type based on part type and value */
+/** Function to determine a context type based on part type and value */
 const determineContextType = (
   part: LogicalPart,
   valueBeforeCursor: string,

--- a/app/vmui/packages/vmui/src/components/Configurators/QueryEditor/LogsQL/useFetchLogsQLOptions.tsx
+++ b/app/vmui/packages/vmui/src/components/Configurators/QueryEditor/LogsQL/useFetchLogsQLOptions.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useRef, Dispatch, SetStateAction } from "preact/compat";
+import { useEffect, useState, useRef } from "preact/compat";
 import dayjs from "dayjs";
 import { ContextData, ContextType } from "./types";
 import { FunctionIcon, LabelIcon, MetricIcon, ValueIcon } from "../../../Main/Icons";

--- a/app/vmui/packages/vmui/src/components/Configurators/QueryEditor/QueryEditor.tsx
+++ b/app/vmui/packages/vmui/src/components/Configurators/QueryEditor/QueryEditor.tsx
@@ -15,6 +15,7 @@ export interface QueryEditorAutocompleteProps {
   caretPosition: [number, number]; // [start, end]
   hasHelperText: boolean;
   includeFunctions: boolean;
+  isOpen: boolean;
   onSelect: (val: string, caretPosition: number) => void;
   onFoundOptions: (val: AutocompleteOptions[]) => void;
 }
@@ -150,7 +151,7 @@ const QueryEditor: FC<QueryEditorProps> = ({
         inputmode={"search"}
         caretPosition={caretPositionInput}
       />
-      {showAutocomplete && autocomplete && AutocompleteEl && (
+      {autocomplete && AutocompleteEl && (
         <AutocompleteEl
           value={value}
           anchorEl={autocompleteAnchorEl}
@@ -159,6 +160,7 @@ const QueryEditor: FC<QueryEditorProps> = ({
           includeFunctions={includeFunctions}
           onSelect={handleSelect}
           onFoundOptions={handleChangeFoundOptions}
+          isOpen={showAutocomplete}
         />
       )}
     </div>

--- a/app/vmui/packages/vmui/src/components/Configurators/QueryEditor/QueryEditorAutocomplete.tsx
+++ b/app/vmui/packages/vmui/src/components/Configurators/QueryEditor/QueryEditorAutocomplete.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useState, useEffect, useMemo, useCallback } from "preact/compat";
+import { FC, useState, useEffect, useMemo, useCallback } from "preact/compat";
 import Autocomplete from "../../Main/Autocomplete/Autocomplete";
 import { useFetchQueryOptions } from "../../../hooks/useFetchQueryOptions";
 import useGetMetricsQL from "../../../hooks/useGetMetricsQL";
@@ -14,7 +14,8 @@ const QueryEditorAutocomplete: FC<QueryEditorAutocompleteProps> = ({
   hasHelperText,
   includeFunctions,
   onSelect,
-  onFoundOptions
+  onFoundOptions,
+  isOpen
 }) => {
   const [offsetPos, setOffsetPos] = useState({ top: 0, left: 0 });
   const metricsqlFunctions = useGetMetricsQL(includeFunctions);
@@ -143,6 +144,10 @@ const QueryEditorAutocomplete: FC<QueryEditorAutocompleteProps> = ({
     span.remove();
     marker.remove();
   }, [anchorEl, caretPosition, hasHelperText]);
+
+  if (!isOpen) {
+    return;
+  }
 
   return (
     <>

--- a/app/vmui/packages/vmui/src/components/Main/ShortcutKeys/constants/keyList.tsx
+++ b/app/vmui/packages/vmui/src/components/Main/ShortcutKeys/constants/keyList.tsx
@@ -1,4 +1,3 @@
-import React from "preact/compat";
 import { isMacOs } from "../../../../utils/detect-device";
 import { VisibilityIcon } from "../../Icons";
 import GraphTips from "../../../Chart/GraphTips/GraphTips";

--- a/app/vmui/packages/vmui/src/hooks/useQuickAutocomplete.ts
+++ b/app/vmui/packages/vmui/src/hooks/useQuickAutocomplete.ts
@@ -1,0 +1,24 @@
+import useEventListener from "./useEventListener";
+import { useQueryDispatch } from "../state/query/QueryStateContext";
+import { useCallback } from "react";
+
+export const useQuickAutocomplete = () => {
+  const queryDispatch = useQueryDispatch();
+
+  const setQuickAutocomplete = useCallback((value: boolean) => {
+    queryDispatch({ type: "SET_AUTOCOMPLETE_QUICK", payload: value });
+  }, [queryDispatch]);
+
+  const handleKeyDown = (e: KeyboardEvent) => {
+    /** @see AUTOCOMPLETE_QUICK_KEY */
+    const { code, ctrlKey, altKey } = e;
+    if (code === "Space" && (ctrlKey || altKey)) {
+      e.preventDefault();
+      setQuickAutocomplete(true);
+    }
+  };
+
+  useEventListener("keydown", handleKeyDown);
+
+  return setQuickAutocomplete;
+};

--- a/app/vmui/packages/vmui/src/pages/ExploreLogs/ExploreLogsHeader/ExploreLogsHeader.tsx
+++ b/app/vmui/packages/vmui/src/pages/ExploreLogs/ExploreLogsHeader/ExploreLogsHeader.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useEffect, useState } from "preact/compat";
+import { FC, useEffect, useState } from "preact/compat";
 import { InfoIcon, PlayIcon, SpinnerIcon, WikiIcon } from "../../../components/Main/Icons";
 import "./style.scss";
 import classNames from "classnames";
@@ -11,6 +11,9 @@ import { useQueryDispatch, useQueryState } from "../../../state/query/QueryState
 import Switch from "../../../components/Main/Switch/Switch";
 import QueryHistory from "../../../components/QueryHistory/QueryHistory";
 import useBoolean from "../../../hooks/useBoolean";
+import { useQuickAutocomplete } from "../../../hooks/useQuickAutocomplete";
+import { AUTOCOMPLETE_QUICK_KEY } from "../../../components/Main/ShortcutKeys/constants/keyList";
+import Tooltip from "../../../components/Main/Tooltip/Tooltip";
 
 export interface ExploreLogHeaderProps {
   query: string;
@@ -32,8 +35,9 @@ const ExploreLogsHeader: FC<ExploreLogHeaderProps> = ({
   onRun,
 }) => {
   const { isMobile } = useDeviceDetect();
-  const { autocomplete, queryHistory } = useQueryState();
+  const { autocomplete, queryHistory, autocompleteQuick } = useQueryState();
   const queryDispatch = useQueryDispatch();
+  const setQuickAutocomplete = useQuickAutocomplete();
 
   const [errorLimit, setErrorLimit] = useState("");
   const [limitInput, setLimitInput] = useState(limit);
@@ -85,6 +89,13 @@ const ExploreLogsHeader: FC<ExploreLogHeaderProps> = ({
     }
   }, [query, awaitQuery]);
 
+  const onChangeHandle = (value: string) => {
+    onChange(value);
+    if (autocompleteQuick) {
+      setQuickAutocomplete(false);
+    }
+  };
+
   return (
     <div
       className={classNames({
@@ -96,12 +107,12 @@ const ExploreLogsHeader: FC<ExploreLogHeaderProps> = ({
       <div className="vm-explore-logs-header-top">
         <QueryEditor
           value={query}
-          autocomplete={autocomplete}
+          autocomplete={autocomplete || autocompleteQuick}
           autocompleteEl={LogsQueryEditorAutocomplete}
           onArrowUp={createHandlerArrow(-1)}
           onArrowDown={createHandlerArrow(1)}
           onEnter={onRun}
-          onChange={onChange}
+          onChange={onChangeHandle}
           label={"Log query"}
           error={error}
         />
@@ -116,12 +127,14 @@ const ExploreLogsHeader: FC<ExploreLogHeaderProps> = ({
       </div>
       <div className="vm-explore-logs-header-bottom">
         <div className="vm-explore-logs-header-bottom-contols">
-          <Switch
-            label={"Autocomplete"}
-            value={autocomplete}
-            onChange={onChangeAutocomplete}
-            fullWidth={isMobile}
-          />
+          <Tooltip title={<>Quick tip: {AUTOCOMPLETE_QUICK_KEY}</>}>
+            <Switch
+              label={"Autocomplete"}
+              value={autocomplete}
+              onChange={onChangeAutocomplete}
+              fullWidth={isMobile}
+            />
+          </Tooltip>
         </div>
         <div className="vm-explore-logs-header-bottom-helpful">
           <a


### PR DESCRIPTION
### Describe Your Changes

Related issue: VictoriaMetrics/VictoriaLogs#70 
- added quick autocompletion for the VictoriaLogs via hotkeys;
- removed unnecessary data fetching for autocompletion;
- removed special chars which triggers autocompletion. Now autocompletion works only for `!`, `-`, `=`. 

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
