### PR TITLE
app/vmagent/remotewrite: Prevent panic during block re-pack on protocol downgrade.

### DIFF
--- a/app/vmagent/remotewrite/client_test.go
+++ b/app/vmagent/remotewrite/client_test.go
@@ -105,7 +105,10 @@ func TestRepackBlockFromZstdToSnappy(t *testing.T) {
 	expectedPlainBlock := []byte(`foobar`)
 
 	zstdBlock := encoding.CompressZSTDLevel(nil, expectedPlainBlock, 1)
-	snappyBlock := mustRepackBlockFromZstdToSnappy(zstdBlock)
+	snappyBlock, err := repackBlockFromZstdToSnappy(zstdBlock)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
 
 	actualPlainBlock, err := snappy.Decode(nil, snappyBlock)
 	if err != nil {
@@ -114,5 +117,16 @@ func TestRepackBlockFromZstdToSnappy(t *testing.T) {
 
 	if string(actualPlainBlock) != string(expectedPlainBlock) {
 		t.Fatalf("unexpected plain block; got %q; want %q", actualPlainBlock, expectedPlainBlock)
+	}
+}
+
+func TestRepackBlockFromZstdToSnappyInvalidBlock(t *testing.T) {
+	snappyBlock, err := repackBlockFromZstdToSnappy([]byte("invalid zstd block"))
+
+	if err == nil {
+		t.Fatalf("expected error for invalid zstd block; got nil")
+	}
+	if len(snappyBlock) != 0 {
+		t.Fatalf("expected empty snappy block; got %d bytes", len(snappyBlock))
 	}
 }

--- a/docs/victoriametrics/changelog/CHANGELOG.md
+++ b/docs/victoriametrics/changelog/CHANGELOG.md
@@ -20,6 +20,8 @@ See also [LTS releases](https://docs.victoriametrics.com/victoriametrics/lts-rel
 
 * SECURITY: upgrade Go builder from Go1.24.4 to Go1.24.5. See [the list of issues addressed in Go1.24.5](https://github.com/golang/go/issues?q=milestone%3AGo1.24.5+label%3ACherryPickApproved).
 
+* BUGFIX: [vmagent](https://docs.victoriametrics.com/vmagent/): Prevent panic when re-packing a corrupted block during protocol downgrade. See [#9417](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/9417).
+
 ## [v1.121.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.121.0)
 
 Released at 2025-07-04


### PR DESCRIPTION
### Describe Your Changes

Also, the protocol is downgraded only if vmagent can re-pack the block successfully. It would prevent an accidental downgrade on a corrupted block.

Fixes https://github.com/VictoriaMetrics/VictoriaMetrics/issues/9417

### Checklist

The following checks are **mandatory**:

- [ ] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [ ] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
