### PR TITLE
app/vmstorage: delete old snapshots after 3 days by default

### DIFF
--- a/app/vmstorage/main.go
+++ b/app/vmstorage/main.go
@@ -31,7 +31,7 @@ var (
 	snapshotAuthKey   = flagutil.NewPassword("snapshotAuthKey", "authKey, which must be passed in query string to /snapshot* pages. It overrides -httpAuth.*")
 	forceMergeAuthKey = flagutil.NewPassword("forceMergeAuthKey", "authKey, which must be passed in query string to /internal/force_merge pages. It overrides -httpAuth.*")
 	forceFlushAuthKey = flagutil.NewPassword("forceFlushAuthKey", "authKey, which must be passed in query string to /internal/force_flush pages. It overrides -httpAuth.*")
-	snapshotsMaxAge   = flagutil.NewRetentionDuration("snapshotsMaxAge", "0", "Automatically delete snapshots older than -snapshotsMaxAge if it is set to non-zero duration. Make sure that backup process has enough time to finish the backup before the corresponding snapshot is automatically deleted")
+	snapshotsMaxAge   = flagutil.NewRetentionDuration("snapshotsMaxAge", "3d", "Automatically delete snapshots older than -snapshotsMaxAge if it is set to non-zero duration. Make sure that backup process has enough time to finish the backup before the corresponding snapshot is automatically deleted")
 	_                 = flag.Duration("snapshotCreateTimeout", 0, "Deprecated: this flag does nothing")
 
 	precisionBits = flag.Int("precisionBits", 64, "The number of precision bits to store per each value. Lower precision bits improves data compression at the cost of precision loss")

--- a/docs/victoriametrics/changelog/CHANGELOG.md
+++ b/docs/victoriametrics/changelog/CHANGELOG.md
@@ -20,6 +20,10 @@ See also [LTS releases](https://docs.victoriametrics.com/victoriametrics/lts-rel
 
 * SECURITY: upgrade Go builder from Go1.24.4 to Go1.24.5. See [the list of issues addressed in Go1.24.5](https://github.com/golang/go/issues?q=milestone%3AGo1.24.5+label%3ACherryPickApproved).
 
+**Update Note 1:**  [vmsingle](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/) and `vmstorage` in [VictoriaMetrics cluster](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/): The `-snapshotsMaxAge` flag default have been changed to `3d`. This enables automatic deletion of snapshots older than 3 days. If you want to keep the previous behavior (never automatically deleting snapshots), please set `-snapshotsMaxAge=0`. See [#9344](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/9344) for the details.
+
+* FEATURE: [vmsingle](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/) and `vmstorage` in [VictoriaMetrics cluster](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/): enable automatic deletion of snapshots older than 3 days by default. This helps to avoid wasting disk space due to snapshots not being removed in case of backup failure. See [#9344](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/9344).
+
 ## [v1.121.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.121.0)
 
 Released at 2025-07-04


### PR DESCRIPTION
Previously, snapshots were never deleted automatically. This lead to disk space waste in case snapshots were left behind and never deleted, which happened in case of backups failure. This required manual investigation and snapshots cleanup.

This change enables removal of snapshots older than 3 days by default. This should give enough time to upload backup in time and also make sure old snapshots are not wasting disk space.

Closes https://github.com/VictoriaMetrics/VictoriaMetrics/issues/9344

