### PR TITLE
issue-7599: apptest: do not cache search results

### DIFF
--- a/apptest/tests/legacy_indexdb_test.go
+++ b/apptest/tests/legacy_indexdb_test.go
@@ -174,6 +174,7 @@ func TestLegacySingleBackupRestore(t *testing.T) {
 			return tc.MustStartVmsingleAt("vmsingle-legacy", legacyVmsinglePath, []string{
 				"-storageDataPath=" + storageDataPath,
 				"-retentionPeriod=100y",
+				"-search.disableCache=true",
 				"-search.maxStalenessInterval=1m",
 			})
 		},
@@ -181,6 +182,7 @@ func TestLegacySingleBackupRestore(t *testing.T) {
 			return tc.MustStartVmsingle("vmsingle-new", []string{
 				"-storageDataPath=" + storageDataPath,
 				"-retentionPeriod=100y",
+				"-search.disableCache=true",
 				"-search.maxStalenessInterval=1m",
 			})
 		},
@@ -229,6 +231,7 @@ func TestLegacyClusterBackupRestore(t *testing.T) {
 				VminsertFlags:    []string{},
 				VmselectInstance: "vmselect",
 				VmselectFlags: []string{
+					"-search.disableCache=true",
 					"-search.maxStalenessInterval=1m",
 				},
 			})
@@ -249,6 +252,7 @@ func TestLegacyClusterBackupRestore(t *testing.T) {
 				VminsertFlags:    []string{},
 				VmselectInstance: "vmselect",
 				VmselectFlags: []string{
+					"-search.disableCache=true",
 					"-search.maxStalenessInterval=1m",
 				},
 			})
@@ -289,14 +293,7 @@ func testLegacyBackupRestore(tc *at.TestCase, opts testLegacyBackupRestoreOpts) 
 	// below.
 	const numMetrics = 1000
 	start := time.Date(2025, 3, 1, 10, 0, 0, 0, time.UTC).Add(-numMetrics * time.Minute).UnixMilli()
-	noCacheOffset := time.Millisecond
-	end := func() int64 {
-		// Use different end timestamp everytime so that the vmstorage does not
-		// return cached results.
-		noCacheOffset++
-		// With 1000 metrics (one per minute), the time range spans 2 months.
-		return time.Date(2025, 3, 1, 10, 0, 0, 0, time.UTC).UnixMilli()
-	}
+	end := time.Date(2025, 3, 1, 10, 0, 0, 0, time.UTC).UnixMilli()
 	genData := func(prefix string) (recs []string, wantSeries []map[string]string, wantQueryResults []*at.QueryResult) {
 		recs = make([]string, numMetrics)
 		wantSeries = make([]map[string]string, numMetrics)
@@ -330,7 +327,7 @@ func testLegacyBackupRestore(tc *at.TestCase, opts testLegacyBackupRestoreOpts) 
 			Got: func() any {
 				return app.PrometheusAPIV1Series(t, query, at.QueryOpts{
 					Start: fmt.Sprintf("%d", start),
-					End:   fmt.Sprintf("%d", end()),
+					End:   fmt.Sprintf("%d", end),
 				}).Sort()
 			},
 			Want: &at.PrometheusAPIV1SeriesResponse{
@@ -345,7 +342,7 @@ func testLegacyBackupRestore(tc *at.TestCase, opts testLegacyBackupRestoreOpts) 
 			Got: func() any {
 				return app.PrometheusAPIV1QueryRange(t, query, at.QueryOpts{
 					Start: fmt.Sprintf("%d", start),
-					End:   fmt.Sprintf("%d", end()),
+					End:   fmt.Sprintf("%d", end),
 					Step:  "60s",
 				})
 			},
@@ -456,16 +453,11 @@ func testLegacyBackupRestore(tc *at.TestCase, opts testLegacyBackupRestoreOpts) 
 
 	// Start legacy SUT with storage containing legacy1+new1 data.
 	//
-	// Ensure that the SearchMetricNames() queries return legacy1 data only.
+	// Ensure that the /series and /query_range queries return legacy1 data only.
 	// new1 data is not returned because legacy vmsingle does not know about
 	// partition indexDBs.
-	//
-	// Ensure that query_range queries return both legacy1 and new1 data. This
-	// is because the samples are stored the same way in both legacy and new
-	// storage and the corresponding metric names are retrieved from the
-	// metricID -> metricName cache, not from indexDB.
 	legacySUT = opts.startLegacySUT()
-	assertQueries(legacySUT, `{__name__=~".*"}`, wantLegacy1Series, wantLegacy1New1QueryResults)
+	assertQueries(legacySUT, `{__name__=~".*"}`, wantLegacy1Series, wantLegacy1QueryResults)
 
 	// Stop legacy SUT and restore legacy1+legacy2 data.
 	// Start legacy SUT and ensure that queries now return legacy1+legacy2 data.


### PR DESCRIPTION
### Describe Your Changes

Currently, select data caching is [persistent](https://github.com/VictoriaMetrics/VictoriaMetrics/blob/aaefe469c14dee3484f48c9fe89fd1557124428e/app/vmselect/main.go#L66) for vmsingle and non-persistent ([1](https://github.com/VictoriaMetrics/VictoriaMetrics/blob/664efe4d50bd9ebb3608819e1294b20b89f2ad97/app/vmselect/main.go#L123), [2](https://github.com/VictoriaMetrics/VictoriaMetrics/blob/c677e7e10f3a00e5c4b7bdfdaae553522d1a6892/app/vmselect/promql/rollup_result_cache.go#L81)) for vmselect. It leads to different results because a cache key uses [rollupResultCacheKeyPrefix](https://github.com/VictoriaMetrics/VictoriaMetrics/blob/c677e7e10f3a00e5c4b7bdfdaae553522d1a6892/app/vmselect/promql/rollup_result_cache.go#L514-L513). 
Caching on the search side could hide bugs - it is better to turn it off completely.

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
