### PR TITLE
app/vmselect/netstorage: do not retry "cannot obtain connection from the pool" errors

### DIFF
--- a/docs/victoriametrics/changelog/CHANGELOG.md
+++ b/docs/victoriametrics/changelog/CHANGELOG.md
@@ -19,6 +19,7 @@ See also [LTS releases](https://docs.victoriametrics.com/victoriametrics/lts-rel
 ## tip
 
 * FEATURE: all the VictoriaMetrics components: support netBSD builds. See this [#9473](https://github.com/VictoriaMetrics/VictoriaMetrics/pull/9473) PR for details. Thanks to the @iamleot.
+* FEATURE: [vmselect](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/) in [VictoriaMetrics cluster](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/): disable retries for requests to `vmstorage` when handshake or dial errors occur. Retries in such cases are ineffective and can amplify the problem. See [#9345](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/9345) and [#9484](https://github.com/VictoriaMetrics/VictoriaMetrics/pull/9484) for details.
 
 ## [v1.122.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.122.0)
 


### PR DESCRIPTION
### Describe Your Changes

Currently, all errors that occur during the handshake and dial phases (except for timeouts) are retried in [execOnConnWithPossibleRetry](https://github.com/VictoriaMetrics/VictoriaMetrics/blob/0c4062b7276cecb3345197f6aa1181cfab1f2f00/app/vmselect/netstorage/netstorage.go#L2431). However, such errors typically result from network issues or CPU exhaustion on the storage side. In both cases, retrying is unlikely to succeed and may instead contribute to additional, unnecessary load on the system.

This PR disables retries for all errors encountered during the handshake and dial process. The goal is to avoid redundant retry attempts in scenarios where they are unlikely to help and may worsen the underlying problem.

Related to https://github.com/VictoriaMetrics/VictoriaMetrics/issues/9345

### Checklist

The following checks are **mandatory**:

- [ ] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [ ] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
