### PR TITLE
lib/backup: added checksum algorithm for all S3 PutObject requests

### DIFF
--- a/docs/victoriametrics/changelog/CHANGELOG.md
+++ b/docs/victoriametrics/changelog/CHANGELOG.md
@@ -36,6 +36,7 @@ See also [LTS releases](https://docs.victoriametrics.com/victoriametrics/lts-rel
 * BUGFIX: [dashboards/victoriametrics-cluster](https://grafana.com/grafana/dashboards/11176): fix panels showing 99th percentile of series or samples read per query or per series. Before, panels were showing the summarized value across all vmselect instances, which didn't make much sense. Now, panels show the max value across the vmselect instances, making it easier to understand complexity of the heaviest queries served.
 * BUGFIX: [vmalert](https://docs.victoriametrics.com/victoriametrics/vmalert/): fix potential data race and missing firing states when replaying alerting rule with `-replay.ruleEvaluationConcurrency>1`.
 * BUGFIX: [vmalert](https://docs.victoriametrics.com/victoriametrics/vmalert/): fix the `{{ $activeAt }}` variable value in annotation templating when the alert has already triggered. See this issue [#9543](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/9543) for details.
+* BUGFIX: [vmbackup](https://docs.victoriametrics.com/vmbackup/), [vmbackupmanager](https://docs.victoriametrics.com/vmbackupmanager/): allow enabling checksum calculation for PUT requests by using `-s3ChecksumAlgorithm` command-line flag. This is required for S3 configurations with WORM being enabled. See [#9532](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/9532).
 
 ## [v1.123.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.123.0)
 
@@ -52,7 +53,6 @@ Released at 2025-08-01
 
 * BUGFIX: [vmauth](https://docs.victoriametrics.com/victoriametrics/vmauth/): do not configure `-httpListenAddr.useProxyProtocol` for `-httpInternalListenAddr`. See this issue [#9515](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/9515) for details.
 * BUGFIX: [vmui](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#vmui): always display the tenant selector if the list of tenants is not empty. See [#9396](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/9396).
-* BUGFIX: [vmbackup](https://docs.victoriametrics.com/vmbackup/), [vmbackupmanager](https://docs.victoriametrics.com/vmbackupmanager/): added checksum header to S3 PutObject operations, which is required to for S3 with WORM enabled. See [#9532](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/9532).
 
 ## [v1.122.1](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.122.1)
 

--- a/docs/victoriametrics/changelog/CHANGELOG.md
+++ b/docs/victoriametrics/changelog/CHANGELOG.md
@@ -52,6 +52,7 @@ Released at 2025-08-01
 
 * BUGFIX: [vmauth](https://docs.victoriametrics.com/victoriametrics/vmauth/): do not configure `-httpListenAddr.useProxyProtocol` for `-httpInternalListenAddr`. See this issue [#9515](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/9515) for details.
 * BUGFIX: [vmui](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#vmui): always display the tenant selector if the list of tenants is not empty. See [#9396](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/9396).
+* BUGFIX: [vmbackup](https://docs.victoriametrics.com/vmbackup/), [vmbackupmanager](https://docs.victoriametrics.com/vmbackupmanager/): added checksum header to S3 PutObject operations, which is required to for S3 with WORM enabled. See [#9532](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/9532).
 
 ## [v1.122.1](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.122.1)
 

--- a/lib/backup/actions/util.go
+++ b/lib/backup/actions/util.go
@@ -31,6 +31,8 @@ var (
 	s3StorageClass   = flag.String("s3StorageClass", "", "The Storage Class applied to objects uploaded to AWS S3. Supported values are: GLACIER, "+
 		"DEEP_ARCHIVE, GLACIER_IR, INTELLIGENT_TIERING, ONEZONE_IA, OUTPOSTS, REDUCED_REDUNDANCY, STANDARD, STANDARD_IA.\n"+
 		"See https://docs.aws.amazon.com/AmazonS3/latest/userguide/storage-class-intro.html")
+	s3ChecksumAlgorithm = flag.String("s3ChecksumAlgorithm", "", "Objects integrity checksum algorithm which is applied while uploading objects to AWS S3. "+
+		"Supported values are: SHA256, SHA1, CRC32C, CRC32")
 	s3TLSInsecureSkipVerify = flag.Bool("s3TLSInsecureSkipVerify", false, "Whether to skip TLS verification when connecting to the S3 endpoint.")
 	s3Tags                  = flag.String("s3ObjectTags", "", `S3 tags to be set for uploaded objects. Must be set in JSON format: {"param1":"value1",...,"paramN":"valueN"}.`)
 )
@@ -262,7 +264,8 @@ func NewRemoteFS(ctx context.Context, path string) (common.RemoteFS, error) {
 			ConfigFilePath:        *configFilePath,
 			CustomEndpoint:        *customS3Endpoint,
 			TLSInsecureSkipVerify: *s3TLSInsecureSkipVerify,
-			StorageClass:          s3remote.StringToS3StorageClass(*s3StorageClass),
+			StorageClass:          s3remote.StringToStorageClass(*s3StorageClass),
+			ChecksumAlgorithm:     s3remote.StringToChecksumAlgorithm(*s3ChecksumAlgorithm),
 			S3ForcePathStyle:      *s3ForcePathStyle,
 			ProfileName:           *configProfile,
 			Bucket:                bucket,

--- a/lib/backup/s3remote/s3.go
+++ b/lib/backup/s3remote/s3.go
@@ -45,9 +45,14 @@ func validateStorageClass(storageClass s3types.StorageClass) error {
 	return fmt.Errorf("unsupported S3 storage class: %s. Supported values: %v", storageClass, supportedStorageClasses)
 }
 
-// StringToS3StorageClass converts string types to AWS S3 StorageClass type for value comparison
-func StringToS3StorageClass(sc string) s3types.StorageClass {
+// StringToStorageClass converts string types to AWS S3 StorageClass type for value comparison
+func StringToStorageClass(sc string) s3types.StorageClass {
 	return s3types.StorageClass(sc)
+}
+
+// StringToChecksumAlgorithm converts string types to AWS S3 ChecksumAlgorithm type for value comparison
+func StringToChecksumAlgorithm(alg string) s3types.ChecksumAlgorithm {
+	return s3types.ChecksumAlgorithm(alg)
 }
 
 // FS represents filesystem for backups in S3.
@@ -74,6 +79,9 @@ type FS struct {
 
 	// Object Storage Class: https://aws.amazon.com/s3/storage-classes/
 	StorageClass s3types.StorageClass
+
+	// Checksum algorithm
+	ChecksumAlgorithm s3types.ChecksumAlgorithm
 
 	// The name of S3 config profile to use.
 	ProfileName string
@@ -340,12 +348,13 @@ func (fs *FS) UploadPart(p common.Part, r io.Reader) error {
 		r: r,
 	}
 	input := &s3.PutObjectInput{
-		Bucket:       aws.String(fs.Bucket),
-		Key:          aws.String(path),
-		Body:         sr,
-		StorageClass: fs.StorageClass,
-		Metadata:     fs.Metadata,
-		Tagging:      fs.tags,
+		Bucket:            aws.String(fs.Bucket),
+		Key:               aws.String(path),
+		Body:              sr,
+		StorageClass:      fs.StorageClass,
+		Metadata:          fs.Metadata,
+		ChecksumAlgorithm: fs.ChecksumAlgorithm,
+		Tagging:           fs.tags,
 	}
 
 	_, err := fs.uploader.Upload(fs.ctx, input)
@@ -432,12 +441,13 @@ func (fs *FS) CreateFile(filePath string, data []byte) error {
 		r: bytes.NewReader(data),
 	}
 	input := &s3.PutObjectInput{
-		Bucket:       aws.String(fs.Bucket),
-		Key:          aws.String(path),
-		Body:         sr,
-		StorageClass: fs.StorageClass,
-		Metadata:     fs.Metadata,
-		Tagging:      fs.tags,
+		Bucket:            aws.String(fs.Bucket),
+		Key:               aws.String(path),
+		Body:              sr,
+		StorageClass:      fs.StorageClass,
+		Metadata:          fs.Metadata,
+		ChecksumAlgorithm: fs.ChecksumAlgorithm,
+		Tagging:           fs.tags,
 	}
 	_, err := fs.uploader.Upload(fs.ctx, input)
 	if err != nil {


### PR DESCRIPTION
fixes https://github.com/VictoriaMetrics/VictoriaMetrics/issues/9532
set checksum algorithm to SHA256, not sure if this property should be configurable

### Describe Your Changes

Please provide a brief description of the changes you made. Be as specific as possible to help others understand the purpose and impact of your modifications.

### Checklist

The following checks are **mandatory**:

- [ ] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [ ] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
