### PR TITLE
dashboards: TCP connections shows spikes on small time ranges

### DIFF
--- a/dashboards/victorialogs-cluster.json
+++ b/dashboards/victorialogs-cluster.json
@@ -3536,6 +3536,7 @@
               "expr": "sum(max_over_time(vm_tcplistener_conns{job=~\"$job\", instance=~\"$instance\"}[$__interval])) by(job)",
               "format": "time_series",
               "hide": false,
+              "interval": "1m",
               "intervalFactor": 1,
               "legendFormat": "__auto",
               "range": true,

--- a/dashboards/victoriametrics-cluster.json
+++ b/dashboards/victoriametrics-cluster.json
@@ -3000,7 +3000,7 @@
               "editorMode": "code",
               "exemplar": true,
               "expr": "sum(max_over_time(vm_tcplistener_conns{job=~\"$job\", instance=~\"$instance\"}[$__interval])) by(job)",
-              "interval": "",
+              "interval": "1m",
               "legendFormat": "{{job}}",
               "range": true,
               "refId": "A"

--- a/dashboards/vm/victorialogs-cluster.json
+++ b/dashboards/vm/victorialogs-cluster.json
@@ -3537,6 +3537,7 @@
               "expr": "sum(max_over_time(vm_tcplistener_conns{job=~\"$job\", instance=~\"$instance\"}[$__interval])) by(job)",
               "format": "time_series",
               "hide": false,
+              "interval": "1m",
               "intervalFactor": 1,
               "legendFormat": "__auto",
               "range": true,

--- a/dashboards/vm/victoriametrics-cluster.json
+++ b/dashboards/vm/victoriametrics-cluster.json
@@ -3001,7 +3001,7 @@
               "editorMode": "code",
               "exemplar": true,
               "expr": "sum(max_over_time(vm_tcplistener_conns{job=~\"$job\", instance=~\"$instance\"}[$__interval])) by(job)",
-              "interval": "",
+              "interval": "1m",
               "legendFormat": "{{job}}",
               "range": true,
               "refId": "A"


### PR DESCRIPTION
### Describe Your Changes

When `$__interval` is small and close to the scrape interval, we start losing some data points, which can cause the sum to show misleading spikes. This change ensures that the minimum interval does not go below 1m to avoid such issues. 

The query works fine for long time ranges, like 7d, 30d, where interval is  bigger than 1m

The query:
```
sum(max_over_time(vm_tcplistener_conns{job=~"$job", instance=~"$instance"}[$__interval])) by(job)
```

Before:
<img width="1511" height="665" alt="Screenshot 2025-07-17 at 17 22 23" src="https://github.com/user-attachments/assets/b15dd3db-cb5e-4c9d-9ce4-4a665c38273e" />

After:
<img width="1510" height="665" alt="Screenshot 2025-07-17 at 17 22 44" src="https://github.com/user-attachments/assets/3f82f6d2-53e4-4a20-830e-2073255f6c01" />

### Checklist

The following checks are **mandatory**:

- [ ] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [ ] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
