### PR TITLE
deployment/docker: fix datasource provision file for cluster

### DIFF
--- a/deployment/docker/auth-vm-cluster.yml
+++ b/deployment/docker/auth-vm-cluster.yml
@@ -1,5 +1,7 @@
 # balance load among vmselects
 # see https://docs.victoriametrics.com/victoriametrics/vmauth/#load-balancing
+# Note: if username and password are changes, please update the Grafana datasource configuration
+# and check other places where these credentials are used.
 users:
   - username: "foo"
     password: "bar"

--- a/deployment/docker/provisioning/datasources/prometheus-datasource/cluster.yml
+++ b/deployment/docker/provisioning/datasources/prometheus-datasource/cluster.yml
@@ -6,6 +6,10 @@ datasources:
       access: proxy
       url: http://vmauth:8427/select/0/prometheus
       isDefault: true
+      # Basic Auth credentials for the datasource
+      # This is used to authenticate with the vmauth service
+      # Note: please check changes in the vmauth configuration `auth-vm-cluster.yml`
+      # to ensure the credential match
       basicAuth: true
       basicAuthUser: foo
       secureJsonData:


### PR DESCRIPTION
### Describe Your Changes

When you try to run `make docker-cluster-up` and try to check metrics in the Explore page of the Grafana, you will see the basic auth request. If you enter the correct login and password from the `auth-vm-cluster.yml` it will continue to ask about the username and password. It happens because the datasource is configured to ask for data vmauth, but in the configuration, no auth information is provided.

Added the basich auth info to the datasource provision file

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
