### PR TITLE
issue-7599: do not force read-only for legacy idbs

### DIFF
--- a/lib/storage/index_db_legacy.go
+++ b/lib/storage/index_db_legacy.go
@@ -4,17 +4,15 @@ import (
 	"math"
 	"path/filepath"
 	"strconv"
-	"sync/atomic"
 
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/logger"
 )
 
-// mustOpenLegacyIndexDBReadOnly opens legacy index db from the given path in
-// read-only mode.
+// mustOpenLegacyIndexDB opens legacy index db from the given path.
 //
 // The last segment of the path should contain unique hex value which
 // will be then used as indexDB.generation
-func mustOpenLegacyIndexDBReadOnly(path string, s *Storage) *indexDB {
+func mustOpenLegacyIndexDB(path string, s *Storage) *indexDB {
 	name := filepath.Base(path)
 	id, err := strconv.ParseUint(name, 16, 64)
 	if err != nil {
@@ -25,7 +23,5 @@ func mustOpenLegacyIndexDBReadOnly(path string, s *Storage) *indexDB {
 		MinTimestamp: 0,
 		MaxTimestamp: math.MaxInt64,
 	}
-	var alwaysReadOnly atomic.Bool
-	alwaysReadOnly.Store(true)
-	return mustOpenIndexDB(id, tr, name, path, s, &alwaysReadOnly)
+	return mustOpenIndexDB(id, tr, name, path, s, &s.isReadOnly)
 }

--- a/lib/storage/storage_legacy.go
+++ b/lib/storage/storage_legacy.go
@@ -82,3 +82,14 @@ func (s *Storage) legacyDeleteSeries(qt *querytracer.Tracer, tfss []*TagFilters,
 
 	return slices.Concat(dmisPrev, dmisCurr), nil
 }
+
+func (s *Storage) legacyDebugFlush() {
+	legacyIDBPrev, legacyIDBCurr := s.getLegacyIndexDBs()
+	if legacyIDBPrev != nil {
+		legacyIDBPrev.tb.DebugFlush()
+	}
+	if legacyIDBCurr != nil {
+		legacyIDBCurr.tb.DebugFlush()
+	}
+	defer s.putLegacyIndexDBs(legacyIDBPrev, legacyIDBCurr)
+}

--- a/lib/storage/storage_legacy.go
+++ b/lib/storage/storage_legacy.go
@@ -91,5 +91,5 @@ func (s *Storage) legacyDebugFlush() {
 	if legacyIDBCurr != nil {
 		legacyIDBCurr.tb.DebugFlush()
 	}
-	defer s.putLegacyIndexDBs(legacyIDBPrev, legacyIDBCurr)
+	s.putLegacyIndexDBs(legacyIDBPrev, legacyIDBCurr)
 }


### PR DESCRIPTION
### Describe Your Changes

`isReadOnly` flag does not prevent writes (which we need to perform in case of deletion), it just [disables background merges](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/2603). In some cases, it could lead to a large number of small parts and hurt performance.

Union of legacy deleted metric ids is already propagated to partitioned indexDBs. We also need to add them to the previous legacy indexDB. 

### Checklist

The following checks are **mandatory**:

- [ ] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
