### PR TITLE
vmselect: properly release tmp blocks for `/federate`

### DIFF
--- a/app/vmselect/prometheus/prometheus.go
+++ b/app/vmselect/prometheus/prometheus.go
@@ -138,6 +138,7 @@ func FederateHandler(startTime time.Time, at *auth.Token, w http.ResponseWriter,
 		return fmt.Errorf("cannot fetch data for %q: %w", sq, err)
 	}
 	if isPartial {
+		rss.Cancel()
 		return fmt.Errorf("cannot export federated metrics, because some of vmstorage nodes are unavailable")
 	}
 


### PR DESCRIPTION
### Describe Your Changes

The `/federate` endpoint handler might return early before calling `rss.RunParallel()`, which causes temporary block files to not be closed properly.

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
