### PR TITLE
docs: mention that single-node supports HA in cluster recommendation

### DIFF
--- a/docs/victoriametrics/Cluster-VictoriaMetrics.md
+++ b/docs/victoriametrics/Cluster-VictoriaMetrics.md
@@ -19,7 +19,7 @@ VictoriaMetrics is a fast, cost-effective and scalable time series database. It 
 It is recommended to use the [single-node version](https://github.com/VictoriaMetrics/VictoriaMetrics) instead of the cluster version
 for ingestion rates lower than a million data points per second.
 The single-node version [scales perfectly](https://medium.com/@valyala/measuring-vertical-scalability-for-time-series-databases-in-google-cloud-92550d78d8ae)
-with the number of CPU cores, RAM and available storage space.
+with the number of CPU cores, RAM and available storage space and can be set up in [High Availability](https://docs.victoriametrics.com/#high-availability) mode.
 The single-node version is easier to configure and operate compared to the cluster version, so think twice before choosing the cluster version.
 See [this question](https://docs.victoriametrics.com/victoriametrics/faq/#which-victoriametrics-type-is-recommended-for-use-in-production---single-node-or-cluster) for more details.
 

--- a/docs/victoriametrics/FAQ.md
+++ b/docs/victoriametrics/FAQ.md
@@ -406,7 +406,7 @@ See also [troubleshooting slow queries](https://docs.victoriametrics.com/victori
 Both [single-node VictoriaMetrics](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/) and
 [VictoriaMetrics cluster](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/) are production-ready.
 
-See [Scalability limits of VictoriaMetrics](https://docs.victoriametrics.com/victoriametrics/faq/#what-are-scalability-limits-of-victoriametrics)).
+See [Scalability limits of VictoriaMetrics](https://docs.victoriametrics.com/victoriametrics/faq/#what-are-scalability-limits-of-victoriametrics).
 
 Single-node VictoriaMetrics requires lower amounts of CPU and RAM for handling the same workload comparing
 to cluster version of VictoriaMetrics, since it doesn't need to pass the encoded data over the network


### PR DESCRIPTION
See context here https://www.reddit.com/r/VictoriaMetrics/comments/1mb60ck/ha_setup_on_onprem_cluster/ Apparently, user was confused with inability of VM single-node to run in HA.

### Describe Your Changes

Please provide a brief description of the changes you made. Be as specific as possible to help others understand the purpose and impact of your modifications.

### Checklist

The following checks are **mandatory**:

- [ ] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [ ] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
