### PR TITLE
logger: adjust logger path format when using in vendor and other repo

### DIFF
--- a/lib/logger/logger.go
+++ b/lib/logger/logger.go
@@ -333,12 +333,18 @@ func simplifyFilePath(file string) string {
 		file = file[n+len("/VictoriaMetrics/"):]
 	}
 
-	// the path may under vendor folder and may contain go module version num.
 	keyword := "/vendor/github.com/VictoriaMetrics/VictoriaMetrics"
 	if vendorIdx := strings.Index(file, keyword); vendorIdx >= 0 {
+		// the path may under vendor folder
 		if slashOffset := strings.Index(file[vendorIdx+len(keyword):], "/"); slashOffset > 0 {
+			// There is no trailing '/' after '/vendor/github.com/VictoriaMetrics/VictoriaMetrics',
+			// so it must contain a Go module version number.
+			//
+			// example:
 			// VictoriaTraces/vendor/github.com/VictoriaMetrics/VictoriaMetrics@v0.0.0-00010101000000-000000000000/1.go
 			// |  vendorIdx |                   len(keyword)                   |             slashOffset          |   |
+			//
+			// remove Go module version number in |<-slashOffset->|.
 			file = file[:vendorIdx+len(keyword)] + file[vendorIdx+len(keyword)+slashOffset:]
 		}
 	}

--- a/lib/logger/logger.go
+++ b/lib/logger/logger.go
@@ -335,7 +335,7 @@ func simplifyFilePath(file string) string {
 
 	// the path may under vendor folder and may contain go module version num.
 	keyword := "/vendor/github.com/VictoriaMetrics/VictoriaMetrics"
-	if vendorIdx := strings.Index(file, "/vendor/github.com/VictoriaMetrics/VictoriaMetrics"); vendorIdx >= 0 {
+	if vendorIdx := strings.Index(file, keyword); vendorIdx >= 0 {
 		if slashOffset := strings.Index(file[vendorIdx+len(keyword):], "/"); slashOffset > 0 {
 			// VictoriaTraces/vendor/github.com/VictoriaMetrics/VictoriaMetrics@v0.0.0-00010101000000-000000000000/1.go
 			// |  vendorIdx |                   len(keyword)                   |             slashOffset          |   |

--- a/lib/logger/logger_test.go
+++ b/lib/logger/logger_test.go
@@ -23,3 +23,77 @@ func TestFormatLogMessage(t *testing.T) {
 	// Format args exceeding the maxArgLen
 	f("foo: %s, %q, %s", []any{"abcde", fmt.Errorf("foo bar baz"), "xx"}, 4, `foo: a..e, "f..z", xx`)
 }
+
+func TestSimplifyFilePath(t *testing.T) {
+	f := func(path, expectedResult string) {
+		t.Helper()
+		result := simplifyFilePath(path)
+		if result != expectedResult {
+			t.Fatalf("unexpected result; got %q, want %q", result, expectedResult)
+		}
+	}
+
+	// log in VictoriaMetrics repo
+	f(
+		`/VictoriaMetrics/VictoriaMetrics/1.go`,
+		"VictoriaMetrics/1.go",
+	)
+
+	// used in other repo
+	f(
+		`/VictoriaMetrics/VictoriaTraces/1.go`,
+		"VictoriaTraces/1.go",
+	)
+
+	// used in other repo as vendor
+	f(
+		`/VictoriaMetrics/VictoriaTraces/vendor/github.com/VictoriaMetrics/VictoriaMetrics/1.go`,
+		"vendor/github.com/VictoriaMetrics/VictoriaMetrics/1.go",
+	)
+
+	// used in other repo as vendor with version num
+	f(
+		`/VictoriaMetrics/VictoriaTraces/vendor/github.com/VictoriaMetrics/VictoriaMetrics@v0.0.0-00010101000000-000000000000/1.go`,
+		"vendor/github.com/VictoriaMetrics/VictoriaMetrics/1.go",
+	)
+
+	// The following tests are for local builds, for which path is the absolute path.
+	f(
+		`/Users/jiekun/repo/github.com/VictoriaMetrics/VictoriaTraces/1.go`,
+		"VictoriaTraces/1.go",
+	)
+	f(
+		`/Users/jiekun/repo/github.com/VictoriaMetrics/VictoriaTraces/vendor/github.com/VictoriaMetrics/VictoriaMetrics/1.go`,
+		"vendor/github.com/VictoriaMetrics/VictoriaMetrics/1.go",
+	)
+	f(
+		`/Users/jiekun/repo/github.com/VictoriaMetrics/VictoriaTraces/vendor/github.com/VictoriaMetrics/VictoriaMetrics@v0.0.0-00010101000000-000000000000/1.go`,
+		"vendor/github.com/VictoriaMetrics/VictoriaMetrics/1.go",
+	)
+	f(
+		`/Users/jiekun/repo/github.com/VictoriaMetrics/VictoriaMetrics-enterprise/1.go`,
+		"VictoriaMetrics-enterprise/1.go",
+	)
+	f(
+		`/Users/jiekun/repo/github.com/VictoriaMetrics/VictoriaTraces-enterprise/1.go`,
+		"VictoriaTraces-enterprise/1.go",
+	)
+	f(
+		`/Users/jiekun/repo/github.com/VictoriaMetrics/VictoriaTraces-enterprise/vendor/github.com/VictoriaMetrics/VictoriaMetrics/1.go`,
+		"vendor/github.com/VictoriaMetrics/VictoriaMetrics/1.go",
+	)
+	f(
+		`/Users/jiekun/repo/github.com/VictoriaMetrics/VictoriaTraces-enterprise/vendor/github.com/VictoriaMetrics/VictoriaMetrics@v0.0.0-00010101000000-000000000000/1.go`,
+		"vendor/github.com/VictoriaMetrics/VictoriaMetrics/1.go",
+	)
+
+	// special cases that user may rename the repo to whatever they want and does not contain `/VictoriaMetrics/`.
+	f(
+		`/Users/jiekun/repo/github.com/VictoriaTraces/1.go`,
+		"/Users/jiekun/repo/github.com/VictoriaTraces/1.go",
+	)
+	f(
+		`/what_ever_path/1.go`,
+		"/what_ever_path/1.go",
+	)
+}

--- a/lib/logger/logger_test.go
+++ b/lib/logger/logger_test.go
@@ -48,13 +48,13 @@ func TestSimplifyFilePath(t *testing.T) {
 	// used in other repo as vendor
 	f(
 		`/VictoriaMetrics/VictoriaTraces/vendor/github.com/VictoriaMetrics/VictoriaMetrics/1.go`,
-		"vendor/github.com/VictoriaMetrics/VictoriaMetrics/1.go",
+		"VictoriaTraces/vendor/github.com/VictoriaMetrics/VictoriaMetrics/1.go",
 	)
 
 	// used in other repo as vendor with version num
 	f(
 		`/VictoriaMetrics/VictoriaTraces/vendor/github.com/VictoriaMetrics/VictoriaMetrics@v0.0.0-00010101000000-000000000000/1.go`,
-		"vendor/github.com/VictoriaMetrics/VictoriaMetrics/1.go",
+		"VictoriaTraces/vendor/github.com/VictoriaMetrics/VictoriaMetrics/1.go",
 	)
 
 	// The following tests are for local builds, for which path is the absolute path.
@@ -64,11 +64,11 @@ func TestSimplifyFilePath(t *testing.T) {
 	)
 	f(
 		`/Users/jiekun/repo/github.com/VictoriaMetrics/VictoriaTraces/vendor/github.com/VictoriaMetrics/VictoriaMetrics/1.go`,
-		"vendor/github.com/VictoriaMetrics/VictoriaMetrics/1.go",
+		"VictoriaTraces/vendor/github.com/VictoriaMetrics/VictoriaMetrics/1.go",
 	)
 	f(
 		`/Users/jiekun/repo/github.com/VictoriaMetrics/VictoriaTraces/vendor/github.com/VictoriaMetrics/VictoriaMetrics@v0.0.0-00010101000000-000000000000/1.go`,
-		"vendor/github.com/VictoriaMetrics/VictoriaMetrics/1.go",
+		"VictoriaTraces/vendor/github.com/VictoriaMetrics/VictoriaMetrics/1.go",
 	)
 	f(
 		`/Users/jiekun/repo/github.com/VictoriaMetrics/VictoriaMetrics-enterprise/1.go`,
@@ -80,11 +80,11 @@ func TestSimplifyFilePath(t *testing.T) {
 	)
 	f(
 		`/Users/jiekun/repo/github.com/VictoriaMetrics/VictoriaTraces-enterprise/vendor/github.com/VictoriaMetrics/VictoriaMetrics/1.go`,
-		"vendor/github.com/VictoriaMetrics/VictoriaMetrics/1.go",
+		"VictoriaTraces-enterprise/vendor/github.com/VictoriaMetrics/VictoriaMetrics/1.go",
 	)
 	f(
 		`/Users/jiekun/repo/github.com/VictoriaMetrics/VictoriaTraces-enterprise/vendor/github.com/VictoriaMetrics/VictoriaMetrics@v0.0.0-00010101000000-000000000000/1.go`,
-		"vendor/github.com/VictoriaMetrics/VictoriaMetrics/1.go",
+		"VictoriaTraces-enterprise/vendor/github.com/VictoriaMetrics/VictoriaMetrics/1.go",
 	)
 
 	// special cases that user may rename the repo to whatever they want and does not contain `/VictoriaMetrics/`.


### PR DESCRIPTION
### Describe Your Changes

Fix: https://github.com/VictoriaMetrics/VictoriaLogs/issues/431

This pull request fix logging path format like:
```
2025-07-09T02:43:18.871Z        info    VictoriaMetrics@v0.0.0-00010101000000-000000000000/lib/httpserver/httpserver.go:147     pprof handlers are exposed at http://0.0.0.0:9428/debug/pprof/
```

See: https://github.com/VictoriaMetrics/VictoriaLogs/issues/431#issuecomment-3051373608

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
