### PR TITLE
docs: override canonical url of pages, that have multiple copies

### DIFF
--- a/docs/victoriametrics/_index.md
+++ b/docs/victoriametrics/_index.md
@@ -5,6 +5,7 @@ menu:
     weight: 10
     identifier: victoriametrics
     pageRef: "/"
+canonical: /victoriametrics/single-server-victoriametrics/
 tags:
   - metrics
 ---

--- a/docs/victoriametrics/changelog/_index.md
+++ b/docs/victoriametrics/changelog/_index.md
@@ -8,6 +8,7 @@ menu:
     weight: 100
 tags:
   - metrics
+canonical: /victoriametrics/changelog/changelog_2025/
 aliases:
   - /CHANGELOG.html
   - /changelog/index.html


### PR DESCRIPTION
### Describe Your Changes

multiple pages, that reference same document in `{% content %}` shortcode same content, but different canonical URLs, added canonical parameter to override default url

### Checklist

The following checks are **mandatory**:

- [ ] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [ ] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
