### PR TITLE
lib/streamaggr: properly clean quantiles output state on flush

### DIFF
--- a/docs/victoriametrics/changelog/CHANGELOG.md
+++ b/docs/victoriametrics/changelog/CHANGELOG.md
@@ -33,6 +33,7 @@ See also [LTS releases](https://docs.victoriametrics.com/victoriametrics/lts-rel
 * BUGFIX: [vmsingle](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/) and `vmstorage` in [VictoriaMetrics cluster](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/): properly return results for search requests with `.+|^$` regex filter expression. See [9290](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/9290) issue for details.
 * BUGFIX: [MetricsQL](https://docs.victoriametrics.com/victoriametrics/metricsql/): fix negative increase result when `-search.maxLookback` or `-search.maxStalenessInterval` are set and data contains gap. See [#8935 (comment)](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8935#issuecomment-2978728661).
 * BUGFIX: [vmalert](https://docs.victoriametrics.com/victoriametrics/vmalert/): remove inline styles from UI to align with `--http.header.csp=default-src 'self'` setting. See [#9236](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/9236).
+* BUGFIX: [stream aggregation](https://docs.victoriametrics.com/victoriametrics/stream-aggregation/): properly clean quantiles output state during flush. See [#9350](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/9350).
 
 ## [v1.120.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.120.0)
 

--- a/lib/streamaggr/quantiles.go
+++ b/lib/streamaggr/quantiles.go
@@ -22,8 +22,9 @@ func (av *quantilesAggrValue) flush(c aggrConfig, ctx *flushCtx, key string, _ b
 	ac := c.(*quantilesAggrConfig)
 	if av.h != nil {
 		ac.quantiles = av.h.Quantiles(ac.quantiles[:0], ac.phis)
+		histogram.PutFast(av.h)
+		av.h = nil
 	}
-	histogram.PutFast(av.h)
 	if len(ac.quantiles) > 0 {
 		for i, quantile := range ac.quantiles {
 			ac.b = strconv.AppendFloat(ac.b[:0], ac.phis[i], 'g', -1, 64)


### PR DESCRIPTION
### Describe Your Changes

fixes https://github.com/VictoriaMetrics/VictoriaMetrics/issues/9350

### Checklist

The following checks are **mandatory**:

- [ ] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
