### PR TITLE
storage: replace mustRemoveDirAtomic with .delete marker deletion

### DIFF
--- a/docs/victoriametrics/changelog/CHANGELOG.md
+++ b/docs/victoriametrics/changelog/CHANGELOG.md
@@ -18,7 +18,7 @@ See also [LTS releases](https://docs.victoriametrics.com/victoriametrics/lts-rel
 
 ## tip
 
-**Update Note 1:** The directory-removal method now marks folders for deletion by creating a hidden `.delete` sentinel file instead of renaming them to `*.must-remove.*`. If you downgrade to a version that still expects the old `must-remove` pattern, those `.delete`-tagged folders will no longer be recognised and will persist on disk. Before running an older release, manually delete every directory that contains a `.delete` sentinel file.
+**Update Note 1: The directory-removal method now marks folders for deletion by creating a hidden `.delete` sentinel file instead of renaming them to `*.must-remove.*`. If you downgrade to a version that still expects the old `must-remove` pattern, those `.delete`-tagged folders will no longer be recognised and will persist on disk. Before running an older release, manually delete every directory that contains a `.delete` sentinel file.**
 
 * FEATURE: all the VictoriaMetrics components: support netBSD builds. See this [#9473](https://github.com/VictoriaMetrics/VictoriaMetrics/pull/9473) PR for details. Thanks to the @iamleot.
 

--- a/docs/victoriametrics/changelog/CHANGELOG.md
+++ b/docs/victoriametrics/changelog/CHANGELOG.md
@@ -18,6 +18,8 @@ See also [LTS releases](https://docs.victoriametrics.com/victoriametrics/lts-rel
 
 ## tip
 
+**Update Note 1:** The directory-removal method now marks folders for deletion by creating a hidden `.delete` sentinel file instead of renaming them to `*.must-remove.*`. If you downgrade to a version that still expects the old `must-remove` pattern, those `.delete`-tagged folders will no longer be recognised and will persist on disk. Before running an older release, manually delete every directory that contains a `.delete` sentinel file.
+
 * FEATURE: all the VictoriaMetrics components: support netBSD builds. See this [#9473](https://github.com/VictoriaMetrics/VictoriaMetrics/pull/9473) PR for details. Thanks to the @iamleot.
 
 ## [v1.122.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.122.0)

--- a/lib/fs/fs.go
+++ b/lib/fs/fs.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
 	"sync"
 
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/atomicutil"
@@ -419,11 +420,12 @@ type freeSpaceEntry struct {
 }
 
 // IsScheduledForRemoval returns true if the supplied path (or name) is marked
-// for asynchronous removal. A directory is considered scheduled if
+// for removal. A directory is considered scheduled if
 // it contains a ".delete" sentinel file created by MustRemoveDirAtomic.
+// or has ".must-remove." in its name (legacy).
 func IsScheduledForRemoval(path string) bool {
 	sentinelPath := filepath.Join(path, ".delete")
-	return IsPathExist(sentinelPath)
+	return IsPathExist(sentinelPath) || strings.Contains(path, ".must-remove.")
 }
 
 // IsDirOrSymlink returns true if de is directory or symlink.

--- a/lib/fs/fs.go
+++ b/lib/fs/fs.go
@@ -7,7 +7,6 @@ import (
 	"path/filepath"
 	"regexp"
 	"sync"
-	"time"
 
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/atomicutil"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/fasttime"
@@ -237,12 +236,6 @@ func MustRemoveDirAtomic(dir string) {
 	parentDir := filepath.Dir(dir)
 	MustSyncPath(parentDir)
 }
-
-var atomicDirRemoveCounter = func() *atomicutil.Uint64 {
-	var x atomicutil.Uint64
-	x.Store(uint64(time.Now().UnixNano()))
-	return &x
-}()
 
 // MustReadDir reads directory entries at the given dir.
 func MustReadDir(dir string) []os.DirEntry {

--- a/lib/fs/fs.go
+++ b/lib/fs/fs.go
@@ -421,7 +421,7 @@ type freeSpaceEntry struct {
 
 // IsScheduledForRemoval returns true if the supplied path (or name) is marked
 // for removal. A directory is considered scheduled if
-// it contains a ".delete" sentinel file created by MustRemoveDirAtomic.
+// it contains a ".delete" sentinel file created by MustRemoveDirAtomic
 // or has ".must-remove." in its name (legacy).
 func IsScheduledForRemoval(path string) bool {
 	sentinelPath := filepath.Join(path, ".delete")

--- a/lib/fs/fs_netbsd.go
+++ b/lib/fs/fs_netbsd.go
@@ -33,7 +33,7 @@ func mustRemoveDirAtomic(dir string) {
 		if de.Name() == ".delete" {
 			continue
 		}
-		MustRemoveAll(filepath.Join(dir, de.Name()))
+		MustRemoveAllSync(filepath.Join(dir, de.Name()))
 	}
 
 	// Remove the directory together with the sentinel atomically.

--- a/lib/fs/fs_nix.go
+++ b/lib/fs/fs_nix.go
@@ -35,7 +35,7 @@ func mustRemoveDirAtomic(dir string) {
 		if de.Name() == ".delete" {
 			continue
 		}
-		MustRemoveAll(filepath.Join(dir, de.Name()))
+		MustRemoveAllSync(filepath.Join(dir, de.Name()))
 	}
 
 	MustRemoveAll(dir)

--- a/lib/fs/fs_nix.go
+++ b/lib/fs/fs_nix.go
@@ -3,8 +3,8 @@
 package fs
 
 import (
-	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/logger"
 	"golang.org/x/sys/unix"
@@ -17,12 +17,28 @@ func freeSpace(stat statfs_t) uint64 {
 }
 
 func mustRemoveDirAtomic(dir string) {
-	n := atomicDirRemoveCounter.Add(1)
-	tmpDir := fmt.Sprintf("%s.must-remove.%d", dir, n)
-	if err := os.Rename(dir, tmpDir); err != nil {
-		logger.Panicf("FATAL: cannot move %s to %s: %s", dir, tmpDir, err)
+	sentinelPath := filepath.Join(dir, ".delete")
+	f, err := os.OpenFile(sentinelPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0644)
+	if err != nil {
+		if !os.IsExist(err) {
+			logger.Panicf("FATAL: cannot create delete sentinel %q: %s", sentinelPath, err)
+		}
+	} else {
+		if err := f.Sync(); err != nil {
+			logger.Panicf("FATAL: cannot sync delete sentinel %q: %s", sentinelPath, err)
+		}
+		MustClose(f)
+		MustSyncPath(dir)
 	}
-	MustRemoveAll(tmpDir)
+
+	for _, de := range MustReadDir(dir) {
+		if de.Name() == ".delete" {
+			continue
+		}
+		MustRemoveAll(filepath.Join(dir, de.Name()))
+	}
+
+	MustRemoveAll(dir)
 }
 
 func statfs(path string, stat *statfs_t) (err error) {

--- a/lib/fs/fs_openbsd.go
+++ b/lib/fs/fs_openbsd.go
@@ -1,8 +1,8 @@
 package fs
 
 import (
-	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/logger"
 	"golang.org/x/sys/unix"
@@ -15,12 +15,28 @@ func freeSpace(stat statfs_t) uint64 {
 }
 
 func mustRemoveDirAtomic(dir string) {
-	n := atomicDirRemoveCounter.Add(1)
-	tmpDir := fmt.Sprintf("%s.must-remove.%d", dir, n)
-	if err := os.Rename(dir, tmpDir); err != nil {
-		logger.Panicf("FATAL: cannot move %s to %s: %s", dir, tmpDir, err)
+	sentinelPath := filepath.Join(dir, ".delete")
+	f, err := os.OpenFile(sentinelPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0644)
+	if err != nil {
+		if !os.IsExist(err) {
+			logger.Panicf("FATAL: cannot create delete sentinel %q: %s", sentinelPath, err)
+		}
+	} else {
+		if err := f.Sync(); err != nil {
+			logger.Panicf("FATAL: cannot sync delete sentinel %q: %s", sentinelPath, err)
+		}
+		MustClose(f)
+		MustSyncPath(dir)
 	}
-	MustRemoveAll(tmpDir)
+
+	for _, de := range MustReadDir(dir) {
+		if de.Name() == ".delete" {
+			continue
+		}
+		MustRemoveAll(filepath.Join(dir, de.Name()))
+	}
+
+	MustRemoveAll(dir)
 }
 
 func statfs(path string, stat *statfs_t) (err error) {

--- a/lib/fs/fs_openbsd.go
+++ b/lib/fs/fs_openbsd.go
@@ -33,7 +33,7 @@ func mustRemoveDirAtomic(dir string) {
 		if de.Name() == ".delete" {
 			continue
 		}
-		MustRemoveAll(filepath.Join(dir, de.Name()))
+		MustRemoveAllSync(filepath.Join(dir, de.Name()))
 	}
 
 	MustRemoveAll(dir)

--- a/lib/fs/fs_solaris.go
+++ b/lib/fs/fs_solaris.go
@@ -29,7 +29,7 @@ func mustRemoveDirAtomic(dir string) {
 		if de.Name() == ".delete" {
 			continue
 		}
-		MustRemoveAll(filepath.Join(dir, de.Name()))
+		MustRemoveAllSync(filepath.Join(dir, de.Name()))
 	}
 
 	MustRemoveAll(dir)

--- a/lib/fs/fs_solaris.go
+++ b/lib/fs/fs_solaris.go
@@ -3,6 +3,7 @@ package fs
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/fs/fsutil"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/logger"
@@ -10,12 +11,28 @@ import (
 )
 
 func mustRemoveDirAtomic(dir string) {
-	n := atomicDirRemoveCounter.Add(1)
-	tmpDir := fmt.Sprintf("%s.must-remove.%d", dir, n)
-	if err := os.Rename(dir, tmpDir); err != nil {
-		logger.Panicf("FATAL: cannot move %s to %s: %s", dir, tmpDir, err)
+	sentinelPath := filepath.Join(dir, ".delete")
+	f, err := os.OpenFile(sentinelPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0644)
+	if err != nil {
+		if !os.IsExist(err) {
+			logger.Panicf("FATAL: cannot create delete sentinel %q: %s", sentinelPath, err)
+		}
+	} else {
+		if err := f.Sync(); err != nil {
+			logger.Panicf("FATAL: cannot sync delete sentinel %q: %s", sentinelPath, err)
+		}
+		MustClose(f)
+		MustSyncPath(dir)
 	}
-	MustRemoveAll(tmpDir)
+
+	for _, de := range MustReadDir(dir) {
+		if de.Name() == ".delete" {
+			continue
+		}
+		MustRemoveAll(filepath.Join(dir, de.Name()))
+	}
+
+	MustRemoveAll(dir)
 }
 
 func mmap(fd int, length int) (data []byte, err error) {


### PR DESCRIPTION
The existing `mustRemoveDirAtomic` relies on atomic directory renames, which are not compatible with object‑storage APIs or network filesystems.

This patch instead writes a `.delete` file inside the target directory, then removes all other entries one by one, and finally deletes the marker itself. On startup, the system scans for directories that still contain a `.delete` file and completes their cleanup.

Note:

1. This may leave the directory empty if a crash occurs after the sentinel is deleted but before the directory itself is removed.
2. ~~`MustRemoveAll` runs asynchronously as a fallback. This could cause issues with new code if the fallback is triggered during startup. Suggestions are welcome :)~~ This was fixed by adding synchronous deletion.