### PR TITLE
VictoriaTraces: Fix ref type typo. Support resource attribute filter

### DIFF
--- a/app/vlselect/traces/jaeger/jaeger.go
+++ b/app/vlselect/traces/jaeger/jaeger.go
@@ -372,7 +372,7 @@ func parseJaegerTraceQueryParam(_ context.Context, r *http.Request) (*query.Trac
 				v = spanKindMap[v]
 			}
 			attributesFilter[field] = v
-		} else if strings.HasPrefix(k, otelpb.InstrumentationScopeAttrPrefix) {
+		} else if strings.HasPrefix(k, otelpb.InstrumentationScopeAttrPrefix) || strings.HasPrefix(k, otelpb.ResourceAttrPrefix) {
 			attributesFilter[k] = v
 		} else {
 			attributesFilter[otelpb.SpanAttrPrefixField+k] = v

--- a/app/vlselect/traces/jaeger/model.go
+++ b/app/vlselect/traces/jaeger/model.go
@@ -216,7 +216,7 @@ func fieldsToSpan(fields []logstorage.Field) (*span, error) {
 				idx, fieldName := fieldSplit[0], fieldSplit[1]
 				if _, ok := refsMap[idx]; !ok {
 					refsMap[idx] = &spanRef{
-						refType: "FOLLOW_FROM", // default FOLLOW_FROM
+						refType: "FOLLOWS_FROM", // default FOLLOWS_FROM
 					}
 				}
 				ref := refsMap[idx]

--- a/app/vlselect/traces/jaeger/model_test.go
+++ b/app/vlselect/traces/jaeger/model_test.go
@@ -117,7 +117,7 @@ func TestFieldsToSpan(t *testing.T) {
 			{
 				traceID: "99999999999",
 				spanID:  "98765",
-				refType: "FOLLOW_FROM",
+				refType: "FOLLOWS_FROM",
 			},
 		},
 		startTime: 0,

--- a/apptest/tests/otlp_ingestion_test.go
+++ b/apptest/tests/otlp_ingestion_test.go
@@ -169,7 +169,7 @@ func testOTLPIngestionJaegerQuery(tc *at.TestCase, sut at.VictoriaTracesWriteQue
 						{
 							TraceID: hex.EncodeToString([]byte(traceID)),
 							SpanID:  hex.EncodeToString([]byte(spanID)),
-							RefType: "FOLLOW_FROM",
+							RefType: "FOLLOWS_FROM",
 						},
 					},
 					StartTime: spanTime.UnixMicro(),


### PR DESCRIPTION
### Describe Your Changes

1. Currently user can't filter trace by resource attributes. This pull request enable such capability when user use `resource_attr:` prefix in tag filter of Jaeger query APIs.
2. Fix ref type typo `FOLLOWS_FROM`. This issue affect the visualization in Grafana and Jaeger.

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
