### PR TITLE
apptest: Do not configure cluster storageDataPath and retentionPeriod by default

### DIFF
--- a/apptest/testcase.go
+++ b/apptest/testcase.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -226,9 +227,17 @@ func (tc *TestCase) MustStartDefaultCluster() *Vmcluster {
 
 	return tc.MustStartCluster(&ClusterOptions{
 		Vmstorage1Instance: "vmstorage1",
+		Vmstorage1Flags: []string{
+			"-storageDataPath=" + filepath.Join(tc.Dir(), "vmstorage1"),
+			"-retentionPeriod=100y",
+		},
 		Vmstorage2Instance: "vmstorage2",
-		VminsertInstance:   "vminsert",
-		VmselectInstance:   "vmselect",
+		Vmstorage2Flags: []string{
+			"-storageDataPath=" + filepath.Join(tc.Dir(), "vmstorage2"),
+			"-retentionPeriod=100y",
+		},
+		VminsertInstance: "vminsert",
+		VmselectInstance: "vmselect",
 	})
 }
 
@@ -258,16 +267,7 @@ type ClusterOptions struct {
 func (tc *TestCase) MustStartCluster(opts *ClusterOptions) *Vmcluster {
 	tc.t.Helper()
 
-	opts.Vmstorage1Flags = append(opts.Vmstorage1Flags, []string{
-		"-storageDataPath=" + tc.Dir() + "/" + opts.Vmstorage1Instance,
-		"-retentionPeriod=100y",
-	}...)
 	vmstorage1 := tc.MustStartVmstorage(opts.Vmstorage1Instance, opts.Vmstorage1Flags)
-
-	opts.Vmstorage2Flags = append(opts.Vmstorage2Flags, []string{
-		"-storageDataPath=" + tc.Dir() + "/" + opts.Vmstorage2Instance,
-		"-retentionPeriod=100y",
-	}...)
 	vmstorage2 := tc.MustStartVmstorage(opts.Vmstorage2Instance, opts.Vmstorage2Flags)
 
 	opts.VminsertFlags = append(opts.VminsertFlags, []string{

--- a/apptest/tests/special_query_regression_test.go
+++ b/apptest/tests/special_query_regression_test.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 
 	at "github.com/VictoriaMetrics/VictoriaMetrics/apptest"
@@ -27,10 +28,18 @@ func TestClusterSpecialQueryRegression(t *testing.T) {
 
 	sut := tc.MustStartCluster(&at.ClusterOptions{
 		Vmstorage1Instance: "vmstorage1",
+		Vmstorage1Flags: []string{
+			"-storageDataPath=" + filepath.Join(tc.Dir(), "vmstorage1"),
+			"-retentionPeriod=100y",
+		},
 		Vmstorage2Instance: "vmstorage2",
-		VminsertInstance:   "vminsert",
-		VminsertFlags:      []string{"-graphiteListenAddr=:0", "-opentsdbListenAddr=127.0.0.1:0"},
-		VmselectInstance:   "vmselect",
+		Vmstorage2Flags: []string{
+			"-storageDataPath=" + filepath.Join(tc.Dir(), "vmstorage2"),
+			"-retentionPeriod=100y",
+		},
+		VminsertInstance: "vminsert",
+		VminsertFlags:    []string{"-graphiteListenAddr=:0", "-opentsdbListenAddr=127.0.0.1:0"},
+		VmselectInstance: "vmselect",
 	})
 	testSpecialQueryRegression(tc, sut)
 }

--- a/apptest/tests/vmctl_native_migration_test.go
+++ b/apptest/tests/vmctl_native_migration_test.go
@@ -3,6 +3,7 @@ package tests
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -50,15 +51,31 @@ func TestClusterTenantsToTenantsVmctlNativeProtocol(t *testing.T) {
 
 	clusterSrc := tc.MustStartCluster(&apptest.ClusterOptions{
 		Vmstorage1Instance: "vmstorageSrc1",
+		Vmstorage1Flags: []string{
+			"-storageDataPath=" + filepath.Join(tc.Dir(), "vmstorage1-src"),
+			"-retentionPeriod=100y",
+		},
 		Vmstorage2Instance: "vmstorageSrc2",
-		VminsertInstance:   "vminsertSrc",
-		VmselectInstance:   "vmselectSrc",
+		Vmstorage2Flags: []string{
+			"-storageDataPath=" + filepath.Join(tc.Dir(), "vmstorage2-src"),
+			"-retentionPeriod=100y",
+		},
+		VminsertInstance: "vminsertSrc",
+		VmselectInstance: "vmselectSrc",
 	})
 	clusterDst := tc.MustStartCluster(&apptest.ClusterOptions{
 		Vmstorage1Instance: "vmstorageDst1",
+		Vmstorage1Flags: []string{
+			"-storageDataPath=" + filepath.Join(tc.Dir(), "vmstorage1-dst"),
+			"-retentionPeriod=100y",
+		},
 		Vmstorage2Instance: "vmstorageDst2",
-		VminsertInstance:   "vminsertDst",
-		VmselectInstance:   "vmselectDst",
+		Vmstorage2Flags: []string{
+			"-storageDataPath=" + filepath.Join(tc.Dir(), "vmstorage2-dst"),
+			"-retentionPeriod=100y",
+		},
+		VminsertInstance: "vminsertDst",
+		VmselectInstance: "vmselectDst",
 	})
 
 	vmSrcAddr := fmt.Sprintf("http://%s/", clusterSrc.Vmselect.HTTPAddr())


### PR DESCRIPTION
Defaults are set only in StartDefaultCluster()

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
