### PR TITLE
lib/promscrape/discovery/gce: add support for ipv6 in metadata labels

### DIFF
--- a/docs/victoriametrics/changelog/CHANGELOG.md
+++ b/docs/victoriametrics/changelog/CHANGELOG.md
@@ -18,6 +18,7 @@ See also [LTS releases](https://docs.victoriametrics.com/victoriametrics/lts-rel
 
 ## tip
 
+* FEATURE: [vmsingle](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/) and [vmagent](https://docs.victoriametrics.com/victoriametrics/vmagent/): add ipv6 address as a metadata label to [gce_sd_configs](https://docs.victoriametrics.com/victoriametrics/sd_configs/#gce_sd_configs)
 * FEATURE: [vmbackupmanager](https://docs.victoriametrics.com/vmbackupmanager/): improve error messages when `vmbackupmanager` fails to create snapshot. See [#9340](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/9340) for the details.
 * FEATURE: [vmbackupmanager](https://docs.victoriametrics.com/vmbackupmanager/): support client-side TLS configuration for creating and deleting snapshots via `-snapshot.tls*` cmd-line flags.
 * FEATURE: [vmsingle](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/) and [vmagent](https://docs.victoriametrics.com/victoriametrics/vmagent/): remove duplicate kubernetes targets from [service-discovery-debug](https://docs.victoriametrics.com/victoriametrics/relabeling/#relabel-debugging) page. See [8626](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8626) issue for details.

--- a/docs/victoriametrics/sd_configs.md
+++ b/docs/victoriametrics/sd_configs.md
@@ -869,6 +869,7 @@ The following meta labels are available on discovered targets during [relabeling
 * `__meta_gce_network`: the network URL of the instance
 * `__meta_gce_private_ip`: the private IP address of the instance
 * `__meta_gce_interface_ipv4_<name>`: IPv4 address of each named interface
+* `__meta_gce_interface_ipv6` : the IPv6 address of the instance
 * `__meta_gce_project`: the GCP project in which the instance is running
 * `__meta_gce_public_ip`: the public IP address of the instance, if present
 * `__meta_gce_subnetwork`: the subnetwork URL of the instance

--- a/lib/promscrape/discovery/gce/instance.go
+++ b/lib/promscrape/discovery/gce/instance.go
@@ -94,17 +94,25 @@ type Instance struct {
 
 // NetworkInterface is network interface from https://cloud.google.com/compute/docs/reference/rest/v1/instances/list
 type NetworkInterface struct {
-	Name          string
-	Network       string
-	Subnetwork    string
-	NetworkIP     string
-	AccessConfigs []AccessConfig
+	Name              string
+	Network           string
+	Subnetwork        string
+	NetworkIP         string
+	Ipv6Address       string
+	AccessConfigs     []AccessConfig
+	Ipv6AccessConfigs []Ipv6AccessConfig
 }
 
 // AccessConfig is access config from https://cloud.google.com/compute/docs/reference/rest/v1/instances/list
 type AccessConfig struct {
 	Type  string
 	NatIP string
+}
+
+// Ipv6AccessConfig is access config from https://cloud.google.com/compute/docs/reference/rest/v1/instances/list
+type Ipv6AccessConfig struct {
+	Type         string
+	ExternalIpv6 string
 }
 
 // TagList is tag list from https://cloud.google.com/compute/docs/reference/rest/v1/instances/list
@@ -168,6 +176,16 @@ func (inst *Instance) appendTargetLabels(ms []*promutil.Labels, project, tagSepa
 		if ac.Type == "ONE_TO_ONE_NAT" {
 			m.Add("__meta_gce_public_ip", ac.NatIP)
 		}
+	}
+	// GCE supports ULA as well as native IPv6
+	if len(iface.Ipv6AccessConfigs) > 0 {
+		ac := iface.Ipv6AccessConfigs[0]
+		if ac.Type == "DIRECT_IPV6" {
+			m.Add("__meta_gce_ipv6", ac.ExternalIpv6)
+		}
+	}
+	if iface.Ipv6Address != "" {
+		m.Add("__meta_gce_ipv6", iface.Ipv6Address)
 	}
 	ms = append(ms, m)
 	return ms


### PR DESCRIPTION
### Describe Your Changes

* Add support in GCE service discovery for finding IPv6 address

Hi! Long time user, first time contributor. :wave: 
This change will expose any IPv6 address assigned to an instance under the meta label `__meta_gce_ipv6`. In GCE an instance can either have a native IPv6 address or an unique local address (ULA) but not both. I have not updated the tests because it's unfortunately outside of my ability (I'm not a programmer nor very familiar with golang). I've compiled and run vmagent against my own GCP project where I have instances without IPv6, with native IPv6 and with ULA IPv6 running. See result below (I've masked and replaced identifying information)
```
## With native IPv6
{__address__="10.4.0.13:80",__meta_gce_instance_id="123213213123",__meta_gce_instance_name="with-native-ipv6",__meta_gce_instance_status="RUNNING",__meta_gce_interface_ipv4_nic0="10.4.0.13",__meta_gce_ipv6="2600:1900::::::", __meta_gce_machine_type="https://www.googleapis.com/compute/v1/projects/myproject/zones/europe-west1-b/machineTypes/e2-micro",__meta_gce_network="https://www.googleapis.com/compute/v1/projects/myproject/global/networks/my-network",__meta_gce_private_ip="10.4.0.13",__meta_gce_project="myproject",__meta_gce_public_ip="1.1.1.1",__meta_gce_subnetwork="https://www.googleapis.com/compute/v1/projects/myproject/regions/europe-west1/subnetworks/subnet-europe-west1",__meta_gce_zone="https://www.googleapis.com/compute/v1/projects/myproject/zones/europe-west1-b",__metrics_path__="/metrics",__scheme__="http",__scrape_interval__="30s",__scrape_timeout__="10s",job="gce"}

## With ULA IPv6
{__address__="10.0.0.115:80",__meta_gce_instance_id="123213213123",__meta_gce_instance_name="with-ula-ipv6",__meta_gce_instance_status="RUNNING",__meta_gce_interface_ipv4_nic0="10.0.0.115",__meta_gce_ipv6="fd20:dee:edd:3800:0:15a:0:0"__meta_gce_machine_type="https://www.googleapis.com/compute/v1/projects/myproject/zones/europe-west1-b/machineTypes/e2-micro",__meta_gce_network="https://www.googleapis.com/compute/v1/projects/myproject/global/networks/my-network",__meta_gce_private_ip="10.0.0.115",__meta_gce_project="myproject",__meta_gce_subnetwork="https://www.googleapis.com/compute/v1/projects/myproject/regions/europe-west1/subnetworks/my-subnet",__meta_gce_zone="https://www.googleapis.com/compute/v1/projects/myproject/zones/europe-west1-d",__metrics_path__="/metrics",__scheme__="http",__scrape_interval__="30s",__scrape_timeout__="10s",job="gce"}

## Without IPv6
{__address__="10.4.0.31:80",__meta_gce_instance_id="123213213123",__meta_gce_instance_name="without-ipv6",__meta_gce_instance_status="RUNNING",__meta_gce_interface_ipv4_nic0="10.4.0.31",__meta_gce_machine_type="https://www.googleapis.com/compute/v1/projects/myproject/zones/europe-west1-b/machineTypes/e2-micro",__meta_gce_network="https://www.googleapis.com/compute/v1/projects/myproject/global/networks/my-network",__meta_gce_private_ip="10.4.0.31",__meta_gce_project="myproject",__meta_gce_public_ip="1.1.1.1",__meta_gce_subnetwork="https://www.googleapis.com/compute/v1/projects/myproject/regions/europe-west1/subnetworks/subnet-europe-west1",__meta_gce_zone="https://www.googleapis.com/compute/v1/projects/myproject/zones/europe-west1-b",__metrics_path__="/metrics",__scheme__="http",__scrape_interval__="30s",__scrape_timeout__="10s",job="gce"}
```
### Checklist

The following checks are **mandatory**:

- [ x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
