### PR TITLE
k8s api watcher: avoid unnecessary blocking during cleanup

### DIFF
--- a/lib/promscrape/discovery/kubernetes/api_watcher.go
+++ b/lib/promscrape/discovery/kubernetes/api_watcher.go
@@ -356,7 +356,11 @@ func groupWatchersCleaner() {
 		time.Sleep(7 * time.Second)
 		groupWatchersLock.Lock()
 		for key, gw := range groupWatchers {
-			gw.mu.Lock()
+			if !gw.mu.TryLock() {
+				// This gw is likely in use, skip it to avoid blocking the loop
+				// Try again in the next cleanup cycle
+				continue
+			}
 			// Calculate the number of apiWatcher instances subscribed to gw.
 			awsTotal := 0
 			for _, uw := range gw.m {


### PR DESCRIPTION
### Describe Your Changes

The `groupWatchersCleaner` iterates through all watchers, attempting to lock them sequentially while holding the global `groupWatchersLock`. Therefore, a large number of group watchers can cause the `groupWatchersLock.Lock()` to block for a noticeable period.

Proposing to use `TryLock` as an optimistic case because if the watcher lock is held, it's more likely that the watcher is in-use.

The changes partially address #9354
https://github.com/VictoriaMetrics/VictoriaMetrics/blob/84f95f362a48d6bc1d905e7bd575e0ef4705dd4d/lib/promscrape/discovery/kubernetes/api_watcher.go#L341-L346

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
