### PR TITLE
vmauth properly accept proxy-protocol header

### DIFF
--- a/docs/victoriametrics/changelog/CHANGELOG.md
+++ b/docs/victoriametrics/changelog/CHANGELOG.md
@@ -20,6 +20,8 @@ See also [LTS releases](https://docs.victoriametrics.com/victoriametrics/lts-rel
 
 * FEATURE: expose `vm_total_disk_space_bytes` metric at the [`/metrics` page](https://docs.victoriametrics.com/#monitoring), which shows the total disk space for the data directory specified via [`-storageDataPath`](https://docs.victoriametrics.com/#storage). This metric can be useful for building alerts and graphs for the percentatge of free disk space via `vm_free_disk_space_bytes / vm_total_disk_space_bytes`. See [this comment](https://github.com/VictoriaMetrics/VictoriaMetrics/pull/9523#issuecomment-3149459926).
 
+* BUGFIX: [vmauth](https://docs.victoriametrics.com/victoriametrics/vmauth/): properly read proxy-protocol header. See this PR [#9546](https://github.com/VictoriaMetrics/VictoriaMetrics/pull/9546) for details.
+
 ## [v1.123.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.123.0)
 
 Released at 2025-08-01

--- a/lib/netutil/proxyprotocol.go
+++ b/lib/netutil/proxyprotocol.go
@@ -31,7 +31,6 @@ func (ppc *proxyProtocolConn) init() {
 			if !errors.Is(err, io.EOF) {
 				proxyProtocolReadErrorLogger.Errorf("cannot read proxy proto conn for TCP addr %q: %s", ppc.Conn.RemoteAddr(), err)
 			}
-			ppc.remoteAddr = ppc.Conn.RemoteAddr()
 			ppc.readErr = err
 			return
 		}

--- a/lib/netutil/proxyprotocol.go
+++ b/lib/netutil/proxyprotocol.go
@@ -2,46 +2,59 @@ package netutil
 
 import (
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"io"
 	"net"
-	"time"
+	"sync"
 
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/bytesutil"
 )
 
 type proxyProtocolConn struct {
 	net.Conn
+	once       sync.Once
 	remoteAddr net.Addr
+	readErr    error
 }
 
-func newProxyProtocolConn(c net.Conn) (net.Conn, error) {
-	// Limit the time needed for reading the proxy protocol header.
-	d := time.Now().Add(5 * time.Second)
-	if err := c.SetReadDeadline(d); err != nil {
-		return nil, fmt.Errorf("cannot set deadline for reading proxy protocol header: %w", err)
-	}
-
-	remoteAddr, err := readProxyProto(c)
-	if err != nil {
-		return nil, fmt.Errorf("proxy protocol error: %w", err)
-	}
-	if remoteAddr == nil {
-		remoteAddr = c.RemoteAddr()
-	}
-
-	// Reset the read deadline.
-	if err := c.SetReadDeadline(time.Time{}); err != nil {
-		return nil, fmt.Errorf("cannot reset deadline after reading proxy protocol header: %w", err)
-	}
-
+func newProxyProtocolConn(c net.Conn) net.Conn {
 	return &proxyProtocolConn{
-		Conn:       c,
-		remoteAddr: remoteAddr,
-	}, nil
+		Conn: c,
+	}
+}
+
+func (ppc *proxyProtocolConn) init() {
+	ppc.once.Do(func() {
+		addr, err := readProxyProto(ppc.Conn)
+		if err != nil {
+			if !errors.Is(err, io.EOF) {
+				proxyProtocolReadErrorLogger.Errorf("cannot read proxy proto conn for TCP addr %q: %s", ppc.Conn.RemoteAddr(), err)
+			}
+			ppc.remoteAddr = ppc.Conn.RemoteAddr()
+			ppc.readErr = err
+			return
+		}
+		if addr == nil {
+			addr = ppc.Conn.RemoteAddr()
+		}
+		ppc.remoteAddr = addr
+	})
+}
+
+func (ppc *proxyProtocolConn) Read(p []byte) (int, error) {
+	ppc.init()
+	if ppc.readErr != nil {
+		return 0, ppc.readErr
+	}
+	return ppc.Conn.Read(p)
 }
 
 func (ppc *proxyProtocolConn) RemoteAddr() net.Addr {
+	ppc.init()
+	if ppc.readErr != nil {
+		return ppc.Conn.RemoteAddr()
+	}
 	return ppc.remoteAddr
 }
 

--- a/lib/netutil/proxyprotocol_test.go
+++ b/lib/netutil/proxyprotocol_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -104,4 +105,89 @@ func TestParseProxyProtocolFail(t *testing.T) {
 		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,
 		// ports
 		0, 80, 0, 0})
+}
+
+func TestProxyProtocolConnReadWriteSuccessful(t *testing.T) {
+	server, client := net.Pipe()
+	defer server.Close()
+	defer client.Close()
+
+	ppc := newProxyProtocolConn(server)
+
+	expectedData := []byte("Hello, World!")
+
+	// Send proxy protocol header and test data from client
+	go func() {
+		proxyHeader := []byte{
+			0x0D, 0x0A, 0x0D, 0x0A, 0x00, 0x0D, 0x0A, 0x51, 0x55, 0x49, 0x54, 0x0A, // signature
+			0x21,       // version 2
+			0x11,       // family IPv4
+			0x00, 0x0C, // length: 12 bytes (IPv4 + ports)
+			192, 168, 1, 100, // source IP
+			10, 0, 0, 1, // destination IP
+			0x1F, 0x90, // source port 8080
+			0x00, 0x50, // destination port 80
+		}
+
+		if _, err := client.Write(proxyHeader); err != nil {
+			t.Fatalf("failed to write proxy protocol header: %v", err)
+		}
+		if _, err := client.Write(expectedData); err != nil {
+			t.Fatalf("failed to write data to proxy connection: %v", err)
+		}
+	}()
+
+	// Read from proxy protocol connection
+	actualData := make([]byte, len(expectedData))
+	n, err := ppc.Read(actualData)
+	if err != nil {
+		t.Fatalf("failed to read from proxy protocol connection: %v", err)
+	}
+	if n != len(expectedData) {
+		t.Fatalf("expected to read %d bytes, got %d", len(expectedData), n)
+	}
+	if !bytes.Equal(actualData, expectedData) {
+		t.Fatalf("expected %q, got %q", expectedData, actualData)
+	}
+
+	// Verify the remote address is correctly extracted
+	expectedAddr := &net.TCPAddr{
+		IP:   net.IPv4(192, 168, 1, 100),
+		Port: 8080,
+	}
+	gotAddr := ppc.RemoteAddr()
+	if !reflect.DeepEqual(gotAddr, expectedAddr) {
+		t.Fatalf("expected remote addr %v, got %v", expectedAddr, gotAddr)
+	}
+}
+
+func TestProxyProtocolConnReadWriteFailure(t *testing.T) {
+	server, client := net.Pipe()
+	defer server.Close()
+	defer client.Close()
+
+	ppc := newProxyProtocolConn(server)
+
+	go func() {
+		invalidProxyHeader := []byte("GET / HTTP/1.1\r\n\r\n")
+
+		defer client.Close()
+		client.Write(invalidProxyHeader)
+	}()
+
+	buf := make([]byte, 100)
+	_, err := ppc.Read(buf)
+	if err == nil {
+		t.Fatal("expected error when reading from proxy protocol connection; got none")
+	}
+	if !strings.HasPrefix(err.Error(), `unexpected proxy protocol header`) {
+		t.Fatalf("unexpected proxy protocol header error expected; got: %v", err)
+	}
+
+	// Should return original remote address on error
+	expectedAddr := server.RemoteAddr()
+	gotAddr := ppc.RemoteAddr()
+	if !reflect.DeepEqual(gotAddr, expectedAddr) {
+		t.Fatalf("expected remote addr %v, got %v", expectedAddr, gotAddr)
+	}
 }

--- a/lib/netutil/tcplistener.go
+++ b/lib/netutil/tcplistener.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io"
 	"net"
 	"time"
 
@@ -102,14 +101,7 @@ func (ln *TCPListener) Accept() (net.Conn, error) {
 			return nil, err
 		}
 		if ln.useProxyProtocol {
-			pConn, err := newProxyProtocolConn(conn)
-			if err != nil {
-				if !errors.Is(err, io.EOF) {
-					proxyProtocolReadErrorLogger.Errorf("cannot read proxy proto conn for TCP addr %q: %s", ln.Addr(), err)
-				}
-				_ = conn.Close()
-				continue
-			}
+			pConn := newProxyProtocolConn(conn)
 			conn = pConn
 		}
 		ln.cm.conns.Inc()


### PR DESCRIPTION
lib/netutil: properly accept proxy protocol

 Previously, tcp listener perform synchronous proxy protocol header
read during connection accept. It could significantly reduce vmauth
performance and lead to timeout at serving http requests.

 This commit changes this logic and performs proxy protocol header
parsing during first Read request from connection or RemoteAddr method
call. It significantly improves performance and reduce possible
bottleneck at connections accept method.