### PR TITLE
app/vmctl: allow overriding tmp files location for prometheus migration

### DIFF
--- a/app/vmctl/flags.go
+++ b/app/vmctl/flags.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/urfave/cli/v2"
@@ -383,6 +384,7 @@ const (
 	promFilterTimeEnd    = "prom-filter-time-end"
 	promFilterLabel      = "prom-filter-label"
 	promFilterLabelValue = "prom-filter-label-value"
+	promTemporaryDirPath = "prom-tmp-dir-path"
 )
 
 var (
@@ -413,6 +415,11 @@ var (
 			Name:  promFilterLabelValue,
 			Usage: fmt.Sprintf("Prometheus regular expression to filter label from %q flag.", promFilterLabel),
 			Value: ".*",
+		},
+		&cli.StringFlag{
+			Name:  promTemporaryDirPath,
+			Usage: "Path to directory to be used for temporary files.",
+			Value: os.TempDir(),
 		},
 	}
 )

--- a/app/vmctl/main.go
+++ b/app/vmctl/main.go
@@ -252,7 +252,8 @@ func main() {
 					}
 
 					promCfg := prometheus.Config{
-						Snapshot: c.String(promSnapshot),
+						Snapshot:     c.String(promSnapshot),
+						TemporaryDir: c.String(promTemporaryDirPath),
 						Filter: prometheus.Filter{
 							TimeMin:    c.String(promFilterTimeStart),
 							TimeMax:    c.String(promFilterTimeEnd),

--- a/app/vmctl/prometheus/prometheus.go
+++ b/app/vmctl/prometheus/prometheus.go
@@ -16,7 +16,8 @@ type Config struct {
 	// Path to snapshot directory
 	Snapshot string
 
-	Filter Filter
+	Filter       Filter
+	TemporaryDir string
 }
 
 // Filter contains configuration for filtering
@@ -54,7 +55,7 @@ func (f filter) inRange(minV, maxV int64) bool {
 // NewClient creates and validates new Client
 // with given Config
 func NewClient(cfg Config) (*Client, error) {
-	db, err := tsdb.OpenDBReadOnly(cfg.Snapshot, "", nil)
+	db, err := tsdb.OpenDBReadOnly(cfg.Snapshot, cfg.TemporaryDir, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open snapshot %q: %s", cfg.Snapshot, err)
 	}

--- a/docs/victoriametrics/changelog/CHANGELOG.md
+++ b/docs/victoriametrics/changelog/CHANGELOG.md
@@ -21,6 +21,7 @@ See also [LTS releases](https://docs.victoriametrics.com/victoriametrics/lts-rel
 * FEATURE: all the VictoriaMetrics components: support NetBSD builds. See this [#9473](https://github.com/VictoriaMetrics/VictoriaMetrics/pull/9473) PR for details. Thanks to the @iamleot.
 * FEATURE: [vmselect](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/) in [VictoriaMetrics cluster](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/): disable retries for requests to `vmstorage` when handshake or dial errors occur. Retries in such cases are ineffective and can amplify the problem. See [#9345](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/9345) and [#9484](https://github.com/VictoriaMetrics/VictoriaMetrics/pull/9484) for details.
 * FEATURE: [vmagent](https://docs.victoriametrics.com/vmagent/) and [vmsingle](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/): improve Kubernetes service discovery performance with large amount of configured role selectors. See this [](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/9354) issue for details. Thanks to the @fxrlv
+* FEATURE: [vmctl](https://docs.victoriametrics.com/victoriametrics/vmctl/): add an option to change path for temporary files storage when migrating from Prometheus snapshots. See [#9505](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/9505) for the details.
 
 ## [v1.122.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.122.0)
 


### PR DESCRIPTION
Previously, vmctl tried to create a tmp directory in a directory with Prometheus snapshot. This is not always possible as snapshot can be mounted in read-only mode.

Use a system default temporary location and allow user to customize the tmp path in order to avoid issues with custom tmp locations.

Closes https://github.com/VictoriaMetrics/VictoriaMetrics/issues/9505
