### PR TITLE
vmalert: move the web types into sub-packages

### DIFF
--- a/app/vmalert/main.go
+++ b/app/vmalert/main.go
@@ -7,7 +7,6 @@ import (
 	"net/url"
 	"os"
 	"sort"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -83,8 +82,7 @@ absolute path to all .tpl files in root.
 )
 
 var (
-	alertURLGeneratorFn notifier.AlertURLGenerator
-	extURL              *url.URL
+	extURL *url.URL
 )
 
 func main() {
@@ -121,7 +119,7 @@ func main() {
 		return
 	}
 
-	alertURLGeneratorFn, err = getAlertURLGenerator(extURL, *externalAlertSource, *validateTemplates)
+	err = notifier.InitAlertURLGeneratorFn(extURL, *externalAlertSource, *validateTemplates)
 	if err != nil {
 		logger.Fatalf("failed to init `external.alert.source`: %s", err)
 	}
@@ -228,7 +226,7 @@ func newManager(ctx context.Context) (*manager, error) {
 		labels[s[:n]] = s[n+1:]
 	}
 
-	nts, err := notifier.Init(alertURLGeneratorFn, labels, *externalURL)
+	nts, err := notifier.Init(notifier.AlertURLGeneratorFn, labels, *externalURL)
 	if err != nil {
 		return nil, fmt.Errorf("failed to init notifier: %w", err)
 	}
@@ -290,35 +288,6 @@ func getHostnameAsExternalURL(addr string, isSecure bool) (*url.URL, error) {
 		schema = "https://"
 	}
 	return url.Parse(fmt.Sprintf("%s%s%s", schema, hname, port))
-}
-
-func getAlertURLGenerator(externalURL *url.URL, externalAlertSource string, validateTemplate bool) (notifier.AlertURLGenerator, error) {
-	if externalAlertSource == "" {
-		return func(a notifier.Alert) string {
-			gID, aID := strconv.FormatUint(a.GroupID, 10), strconv.FormatUint(a.ID, 10)
-			return fmt.Sprintf("%s/vmalert/alert?%s=%s&%s=%s", externalURL, paramGroupID, gID, paramAlertID, aID)
-		}, nil
-	}
-	if validateTemplate {
-		if err := notifier.ValidateTemplates(map[string]string{
-			"tpl": externalAlertSource,
-		}); err != nil {
-			return nil, fmt.Errorf("error validating source template %s: %w", externalAlertSource, err)
-		}
-	}
-	m := map[string]string{
-		"tpl": externalAlertSource,
-	}
-	return func(alert notifier.Alert) string {
-		qFn := func(_ string) ([]datasource.Metric, error) {
-			return nil, fmt.Errorf("`query` template isn't supported for alert source template")
-		}
-		templated, err := alert.ExecTemplate(qFn, alert.Labels, m)
-		if err != nil {
-			logger.Errorf("cannot template alert source: %s", err)
-		}
-		return fmt.Sprintf("%s/%s", externalURL, templated["tpl"])
-	}, nil
 }
 
 func usage() {

--- a/app/vmalert/main_test.go
+++ b/app/vmalert/main_test.go
@@ -49,30 +49,6 @@ func TestGetExternalURL(t *testing.T) {
 	}
 }
 
-func TestGetAlertURLGenerator(t *testing.T) {
-	testAlert := notifier.Alert{GroupID: 42, ID: 2, Value: 4, Labels: map[string]string{"tenant": "baz"}}
-	u, _ := url.Parse("https://victoriametrics.com/path")
-	fn, err := getAlertURLGenerator(u, "", false)
-	if err != nil {
-		t.Fatalf("unexpected error %s", err)
-	}
-	exp := fmt.Sprintf("https://victoriametrics.com/path/vmalert/alert?%s=42&%s=2", paramGroupID, paramAlertID)
-	if exp != fn(testAlert) {
-		t.Fatalf("unexpected url want %s, got %s", exp, fn(testAlert))
-	}
-	_, err = getAlertURLGenerator(nil, "foo?{{invalid}}", true)
-	if err == nil {
-		t.Fatalf("expected template validation error got nil")
-	}
-	fn, err = getAlertURLGenerator(u, "foo?query={{$value}}&ds={{ $labels.tenant }}", true)
-	if err != nil {
-		t.Fatalf("unexpected error %s", err)
-	}
-	if exp := "https://victoriametrics.com/path/foo?query=4&ds=baz"; exp != fn(testAlert) {
-		t.Fatalf("unexpected url want %s, got %s", exp, fn(testAlert))
-	}
-}
-
 func TestConfigReload(t *testing.T) {
 	originalRulePath := *rulePath
 	originalExternalURL := extURL

--- a/app/vmalert/manager.go
+++ b/app/vmalert/manager.go
@@ -30,24 +30,24 @@ type manager struct {
 }
 
 // ruleAPI generates apiRule object from alert by its ID(hash)
-func (m *manager) ruleAPI(gID, rID uint64) (apiRule, error) {
+func (m *manager) ruleAPI(gID, rID uint64) (rule.ApiRule, error) {
 	m.groupsMu.RLock()
 	defer m.groupsMu.RUnlock()
 
 	g, ok := m.groups[gID]
 	if !ok {
-		return apiRule{}, fmt.Errorf("can't find group with id %d", gID)
+		return rule.ApiRule{}, fmt.Errorf("can't find group with id %d", gID)
 	}
-	for _, rule := range g.Rules {
-		if rule.ID() == rID {
-			return ruleToAPI(rule), nil
+	for _, r := range g.Rules {
+		if r.ID() == rID {
+			return rule.RuleToAPI(r), nil
 		}
 	}
-	return apiRule{}, fmt.Errorf("can't find rule with id %d in group %q", rID, g.Name)
+	return rule.ApiRule{}, fmt.Errorf("can't find rule with id %d in group %q", rID, g.Name)
 }
 
 // alertAPI generates apiAlert object from alert by its ID(hash)
-func (m *manager) alertAPI(gID, aID uint64) (*apiAlert, error) {
+func (m *manager) alertAPI(gID, aID uint64) (*rule.ApiAlert, error) {
 	m.groupsMu.RLock()
 	defer m.groupsMu.RUnlock()
 
@@ -60,7 +60,7 @@ func (m *manager) alertAPI(gID, aID uint64) (*apiAlert, error) {
 		if !ok {
 			continue
 		}
-		if apiAlert := alertToAPI(ar, aID); apiAlert != nil {
+		if apiAlert := rule.AlertToAPI(ar, aID); apiAlert != nil {
 			return apiAlert, nil
 		}
 	}

--- a/app/vmalert/notifier/web.go
+++ b/app/vmalert/notifier/web.go
@@ -1,0 +1,11 @@
+package notifier
+
+type ApiNotifier struct {
+	Kind    string       `json:"kind"`
+	Targets []*ApiTarget `json:"targets"`
+}
+
+type ApiTarget struct {
+	Address string            `json:"address"`
+	Labels  map[string]string `json:"labels"`
+}

--- a/app/vmalert/rule/group.go
+++ b/app/vmalert/rule/group.go
@@ -2,7 +2,6 @@ package rule
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
@@ -470,18 +469,6 @@ func (g *Group) Start(ctx context.Context, nts func() []notifier.Notifier, rw re
 // UpdateWith inserts new group to updateCh
 func (g *Group) UpdateWith(newGroup *Group) {
 	g.updateCh <- newGroup
-}
-
-// DeepCopy returns a deep copy of group
-func (g *Group) DeepCopy() *Group {
-	g.mu.RLock()
-	data, _ := json.Marshal(g)
-	g.mu.RUnlock()
-	newG := Group{}
-	_ = json.Unmarshal(data, &newG)
-	newG.Rules = g.Rules
-	newG.id = g.id
-	return &newG
 }
 
 // if offset is specified, delayBeforeStart returns a duration to help aligning timestamp with offset;

--- a/app/vmalert/rule/web.go
+++ b/app/vmalert/rule/web.go
@@ -1,4 +1,4 @@
-package main
+package rule
 
 import (
 	"fmt"
@@ -8,79 +8,26 @@ import (
 	"time"
 
 	"github.com/VictoriaMetrics/VictoriaMetrics/app/vmalert/notifier"
-	"github.com/VictoriaMetrics/VictoriaMetrics/app/vmalert/rule"
 )
 
 const (
 	// ParamGroupID is group id key in url parameter
-	paramGroupID = "group_id"
+	ParamGroupID = "group_id"
 	// ParamAlertID is alert id key in url parameter
-	paramAlertID = "alert_id"
+	ParamAlertID = "alert_id"
 	// ParamRuleID is rule id key in url parameter
-	paramRuleID = "rule_id"
+	ParamRuleID = "rule_id"
+
+	RuleTypeRecording = "recording"
+	RuleTypeAlerting  = "alerting"
 )
 
-type apiNotifier struct {
-	Kind    string       `json:"kind"`
-	Targets []*apiTarget `json:"targets"`
-}
-
-type apiTarget struct {
-	Address string            `json:"address"`
-	Labels  map[string]string `json:"labels"`
-}
-
-// apiAlert represents a notifier.AlertingRule state
-// for WEB view
-// https://github.com/prometheus/compliance/blob/main/alert_generator/specification.md#get-apiv1rules
-type apiAlert struct {
-	State       string            `json:"state"`
-	Name        string            `json:"name"`
-	Value       string            `json:"value"`
-	Labels      map[string]string `json:"labels,omitempty"`
-	Annotations map[string]string `json:"annotations"`
-	ActiveAt    time.Time         `json:"activeAt"`
-
-	// Additional fields
-
-	// ID is an unique Alert's ID within a group
-	ID string `json:"id"`
-	// RuleID is an unique Rule's ID within a group
-	RuleID string `json:"rule_id"`
-	// GroupID is an unique Group's ID
-	GroupID string `json:"group_id"`
-	// Expression contains the PromQL/MetricsQL expression
-	// for Rule's evaluation
-	Expression string `json:"expression"`
-	// SourceLink contains a link to a system which should show
-	// why Alert was generated
-	SourceLink string `json:"source"`
-	// Restored shows whether Alert's state was restored on restart
-	Restored bool `json:"restored"`
-	// Stabilizing shows when firing state is kept because of
-	// `keep_firing_for` instead of real alert
-	Stabilizing bool `json:"stabilizing"`
-}
-
-// WebLink returns a link to the alert which can be used in UI.
-func (aa *apiAlert) WebLink() string {
-	return fmt.Sprintf("alert?%s=%s&%s=%s",
-		paramGroupID, aa.GroupID, paramAlertID, aa.ID)
-}
-
-// APILink returns a link to the alert's JSON representation.
-func (aa *apiAlert) APILink() string {
-	return fmt.Sprintf("api/v1/alert?%s=%s&%s=%s",
-		paramGroupID, aa.GroupID, paramAlertID, aa.ID)
-}
-
-// apiGroup represents Group for web view
-// https://github.com/prometheus/compliance/blob/main/alert_generator/specification.md#get-apiv1rules
-type apiGroup struct {
+// ApiGroup represents a Group for web view
+type ApiGroup struct {
 	// Name is the group name as present in the config
 	Name string `json:"name"`
 	// Rules contains both recording and alerting rules
-	Rules []apiRule `json:"rules"`
+	Rules []ApiRule `json:"rules"`
 	// Interval is the Group's evaluation interval in float seconds as present in the file.
 	Interval float64 `json:"interval"`
 	// LastEvaluation is the timestamp of the last time the Group was executed
@@ -116,15 +63,15 @@ type apiGroup struct {
 	NoMatch int
 }
 
-// groupAlerts represents a group of alerts for WEB view
-type groupAlerts struct {
-	Group  *apiGroup
-	Alerts []*apiAlert
+// GroupAlerts represents a Group with its Alerts for web view
+type GroupAlerts struct {
+	Group  *ApiGroup
+	Alerts []*ApiAlert
 }
 
-// apiRule represents a Rule for web view
+// ApiRule represents a Rule for web view
 // see https://github.com/prometheus/compliance/blob/main/alert_generator/specification.md#get-apiv1rules
-type apiRule struct {
+type ApiRule struct {
 	// State must be one of these under following scenarios
 	//  "pending": at least 1 alert in the rule in pending state and no other alert in firing ruleState.
 	//  "firing": at least 1 alert in the rule in firing state.
@@ -146,7 +93,7 @@ type apiRule struct {
 	// LastEvaluation is the timestamp of the last time the rule was executed
 	LastEvaluation time.Time `json:"lastEvaluation"`
 	// Alerts  is the list of all the alerts in this rule that are currently pending or firing
-	Alerts []*apiAlert `json:"alerts,omitempty"`
+	Alerts []*ApiAlert `json:"alerts,omitempty"`
 	// Health is the health of rule evaluation.
 	// It MUST be one of "ok", "err", "unknown"
 	Health string `json:"health"`
@@ -177,47 +124,86 @@ type apiRule struct {
 	// MaxUpdates is the max number of recorded ruleStateEntry objects
 	MaxUpdates int `json:"max_updates_entries"`
 	// Updates contains the ordered list of recorded ruleStateEntry objects
-	Updates []rule.StateEntry `json:"-"`
+	Updates []StateEntry `json:"-"`
 }
 
-// apiRuleWithUpdates represents apiRule but with extra fields for marshalling
-type apiRuleWithUpdates struct {
-	apiRule
-	// Updates contains the ordered list of recorded ruleStateEntry objects
-	StateUpdates []rule.StateEntry `json:"updates,omitempty"`
-}
+// ApiAlert represents a notifier.AlertingRule state
+// for WEB view
+// https://github.com/prometheus/compliance/blob/main/alert_generator/specification.md#get-apiv1rules
+type ApiAlert struct {
+	State       string            `json:"state"`
+	Name        string            `json:"name"`
+	Value       string            `json:"value"`
+	Labels      map[string]string `json:"labels,omitempty"`
+	Annotations map[string]string `json:"annotations"`
+	ActiveAt    time.Time         `json:"activeAt"`
 
-// APILink returns a link to the rule's JSON representation.
-func (ar apiRule) APILink() string {
-	return fmt.Sprintf("api/v1/rule?%s=%s&%s=%s",
-		paramGroupID, ar.GroupID, paramRuleID, ar.ID)
+	// Additional fields
+
+	// ID is an unique Alert's ID within a group
+	ID string `json:"id"`
+	// RuleID is an unique Rule's ID within a group
+	RuleID string `json:"rule_id"`
+	// GroupID is an unique Group's ID
+	GroupID string `json:"group_id"`
+	// Expression contains the PromQL/MetricsQL expression
+	// for Rule's evaluation
+	Expression string `json:"expression"`
+	// SourceLink contains a link to a system which should show
+	// why Alert was generated
+	SourceLink string `json:"source"`
+	// Restored shows whether Alert's state was restored on restart
+	Restored bool `json:"restored"`
+	// Stabilizing shows when firing state is kept because of
+	// `keep_firing_for` instead of real alert
+	Stabilizing bool `json:"stabilizing"`
 }
 
 // WebLink returns a link to the alert which can be used in UI.
-func (ar apiRule) WebLink() string {
-	return fmt.Sprintf("rule?%s=%s&%s=%s",
-		paramGroupID, ar.GroupID, paramRuleID, ar.ID)
+func (aa *ApiAlert) WebLink() string {
+	return fmt.Sprintf("alert?%s=%s&%s=%s",
+		ParamGroupID, aa.GroupID, ParamAlertID, aa.ID)
 }
 
-func ruleToAPI(r any) apiRule {
-	if ar, ok := r.(*rule.AlertingRule); ok {
+// APILink returns a link to the alert's JSON representation.
+func (aa *ApiAlert) APILink() string {
+	return fmt.Sprintf("api/v1/alert?%s=%s&%s=%s",
+		ParamGroupID, aa.GroupID, ParamAlertID, aa.ID)
+}
+
+// ApiRuleWithUpdates represents ApiRule but with extra fields for marshalling
+type ApiRuleWithUpdates struct {
+	ApiRule
+	// Updates contains the ordered list of recorded ruleStateEntry objects
+	StateUpdates []StateEntry `json:"updates,omitempty"`
+}
+
+// APILink returns a link to the rule's JSON representation.
+func (ar ApiRule) APILink() string {
+	return fmt.Sprintf("api/v1/rule?%s=%s&%s=%s",
+		ParamGroupID, ar.GroupID, ParamRuleID, ar.ID)
+}
+
+// WebLink returns a link to the alert which can be used in UI.
+func (ar ApiRule) WebLink() string {
+	return fmt.Sprintf("rule?%s=%s&%s=%s",
+		ParamGroupID, ar.GroupID, ParamRuleID, ar.ID)
+}
+
+func RuleToAPI(r any) ApiRule {
+	if ar, ok := r.(*AlertingRule); ok {
 		return alertingToAPI(ar)
 	}
-	if rr, ok := r.(*rule.RecordingRule); ok {
+	if rr, ok := r.(*RecordingRule); ok {
 		return recordingToAPI(rr)
 	}
-	return apiRule{}
+	return ApiRule{}
 }
 
-const (
-	ruleTypeRecording = "recording"
-	ruleTypeAlerting  = "alerting"
-)
-
-func recordingToAPI(rr *rule.RecordingRule) apiRule {
-	lastState := rule.GetLastEntry(rr)
-	r := apiRule{
-		Type:              ruleTypeRecording,
+func recordingToAPI(rr *RecordingRule) ApiRule {
+	lastState := GetLastEntry(rr)
+	r := ApiRule{
+		Type:              RuleTypeRecording,
 		DatasourceType:    rr.Type.String(),
 		Name:              rr.Name,
 		Query:             rr.Expr,
@@ -227,8 +213,8 @@ func recordingToAPI(rr *rule.RecordingRule) apiRule {
 		Health:            "ok",
 		LastSamples:       lastState.Samples,
 		LastSeriesFetched: lastState.SeriesFetched,
-		MaxUpdates:        rule.GetRuleStateSize(rr),
-		Updates:           rule.GetAllRuleState(rr),
+		MaxUpdates:        GetRuleStateSize(rr),
+		Updates:           GetAllRuleState(rr),
 
 		// encode as strings to avoid rounding
 		ID:        fmt.Sprintf("%d", rr.ID()),
@@ -243,11 +229,11 @@ func recordingToAPI(rr *rule.RecordingRule) apiRule {
 	return r
 }
 
-// alertingToAPI returns Rule representation in form of apiRule
-func alertingToAPI(ar *rule.AlertingRule) apiRule {
-	lastState := rule.GetLastEntry(ar)
-	r := apiRule{
-		Type:              ruleTypeAlerting,
+// alertingToAPI returns Rule representation in form of ApiRule
+func alertingToAPI(ar *AlertingRule) ApiRule {
+	lastState := GetLastEntry(ar)
+	r := ApiRule{
+		Type:              RuleTypeAlerting,
 		DatasourceType:    ar.Type.String(),
 		Name:              ar.Name,
 		Query:             ar.Expr,
@@ -259,11 +245,11 @@ func alertingToAPI(ar *rule.AlertingRule) apiRule {
 		EvaluationTime:    lastState.Duration.Seconds(),
 		Health:            "ok",
 		State:             "inactive",
-		Alerts:            ruleToAPIAlert(ar),
+		Alerts:            RuleToAPIAlert(ar),
 		LastSamples:       lastState.Samples,
 		LastSeriesFetched: lastState.SeriesFetched,
-		MaxUpdates:        rule.GetRuleStateSize(ar),
-		Updates:           rule.GetAllRuleState(ar),
+		MaxUpdates:        GetRuleStateSize(ar),
+		Updates:           GetAllRuleState(ar),
 		Debug:             ar.Debug,
 
 		// encode as strings to avoid rounding in JSON
@@ -290,30 +276,30 @@ func alertingToAPI(ar *rule.AlertingRule) apiRule {
 	return r
 }
 
-// ruleToAPIAlert generates list of apiAlert objects from existing alerts
-func ruleToAPIAlert(ar *rule.AlertingRule) []*apiAlert {
-	var alerts []*apiAlert
+// RuleToAPIAlert generates list of apiAlert objects from existing alerts
+func RuleToAPIAlert(ar *AlertingRule) []*ApiAlert {
+	var alerts []*ApiAlert
 	for _, a := range ar.GetAlerts() {
 		if a.State == notifier.StateInactive {
 			continue
 		}
-		alerts = append(alerts, newAlertAPI(ar, a))
+		alerts = append(alerts, NewAlertAPI(ar, a))
 	}
 	return alerts
 }
 
-// alertToAPI generates apiAlert object from alert by its id(hash)
-func alertToAPI(ar *rule.AlertingRule, id uint64) *apiAlert {
+// AlertToAPI generates apiAlert object from alert by its id(hash)
+func AlertToAPI(ar *AlertingRule, id uint64) *ApiAlert {
 	a := ar.GetAlert(id)
 	if a == nil {
 		return nil
 	}
-	return newAlertAPI(ar, a)
+	return NewAlertAPI(ar, a)
 }
 
 // NewAlertAPI creates apiAlert for notifier.Alert
-func newAlertAPI(ar *rule.AlertingRule, a *notifier.Alert) *apiAlert {
-	aa := &apiAlert{
+func NewAlertAPI(ar *AlertingRule, a *notifier.Alert) *ApiAlert {
+	aa := &ApiAlert{
 		// encode as strings to avoid rounding
 		ID:      fmt.Sprintf("%d", a.ID),
 		GroupID: fmt.Sprintf("%d", a.GroupID),
@@ -328,8 +314,8 @@ func newAlertAPI(ar *rule.AlertingRule, a *notifier.Alert) *apiAlert {
 		Restored:    a.Restored,
 		Value:       strconv.FormatFloat(a.Value, 'f', -1, 32),
 	}
-	if alertURLGeneratorFn != nil {
-		aa.SourceLink = alertURLGeneratorFn(*a)
+	if notifier.AlertURLGeneratorFn != nil {
+		aa.SourceLink = notifier.AlertURLGeneratorFn(*a)
 	}
 	if a.State == notifier.StateFiring && !a.KeepFiringSince.IsZero() {
 		aa.Stabilizing = true
@@ -337,9 +323,10 @@ func newAlertAPI(ar *rule.AlertingRule, a *notifier.Alert) *apiAlert {
 	return aa
 }
 
-func groupToAPI(g *rule.Group) *apiGroup {
-	g = g.DeepCopy()
-	ag := apiGroup{
+func GroupToAPI(g *Group) *ApiGroup {
+	g.mu.RLock()
+	defer g.mu.RUnlock()
+	ag := ApiGroup{
 		// encode as string to avoid rounding
 		ID:              strconv.FormatUint(g.GetID(), 10),
 		Name:            g.Name,
@@ -359,9 +346,9 @@ func groupToAPI(g *rule.Group) *apiGroup {
 	if g.EvalDelay != nil {
 		ag.EvalDelay = g.EvalDelay.Seconds()
 	}
-	ag.Rules = make([]apiRule, 0)
+	ag.Rules = make([]ApiRule, 0)
 	for _, r := range g.Rules {
-		ag.Rules = append(ag.Rules, ruleToAPI(r))
+		ag.Rules = append(ag.Rules, RuleToAPI(r))
 	}
 	return &ag
 }

--- a/app/vmalert/rule/web_test.go
+++ b/app/vmalert/rule/web_test.go
@@ -1,4 +1,4 @@
-package main
+package rule
 
 import (
 	"fmt"
@@ -8,7 +8,6 @@ import (
 
 	"github.com/VictoriaMetrics/VictoriaMetrics/app/vmalert/config"
 	"github.com/VictoriaMetrics/VictoriaMetrics/app/vmalert/datasource"
-	"github.com/VictoriaMetrics/VictoriaMetrics/app/vmalert/rule"
 )
 
 func TestRecordingToApi(t *testing.T) {
@@ -17,7 +16,7 @@ func TestRecordingToApi(t *testing.T) {
 		Values: []float64{1}, Timestamps: []int64{0},
 	})
 	entriesLimit := 44
-	g := rule.NewGroup(config.Group{
+	g := NewGroup(config.Group{
 		Name:        "group",
 		File:        "rules.yaml",
 		Concurrency: 1,
@@ -31,21 +30,21 @@ func TestRecordingToApi(t *testing.T) {
 			},
 		},
 	}, fq, 1*time.Minute, nil)
-	rr := g.Rules[0].(*rule.RecordingRule)
+	rr := g.Rules[0].(*RecordingRule)
 
-	expectedRes := apiRule{
+	expectedRes := ApiRule{
 		Name:           "record_name",
 		Query:          "up",
 		Labels:         map[string]string{"label": "value"},
 		Health:         "ok",
-		Type:           ruleTypeRecording,
+		Type:           RuleTypeRecording,
 		DatasourceType: "prometheus",
 		ID:             "1248",
 		GroupID:        fmt.Sprintf("%d", g.CreateID()),
 		GroupName:      "group",
 		File:           "rules.yaml",
 		MaxUpdates:     44,
-		Updates:        make([]rule.StateEntry, 0),
+		Updates:        make([]StateEntry, 0),
 	}
 
 	res := recordingToAPI(rr)

--- a/app/vmalert/web.go
+++ b/app/vmalert/web.go
@@ -29,7 +29,7 @@ var (
 		{"api/v1/rules", "list all loaded groups and rules"},
 		{"api/v1/alerts", "list all active alerts"},
 		{"api/v1/notifiers", "list all notifiers"},
-		{fmt.Sprintf("api/v1/alert?%s=<int>&%s=<int>", paramGroupID, paramAlertID), "get alert status by group and alert ID"},
+		{fmt.Sprintf("api/v1/alert?%s=<int>&%s=<int>", rule.ParamGroupID, rule.ParamAlertID), "get alert status by group and alert ID"},
 	}
 	systemLinks = [][2]string{
 		{"vmalert/groups", "UI"},
@@ -45,8 +45,8 @@ var (
 		{Name: "Docs", URL: "https://docs.victoriametrics.com/victoriametrics/vmalert/"},
 	}
 	ruleTypeMap = map[string]string{
-		"alert":  ruleTypeAlerting,
-		"record": ruleTypeRecording,
+		"alert":  rule.RuleTypeAlerting,
+		"record": rule.RuleTypeRecording,
 	}
 )
 
@@ -112,7 +112,7 @@ func (rh *requestHandler) handler(w http.ResponseWriter, r *http.Request) bool {
 	case "/rules":
 		// Grafana makes an extra request to `/rules`
 		// handler in addition to `/api/v1/rules` calls in alerts UI
-		var data []*apiGroup
+		var data []*rule.ApiGroup
 		rf, err := newRulesFilter(r)
 		if err != nil {
 			httpserver.Errorf(w, r, "%s", err)
@@ -178,14 +178,14 @@ func (rh *requestHandler) handler(w http.ResponseWriter, r *http.Request) bool {
 		w.Write(data)
 		return true
 	case "/vmalert/api/v1/rule", "/api/v1/rule":
-		rule, err := rh.getRule(r)
+		apiRule, err := rh.getRule(r)
 		if err != nil {
 			httpserver.Errorf(w, r, "%s", err)
 			return true
 		}
-		rwu := apiRuleWithUpdates{
-			apiRule:      rule,
-			StateUpdates: rule.Updates,
+		rwu := rule.ApiRuleWithUpdates{
+			ApiRule:      apiRule,
+			StateUpdates: apiRule.Updates,
 		}
 		data, err := json.Marshal(rwu)
 		if err != nil {
@@ -209,30 +209,30 @@ func (rh *requestHandler) handler(w http.ResponseWriter, r *http.Request) bool {
 	}
 }
 
-func (rh *requestHandler) getRule(r *http.Request) (apiRule, error) {
-	groupID, err := strconv.ParseUint(r.FormValue(paramGroupID), 10, 64)
+func (rh *requestHandler) getRule(r *http.Request) (rule.ApiRule, error) {
+	groupID, err := strconv.ParseUint(r.FormValue(rule.ParamGroupID), 10, 64)
 	if err != nil {
-		return apiRule{}, fmt.Errorf("failed to read %q param: %w", paramGroupID, err)
+		return rule.ApiRule{}, fmt.Errorf("failed to read %q param: %w", rule.ParamGroupID, err)
 	}
-	ruleID, err := strconv.ParseUint(r.FormValue(paramRuleID), 10, 64)
+	ruleID, err := strconv.ParseUint(r.FormValue(rule.ParamRuleID), 10, 64)
 	if err != nil {
-		return apiRule{}, fmt.Errorf("failed to read %q param: %w", paramRuleID, err)
+		return rule.ApiRule{}, fmt.Errorf("failed to read %q param: %w", rule.ParamRuleID, err)
 	}
 	obj, err := rh.m.ruleAPI(groupID, ruleID)
 	if err != nil {
-		return apiRule{}, errResponse(err, http.StatusNotFound)
+		return rule.ApiRule{}, errResponse(err, http.StatusNotFound)
 	}
 	return obj, nil
 }
 
-func (rh *requestHandler) getAlert(r *http.Request) (*apiAlert, error) {
-	groupID, err := strconv.ParseUint(r.FormValue(paramGroupID), 10, 64)
+func (rh *requestHandler) getAlert(r *http.Request) (*rule.ApiAlert, error) {
+	groupID, err := strconv.ParseUint(r.FormValue(rule.ParamGroupID), 10, 64)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read %q param: %w", paramGroupID, err)
+		return nil, fmt.Errorf("failed to read %q param: %w", rule.ParamGroupID, err)
 	}
-	alertID, err := strconv.ParseUint(r.FormValue(paramAlertID), 10, 64)
+	alertID, err := strconv.ParseUint(r.FormValue(rule.ParamAlertID), 10, 64)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read %q param: %w", paramAlertID, err)
+		return nil, fmt.Errorf("failed to read %q param: %w", rule.ParamAlertID, err)
 	}
 	a, err := rh.m.alertAPI(groupID, alertID)
 	if err != nil {
@@ -244,7 +244,7 @@ func (rh *requestHandler) getAlert(r *http.Request) (*apiAlert, error) {
 type listGroupsResponse struct {
 	Status string `json:"status"`
 	Data   struct {
-		Groups []*apiGroup `json:"groups"`
+		Groups []*rule.ApiGroup `json:"groups"`
 	} `json:"data"`
 }
 
@@ -310,19 +310,19 @@ func (rf *rulesFilter) matchesGroup(group *rule.Group) bool {
 	return true
 }
 
-func (rh *requestHandler) groups(rf *rulesFilter) []*apiGroup {
+func (rh *requestHandler) groups(rf *rulesFilter) []*rule.ApiGroup {
 	rh.m.groupsMu.RLock()
 	defer rh.m.groupsMu.RUnlock()
 
-	groups := make([]*apiGroup, 0)
+	groups := make([]*rule.ApiGroup, 0)
 	for _, group := range rh.m.groups {
 		if !rf.matchesGroup(group) {
 			continue
 		}
-		g := groupToAPI(group)
+		g := rule.GroupToAPI(group)
 		// the returned list should always be non-nil
 		// https://github.com/VictoriaMetrics/VictoriaMetrics/issues/4221
-		filteredRules := make([]apiRule, 0)
+		filteredRules := make([]rule.ApiRule, 0)
 		for _, rule := range g.Rules {
 			if rf.ruleType != "" && rf.ruleType != rule.Type {
 				continue
@@ -350,7 +350,7 @@ func (rh *requestHandler) groups(rf *rulesFilter) []*apiGroup {
 		groups = append(groups, g)
 	}
 	// sort list of groups for deterministic output
-	slices.SortFunc(groups, func(a, b *apiGroup) int {
+	slices.SortFunc(groups, func(a, b *rule.ApiGroup) int {
 		if a.Name != b.Name {
 			return strings.Compare(a.Name, b.Name)
 		}
@@ -375,32 +375,32 @@ func (rh *requestHandler) listGroups(rf *rulesFilter) ([]byte, error) {
 type listAlertsResponse struct {
 	Status string `json:"status"`
 	Data   struct {
-		Alerts []*apiAlert `json:"alerts"`
+		Alerts []*rule.ApiAlert `json:"alerts"`
 	} `json:"data"`
 }
 
-func (rh *requestHandler) groupAlerts() []groupAlerts {
+func (rh *requestHandler) groupAlerts() []rule.GroupAlerts {
 	rh.m.groupsMu.RLock()
 	defer rh.m.groupsMu.RUnlock()
 
-	var gAlerts []groupAlerts
+	var gAlerts []rule.GroupAlerts
 	for _, g := range rh.m.groups {
-		var alerts []*apiAlert
+		var alerts []*rule.ApiAlert
 		for _, r := range g.Rules {
 			a, ok := r.(*rule.AlertingRule)
 			if !ok {
 				continue
 			}
-			alerts = append(alerts, ruleToAPIAlert(a)...)
+			alerts = append(alerts, rule.RuleToAPIAlert(a)...)
 		}
 		if len(alerts) > 0 {
-			gAlerts = append(gAlerts, groupAlerts{
-				Group:  groupToAPI(g),
+			gAlerts = append(gAlerts, rule.GroupAlerts{
+				Group:  rule.GroupToAPI(g),
 				Alerts: alerts,
 			})
 		}
 	}
-	slices.SortFunc(gAlerts, func(a, b groupAlerts) int {
+	slices.SortFunc(gAlerts, func(a, b rule.GroupAlerts) int {
 		return strings.Compare(a.Group.Name, b.Group.Name)
 	})
 	return gAlerts
@@ -411,7 +411,7 @@ func (rh *requestHandler) listAlerts(rf *rulesFilter) ([]byte, error) {
 	defer rh.m.groupsMu.RUnlock()
 
 	lr := listAlertsResponse{Status: "success"}
-	lr.Data.Alerts = make([]*apiAlert, 0)
+	lr.Data.Alerts = make([]*rule.ApiAlert, 0)
 	for _, group := range rh.m.groups {
 		if !rf.matchesGroup(group) {
 			continue
@@ -421,12 +421,12 @@ func (rh *requestHandler) listAlerts(rf *rulesFilter) ([]byte, error) {
 			if !ok {
 				continue
 			}
-			lr.Data.Alerts = append(lr.Data.Alerts, ruleToAPIAlert(a)...)
+			lr.Data.Alerts = append(lr.Data.Alerts, rule.RuleToAPIAlert(a)...)
 		}
 	}
 
 	// sort list of alerts for deterministic output
-	slices.SortFunc(lr.Data.Alerts, func(a, b *apiAlert) int {
+	slices.SortFunc(lr.Data.Alerts, func(a, b *rule.ApiAlert) int {
 		return strings.Compare(a.ID, b.ID)
 	})
 
@@ -443,7 +443,7 @@ func (rh *requestHandler) listAlerts(rf *rulesFilter) ([]byte, error) {
 type listNotifiersResponse struct {
 	Status string `json:"status"`
 	Data   struct {
-		Notifiers []*apiNotifier `json:"notifiers"`
+		Notifiers []*notifier.ApiNotifier `json:"notifiers"`
 	} `json:"data"`
 }
 
@@ -451,19 +451,19 @@ func (rh *requestHandler) listNotifiers() ([]byte, error) {
 	targets := notifier.GetTargets()
 
 	lr := listNotifiersResponse{Status: "success"}
-	lr.Data.Notifiers = make([]*apiNotifier, 0)
+	lr.Data.Notifiers = make([]*notifier.ApiNotifier, 0)
 	for protoName, protoTargets := range targets {
-		notifier := &apiNotifier{
+		nr := &notifier.ApiNotifier{
 			Kind:    string(protoName),
-			Targets: make([]*apiTarget, 0, len(protoTargets)),
+			Targets: make([]*notifier.ApiTarget, 0, len(protoTargets)),
 		}
 		for _, target := range protoTargets {
-			notifier.Targets = append(notifier.Targets, &apiTarget{
+			nr.Targets = append(nr.Targets, &notifier.ApiTarget{
 				Address: target.Addr(),
 				Labels:  target.Labels.ToMap(),
 			})
 		}
-		lr.Data.Notifiers = append(lr.Data.Notifiers, notifier)
+		lr.Data.Notifiers = append(lr.Data.Notifiers, nr)
 	}
 
 	b, err := json.Marshal(lr)

--- a/app/vmalert/web.qtpl
+++ b/app/vmalert/web.qtpl
@@ -8,6 +8,7 @@
     "github.com/VictoriaMetrics/VictoriaMetrics/app/vmalert/tpl"
     "github.com/VictoriaMetrics/VictoriaMetrics/app/vmalert/vmalertutil"
     "github.com/VictoriaMetrics/VictoriaMetrics/app/vmalert/notifier"
+    "github.com/VictoriaMetrics/VictoriaMetrics/app/vmalert/rule"
 ) %}
 
 {% func Controls(prefix, currentIcon, currentText string, icons, filters map[string]string, search bool) %}
@@ -93,7 +94,7 @@
     {%= tpl.Footer(r) %}
 {% endfunc %}
 
-{% func ListGroups(r *http.Request, groups []*apiGroup, filter string) %}
+{% func ListGroups(r *http.Request, groups []*rule.ApiGroup, filter string) %}
     {%code
         prefix := vmalertutil.Prefix(r.URL.Path)
         filters := map[string]string{
@@ -222,7 +223,7 @@
 {% endfunc %}
 
 
-{% func ListAlerts(r *http.Request, groupAlerts []groupAlerts) %}
+{% func ListAlerts(r *http.Request, groupAlerts []rule.GroupAlerts) %}
     {%code prefix := vmalertutil.Prefix(r.URL.Path) %}
     {%= tpl.Header(r, navItems, "Alerts", getLastConfigError()) %}
     {%= Controls(prefix, "", "", nil, nil, true) %}
@@ -231,7 +232,7 @@
              {%code
                  g := ga.Group
                  var keys []string
-                 alertsByRule := make(map[string][]*apiAlert)
+                 alertsByRule := make(map[string][]*rule.ApiAlert)
                  for _, alert := range ga.Alerts {
                      if len(alertsByRule[alert.RuleID]) < 1 {
                          keys = append(keys, alert.RuleID)
@@ -378,7 +379,7 @@
     {%= tpl.Footer(r) %}
 {% endfunc %}
 
-{% func Alert(r *http.Request, alert *apiAlert) %}
+{% func Alert(r *http.Request, alert *rule.ApiAlert) %}
     {%code prefix := vmalertutil.Prefix(r.URL.Path) %}
     {%= tpl.Header(r, navItems, "", getLastConfigError()) %}
     {%code
@@ -464,7 +465,7 @@
 {% endfunc %}
 
 
-{% func RuleDetails(r *http.Request, rule apiRule) %}
+{% func RuleDetails(r *http.Request, rule rule.ApiRule) %}
     {%code prefix := vmalertutil.Prefix(r.URL.Path) %}
     {%= tpl.Header(r, navItems, "", getLastConfigError()) %}
     {%code
@@ -649,7 +650,7 @@
 <span class="badge bg-warning text-dark" title="This firing state is kept because of `keep_firing_for`">stabilizing</span>
 {% endfunc %}
 
-{% func seriesFetchedWarn(prefix string, r apiRule) %}
+{% func seriesFetchedWarn(prefix string, r rule.ApiRule) %}
 {% if isNoMatch(r) %}
 <svg
     data-bs-toggle="tooltip"
@@ -663,7 +664,7 @@
 {% endfunc %}
 
 {%code
-  func isNoMatch (r apiRule) bool {
+  func isNoMatch (r rule.ApiRule) bool {
     return r.LastSamples == 0 && r.LastSeriesFetched != nil && *r.LastSeriesFetched == 0
   }
 %}

--- a/app/vmalert/web.qtpl.go
+++ b/app/vmalert/web.qtpl.go
@@ -11,26 +11,27 @@ import (
 	"time"
 
 	"github.com/VictoriaMetrics/VictoriaMetrics/app/vmalert/notifier"
+	"github.com/VictoriaMetrics/VictoriaMetrics/app/vmalert/rule"
 	"github.com/VictoriaMetrics/VictoriaMetrics/app/vmalert/tpl"
 	"github.com/VictoriaMetrics/VictoriaMetrics/app/vmalert/vmalertutil"
 )
 
-//line app/vmalert/web.qtpl:13
+//line app/vmalert/web.qtpl:14
 import (
 	qtio422016 "io"
 
 	qt422016 "github.com/valyala/quicktemplate"
 )
 
-//line app/vmalert/web.qtpl:13
+//line app/vmalert/web.qtpl:14
 var (
 	_ = qtio422016.Copy
 	_ = qt422016.AcquireByteBuffer
 )
 
-//line app/vmalert/web.qtpl:13
+//line app/vmalert/web.qtpl:14
 func StreamControls(qw422016 *qt422016.Writer, prefix, currentIcon, currentText string, icons, filters map[string]string, search bool) {
-//line app/vmalert/web.qtpl:13
+//line app/vmalert/web.qtpl:14
 	qw422016.N().S(`
     <div class="btn-toolbar mb-3" role="toolbar">
         <div class="d-flex gap-2 justify-content-between w-100">
@@ -39,9 +40,9 @@ func StreamControls(qw422016 *qt422016.Writer, prefix, currentIcon, currentText 
                     <span class="d-none d-md-block">Collapse All</span>
                     <svg class="d-md-none" height="20" width="20">
                         <use href="`)
-//line app/vmalert/web.qtpl:20
+//line app/vmalert/web.qtpl:21
 	qw422016.E().S(prefix)
-//line app/vmalert/web.qtpl:20
+//line app/vmalert/web.qtpl:21
 	qw422016.N().S(`static/icons/icons.svg#collapse"/>
                     </svg>
                 </a>
@@ -49,23 +50,23 @@ func StreamControls(qw422016 *qt422016.Writer, prefix, currentIcon, currentText 
                     <span class="d-none d-md-block">Expand All</span>
                     <svg class="d-md-none" width="20" height="20">
                         <use href="`)
-//line app/vmalert/web.qtpl:26
+//line app/vmalert/web.qtpl:27
 	qw422016.E().S(prefix)
-//line app/vmalert/web.qtpl:26
+//line app/vmalert/web.qtpl:27
 	qw422016.N().S(`static/icons/icons.svg#expand"/>
                     </svg>
                 </a>
                 `)
-//line app/vmalert/web.qtpl:29
+//line app/vmalert/web.qtpl:30
 	if len(filters) > 0 {
-//line app/vmalert/web.qtpl:29
+//line app/vmalert/web.qtpl:30
 		qw422016.N().S(`
                     <span class="d-none d-md-inline-block">Filter by status:</span>
                     <svg class="d-md-none" width="20" height="20">
                         <use href="`)
-//line app/vmalert/web.qtpl:32
+//line app/vmalert/web.qtpl:33
 		qw422016.E().S(prefix)
-//line app/vmalert/web.qtpl:32
+//line app/vmalert/web.qtpl:33
 		qw422016.N().S(`static/icons/icons.svg#filter">
                     </svg>
                     <div class="dropdown">
@@ -76,251 +77,251 @@ func StreamControls(qw422016 *qt422016.Writer, prefix, currentIcon, currentText 
                             aria-expanded="false"
                         >
                             <span class="d-none d-md-inline-block">`)
-//line app/vmalert/web.qtpl:41
+//line app/vmalert/web.qtpl:42
 		qw422016.E().S(currentText)
-//line app/vmalert/web.qtpl:41
+//line app/vmalert/web.qtpl:42
 		qw422016.N().S(`</span>
                             <svg class="d-md-none" width="22" height="22">
                                 <use href="`)
-//line app/vmalert/web.qtpl:43
+//line app/vmalert/web.qtpl:44
 		qw422016.E().S(prefix)
-//line app/vmalert/web.qtpl:43
+//line app/vmalert/web.qtpl:44
 		qw422016.N().S(`static/icons/icons.svg#`)
-//line app/vmalert/web.qtpl:43
+//line app/vmalert/web.qtpl:44
 		qw422016.E().S(currentIcon)
-//line app/vmalert/web.qtpl:43
+//line app/vmalert/web.qtpl:44
 		qw422016.N().S(`"/>
                             </svg>
                         </button>
                         <ul class="dropdown-menu">
                             `)
-//line app/vmalert/web.qtpl:47
+//line app/vmalert/web.qtpl:48
 		for key, title := range filters {
-//line app/vmalert/web.qtpl:47
+//line app/vmalert/web.qtpl:48
 			qw422016.N().S(`
                                 `)
-//line app/vmalert/web.qtpl:48
+//line app/vmalert/web.qtpl:49
 			if title != currentText {
-//line app/vmalert/web.qtpl:48
+//line app/vmalert/web.qtpl:49
 				qw422016.N().S(`
                                     <li>
                                         <a class="dropdown-item" onclick="groupFilter('`)
-//line app/vmalert/web.qtpl:50
+//line app/vmalert/web.qtpl:51
 				qw422016.E().S(key)
-//line app/vmalert/web.qtpl:50
+//line app/vmalert/web.qtpl:51
 				qw422016.N().S(`')">
                                             <span class="d-none d-md-inline-block">`)
-//line app/vmalert/web.qtpl:51
+//line app/vmalert/web.qtpl:52
 				qw422016.E().S(title)
-//line app/vmalert/web.qtpl:51
+//line app/vmalert/web.qtpl:52
 				qw422016.N().S(`</span>
                                             <svg class="d-md-none" width="22" height="22">
                                                 <use href="`)
-//line app/vmalert/web.qtpl:53
+//line app/vmalert/web.qtpl:54
 				qw422016.E().S(prefix)
-//line app/vmalert/web.qtpl:53
+//line app/vmalert/web.qtpl:54
 				qw422016.N().S(`static/icons/icons.svg#`)
-//line app/vmalert/web.qtpl:53
+//line app/vmalert/web.qtpl:54
 				qw422016.E().S(icons[key])
-//line app/vmalert/web.qtpl:53
+//line app/vmalert/web.qtpl:54
 				qw422016.N().S(`"/>
                                             </svg>
                                         </a>
                                     </li>
                                 `)
-//line app/vmalert/web.qtpl:57
+//line app/vmalert/web.qtpl:58
 			}
-//line app/vmalert/web.qtpl:57
+//line app/vmalert/web.qtpl:58
 			qw422016.N().S(`
                             `)
-//line app/vmalert/web.qtpl:58
+//line app/vmalert/web.qtpl:59
 		}
-//line app/vmalert/web.qtpl:58
+//line app/vmalert/web.qtpl:59
 		qw422016.N().S(`
                         </ul>
                     </div>
                 `)
-//line app/vmalert/web.qtpl:61
+//line app/vmalert/web.qtpl:62
 	}
-//line app/vmalert/web.qtpl:61
+//line app/vmalert/web.qtpl:62
 	qw422016.N().S(`
             </div>
             `)
-//line app/vmalert/web.qtpl:63
+//line app/vmalert/web.qtpl:64
 	if search {
-//line app/vmalert/web.qtpl:63
+//line app/vmalert/web.qtpl:64
 		qw422016.N().S(`
                 <div class="input-group flex-grow-1 justify-content-end">
                     <span class="input-group-text">
                         <svg height="25" width="20">
                             <use href="`)
-//line app/vmalert/web.qtpl:67
+//line app/vmalert/web.qtpl:68
 		qw422016.E().S(prefix)
-//line app/vmalert/web.qtpl:67
+//line app/vmalert/web.qtpl:68
 		qw422016.N().S(`static/icons/icons.svg#search">
                         </svg>
                     </span>
                     <input id="search" placeholder="Filter by group, rule or labels" type="text" class="form-control"/>
                 </div>
             `)
-//line app/vmalert/web.qtpl:72
+//line app/vmalert/web.qtpl:73
 	}
-//line app/vmalert/web.qtpl:72
+//line app/vmalert/web.qtpl:73
 	qw422016.N().S(`
         </div>
     </div>
 `)
-//line app/vmalert/web.qtpl:75
+//line app/vmalert/web.qtpl:76
 }
 
-//line app/vmalert/web.qtpl:75
+//line app/vmalert/web.qtpl:76
 func WriteControls(qq422016 qtio422016.Writer, prefix, currentIcon, currentText string, icons, filters map[string]string, search bool) {
-//line app/vmalert/web.qtpl:75
+//line app/vmalert/web.qtpl:76
 	qw422016 := qt422016.AcquireWriter(qq422016)
-//line app/vmalert/web.qtpl:75
+//line app/vmalert/web.qtpl:76
 	StreamControls(qw422016, prefix, currentIcon, currentText, icons, filters, search)
-//line app/vmalert/web.qtpl:75
+//line app/vmalert/web.qtpl:76
 	qt422016.ReleaseWriter(qw422016)
-//line app/vmalert/web.qtpl:75
+//line app/vmalert/web.qtpl:76
 }
 
-//line app/vmalert/web.qtpl:75
+//line app/vmalert/web.qtpl:76
 func Controls(prefix, currentIcon, currentText string, icons, filters map[string]string, search bool) string {
-//line app/vmalert/web.qtpl:75
+//line app/vmalert/web.qtpl:76
 	qb422016 := qt422016.AcquireByteBuffer()
-//line app/vmalert/web.qtpl:75
+//line app/vmalert/web.qtpl:76
 	WriteControls(qb422016, prefix, currentIcon, currentText, icons, filters, search)
-//line app/vmalert/web.qtpl:75
+//line app/vmalert/web.qtpl:76
 	qs422016 := string(qb422016.B)
-//line app/vmalert/web.qtpl:75
+//line app/vmalert/web.qtpl:76
 	qt422016.ReleaseByteBuffer(qb422016)
-//line app/vmalert/web.qtpl:75
+//line app/vmalert/web.qtpl:76
 	return qs422016
-//line app/vmalert/web.qtpl:75
+//line app/vmalert/web.qtpl:76
 }
 
-//line app/vmalert/web.qtpl:77
+//line app/vmalert/web.qtpl:78
 func StreamWelcome(qw422016 *qt422016.Writer, r *http.Request) {
-//line app/vmalert/web.qtpl:77
+//line app/vmalert/web.qtpl:78
 	qw422016.N().S(`
     `)
-//line app/vmalert/web.qtpl:78
+//line app/vmalert/web.qtpl:79
 	tpl.StreamHeader(qw422016, r, navItems, "vmalert", getLastConfigError())
-//line app/vmalert/web.qtpl:78
+//line app/vmalert/web.qtpl:79
 	qw422016.N().S(`
     <p>
         API:<br>
         `)
-//line app/vmalert/web.qtpl:81
+//line app/vmalert/web.qtpl:82
 	for _, p := range apiLinks {
-//line app/vmalert/web.qtpl:81
+//line app/vmalert/web.qtpl:82
 		qw422016.N().S(`
             `)
-//line app/vmalert/web.qtpl:82
+//line app/vmalert/web.qtpl:83
 		p, doc := p[0], p[1]
 
-//line app/vmalert/web.qtpl:82
+//line app/vmalert/web.qtpl:83
 		qw422016.N().S(`
             <a href="`)
-//line app/vmalert/web.qtpl:83
+//line app/vmalert/web.qtpl:84
 		qw422016.E().S(p)
-//line app/vmalert/web.qtpl:83
+//line app/vmalert/web.qtpl:84
 		qw422016.N().S(`">`)
-//line app/vmalert/web.qtpl:83
+//line app/vmalert/web.qtpl:84
 		qw422016.E().S(p)
-//line app/vmalert/web.qtpl:83
+//line app/vmalert/web.qtpl:84
 		qw422016.N().S(`</a> - `)
-//line app/vmalert/web.qtpl:83
+//line app/vmalert/web.qtpl:84
 		qw422016.E().S(doc)
-//line app/vmalert/web.qtpl:83
+//line app/vmalert/web.qtpl:84
 		qw422016.N().S(`<br/>
         `)
-//line app/vmalert/web.qtpl:84
+//line app/vmalert/web.qtpl:85
 	}
-//line app/vmalert/web.qtpl:84
+//line app/vmalert/web.qtpl:85
 	qw422016.N().S(`
         `)
-//line app/vmalert/web.qtpl:85
+//line app/vmalert/web.qtpl:86
 	if r.Header.Get("X-Forwarded-For") == "" {
-//line app/vmalert/web.qtpl:85
+//line app/vmalert/web.qtpl:86
 		qw422016.N().S(`
             System:<br>
             `)
-//line app/vmalert/web.qtpl:87
+//line app/vmalert/web.qtpl:88
 		for _, p := range systemLinks {
-//line app/vmalert/web.qtpl:87
+//line app/vmalert/web.qtpl:88
 			qw422016.N().S(`
                 `)
-//line app/vmalert/web.qtpl:88
+//line app/vmalert/web.qtpl:89
 			p, doc := p[0], p[1]
 
-//line app/vmalert/web.qtpl:88
+//line app/vmalert/web.qtpl:89
 			qw422016.N().S(`
                 <a href="`)
-//line app/vmalert/web.qtpl:89
+//line app/vmalert/web.qtpl:90
 			qw422016.E().S(p)
-//line app/vmalert/web.qtpl:89
+//line app/vmalert/web.qtpl:90
 			qw422016.N().S(`">`)
-//line app/vmalert/web.qtpl:89
+//line app/vmalert/web.qtpl:90
 			qw422016.E().S(p)
-//line app/vmalert/web.qtpl:89
+//line app/vmalert/web.qtpl:90
 			qw422016.N().S(`</a> - `)
-//line app/vmalert/web.qtpl:89
+//line app/vmalert/web.qtpl:90
 			qw422016.E().S(doc)
-//line app/vmalert/web.qtpl:89
+//line app/vmalert/web.qtpl:90
 			qw422016.N().S(`<br/>
             `)
-//line app/vmalert/web.qtpl:90
+//line app/vmalert/web.qtpl:91
 		}
-//line app/vmalert/web.qtpl:90
+//line app/vmalert/web.qtpl:91
 		qw422016.N().S(`
         `)
-//line app/vmalert/web.qtpl:91
+//line app/vmalert/web.qtpl:92
 	}
-//line app/vmalert/web.qtpl:91
+//line app/vmalert/web.qtpl:92
 	qw422016.N().S(`
     </p>
     `)
-//line app/vmalert/web.qtpl:93
+//line app/vmalert/web.qtpl:94
 	tpl.StreamFooter(qw422016, r)
-//line app/vmalert/web.qtpl:93
+//line app/vmalert/web.qtpl:94
 	qw422016.N().S(`
 `)
-//line app/vmalert/web.qtpl:94
+//line app/vmalert/web.qtpl:95
 }
 
-//line app/vmalert/web.qtpl:94
+//line app/vmalert/web.qtpl:95
 func WriteWelcome(qq422016 qtio422016.Writer, r *http.Request) {
-//line app/vmalert/web.qtpl:94
+//line app/vmalert/web.qtpl:95
 	qw422016 := qt422016.AcquireWriter(qq422016)
-//line app/vmalert/web.qtpl:94
+//line app/vmalert/web.qtpl:95
 	StreamWelcome(qw422016, r)
-//line app/vmalert/web.qtpl:94
+//line app/vmalert/web.qtpl:95
 	qt422016.ReleaseWriter(qw422016)
-//line app/vmalert/web.qtpl:94
+//line app/vmalert/web.qtpl:95
 }
 
-//line app/vmalert/web.qtpl:94
+//line app/vmalert/web.qtpl:95
 func Welcome(r *http.Request) string {
-//line app/vmalert/web.qtpl:94
+//line app/vmalert/web.qtpl:95
 	qb422016 := qt422016.AcquireByteBuffer()
-//line app/vmalert/web.qtpl:94
+//line app/vmalert/web.qtpl:95
 	WriteWelcome(qb422016, r)
-//line app/vmalert/web.qtpl:94
+//line app/vmalert/web.qtpl:95
 	qs422016 := string(qb422016.B)
-//line app/vmalert/web.qtpl:94
+//line app/vmalert/web.qtpl:95
 	qt422016.ReleaseByteBuffer(qb422016)
-//line app/vmalert/web.qtpl:94
+//line app/vmalert/web.qtpl:95
 	return qs422016
-//line app/vmalert/web.qtpl:94
+//line app/vmalert/web.qtpl:95
 }
 
-//line app/vmalert/web.qtpl:96
-func StreamListGroups(qw422016 *qt422016.Writer, r *http.Request, groups []*apiGroup, filter string) {
-//line app/vmalert/web.qtpl:96
+//line app/vmalert/web.qtpl:97
+func StreamListGroups(qw422016 *qt422016.Writer, r *http.Request, groups []*rule.ApiGroup, filter string) {
+//line app/vmalert/web.qtpl:97
 	qw422016.N().S(`
     `)
-//line app/vmalert/web.qtpl:98
+//line app/vmalert/web.qtpl:99
 	prefix := vmalertutil.Prefix(r.URL.Path)
 	filters := map[string]string{
 		"":          "All",
@@ -335,106 +336,106 @@ func StreamListGroups(qw422016 *qt422016.Writer, r *http.Request, groups []*apiG
 	currentText := filters[filter]
 	currentIcon := icons[filter]
 
-//line app/vmalert/web.qtpl:111
+//line app/vmalert/web.qtpl:112
 	qw422016.N().S(`
     `)
-//line app/vmalert/web.qtpl:112
+//line app/vmalert/web.qtpl:113
 	tpl.StreamHeader(qw422016, r, navItems, "Groups", getLastConfigError())
-//line app/vmalert/web.qtpl:112
+//line app/vmalert/web.qtpl:113
 	qw422016.N().S(`
         `)
-//line app/vmalert/web.qtpl:113
+//line app/vmalert/web.qtpl:114
 	StreamControls(qw422016, prefix, currentIcon, currentText, icons, filters, true)
-//line app/vmalert/web.qtpl:113
+//line app/vmalert/web.qtpl:114
 	qw422016.N().S(`
         `)
-//line app/vmalert/web.qtpl:114
+//line app/vmalert/web.qtpl:115
 	if len(groups) > 0 {
-//line app/vmalert/web.qtpl:114
+//line app/vmalert/web.qtpl:115
 		qw422016.N().S(`
             `)
-//line app/vmalert/web.qtpl:115
+//line app/vmalert/web.qtpl:116
 		for _, g := range groups {
-//line app/vmalert/web.qtpl:115
+//line app/vmalert/web.qtpl:116
 			qw422016.N().S(`
                 <div id="group-`)
-//line app/vmalert/web.qtpl:116
+//line app/vmalert/web.qtpl:117
 			qw422016.E().S(g.ID)
-//line app/vmalert/web.qtpl:116
+//line app/vmalert/web.qtpl:117
 			qw422016.N().S(`" class="d-flex w-100 border-0 flex-column group-items`)
-//line app/vmalert/web.qtpl:116
+//line app/vmalert/web.qtpl:117
 			if g.Unhealthy > 0 {
-//line app/vmalert/web.qtpl:116
+//line app/vmalert/web.qtpl:117
 				qw422016.N().S(` alert-danger`)
-//line app/vmalert/web.qtpl:116
+//line app/vmalert/web.qtpl:117
 			}
-//line app/vmalert/web.qtpl:116
+//line app/vmalert/web.qtpl:117
 			qw422016.N().S(`">
                     <span class="d-flex justify-content-between">
                         <a href="#group-`)
-//line app/vmalert/web.qtpl:118
+//line app/vmalert/web.qtpl:119
 			qw422016.E().S(g.ID)
-//line app/vmalert/web.qtpl:118
+//line app/vmalert/web.qtpl:119
 			qw422016.N().S(`">`)
-//line app/vmalert/web.qtpl:118
+//line app/vmalert/web.qtpl:119
 			qw422016.E().S(g.Name)
-//line app/vmalert/web.qtpl:118
+//line app/vmalert/web.qtpl:119
 			if g.Type != "prometheus" {
-//line app/vmalert/web.qtpl:118
+//line app/vmalert/web.qtpl:119
 				qw422016.N().S(` (`)
-//line app/vmalert/web.qtpl:118
+//line app/vmalert/web.qtpl:119
 				qw422016.E().S(g.Type)
-//line app/vmalert/web.qtpl:118
+//line app/vmalert/web.qtpl:119
 				qw422016.N().S(`)`)
-//line app/vmalert/web.qtpl:118
+//line app/vmalert/web.qtpl:119
 			}
-//line app/vmalert/web.qtpl:118
+//line app/vmalert/web.qtpl:119
 			qw422016.N().S(` (every `)
-//line app/vmalert/web.qtpl:118
+//line app/vmalert/web.qtpl:119
 			qw422016.N().FPrec(g.Interval, 0)
-//line app/vmalert/web.qtpl:118
+//line app/vmalert/web.qtpl:119
 			qw422016.N().S(`s) #</a>
                         <span
                             class="flex-grow-1 d-flex justify-content-end"
                             role="button"
                             data-bs-toggle="collapse"
                             data-bs-target="#sub-`)
-//line app/vmalert/web.qtpl:123
+//line app/vmalert/web.qtpl:124
 			qw422016.E().S(g.ID)
-//line app/vmalert/web.qtpl:123
+//line app/vmalert/web.qtpl:124
 			qw422016.N().S(`"
                         >
                             <span class="d-flex gap-2">
                                 `)
-//line app/vmalert/web.qtpl:126
+//line app/vmalert/web.qtpl:127
 			if g.Unhealthy > 0 {
-//line app/vmalert/web.qtpl:126
+//line app/vmalert/web.qtpl:127
 				qw422016.N().S(`<span class="badge bg-danger" title="Number of rules with status Error">`)
-//line app/vmalert/web.qtpl:126
+//line app/vmalert/web.qtpl:127
 				qw422016.N().D(g.Unhealthy)
-//line app/vmalert/web.qtpl:126
+//line app/vmalert/web.qtpl:127
 				qw422016.N().S(`</span> `)
-//line app/vmalert/web.qtpl:126
+//line app/vmalert/web.qtpl:127
 			}
-//line app/vmalert/web.qtpl:126
+//line app/vmalert/web.qtpl:127
 			qw422016.N().S(`
                                 `)
-//line app/vmalert/web.qtpl:127
+//line app/vmalert/web.qtpl:128
 			if g.NoMatch > 0 {
-//line app/vmalert/web.qtpl:127
+//line app/vmalert/web.qtpl:128
 				qw422016.N().S(`<span class="badge bg-warning" title="Number of rules with status NoMatch">`)
-//line app/vmalert/web.qtpl:127
+//line app/vmalert/web.qtpl:128
 				qw422016.N().D(g.NoMatch)
-//line app/vmalert/web.qtpl:127
+//line app/vmalert/web.qtpl:128
 				qw422016.N().S(`</span> `)
-//line app/vmalert/web.qtpl:127
+//line app/vmalert/web.qtpl:128
 			}
-//line app/vmalert/web.qtpl:127
+//line app/vmalert/web.qtpl:128
 			qw422016.N().S(`
                                 <span class="badge bg-success" title="Number of rules with status Ok">`)
-//line app/vmalert/web.qtpl:128
+//line app/vmalert/web.qtpl:129
 			qw422016.N().D(g.Healthy)
-//line app/vmalert/web.qtpl:128
+//line app/vmalert/web.qtpl:129
 			qw422016.N().S(`</span>
                             </span>
                         </span>
@@ -444,81 +445,81 @@ func StreamListGroups(qw422016 *qt422016.Writer, r *http.Request, groups []*apiG
                         role="button"
                         data-bs-toggle="collapse"
                         data-bs-target="#sub-`)
-//line app/vmalert/web.qtpl:136
+//line app/vmalert/web.qtpl:137
 			qw422016.E().S(g.ID)
-//line app/vmalert/web.qtpl:136
+//line app/vmalert/web.qtpl:137
 			qw422016.N().S(`"
                     >
                         <span class="fs-6 text-start w-100 fw-lighter">`)
-//line app/vmalert/web.qtpl:138
+//line app/vmalert/web.qtpl:139
 			qw422016.E().S(g.File)
-//line app/vmalert/web.qtpl:138
+//line app/vmalert/web.qtpl:139
 			qw422016.N().S(`</span>
                         `)
-//line app/vmalert/web.qtpl:139
+//line app/vmalert/web.qtpl:140
 			if len(g.Params) > 0 {
-//line app/vmalert/web.qtpl:139
+//line app/vmalert/web.qtpl:140
 				qw422016.N().S(`
                             <span class="fs-6 text-start w-100 d-flex justify-content-between fw-lighter">
                                 <span>Extra params</span>
                                 <span class="d-flex align-items-center gap-2">
                                     `)
-//line app/vmalert/web.qtpl:143
+//line app/vmalert/web.qtpl:144
 				for _, param := range g.Params {
-//line app/vmalert/web.qtpl:143
+//line app/vmalert/web.qtpl:144
 					qw422016.N().S(`
                                         <span class="badge bg-primary">`)
-//line app/vmalert/web.qtpl:144
+//line app/vmalert/web.qtpl:145
 					qw422016.E().S(param)
-//line app/vmalert/web.qtpl:144
+//line app/vmalert/web.qtpl:145
 					qw422016.N().S(`</span>
                                     `)
-//line app/vmalert/web.qtpl:145
+//line app/vmalert/web.qtpl:146
 				}
-//line app/vmalert/web.qtpl:145
+//line app/vmalert/web.qtpl:146
 				qw422016.N().S(`
                                 </span>
                             </span>
                         `)
-//line app/vmalert/web.qtpl:148
+//line app/vmalert/web.qtpl:149
 			}
-//line app/vmalert/web.qtpl:148
+//line app/vmalert/web.qtpl:149
 			qw422016.N().S(`
                         `)
-//line app/vmalert/web.qtpl:149
+//line app/vmalert/web.qtpl:150
 			if len(g.Headers) > 0 {
-//line app/vmalert/web.qtpl:149
+//line app/vmalert/web.qtpl:150
 				qw422016.N().S(`
                             <span class="fs-6 text-start w-100 d-flex justify-content-between fw-lighter">
                                 <span>Extra headers</span>
                                 <span class="d-flex align-items-center gap-2">
                                     `)
-//line app/vmalert/web.qtpl:153
+//line app/vmalert/web.qtpl:154
 				for _, header := range g.Headers {
-//line app/vmalert/web.qtpl:153
+//line app/vmalert/web.qtpl:154
 					qw422016.N().S(`
                                         <span class="badge bg-primary label">`)
-//line app/vmalert/web.qtpl:154
+//line app/vmalert/web.qtpl:155
 					qw422016.E().S(header)
-//line app/vmalert/web.qtpl:154
+//line app/vmalert/web.qtpl:155
 					qw422016.N().S(`</span>
                                     `)
-//line app/vmalert/web.qtpl:155
+//line app/vmalert/web.qtpl:156
 				}
-//line app/vmalert/web.qtpl:155
+//line app/vmalert/web.qtpl:156
 				qw422016.N().S(`
                                 </span>
                             </span>
                         `)
-//line app/vmalert/web.qtpl:158
+//line app/vmalert/web.qtpl:159
 			}
-//line app/vmalert/web.qtpl:158
+//line app/vmalert/web.qtpl:159
 			qw422016.N().S(`
                     </span>
                     <div class="collapse sub-items" id="sub-`)
-//line app/vmalert/web.qtpl:160
+//line app/vmalert/web.qtpl:161
 			qw422016.E().S(g.ID)
-//line app/vmalert/web.qtpl:160
+//line app/vmalert/web.qtpl:161
 			qw422016.N().S(`">
                         <table class="table table-striped table-hover table-sm">
                             <thead>
@@ -530,258 +531,258 @@ func StreamListGroups(qw422016 *qt422016.Writer, r *http.Request, groups []*apiG
                             </thead>
                             <tbody>
                                 `)
-//line app/vmalert/web.qtpl:170
+//line app/vmalert/web.qtpl:171
 			for _, r := range g.Rules {
-//line app/vmalert/web.qtpl:170
+//line app/vmalert/web.qtpl:171
 				qw422016.N().S(`
                                     <tr class="sub-item`)
-//line app/vmalert/web.qtpl:171
+//line app/vmalert/web.qtpl:172
 				if r.LastError != "" {
-//line app/vmalert/web.qtpl:171
+//line app/vmalert/web.qtpl:172
 					qw422016.N().S(` alert-danger`)
-//line app/vmalert/web.qtpl:171
+//line app/vmalert/web.qtpl:172
 				}
-//line app/vmalert/web.qtpl:171
+//line app/vmalert/web.qtpl:172
 				qw422016.N().S(`">
                                         <td>
                                             <div class="row">
                                                 <div class="col-12 mb-2">
                                                     `)
-//line app/vmalert/web.qtpl:175
+//line app/vmalert/web.qtpl:176
 				if r.Type == "alerting" {
-//line app/vmalert/web.qtpl:175
+//line app/vmalert/web.qtpl:176
 					qw422016.N().S(`
                                                         `)
-//line app/vmalert/web.qtpl:176
+//line app/vmalert/web.qtpl:177
 					if r.KeepFiringFor > 0 {
-//line app/vmalert/web.qtpl:176
+//line app/vmalert/web.qtpl:177
 						qw422016.N().S(`
                                                             <b>alert:</b> `)
-//line app/vmalert/web.qtpl:177
+//line app/vmalert/web.qtpl:178
 						qw422016.E().S(r.Name)
-//line app/vmalert/web.qtpl:177
+//line app/vmalert/web.qtpl:178
 						qw422016.N().S(` (for: `)
-//line app/vmalert/web.qtpl:177
+//line app/vmalert/web.qtpl:178
 						qw422016.E().V(r.Duration)
-//line app/vmalert/web.qtpl:177
+//line app/vmalert/web.qtpl:178
 						qw422016.N().S(` seconds, keep_firing_for: `)
-//line app/vmalert/web.qtpl:177
+//line app/vmalert/web.qtpl:178
 						qw422016.E().V(r.KeepFiringFor)
-//line app/vmalert/web.qtpl:177
+//line app/vmalert/web.qtpl:178
 						qw422016.N().S(` seconds)
                                                         `)
-//line app/vmalert/web.qtpl:178
+//line app/vmalert/web.qtpl:179
 					} else {
-//line app/vmalert/web.qtpl:178
+//line app/vmalert/web.qtpl:179
 						qw422016.N().S(`
                                                             <b>alert:</b> `)
-//line app/vmalert/web.qtpl:179
+//line app/vmalert/web.qtpl:180
 						qw422016.E().S(r.Name)
-//line app/vmalert/web.qtpl:179
+//line app/vmalert/web.qtpl:180
 						qw422016.N().S(` (for: `)
-//line app/vmalert/web.qtpl:179
+//line app/vmalert/web.qtpl:180
 						qw422016.E().V(r.Duration)
-//line app/vmalert/web.qtpl:179
+//line app/vmalert/web.qtpl:180
 						qw422016.N().S(` seconds)
                                                         `)
-//line app/vmalert/web.qtpl:180
+//line app/vmalert/web.qtpl:181
 					}
-//line app/vmalert/web.qtpl:180
+//line app/vmalert/web.qtpl:181
 					qw422016.N().S(`
                                                     `)
-//line app/vmalert/web.qtpl:181
+//line app/vmalert/web.qtpl:182
 				} else {
-//line app/vmalert/web.qtpl:181
+//line app/vmalert/web.qtpl:182
 					qw422016.N().S(`
                                                         <b>record:</b> `)
-//line app/vmalert/web.qtpl:182
+//line app/vmalert/web.qtpl:183
 					qw422016.E().S(r.Name)
-//line app/vmalert/web.qtpl:182
+//line app/vmalert/web.qtpl:183
 					qw422016.N().S(`
                                                     `)
-//line app/vmalert/web.qtpl:183
+//line app/vmalert/web.qtpl:184
 				}
-//line app/vmalert/web.qtpl:183
+//line app/vmalert/web.qtpl:184
 				qw422016.N().S(`
                                                     |
                                                     `)
-//line app/vmalert/web.qtpl:185
+//line app/vmalert/web.qtpl:186
 				streamseriesFetchedWarn(qw422016, prefix, r)
-//line app/vmalert/web.qtpl:185
+//line app/vmalert/web.qtpl:186
 				qw422016.N().S(`
                                                     <span><a target="_blank" href="`)
-//line app/vmalert/web.qtpl:186
+//line app/vmalert/web.qtpl:187
 				qw422016.E().S(prefix + r.WebLink())
-//line app/vmalert/web.qtpl:186
+//line app/vmalert/web.qtpl:187
 				qw422016.N().S(`">Details</a></span>
                                                 </div>
                                                 <div class="col-12">
                                                     <code><pre>`)
-//line app/vmalert/web.qtpl:189
+//line app/vmalert/web.qtpl:190
 				qw422016.E().S(r.Query)
-//line app/vmalert/web.qtpl:189
+//line app/vmalert/web.qtpl:190
 				qw422016.N().S(`</pre></code>
                                                 </div>
                                                 <div class="col-12 mb-2">
                                                     `)
-//line app/vmalert/web.qtpl:192
+//line app/vmalert/web.qtpl:193
 				if len(r.Labels) > 0 {
-//line app/vmalert/web.qtpl:192
+//line app/vmalert/web.qtpl:193
 					qw422016.N().S(` <b>Labels:</b>`)
-//line app/vmalert/web.qtpl:192
+//line app/vmalert/web.qtpl:193
 				}
-//line app/vmalert/web.qtpl:192
+//line app/vmalert/web.qtpl:193
 				qw422016.N().S(`
                                                     `)
-//line app/vmalert/web.qtpl:193
+//line app/vmalert/web.qtpl:194
 				for k, v := range r.Labels {
-//line app/vmalert/web.qtpl:193
+//line app/vmalert/web.qtpl:194
 					qw422016.N().S(`
                                                         <span class="ms-1 badge bg-primary label">`)
-//line app/vmalert/web.qtpl:194
+//line app/vmalert/web.qtpl:195
 					qw422016.E().S(k)
-//line app/vmalert/web.qtpl:194
+//line app/vmalert/web.qtpl:195
 					qw422016.N().S(`=`)
-//line app/vmalert/web.qtpl:194
+//line app/vmalert/web.qtpl:195
 					qw422016.E().S(v)
-//line app/vmalert/web.qtpl:194
+//line app/vmalert/web.qtpl:195
 					qw422016.N().S(`</span>
                                                     `)
-//line app/vmalert/web.qtpl:195
+//line app/vmalert/web.qtpl:196
 				}
-//line app/vmalert/web.qtpl:195
+//line app/vmalert/web.qtpl:196
 				qw422016.N().S(`
                                                 </div>
                                                 `)
-//line app/vmalert/web.qtpl:197
+//line app/vmalert/web.qtpl:198
 				if r.LastError != "" {
-//line app/vmalert/web.qtpl:197
+//line app/vmalert/web.qtpl:198
 					qw422016.N().S(`
                                                     <div class="col-12">
                                                         <b>Error:</b>
                                                         <div class="error-cell">
                                                             `)
-//line app/vmalert/web.qtpl:201
+//line app/vmalert/web.qtpl:202
 					qw422016.E().S(r.LastError)
-//line app/vmalert/web.qtpl:201
+//line app/vmalert/web.qtpl:202
 					qw422016.N().S(`
                                                         </div>
                                                     </div>
                                                 `)
-//line app/vmalert/web.qtpl:204
+//line app/vmalert/web.qtpl:205
 				}
-//line app/vmalert/web.qtpl:204
+//line app/vmalert/web.qtpl:205
 				qw422016.N().S(`
                                             </div>
                                         </td>
                                         <td class="text-center">`)
-//line app/vmalert/web.qtpl:207
+//line app/vmalert/web.qtpl:208
 				qw422016.N().D(r.LastSamples)
-//line app/vmalert/web.qtpl:207
+//line app/vmalert/web.qtpl:208
 				qw422016.N().S(`</td>
                                         <td class="text-center">`)
-//line app/vmalert/web.qtpl:208
+//line app/vmalert/web.qtpl:209
 				qw422016.N().FPrec(time.Since(r.LastEvaluation).Seconds(), 3)
-//line app/vmalert/web.qtpl:208
+//line app/vmalert/web.qtpl:209
 				qw422016.N().S(`s ago</td>
                                     </tr>
                                 `)
-//line app/vmalert/web.qtpl:210
+//line app/vmalert/web.qtpl:211
 			}
-//line app/vmalert/web.qtpl:210
+//line app/vmalert/web.qtpl:211
 			qw422016.N().S(`
                             </tbody>
                         </table>
                     </div>
                 </div>
             `)
-//line app/vmalert/web.qtpl:215
+//line app/vmalert/web.qtpl:216
 		}
-//line app/vmalert/web.qtpl:215
+//line app/vmalert/web.qtpl:216
 		qw422016.N().S(`
         `)
-//line app/vmalert/web.qtpl:216
+//line app/vmalert/web.qtpl:217
 	} else {
-//line app/vmalert/web.qtpl:216
+//line app/vmalert/web.qtpl:217
 		qw422016.N().S(`
             <div>
                 <p>No groups...</p>
             </div>
         `)
-//line app/vmalert/web.qtpl:220
+//line app/vmalert/web.qtpl:221
 	}
-//line app/vmalert/web.qtpl:220
+//line app/vmalert/web.qtpl:221
 	qw422016.N().S(`
     `)
-//line app/vmalert/web.qtpl:221
+//line app/vmalert/web.qtpl:222
 	tpl.StreamFooter(qw422016, r)
-//line app/vmalert/web.qtpl:221
+//line app/vmalert/web.qtpl:222
 	qw422016.N().S(`
 `)
-//line app/vmalert/web.qtpl:222
+//line app/vmalert/web.qtpl:223
 }
 
-//line app/vmalert/web.qtpl:222
-func WriteListGroups(qq422016 qtio422016.Writer, r *http.Request, groups []*apiGroup, filter string) {
-//line app/vmalert/web.qtpl:222
+//line app/vmalert/web.qtpl:223
+func WriteListGroups(qq422016 qtio422016.Writer, r *http.Request, groups []*rule.ApiGroup, filter string) {
+//line app/vmalert/web.qtpl:223
 	qw422016 := qt422016.AcquireWriter(qq422016)
-//line app/vmalert/web.qtpl:222
+//line app/vmalert/web.qtpl:223
 	StreamListGroups(qw422016, r, groups, filter)
-//line app/vmalert/web.qtpl:222
+//line app/vmalert/web.qtpl:223
 	qt422016.ReleaseWriter(qw422016)
-//line app/vmalert/web.qtpl:222
+//line app/vmalert/web.qtpl:223
 }
 
-//line app/vmalert/web.qtpl:222
-func ListGroups(r *http.Request, groups []*apiGroup, filter string) string {
-//line app/vmalert/web.qtpl:222
+//line app/vmalert/web.qtpl:223
+func ListGroups(r *http.Request, groups []*rule.ApiGroup, filter string) string {
+//line app/vmalert/web.qtpl:223
 	qb422016 := qt422016.AcquireByteBuffer()
-//line app/vmalert/web.qtpl:222
+//line app/vmalert/web.qtpl:223
 	WriteListGroups(qb422016, r, groups, filter)
-//line app/vmalert/web.qtpl:222
+//line app/vmalert/web.qtpl:223
 	qs422016 := string(qb422016.B)
-//line app/vmalert/web.qtpl:222
+//line app/vmalert/web.qtpl:223
 	qt422016.ReleaseByteBuffer(qb422016)
-//line app/vmalert/web.qtpl:222
+//line app/vmalert/web.qtpl:223
 	return qs422016
-//line app/vmalert/web.qtpl:222
+//line app/vmalert/web.qtpl:223
 }
 
-//line app/vmalert/web.qtpl:225
-func StreamListAlerts(qw422016 *qt422016.Writer, r *http.Request, groupAlerts []groupAlerts) {
-//line app/vmalert/web.qtpl:225
+//line app/vmalert/web.qtpl:226
+func StreamListAlerts(qw422016 *qt422016.Writer, r *http.Request, groupAlerts []rule.GroupAlerts) {
+//line app/vmalert/web.qtpl:226
 	qw422016.N().S(`
     `)
-//line app/vmalert/web.qtpl:226
+//line app/vmalert/web.qtpl:227
 	prefix := vmalertutil.Prefix(r.URL.Path)
 
-//line app/vmalert/web.qtpl:226
+//line app/vmalert/web.qtpl:227
 	qw422016.N().S(`
     `)
-//line app/vmalert/web.qtpl:227
+//line app/vmalert/web.qtpl:228
 	tpl.StreamHeader(qw422016, r, navItems, "Alerts", getLastConfigError())
-//line app/vmalert/web.qtpl:227
+//line app/vmalert/web.qtpl:228
 	qw422016.N().S(`
     `)
-//line app/vmalert/web.qtpl:228
+//line app/vmalert/web.qtpl:229
 	StreamControls(qw422016, prefix, "", "", nil, nil, true)
-//line app/vmalert/web.qtpl:228
+//line app/vmalert/web.qtpl:229
 	qw422016.N().S(`
     `)
-//line app/vmalert/web.qtpl:229
+//line app/vmalert/web.qtpl:230
 	if len(groupAlerts) > 0 {
-//line app/vmalert/web.qtpl:229
+//line app/vmalert/web.qtpl:230
 		qw422016.N().S(`
          `)
-//line app/vmalert/web.qtpl:230
+//line app/vmalert/web.qtpl:231
 		for _, ga := range groupAlerts {
-//line app/vmalert/web.qtpl:230
+//line app/vmalert/web.qtpl:231
 			qw422016.N().S(`
              `)
-//line app/vmalert/web.qtpl:232
+//line app/vmalert/web.qtpl:233
 			g := ga.Group
 			var keys []string
-			alertsByRule := make(map[string][]*apiAlert)
+			alertsByRule := make(map[string][]*rule.ApiAlert)
 			for _, alert := range ga.Alerts {
 				if len(alertsByRule[alert.RuleID]) < 1 {
 					keys = append(keys, alert.RuleID)
@@ -790,47 +791,47 @@ func StreamListAlerts(qw422016 *qt422016.Writer, r *http.Request, groupAlerts []
 			}
 			sort.Strings(keys)
 
-//line app/vmalert/web.qtpl:242
+//line app/vmalert/web.qtpl:243
 			qw422016.N().S(`
              <div class="d-flex w-100 flex-column group-items alert-danger">
                  <span id="group-`)
-//line app/vmalert/web.qtpl:244
+//line app/vmalert/web.qtpl:245
 			qw422016.E().S(g.ID)
-//line app/vmalert/web.qtpl:244
+//line app/vmalert/web.qtpl:245
 			qw422016.N().S(`" class="d-flex justify-content-between">
                      <a href="#group-`)
-//line app/vmalert/web.qtpl:245
+//line app/vmalert/web.qtpl:246
 			qw422016.E().S(g.ID)
-//line app/vmalert/web.qtpl:245
+//line app/vmalert/web.qtpl:246
 			qw422016.N().S(`">`)
-//line app/vmalert/web.qtpl:245
+//line app/vmalert/web.qtpl:246
 			qw422016.E().S(g.Name)
-//line app/vmalert/web.qtpl:245
+//line app/vmalert/web.qtpl:246
 			if g.Type != "prometheus" {
-//line app/vmalert/web.qtpl:245
+//line app/vmalert/web.qtpl:246
 				qw422016.N().S(` (`)
-//line app/vmalert/web.qtpl:245
+//line app/vmalert/web.qtpl:246
 				qw422016.E().S(g.Type)
-//line app/vmalert/web.qtpl:245
+//line app/vmalert/web.qtpl:246
 				qw422016.N().S(`)`)
-//line app/vmalert/web.qtpl:245
+//line app/vmalert/web.qtpl:246
 			}
-//line app/vmalert/web.qtpl:245
+//line app/vmalert/web.qtpl:246
 			qw422016.N().S(`</a>
                      <span
                          class="flex-grow-1 d-flex justify-content-end"
                          role="button"
                          data-bs-toggle="collapse"
                          data-bs-target="#sub-`)
-//line app/vmalert/web.qtpl:250
+//line app/vmalert/web.qtpl:251
 			qw422016.E().S(g.ID)
-//line app/vmalert/web.qtpl:250
+//line app/vmalert/web.qtpl:251
 			qw422016.N().S(`"
                      >
                          <span class="badge bg-danger" title="Number of active alerts">`)
-//line app/vmalert/web.qtpl:252
+//line app/vmalert/web.qtpl:253
 			qw422016.N().D(len(ga.Alerts))
-//line app/vmalert/web.qtpl:252
+//line app/vmalert/web.qtpl:253
 			qw422016.N().S(`</span>
                      </span>
                  </span>
@@ -840,28 +841,28 @@ func StreamListAlerts(qw422016 *qt422016.Writer, r *http.Request, groupAlerts []
                          role="button" 
                          data-bs-toggle="collapse"
                          data-bs-target="#sub-`)
-//line app/vmalert/web.qtpl:260
+//line app/vmalert/web.qtpl:261
 			qw422016.E().S(g.ID)
-//line app/vmalert/web.qtpl:260
+//line app/vmalert/web.qtpl:261
 			qw422016.N().S(`"
                      >`)
-//line app/vmalert/web.qtpl:261
+//line app/vmalert/web.qtpl:262
 			qw422016.E().S(g.File)
-//line app/vmalert/web.qtpl:261
+//line app/vmalert/web.qtpl:262
 			qw422016.N().S(`</span>
                  </span>
                  <div class="collapse sub-items" id="sub-`)
-//line app/vmalert/web.qtpl:263
+//line app/vmalert/web.qtpl:264
 			qw422016.E().S(g.ID)
-//line app/vmalert/web.qtpl:263
+//line app/vmalert/web.qtpl:264
 			qw422016.N().S(`">
                      `)
-//line app/vmalert/web.qtpl:264
+//line app/vmalert/web.qtpl:265
 			for _, ruleID := range keys {
-//line app/vmalert/web.qtpl:264
+//line app/vmalert/web.qtpl:265
 				qw422016.N().S(`
                          `)
-//line app/vmalert/web.qtpl:266
+//line app/vmalert/web.qtpl:267
 				defaultAR := alertsByRule[ruleID][0]
 				var labelKeys []string
 				for k := range defaultAR.Labels {
@@ -869,29 +870,29 @@ func StreamListAlerts(qw422016 *qt422016.Writer, r *http.Request, groupAlerts []
 				}
 				sort.Strings(labelKeys)
 
-//line app/vmalert/web.qtpl:272
+//line app/vmalert/web.qtpl:273
 				qw422016.N().S(`
                          <br>
                          <div class="sub-item">
                              <b>alert:</b> `)
-//line app/vmalert/web.qtpl:275
+//line app/vmalert/web.qtpl:276
 				qw422016.E().S(defaultAR.Name)
-//line app/vmalert/web.qtpl:275
+//line app/vmalert/web.qtpl:276
 				qw422016.N().S(` (`)
-//line app/vmalert/web.qtpl:275
+//line app/vmalert/web.qtpl:276
 				qw422016.N().D(len(alertsByRule[ruleID]))
-//line app/vmalert/web.qtpl:275
+//line app/vmalert/web.qtpl:276
 				qw422016.N().S(`)
                              | <span><a target="_blank" href="`)
-//line app/vmalert/web.qtpl:276
+//line app/vmalert/web.qtpl:277
 				qw422016.E().S(defaultAR.SourceLink)
-//line app/vmalert/web.qtpl:276
+//line app/vmalert/web.qtpl:277
 				qw422016.N().S(`">Source</a></span>
                              <br>
                              <b>expr:</b><code><pre>`)
-//line app/vmalert/web.qtpl:278
+//line app/vmalert/web.qtpl:279
 				qw422016.E().S(defaultAR.Expression)
-//line app/vmalert/web.qtpl:278
+//line app/vmalert/web.qtpl:279
 				qw422016.N().S(`</pre></code>
                              <table class="table table-striped table-hover table-sm">
                                  <thead>
@@ -905,222 +906,222 @@ func StreamListAlerts(qw422016 *qt422016.Writer, r *http.Request, groupAlerts []
                                  </thead>
                                  <tbody>
                                      `)
-//line app/vmalert/web.qtpl:290
+//line app/vmalert/web.qtpl:291
 				for _, ar := range alertsByRule[ruleID] {
-//line app/vmalert/web.qtpl:290
+//line app/vmalert/web.qtpl:291
 					qw422016.N().S(`
                                          <tr>
                                              <td>
                                                  `)
-//line app/vmalert/web.qtpl:293
+//line app/vmalert/web.qtpl:294
 					for _, k := range labelKeys {
-//line app/vmalert/web.qtpl:293
+//line app/vmalert/web.qtpl:294
 						qw422016.N().S(`
                                                      <span class="ms-1 badge bg-primary label">`)
-//line app/vmalert/web.qtpl:294
+//line app/vmalert/web.qtpl:295
 						qw422016.E().S(k)
-//line app/vmalert/web.qtpl:294
+//line app/vmalert/web.qtpl:295
 						qw422016.N().S(`=`)
-//line app/vmalert/web.qtpl:294
+//line app/vmalert/web.qtpl:295
 						qw422016.E().S(ar.Labels[k])
-//line app/vmalert/web.qtpl:294
+//line app/vmalert/web.qtpl:295
 						qw422016.N().S(`</span>
                                                  `)
-//line app/vmalert/web.qtpl:295
+//line app/vmalert/web.qtpl:296
 					}
-//line app/vmalert/web.qtpl:295
+//line app/vmalert/web.qtpl:296
 					qw422016.N().S(`
                                              </td>
                                              <td>`)
-//line app/vmalert/web.qtpl:297
+//line app/vmalert/web.qtpl:298
 					streambadgeState(qw422016, ar.State)
-//line app/vmalert/web.qtpl:297
+//line app/vmalert/web.qtpl:298
 					qw422016.N().S(`</td>
                                              <td>
                                                  `)
-//line app/vmalert/web.qtpl:299
+//line app/vmalert/web.qtpl:300
 					qw422016.E().S(ar.ActiveAt.Format("2006-01-02T15:04:05Z07:00"))
-//line app/vmalert/web.qtpl:299
+//line app/vmalert/web.qtpl:300
 					qw422016.N().S(`
                                                  `)
-//line app/vmalert/web.qtpl:300
+//line app/vmalert/web.qtpl:301
 					if ar.Restored {
-//line app/vmalert/web.qtpl:300
+//line app/vmalert/web.qtpl:301
 						streambadgeRestored(qw422016)
-//line app/vmalert/web.qtpl:300
+//line app/vmalert/web.qtpl:301
 					}
-//line app/vmalert/web.qtpl:300
+//line app/vmalert/web.qtpl:301
 					qw422016.N().S(`
                                                  `)
-//line app/vmalert/web.qtpl:301
+//line app/vmalert/web.qtpl:302
 					if ar.Stabilizing {
-//line app/vmalert/web.qtpl:301
+//line app/vmalert/web.qtpl:302
 						streambadgeStabilizing(qw422016)
-//line app/vmalert/web.qtpl:301
+//line app/vmalert/web.qtpl:302
 					}
-//line app/vmalert/web.qtpl:301
+//line app/vmalert/web.qtpl:302
 					qw422016.N().S(`
                                              </td>
                                              <td>`)
-//line app/vmalert/web.qtpl:303
+//line app/vmalert/web.qtpl:304
 					qw422016.E().S(ar.Value)
-//line app/vmalert/web.qtpl:303
+//line app/vmalert/web.qtpl:304
 					qw422016.N().S(`</td>
                                              <td><a href="`)
-//line app/vmalert/web.qtpl:304
+//line app/vmalert/web.qtpl:305
 					qw422016.E().S(prefix + ar.WebLink())
-//line app/vmalert/web.qtpl:304
+//line app/vmalert/web.qtpl:305
 					qw422016.N().S(`">Details</a></td>
                                          </tr>
                                      `)
-//line app/vmalert/web.qtpl:306
+//line app/vmalert/web.qtpl:307
 				}
-//line app/vmalert/web.qtpl:306
+//line app/vmalert/web.qtpl:307
 				qw422016.N().S(`
                                  </tbody>
                              </table>
                          </div>
                      `)
-//line app/vmalert/web.qtpl:310
+//line app/vmalert/web.qtpl:311
 			}
-//line app/vmalert/web.qtpl:310
+//line app/vmalert/web.qtpl:311
 			qw422016.N().S(`
                  </div>
              </div>
          `)
-//line app/vmalert/web.qtpl:313
+//line app/vmalert/web.qtpl:314
 		}
-//line app/vmalert/web.qtpl:313
+//line app/vmalert/web.qtpl:314
 		qw422016.N().S(`
      `)
-//line app/vmalert/web.qtpl:314
+//line app/vmalert/web.qtpl:315
 	} else {
-//line app/vmalert/web.qtpl:314
+//line app/vmalert/web.qtpl:315
 		qw422016.N().S(`
          <div>
              <p>No active alerts...</p>
          </div>
      `)
-//line app/vmalert/web.qtpl:318
+//line app/vmalert/web.qtpl:319
 	}
-//line app/vmalert/web.qtpl:318
+//line app/vmalert/web.qtpl:319
 	qw422016.N().S(`
      `)
-//line app/vmalert/web.qtpl:319
+//line app/vmalert/web.qtpl:320
 	tpl.StreamFooter(qw422016, r)
-//line app/vmalert/web.qtpl:319
+//line app/vmalert/web.qtpl:320
 	qw422016.N().S(`
 `)
-//line app/vmalert/web.qtpl:320
+//line app/vmalert/web.qtpl:321
 }
 
-//line app/vmalert/web.qtpl:320
-func WriteListAlerts(qq422016 qtio422016.Writer, r *http.Request, groupAlerts []groupAlerts) {
-//line app/vmalert/web.qtpl:320
+//line app/vmalert/web.qtpl:321
+func WriteListAlerts(qq422016 qtio422016.Writer, r *http.Request, groupAlerts []rule.GroupAlerts) {
+//line app/vmalert/web.qtpl:321
 	qw422016 := qt422016.AcquireWriter(qq422016)
-//line app/vmalert/web.qtpl:320
+//line app/vmalert/web.qtpl:321
 	StreamListAlerts(qw422016, r, groupAlerts)
-//line app/vmalert/web.qtpl:320
+//line app/vmalert/web.qtpl:321
 	qt422016.ReleaseWriter(qw422016)
-//line app/vmalert/web.qtpl:320
+//line app/vmalert/web.qtpl:321
 }
 
-//line app/vmalert/web.qtpl:320
-func ListAlerts(r *http.Request, groupAlerts []groupAlerts) string {
-//line app/vmalert/web.qtpl:320
+//line app/vmalert/web.qtpl:321
+func ListAlerts(r *http.Request, groupAlerts []rule.GroupAlerts) string {
+//line app/vmalert/web.qtpl:321
 	qb422016 := qt422016.AcquireByteBuffer()
-//line app/vmalert/web.qtpl:320
+//line app/vmalert/web.qtpl:321
 	WriteListAlerts(qb422016, r, groupAlerts)
-//line app/vmalert/web.qtpl:320
+//line app/vmalert/web.qtpl:321
 	qs422016 := string(qb422016.B)
-//line app/vmalert/web.qtpl:320
+//line app/vmalert/web.qtpl:321
 	qt422016.ReleaseByteBuffer(qb422016)
-//line app/vmalert/web.qtpl:320
+//line app/vmalert/web.qtpl:321
 	return qs422016
-//line app/vmalert/web.qtpl:320
+//line app/vmalert/web.qtpl:321
 }
 
-//line app/vmalert/web.qtpl:322
+//line app/vmalert/web.qtpl:323
 func StreamListTargets(qw422016 *qt422016.Writer, r *http.Request, targets map[notifier.TargetType][]notifier.Target) {
-//line app/vmalert/web.qtpl:322
+//line app/vmalert/web.qtpl:323
 	qw422016.N().S(`
     `)
-//line app/vmalert/web.qtpl:323
+//line app/vmalert/web.qtpl:324
 	prefix := vmalertutil.Prefix(r.URL.Path)
 
-//line app/vmalert/web.qtpl:323
+//line app/vmalert/web.qtpl:324
 	qw422016.N().S(`
     `)
-//line app/vmalert/web.qtpl:324
+//line app/vmalert/web.qtpl:325
 	tpl.StreamHeader(qw422016, r, navItems, "Notifiers", getLastConfigError())
-//line app/vmalert/web.qtpl:324
+//line app/vmalert/web.qtpl:325
 	qw422016.N().S(`
     `)
-//line app/vmalert/web.qtpl:325
+//line app/vmalert/web.qtpl:326
 	StreamControls(qw422016, prefix, "", "", nil, nil, false)
-//line app/vmalert/web.qtpl:325
+//line app/vmalert/web.qtpl:326
 	qw422016.N().S(`
     `)
-//line app/vmalert/web.qtpl:326
+//line app/vmalert/web.qtpl:327
 	if len(targets) > 0 {
-//line app/vmalert/web.qtpl:326
+//line app/vmalert/web.qtpl:327
 		qw422016.N().S(`
         `)
-//line app/vmalert/web.qtpl:328
+//line app/vmalert/web.qtpl:329
 		var keys []string
 		for key := range targets {
 			keys = append(keys, string(key))
 		}
 		sort.Strings(keys)
 
-//line app/vmalert/web.qtpl:333
+//line app/vmalert/web.qtpl:334
 		qw422016.N().S(`
         `)
-//line app/vmalert/web.qtpl:334
+//line app/vmalert/web.qtpl:335
 		for i := range keys {
-//line app/vmalert/web.qtpl:334
+//line app/vmalert/web.qtpl:335
 			qw422016.N().S(`
             `)
-//line app/vmalert/web.qtpl:336
+//line app/vmalert/web.qtpl:337
 			typeK, ns := keys[i], targets[notifier.TargetType(keys[i])]
 			count := len(ns)
 
-//line app/vmalert/web.qtpl:338
+//line app/vmalert/web.qtpl:339
 			qw422016.N().S(`
             <div class="d-flex w-100 flex-column group-items">
                 <span class="d-flex justify-content-between" id="group-`)
-//line app/vmalert/web.qtpl:340
+//line app/vmalert/web.qtpl:341
 			qw422016.E().S(typeK)
-//line app/vmalert/web.qtpl:340
+//line app/vmalert/web.qtpl:341
 			qw422016.N().S(`">
                     <a href="#group-`)
-//line app/vmalert/web.qtpl:341
+//line app/vmalert/web.qtpl:342
 			qw422016.E().S(typeK)
-//line app/vmalert/web.qtpl:341
+//line app/vmalert/web.qtpl:342
 			qw422016.N().S(`">`)
-//line app/vmalert/web.qtpl:341
+//line app/vmalert/web.qtpl:342
 			qw422016.E().S(typeK)
-//line app/vmalert/web.qtpl:341
+//line app/vmalert/web.qtpl:342
 			qw422016.N().S(` (`)
-//line app/vmalert/web.qtpl:341
+//line app/vmalert/web.qtpl:342
 			qw422016.N().D(count)
-//line app/vmalert/web.qtpl:341
+//line app/vmalert/web.qtpl:342
 			qw422016.N().S(`)</a>
                     <span
                         class="flex-grow-1"
                         role="button"
                         data-bs-toggle="collapse"
                         data-bs-target="#sub-`)
-//line app/vmalert/web.qtpl:346
+//line app/vmalert/web.qtpl:347
 			qw422016.E().S(typeK)
-//line app/vmalert/web.qtpl:346
+//line app/vmalert/web.qtpl:347
 			qw422016.N().S(`"
                     ></span>
                 </span>
                 <div id="sub-`)
-//line app/vmalert/web.qtpl:349
+//line app/vmalert/web.qtpl:350
 			qw422016.E().S(typeK)
-//line app/vmalert/web.qtpl:349
+//line app/vmalert/web.qtpl:350
 			qw422016.N().S(`" class="collapse show sub-items">
                     <table class="table table-striped table-hover table-sm">
                         <thead>
@@ -1131,117 +1132,117 @@ func StreamListTargets(qw422016 *qt422016.Writer, r *http.Request, targets map[n
                         </thead>
                         <tbody>
                             `)
-//line app/vmalert/web.qtpl:358
+//line app/vmalert/web.qtpl:359
 			for _, n := range ns {
-//line app/vmalert/web.qtpl:358
+//line app/vmalert/web.qtpl:359
 				qw422016.N().S(`
                                 <tr>
                                     <td>
                                         `)
-//line app/vmalert/web.qtpl:361
+//line app/vmalert/web.qtpl:362
 				for _, l := range n.Labels.GetLabels() {
-//line app/vmalert/web.qtpl:361
+//line app/vmalert/web.qtpl:362
 					qw422016.N().S(`
                                             <span class="ms-1 badge bg-primary">`)
-//line app/vmalert/web.qtpl:362
+//line app/vmalert/web.qtpl:363
 					qw422016.E().S(l.Name)
-//line app/vmalert/web.qtpl:362
+//line app/vmalert/web.qtpl:363
 					qw422016.N().S(`=`)
-//line app/vmalert/web.qtpl:362
+//line app/vmalert/web.qtpl:363
 					qw422016.E().S(l.Value)
-//line app/vmalert/web.qtpl:362
+//line app/vmalert/web.qtpl:363
 					qw422016.N().S(`</span>
                                         `)
-//line app/vmalert/web.qtpl:363
+//line app/vmalert/web.qtpl:364
 				}
-//line app/vmalert/web.qtpl:363
+//line app/vmalert/web.qtpl:364
 				qw422016.N().S(`
                                     </td>
                                     <td>`)
-//line app/vmalert/web.qtpl:365
+//line app/vmalert/web.qtpl:366
 				qw422016.E().S(n.Notifier.Addr())
-//line app/vmalert/web.qtpl:365
+//line app/vmalert/web.qtpl:366
 				qw422016.N().S(`</td>
                                 </tr>
                             `)
-//line app/vmalert/web.qtpl:367
+//line app/vmalert/web.qtpl:368
 			}
-//line app/vmalert/web.qtpl:367
+//line app/vmalert/web.qtpl:368
 			qw422016.N().S(`
                         </tbody>
                     </table>
                 </div>
             </div>
         `)
-//line app/vmalert/web.qtpl:372
+//line app/vmalert/web.qtpl:373
 		}
-//line app/vmalert/web.qtpl:372
+//line app/vmalert/web.qtpl:373
 		qw422016.N().S(`
     `)
-//line app/vmalert/web.qtpl:373
+//line app/vmalert/web.qtpl:374
 	} else {
-//line app/vmalert/web.qtpl:373
+//line app/vmalert/web.qtpl:374
 		qw422016.N().S(`
         <div>
             <p>No targets...</p>
         </div>
     `)
-//line app/vmalert/web.qtpl:377
+//line app/vmalert/web.qtpl:378
 	}
-//line app/vmalert/web.qtpl:377
+//line app/vmalert/web.qtpl:378
 	qw422016.N().S(`
     `)
-//line app/vmalert/web.qtpl:378
+//line app/vmalert/web.qtpl:379
 	tpl.StreamFooter(qw422016, r)
-//line app/vmalert/web.qtpl:378
+//line app/vmalert/web.qtpl:379
 	qw422016.N().S(`
 `)
-//line app/vmalert/web.qtpl:379
+//line app/vmalert/web.qtpl:380
 }
 
-//line app/vmalert/web.qtpl:379
+//line app/vmalert/web.qtpl:380
 func WriteListTargets(qq422016 qtio422016.Writer, r *http.Request, targets map[notifier.TargetType][]notifier.Target) {
-//line app/vmalert/web.qtpl:379
+//line app/vmalert/web.qtpl:380
 	qw422016 := qt422016.AcquireWriter(qq422016)
-//line app/vmalert/web.qtpl:379
+//line app/vmalert/web.qtpl:380
 	StreamListTargets(qw422016, r, targets)
-//line app/vmalert/web.qtpl:379
+//line app/vmalert/web.qtpl:380
 	qt422016.ReleaseWriter(qw422016)
-//line app/vmalert/web.qtpl:379
+//line app/vmalert/web.qtpl:380
 }
 
-//line app/vmalert/web.qtpl:379
+//line app/vmalert/web.qtpl:380
 func ListTargets(r *http.Request, targets map[notifier.TargetType][]notifier.Target) string {
-//line app/vmalert/web.qtpl:379
+//line app/vmalert/web.qtpl:380
 	qb422016 := qt422016.AcquireByteBuffer()
-//line app/vmalert/web.qtpl:379
+//line app/vmalert/web.qtpl:380
 	WriteListTargets(qb422016, r, targets)
-//line app/vmalert/web.qtpl:379
+//line app/vmalert/web.qtpl:380
 	qs422016 := string(qb422016.B)
-//line app/vmalert/web.qtpl:379
+//line app/vmalert/web.qtpl:380
 	qt422016.ReleaseByteBuffer(qb422016)
-//line app/vmalert/web.qtpl:379
+//line app/vmalert/web.qtpl:380
 	return qs422016
-//line app/vmalert/web.qtpl:379
+//line app/vmalert/web.qtpl:380
 }
 
-//line app/vmalert/web.qtpl:381
-func StreamAlert(qw422016 *qt422016.Writer, r *http.Request, alert *apiAlert) {
-//line app/vmalert/web.qtpl:381
+//line app/vmalert/web.qtpl:382
+func StreamAlert(qw422016 *qt422016.Writer, r *http.Request, alert *rule.ApiAlert) {
+//line app/vmalert/web.qtpl:382
 	qw422016.N().S(`
     `)
-//line app/vmalert/web.qtpl:382
+//line app/vmalert/web.qtpl:383
 	prefix := vmalertutil.Prefix(r.URL.Path)
 
-//line app/vmalert/web.qtpl:382
+//line app/vmalert/web.qtpl:383
 	qw422016.N().S(`
     `)
-//line app/vmalert/web.qtpl:383
+//line app/vmalert/web.qtpl:384
 	tpl.StreamHeader(qw422016, r, navItems, "", getLastConfigError())
-//line app/vmalert/web.qtpl:383
+//line app/vmalert/web.qtpl:384
 	qw422016.N().S(`
     `)
-//line app/vmalert/web.qtpl:385
+//line app/vmalert/web.qtpl:386
 	var labelKeys []string
 	for k := range alert.Labels {
 		labelKeys = append(labelKeys, k)
@@ -1253,28 +1254,28 @@ func StreamAlert(qw422016 *qt422016.Writer, r *http.Request, alert *apiAlert) {
 	}
 	sort.Strings(annotationKeys)
 
-//line app/vmalert/web.qtpl:395
+//line app/vmalert/web.qtpl:396
 	qw422016.N().S(`
     <div class="display-6 pb-3 mb-3">Alert: `)
-//line app/vmalert/web.qtpl:396
+//line app/vmalert/web.qtpl:397
 	qw422016.E().S(alert.Name)
-//line app/vmalert/web.qtpl:396
+//line app/vmalert/web.qtpl:397
 	qw422016.N().S(`<span class="ms-2 badge `)
-//line app/vmalert/web.qtpl:396
+//line app/vmalert/web.qtpl:397
 	if alert.State == "firing" {
-//line app/vmalert/web.qtpl:396
+//line app/vmalert/web.qtpl:397
 		qw422016.N().S(`bg-danger`)
-//line app/vmalert/web.qtpl:396
+//line app/vmalert/web.qtpl:397
 	} else {
-//line app/vmalert/web.qtpl:396
+//line app/vmalert/web.qtpl:397
 		qw422016.N().S(` bg-warning text-dark`)
-//line app/vmalert/web.qtpl:396
+//line app/vmalert/web.qtpl:397
 	}
-//line app/vmalert/web.qtpl:396
+//line app/vmalert/web.qtpl:397
 	qw422016.N().S(`">`)
-//line app/vmalert/web.qtpl:396
+//line app/vmalert/web.qtpl:397
 	qw422016.E().S(alert.State)
-//line app/vmalert/web.qtpl:396
+//line app/vmalert/web.qtpl:397
 	qw422016.N().S(`</span></div>
     <div class="container border-bottom p-2">
       <div class="row">
@@ -1283,9 +1284,9 @@ func StreamAlert(qw422016 *qt422016.Writer, r *http.Request, alert *apiAlert) {
         </div>
         <div class="col">
           `)
-//line app/vmalert/web.qtpl:403
+//line app/vmalert/web.qtpl:404
 	qw422016.E().S(alert.ActiveAt.Format("2006-01-02T15:04:05Z07:00"))
-//line app/vmalert/web.qtpl:403
+//line app/vmalert/web.qtpl:404
 	qw422016.N().S(`
         </div>
       </div>
@@ -1297,9 +1298,9 @@ func StreamAlert(qw422016 *qt422016.Writer, r *http.Request, alert *apiAlert) {
         </div>
         <div class="col">
           <code><pre>`)
-//line app/vmalert/web.qtpl:413
+//line app/vmalert/web.qtpl:414
 	qw422016.E().S(alert.Expression)
-//line app/vmalert/web.qtpl:413
+//line app/vmalert/web.qtpl:414
 	qw422016.N().S(`</pre></code>
         </div>
       </div>
@@ -1311,23 +1312,23 @@ func StreamAlert(qw422016 *qt422016.Writer, r *http.Request, alert *apiAlert) {
         </div>
         <div class="col">
            `)
-//line app/vmalert/web.qtpl:423
+//line app/vmalert/web.qtpl:424
 	for _, k := range labelKeys {
-//line app/vmalert/web.qtpl:423
+//line app/vmalert/web.qtpl:424
 		qw422016.N().S(`
                 <span class="m-1 badge bg-primary">`)
-//line app/vmalert/web.qtpl:424
+//line app/vmalert/web.qtpl:425
 		qw422016.E().S(k)
-//line app/vmalert/web.qtpl:424
+//line app/vmalert/web.qtpl:425
 		qw422016.N().S(`=`)
-//line app/vmalert/web.qtpl:424
+//line app/vmalert/web.qtpl:425
 		qw422016.E().S(alert.Labels[k])
-//line app/vmalert/web.qtpl:424
+//line app/vmalert/web.qtpl:425
 		qw422016.N().S(`</span>
           `)
-//line app/vmalert/web.qtpl:425
+//line app/vmalert/web.qtpl:426
 	}
-//line app/vmalert/web.qtpl:425
+//line app/vmalert/web.qtpl:426
 	qw422016.N().S(`
         </div>
       </div>
@@ -1339,24 +1340,24 @@ func StreamAlert(qw422016 *qt422016.Writer, r *http.Request, alert *apiAlert) {
         </div>
         <div class="col">
            `)
-//line app/vmalert/web.qtpl:435
+//line app/vmalert/web.qtpl:436
 	for _, k := range annotationKeys {
-//line app/vmalert/web.qtpl:435
+//line app/vmalert/web.qtpl:436
 		qw422016.N().S(`
                 <b>`)
-//line app/vmalert/web.qtpl:436
+//line app/vmalert/web.qtpl:437
 		qw422016.E().S(k)
-//line app/vmalert/web.qtpl:436
+//line app/vmalert/web.qtpl:437
 		qw422016.N().S(`:</b><br>
                 <p>`)
-//line app/vmalert/web.qtpl:437
+//line app/vmalert/web.qtpl:438
 		qw422016.E().S(alert.Annotations[k])
-//line app/vmalert/web.qtpl:437
+//line app/vmalert/web.qtpl:438
 		qw422016.N().S(`</p>
           `)
-//line app/vmalert/web.qtpl:438
+//line app/vmalert/web.qtpl:439
 	}
-//line app/vmalert/web.qtpl:438
+//line app/vmalert/web.qtpl:439
 	qw422016.N().S(`
         </div>
       </div>
@@ -1368,17 +1369,17 @@ func StreamAlert(qw422016 *qt422016.Writer, r *http.Request, alert *apiAlert) {
         </div>
         <div class="col">
            <a target="_blank" href="`)
-//line app/vmalert/web.qtpl:448
+//line app/vmalert/web.qtpl:449
 	qw422016.E().S(prefix)
-//line app/vmalert/web.qtpl:448
+//line app/vmalert/web.qtpl:449
 	qw422016.N().S(`groups#group-`)
-//line app/vmalert/web.qtpl:448
+//line app/vmalert/web.qtpl:449
 	qw422016.E().S(alert.GroupID)
-//line app/vmalert/web.qtpl:448
+//line app/vmalert/web.qtpl:449
 	qw422016.N().S(`">`)
-//line app/vmalert/web.qtpl:448
+//line app/vmalert/web.qtpl:449
 	qw422016.E().S(alert.GroupID)
-//line app/vmalert/web.qtpl:448
+//line app/vmalert/web.qtpl:449
 	qw422016.N().S(`</a>
         </div>
       </div>
@@ -1390,66 +1391,66 @@ func StreamAlert(qw422016 *qt422016.Writer, r *http.Request, alert *apiAlert) {
         </div>
         <div class="col">
            <a target="_blank" href="`)
-//line app/vmalert/web.qtpl:458
+//line app/vmalert/web.qtpl:459
 	qw422016.E().S(alert.SourceLink)
-//line app/vmalert/web.qtpl:458
+//line app/vmalert/web.qtpl:459
 	qw422016.N().S(`">Link</a>
         </div>
       </div>
     </div>
     `)
-//line app/vmalert/web.qtpl:462
+//line app/vmalert/web.qtpl:463
 	tpl.StreamFooter(qw422016, r)
-//line app/vmalert/web.qtpl:462
+//line app/vmalert/web.qtpl:463
 	qw422016.N().S(`
 
 `)
-//line app/vmalert/web.qtpl:464
+//line app/vmalert/web.qtpl:465
 }
 
-//line app/vmalert/web.qtpl:464
-func WriteAlert(qq422016 qtio422016.Writer, r *http.Request, alert *apiAlert) {
-//line app/vmalert/web.qtpl:464
+//line app/vmalert/web.qtpl:465
+func WriteAlert(qq422016 qtio422016.Writer, r *http.Request, alert *rule.ApiAlert) {
+//line app/vmalert/web.qtpl:465
 	qw422016 := qt422016.AcquireWriter(qq422016)
-//line app/vmalert/web.qtpl:464
+//line app/vmalert/web.qtpl:465
 	StreamAlert(qw422016, r, alert)
-//line app/vmalert/web.qtpl:464
+//line app/vmalert/web.qtpl:465
 	qt422016.ReleaseWriter(qw422016)
-//line app/vmalert/web.qtpl:464
+//line app/vmalert/web.qtpl:465
 }
 
-//line app/vmalert/web.qtpl:464
-func Alert(r *http.Request, alert *apiAlert) string {
-//line app/vmalert/web.qtpl:464
+//line app/vmalert/web.qtpl:465
+func Alert(r *http.Request, alert *rule.ApiAlert) string {
+//line app/vmalert/web.qtpl:465
 	qb422016 := qt422016.AcquireByteBuffer()
-//line app/vmalert/web.qtpl:464
+//line app/vmalert/web.qtpl:465
 	WriteAlert(qb422016, r, alert)
-//line app/vmalert/web.qtpl:464
+//line app/vmalert/web.qtpl:465
 	qs422016 := string(qb422016.B)
-//line app/vmalert/web.qtpl:464
+//line app/vmalert/web.qtpl:465
 	qt422016.ReleaseByteBuffer(qb422016)
-//line app/vmalert/web.qtpl:464
+//line app/vmalert/web.qtpl:465
 	return qs422016
-//line app/vmalert/web.qtpl:464
+//line app/vmalert/web.qtpl:465
 }
 
-//line app/vmalert/web.qtpl:467
-func StreamRuleDetails(qw422016 *qt422016.Writer, r *http.Request, rule apiRule) {
-//line app/vmalert/web.qtpl:467
+//line app/vmalert/web.qtpl:468
+func StreamRuleDetails(qw422016 *qt422016.Writer, r *http.Request, rule rule.ApiRule) {
+//line app/vmalert/web.qtpl:468
 	qw422016.N().S(`
     `)
-//line app/vmalert/web.qtpl:468
+//line app/vmalert/web.qtpl:469
 	prefix := vmalertutil.Prefix(r.URL.Path)
 
-//line app/vmalert/web.qtpl:468
+//line app/vmalert/web.qtpl:469
 	qw422016.N().S(`
     `)
-//line app/vmalert/web.qtpl:469
+//line app/vmalert/web.qtpl:470
 	tpl.StreamHeader(qw422016, r, navItems, "", getLastConfigError())
-//line app/vmalert/web.qtpl:469
+//line app/vmalert/web.qtpl:470
 	qw422016.N().S(`
     `)
-//line app/vmalert/web.qtpl:471
+//line app/vmalert/web.qtpl:472
 	var labelKeys []string
 	for k := range rule.Labels {
 		labelKeys = append(labelKeys, k)
@@ -1473,28 +1474,28 @@ func StreamRuleDetails(qw422016 *qt422016.Writer, r *http.Request, rule apiRule)
 		}
 	}
 
-//line app/vmalert/web.qtpl:494
+//line app/vmalert/web.qtpl:495
 	qw422016.N().S(`
     <div class="display-6 pb-3 mb-3">Rule: `)
-//line app/vmalert/web.qtpl:495
+//line app/vmalert/web.qtpl:496
 	qw422016.E().S(rule.Name)
-//line app/vmalert/web.qtpl:495
+//line app/vmalert/web.qtpl:496
 	qw422016.N().S(`<span class="ms-2 badge `)
-//line app/vmalert/web.qtpl:495
+//line app/vmalert/web.qtpl:496
 	if rule.Health != "ok" {
-//line app/vmalert/web.qtpl:495
+//line app/vmalert/web.qtpl:496
 		qw422016.N().S(`bg-danger`)
-//line app/vmalert/web.qtpl:495
+//line app/vmalert/web.qtpl:496
 	} else {
-//line app/vmalert/web.qtpl:495
+//line app/vmalert/web.qtpl:496
 		qw422016.N().S(` bg-success text-dark`)
-//line app/vmalert/web.qtpl:495
+//line app/vmalert/web.qtpl:496
 	}
-//line app/vmalert/web.qtpl:495
+//line app/vmalert/web.qtpl:496
 	qw422016.N().S(`">`)
-//line app/vmalert/web.qtpl:495
+//line app/vmalert/web.qtpl:496
 	qw422016.E().S(rule.Health)
-//line app/vmalert/web.qtpl:495
+//line app/vmalert/web.qtpl:496
 	qw422016.N().S(`</span></div>
     <div class="container border-bottom p-2">
       <div class="row">
@@ -1503,17 +1504,17 @@ func StreamRuleDetails(qw422016 *qt422016.Writer, r *http.Request, rule apiRule)
         </div>
         <div class="col">
           <code><pre>`)
-//line app/vmalert/web.qtpl:502
+//line app/vmalert/web.qtpl:503
 	qw422016.E().S(rule.Query)
-//line app/vmalert/web.qtpl:502
+//line app/vmalert/web.qtpl:503
 	qw422016.N().S(`</pre></code>
         </div>
       </div>
     </div>
     `)
-//line app/vmalert/web.qtpl:506
+//line app/vmalert/web.qtpl:507
 	if rule.Type == "alerting" {
-//line app/vmalert/web.qtpl:506
+//line app/vmalert/web.qtpl:507
 		qw422016.N().S(`
     <div class="container border-bottom p-2">
       <div class="row">
@@ -1522,17 +1523,17 @@ func StreamRuleDetails(qw422016 *qt422016.Writer, r *http.Request, rule apiRule)
         </div>
         <div class="col">
          `)
-//line app/vmalert/web.qtpl:513
+//line app/vmalert/web.qtpl:514
 		qw422016.E().V(rule.Duration)
-//line app/vmalert/web.qtpl:513
+//line app/vmalert/web.qtpl:514
 		qw422016.N().S(` seconds
         </div>
       </div>
     </div>
     `)
-//line app/vmalert/web.qtpl:517
+//line app/vmalert/web.qtpl:518
 		if rule.KeepFiringFor > 0 {
-//line app/vmalert/web.qtpl:517
+//line app/vmalert/web.qtpl:518
 			qw422016.N().S(`
     <div class="container border-bottom p-2">
       <div class="row">
@@ -1541,22 +1542,22 @@ func StreamRuleDetails(qw422016 *qt422016.Writer, r *http.Request, rule apiRule)
         </div>
         <div class="col">
          `)
-//line app/vmalert/web.qtpl:524
+//line app/vmalert/web.qtpl:525
 			qw422016.E().V(rule.KeepFiringFor)
-//line app/vmalert/web.qtpl:524
+//line app/vmalert/web.qtpl:525
 			qw422016.N().S(` seconds
         </div>
       </div>
     </div>
     `)
-//line app/vmalert/web.qtpl:528
+//line app/vmalert/web.qtpl:529
 		}
-//line app/vmalert/web.qtpl:528
+//line app/vmalert/web.qtpl:529
 		qw422016.N().S(`
     `)
-//line app/vmalert/web.qtpl:529
+//line app/vmalert/web.qtpl:530
 	}
-//line app/vmalert/web.qtpl:529
+//line app/vmalert/web.qtpl:530
 	qw422016.N().S(`
     <div class="container border-bottom p-2">
       <div class="row">
@@ -1565,31 +1566,31 @@ func StreamRuleDetails(qw422016 *qt422016.Writer, r *http.Request, rule apiRule)
         </div>
         <div class="col">
           `)
-//line app/vmalert/web.qtpl:536
+//line app/vmalert/web.qtpl:537
 	for _, k := range labelKeys {
-//line app/vmalert/web.qtpl:536
+//line app/vmalert/web.qtpl:537
 		qw422016.N().S(`
                 <span class="m-1 badge bg-primary">`)
-//line app/vmalert/web.qtpl:537
+//line app/vmalert/web.qtpl:538
 		qw422016.E().S(k)
-//line app/vmalert/web.qtpl:537
+//line app/vmalert/web.qtpl:538
 		qw422016.N().S(`=`)
-//line app/vmalert/web.qtpl:537
+//line app/vmalert/web.qtpl:538
 		qw422016.E().S(rule.Labels[k])
-//line app/vmalert/web.qtpl:537
+//line app/vmalert/web.qtpl:538
 		qw422016.N().S(`</span>
           `)
-//line app/vmalert/web.qtpl:538
+//line app/vmalert/web.qtpl:539
 	}
-//line app/vmalert/web.qtpl:538
+//line app/vmalert/web.qtpl:539
 	qw422016.N().S(`
         </div>
       </div>
     </div>
     `)
-//line app/vmalert/web.qtpl:542
+//line app/vmalert/web.qtpl:543
 	if rule.Type == "alerting" {
-//line app/vmalert/web.qtpl:542
+//line app/vmalert/web.qtpl:543
 		qw422016.N().S(`
     <div class="container border-bottom p-2">
       <div class="row">
@@ -1598,24 +1599,24 @@ func StreamRuleDetails(qw422016 *qt422016.Writer, r *http.Request, rule apiRule)
         </div>
         <div class="col">
           `)
-//line app/vmalert/web.qtpl:549
+//line app/vmalert/web.qtpl:550
 		for _, k := range annotationKeys {
-//line app/vmalert/web.qtpl:549
+//line app/vmalert/web.qtpl:550
 			qw422016.N().S(`
                 <b>`)
-//line app/vmalert/web.qtpl:550
+//line app/vmalert/web.qtpl:551
 			qw422016.E().S(k)
-//line app/vmalert/web.qtpl:550
+//line app/vmalert/web.qtpl:551
 			qw422016.N().S(`:</b><br>
                 <p>`)
-//line app/vmalert/web.qtpl:551
+//line app/vmalert/web.qtpl:552
 			qw422016.E().S(rule.Annotations[k])
-//line app/vmalert/web.qtpl:551
+//line app/vmalert/web.qtpl:552
 			qw422016.N().S(`</p>
           `)
-//line app/vmalert/web.qtpl:552
+//line app/vmalert/web.qtpl:553
 		}
-//line app/vmalert/web.qtpl:552
+//line app/vmalert/web.qtpl:553
 		qw422016.N().S(`
         </div>
       </div>
@@ -1627,17 +1628,17 @@ func StreamRuleDetails(qw422016 *qt422016.Writer, r *http.Request, rule apiRule)
         </div>
         <div class="col">
            `)
-//line app/vmalert/web.qtpl:562
+//line app/vmalert/web.qtpl:563
 		qw422016.E().V(rule.Debug)
-//line app/vmalert/web.qtpl:562
+//line app/vmalert/web.qtpl:563
 		qw422016.N().S(`
         </div>
       </div>
     </div>
     `)
-//line app/vmalert/web.qtpl:566
+//line app/vmalert/web.qtpl:567
 	}
-//line app/vmalert/web.qtpl:566
+//line app/vmalert/web.qtpl:567
 	qw422016.N().S(`
     <div class="container border-bottom p-2">
       <div class="row">
@@ -1646,17 +1647,17 @@ func StreamRuleDetails(qw422016 *qt422016.Writer, r *http.Request, rule apiRule)
         </div>
         <div class="col">
            <a target="_blank" href="`)
-//line app/vmalert/web.qtpl:573
+//line app/vmalert/web.qtpl:574
 	qw422016.E().S(prefix)
-//line app/vmalert/web.qtpl:573
+//line app/vmalert/web.qtpl:574
 	qw422016.N().S(`groups#group-`)
-//line app/vmalert/web.qtpl:573
+//line app/vmalert/web.qtpl:574
 	qw422016.E().S(rule.GroupID)
-//line app/vmalert/web.qtpl:573
+//line app/vmalert/web.qtpl:574
 	qw422016.N().S(`">`)
-//line app/vmalert/web.qtpl:573
+//line app/vmalert/web.qtpl:574
 	qw422016.E().S(rule.GroupID)
-//line app/vmalert/web.qtpl:573
+//line app/vmalert/web.qtpl:574
 	qw422016.N().S(`</a>
         </div>
       </div>
@@ -1664,9 +1665,9 @@ func StreamRuleDetails(qw422016 *qt422016.Writer, r *http.Request, rule apiRule)
 
     <br>
     `)
-//line app/vmalert/web.qtpl:579
+//line app/vmalert/web.qtpl:580
 	if seriesFetchedWarning {
-//line app/vmalert/web.qtpl:579
+//line app/vmalert/web.qtpl:580
 		qw422016.N().S(`
     <div class="alert alert-warning" role="alert">
        <strong>Warning:</strong> some of updates have "Series fetched" equal to 0.<br>
@@ -1680,18 +1681,18 @@ func StreamRuleDetails(qw422016 *qt422016.Writer, r *http.Request, rule apiRule)
        See more details about this detection <a target="_blank" href="https://github.com/VictoriaMetrics/VictoriaMetrics/issues/4039">here</a>.
     </div>
     `)
-//line app/vmalert/web.qtpl:591
+//line app/vmalert/web.qtpl:592
 	}
-//line app/vmalert/web.qtpl:591
+//line app/vmalert/web.qtpl:592
 	qw422016.N().S(`
     <div class="display-6 pb-3">Last `)
-//line app/vmalert/web.qtpl:592
+//line app/vmalert/web.qtpl:593
 	qw422016.N().D(len(rule.Updates))
-//line app/vmalert/web.qtpl:592
+//line app/vmalert/web.qtpl:593
 	qw422016.N().S(`/`)
-//line app/vmalert/web.qtpl:592
+//line app/vmalert/web.qtpl:593
 	qw422016.N().D(rule.MaxUpdates)
-//line app/vmalert/web.qtpl:592
+//line app/vmalert/web.qtpl:593
 	qw422016.N().S(` updates</span>:</div>
         <table class="table table-striped table-hover table-sm">
             <thead>
@@ -1699,13 +1700,13 @@ func StreamRuleDetails(qw422016 *qt422016.Writer, r *http.Request, rule apiRule)
                     <th scope="col" title="The time when event was created">Updated at</th>
                     <th scope="col" class="w-10 text-center" title="How many series expression returns. Each series will represent an alert.">Series returned</th>
                     `)
-//line app/vmalert/web.qtpl:598
+//line app/vmalert/web.qtpl:599
 	if seriesFetchedEnabled {
-//line app/vmalert/web.qtpl:598
+//line app/vmalert/web.qtpl:599
 		qw422016.N().S(`<th scope="col" class="w-10 text-center" title="How many series were scanned by datasource during the evaluation">Series fetched</th>`)
-//line app/vmalert/web.qtpl:598
+//line app/vmalert/web.qtpl:599
 	}
-//line app/vmalert/web.qtpl:598
+//line app/vmalert/web.qtpl:599
 	qw422016.N().S(`
                     <th scope="col" class="w-10 text-center" title="How many seconds request took">Duration</th>
                     <th scope="col" class="text-center" title="Time used for rule execution">Executed at</th>
@@ -1715,285 +1716,285 @@ func StreamRuleDetails(qw422016 *qt422016.Writer, r *http.Request, rule apiRule)
             <tbody>
 
      `)
-//line app/vmalert/web.qtpl:606
+//line app/vmalert/web.qtpl:607
 	for _, u := range rule.Updates {
-//line app/vmalert/web.qtpl:606
+//line app/vmalert/web.qtpl:607
 		qw422016.N().S(`
              <tr`)
-//line app/vmalert/web.qtpl:607
+//line app/vmalert/web.qtpl:608
 		if u.Err != nil {
-//line app/vmalert/web.qtpl:607
+//line app/vmalert/web.qtpl:608
 			qw422016.N().S(` class="alert-danger"`)
-//line app/vmalert/web.qtpl:607
+//line app/vmalert/web.qtpl:608
 		}
-//line app/vmalert/web.qtpl:607
+//line app/vmalert/web.qtpl:608
 		qw422016.N().S(`>
                  <td>
                     <span class="badge bg-primary rounded-pill me-3" title="Updated at">`)
-//line app/vmalert/web.qtpl:609
+//line app/vmalert/web.qtpl:610
 		qw422016.E().S(u.Time.Format(time.RFC3339))
-//line app/vmalert/web.qtpl:609
+//line app/vmalert/web.qtpl:610
 		qw422016.N().S(`</span>
                  </td>
                  <td class="text-center">`)
-//line app/vmalert/web.qtpl:611
+//line app/vmalert/web.qtpl:612
 		qw422016.N().D(u.Samples)
-//line app/vmalert/web.qtpl:611
+//line app/vmalert/web.qtpl:612
 		qw422016.N().S(`</td>
                  `)
-//line app/vmalert/web.qtpl:612
+//line app/vmalert/web.qtpl:613
 		if seriesFetchedEnabled {
-//line app/vmalert/web.qtpl:612
+//line app/vmalert/web.qtpl:613
 			qw422016.N().S(`<td class="text-center">`)
-//line app/vmalert/web.qtpl:612
+//line app/vmalert/web.qtpl:613
 			if u.SeriesFetched != nil {
-//line app/vmalert/web.qtpl:612
+//line app/vmalert/web.qtpl:613
 				qw422016.N().D(*u.SeriesFetched)
-//line app/vmalert/web.qtpl:612
+//line app/vmalert/web.qtpl:613
 			}
-//line app/vmalert/web.qtpl:612
+//line app/vmalert/web.qtpl:613
 			qw422016.N().S(`</td>`)
-//line app/vmalert/web.qtpl:612
+//line app/vmalert/web.qtpl:613
 		}
-//line app/vmalert/web.qtpl:612
+//line app/vmalert/web.qtpl:613
 		qw422016.N().S(`
                  <td class="text-center">`)
-//line app/vmalert/web.qtpl:613
+//line app/vmalert/web.qtpl:614
 		qw422016.N().FPrec(u.Duration.Seconds(), 3)
-//line app/vmalert/web.qtpl:613
+//line app/vmalert/web.qtpl:614
 		qw422016.N().S(`s</td>
                  <td class="text-center">`)
-//line app/vmalert/web.qtpl:614
+//line app/vmalert/web.qtpl:615
 		qw422016.E().S(u.At.Format(time.RFC3339))
-//line app/vmalert/web.qtpl:614
+//line app/vmalert/web.qtpl:615
 		qw422016.N().S(`</td>
                  <td>
                     <textarea class="curl-area" rows="1" onclick="this.focus();this.select()">`)
-//line app/vmalert/web.qtpl:616
+//line app/vmalert/web.qtpl:617
 		qw422016.E().S(u.Curl)
-//line app/vmalert/web.qtpl:616
+//line app/vmalert/web.qtpl:617
 		qw422016.N().S(`</textarea>
                 </td>
              </tr>
           </li>
           `)
-//line app/vmalert/web.qtpl:620
+//line app/vmalert/web.qtpl:621
 		if u.Err != nil {
-//line app/vmalert/web.qtpl:620
+//line app/vmalert/web.qtpl:621
 			qw422016.N().S(`
              <tr`)
-//line app/vmalert/web.qtpl:621
+//line app/vmalert/web.qtpl:622
 			if u.Err != nil {
-//line app/vmalert/web.qtpl:621
+//line app/vmalert/web.qtpl:622
 				qw422016.N().S(` class="alert-danger"`)
-//line app/vmalert/web.qtpl:621
+//line app/vmalert/web.qtpl:622
 			}
-//line app/vmalert/web.qtpl:621
+//line app/vmalert/web.qtpl:622
 			qw422016.N().S(`>
                <td colspan="`)
-//line app/vmalert/web.qtpl:622
+//line app/vmalert/web.qtpl:623
 			if seriesFetchedEnabled {
-//line app/vmalert/web.qtpl:622
+//line app/vmalert/web.qtpl:623
 				qw422016.N().S(`6`)
-//line app/vmalert/web.qtpl:622
+//line app/vmalert/web.qtpl:623
 			} else {
-//line app/vmalert/web.qtpl:622
+//line app/vmalert/web.qtpl:623
 				qw422016.N().S(`5`)
-//line app/vmalert/web.qtpl:622
+//line app/vmalert/web.qtpl:623
 			}
-//line app/vmalert/web.qtpl:622
+//line app/vmalert/web.qtpl:623
 			qw422016.N().S(`">
                    <span class="alert-danger">`)
-//line app/vmalert/web.qtpl:623
+//line app/vmalert/web.qtpl:624
 			qw422016.E().V(u.Err)
-//line app/vmalert/web.qtpl:623
+//line app/vmalert/web.qtpl:624
 			qw422016.N().S(`</span>
                </td>
              </tr>
           `)
-//line app/vmalert/web.qtpl:626
+//line app/vmalert/web.qtpl:627
 		}
-//line app/vmalert/web.qtpl:626
+//line app/vmalert/web.qtpl:627
 		qw422016.N().S(`
      `)
-//line app/vmalert/web.qtpl:627
+//line app/vmalert/web.qtpl:628
 	}
-//line app/vmalert/web.qtpl:627
+//line app/vmalert/web.qtpl:628
 	qw422016.N().S(`
 
     `)
-//line app/vmalert/web.qtpl:629
+//line app/vmalert/web.qtpl:630
 	tpl.StreamFooter(qw422016, r)
-//line app/vmalert/web.qtpl:629
+//line app/vmalert/web.qtpl:630
 	qw422016.N().S(`
 `)
-//line app/vmalert/web.qtpl:630
+//line app/vmalert/web.qtpl:631
 }
 
-//line app/vmalert/web.qtpl:630
-func WriteRuleDetails(qq422016 qtio422016.Writer, r *http.Request, rule apiRule) {
-//line app/vmalert/web.qtpl:630
+//line app/vmalert/web.qtpl:631
+func WriteRuleDetails(qq422016 qtio422016.Writer, r *http.Request, rule rule.ApiRule) {
+//line app/vmalert/web.qtpl:631
 	qw422016 := qt422016.AcquireWriter(qq422016)
-//line app/vmalert/web.qtpl:630
+//line app/vmalert/web.qtpl:631
 	StreamRuleDetails(qw422016, r, rule)
-//line app/vmalert/web.qtpl:630
+//line app/vmalert/web.qtpl:631
 	qt422016.ReleaseWriter(qw422016)
-//line app/vmalert/web.qtpl:630
+//line app/vmalert/web.qtpl:631
 }
 
-//line app/vmalert/web.qtpl:630
-func RuleDetails(r *http.Request, rule apiRule) string {
-//line app/vmalert/web.qtpl:630
+//line app/vmalert/web.qtpl:631
+func RuleDetails(r *http.Request, rule rule.ApiRule) string {
+//line app/vmalert/web.qtpl:631
 	qb422016 := qt422016.AcquireByteBuffer()
-//line app/vmalert/web.qtpl:630
+//line app/vmalert/web.qtpl:631
 	WriteRuleDetails(qb422016, r, rule)
-//line app/vmalert/web.qtpl:630
+//line app/vmalert/web.qtpl:631
 	qs422016 := string(qb422016.B)
-//line app/vmalert/web.qtpl:630
+//line app/vmalert/web.qtpl:631
 	qt422016.ReleaseByteBuffer(qb422016)
-//line app/vmalert/web.qtpl:630
+//line app/vmalert/web.qtpl:631
 	return qs422016
-//line app/vmalert/web.qtpl:630
+//line app/vmalert/web.qtpl:631
 }
 
-//line app/vmalert/web.qtpl:634
+//line app/vmalert/web.qtpl:635
 func streambadgeState(qw422016 *qt422016.Writer, state string) {
-//line app/vmalert/web.qtpl:634
+//line app/vmalert/web.qtpl:635
 	qw422016.N().S(`
 `)
-//line app/vmalert/web.qtpl:636
+//line app/vmalert/web.qtpl:637
 	badgeClass := "bg-warning text-dark"
 	if state == "firing" {
 		badgeClass = "bg-danger"
 	}
 
-//line app/vmalert/web.qtpl:640
+//line app/vmalert/web.qtpl:641
 	qw422016.N().S(`
 <span class="badge `)
-//line app/vmalert/web.qtpl:641
+//line app/vmalert/web.qtpl:642
 	qw422016.E().S(badgeClass)
-//line app/vmalert/web.qtpl:641
+//line app/vmalert/web.qtpl:642
 	qw422016.N().S(`">`)
-//line app/vmalert/web.qtpl:641
+//line app/vmalert/web.qtpl:642
 	qw422016.E().S(state)
-//line app/vmalert/web.qtpl:641
+//line app/vmalert/web.qtpl:642
 	qw422016.N().S(`</span>
 `)
-//line app/vmalert/web.qtpl:642
+//line app/vmalert/web.qtpl:643
 }
 
-//line app/vmalert/web.qtpl:642
+//line app/vmalert/web.qtpl:643
 func writebadgeState(qq422016 qtio422016.Writer, state string) {
-//line app/vmalert/web.qtpl:642
+//line app/vmalert/web.qtpl:643
 	qw422016 := qt422016.AcquireWriter(qq422016)
-//line app/vmalert/web.qtpl:642
+//line app/vmalert/web.qtpl:643
 	streambadgeState(qw422016, state)
-//line app/vmalert/web.qtpl:642
+//line app/vmalert/web.qtpl:643
 	qt422016.ReleaseWriter(qw422016)
-//line app/vmalert/web.qtpl:642
+//line app/vmalert/web.qtpl:643
 }
 
-//line app/vmalert/web.qtpl:642
+//line app/vmalert/web.qtpl:643
 func badgeState(state string) string {
-//line app/vmalert/web.qtpl:642
+//line app/vmalert/web.qtpl:643
 	qb422016 := qt422016.AcquireByteBuffer()
-//line app/vmalert/web.qtpl:642
+//line app/vmalert/web.qtpl:643
 	writebadgeState(qb422016, state)
-//line app/vmalert/web.qtpl:642
+//line app/vmalert/web.qtpl:643
 	qs422016 := string(qb422016.B)
-//line app/vmalert/web.qtpl:642
+//line app/vmalert/web.qtpl:643
 	qt422016.ReleaseByteBuffer(qb422016)
-//line app/vmalert/web.qtpl:642
+//line app/vmalert/web.qtpl:643
 	return qs422016
-//line app/vmalert/web.qtpl:642
+//line app/vmalert/web.qtpl:643
 }
 
-//line app/vmalert/web.qtpl:644
+//line app/vmalert/web.qtpl:645
 func streambadgeRestored(qw422016 *qt422016.Writer) {
-//line app/vmalert/web.qtpl:644
+//line app/vmalert/web.qtpl:645
 	qw422016.N().S(`
 <span class="badge bg-warning text-dark" title="Alert state was restored after the service restart from remote storage">restored</span>
 `)
-//line app/vmalert/web.qtpl:646
+//line app/vmalert/web.qtpl:647
 }
 
-//line app/vmalert/web.qtpl:646
+//line app/vmalert/web.qtpl:647
 func writebadgeRestored(qq422016 qtio422016.Writer) {
-//line app/vmalert/web.qtpl:646
+//line app/vmalert/web.qtpl:647
 	qw422016 := qt422016.AcquireWriter(qq422016)
-//line app/vmalert/web.qtpl:646
+//line app/vmalert/web.qtpl:647
 	streambadgeRestored(qw422016)
-//line app/vmalert/web.qtpl:646
+//line app/vmalert/web.qtpl:647
 	qt422016.ReleaseWriter(qw422016)
-//line app/vmalert/web.qtpl:646
+//line app/vmalert/web.qtpl:647
 }
 
-//line app/vmalert/web.qtpl:646
+//line app/vmalert/web.qtpl:647
 func badgeRestored() string {
-//line app/vmalert/web.qtpl:646
+//line app/vmalert/web.qtpl:647
 	qb422016 := qt422016.AcquireByteBuffer()
-//line app/vmalert/web.qtpl:646
+//line app/vmalert/web.qtpl:647
 	writebadgeRestored(qb422016)
-//line app/vmalert/web.qtpl:646
+//line app/vmalert/web.qtpl:647
 	qs422016 := string(qb422016.B)
-//line app/vmalert/web.qtpl:646
+//line app/vmalert/web.qtpl:647
 	qt422016.ReleaseByteBuffer(qb422016)
-//line app/vmalert/web.qtpl:646
+//line app/vmalert/web.qtpl:647
 	return qs422016
-//line app/vmalert/web.qtpl:646
+//line app/vmalert/web.qtpl:647
 }
 
-//line app/vmalert/web.qtpl:648
+//line app/vmalert/web.qtpl:649
 func streambadgeStabilizing(qw422016 *qt422016.Writer) {
-//line app/vmalert/web.qtpl:648
+//line app/vmalert/web.qtpl:649
 	qw422016.N().S(`
 <span class="badge bg-warning text-dark" title="This firing state is kept because of `)
-//line app/vmalert/web.qtpl:648
+//line app/vmalert/web.qtpl:649
 	qw422016.N().S("`")
-//line app/vmalert/web.qtpl:648
+//line app/vmalert/web.qtpl:649
 	qw422016.N().S(`keep_firing_for`)
-//line app/vmalert/web.qtpl:648
+//line app/vmalert/web.qtpl:649
 	qw422016.N().S("`")
-//line app/vmalert/web.qtpl:648
+//line app/vmalert/web.qtpl:649
 	qw422016.N().S(`">stabilizing</span>
 `)
-//line app/vmalert/web.qtpl:650
+//line app/vmalert/web.qtpl:651
 }
 
-//line app/vmalert/web.qtpl:650
+//line app/vmalert/web.qtpl:651
 func writebadgeStabilizing(qq422016 qtio422016.Writer) {
-//line app/vmalert/web.qtpl:650
+//line app/vmalert/web.qtpl:651
 	qw422016 := qt422016.AcquireWriter(qq422016)
-//line app/vmalert/web.qtpl:650
+//line app/vmalert/web.qtpl:651
 	streambadgeStabilizing(qw422016)
-//line app/vmalert/web.qtpl:650
+//line app/vmalert/web.qtpl:651
 	qt422016.ReleaseWriter(qw422016)
-//line app/vmalert/web.qtpl:650
+//line app/vmalert/web.qtpl:651
 }
 
-//line app/vmalert/web.qtpl:650
+//line app/vmalert/web.qtpl:651
 func badgeStabilizing() string {
-//line app/vmalert/web.qtpl:650
+//line app/vmalert/web.qtpl:651
 	qb422016 := qt422016.AcquireByteBuffer()
-//line app/vmalert/web.qtpl:650
+//line app/vmalert/web.qtpl:651
 	writebadgeStabilizing(qb422016)
-//line app/vmalert/web.qtpl:650
+//line app/vmalert/web.qtpl:651
 	qs422016 := string(qb422016.B)
-//line app/vmalert/web.qtpl:650
+//line app/vmalert/web.qtpl:651
 	qt422016.ReleaseByteBuffer(qb422016)
-//line app/vmalert/web.qtpl:650
+//line app/vmalert/web.qtpl:651
 	return qs422016
-//line app/vmalert/web.qtpl:650
+//line app/vmalert/web.qtpl:651
 }
 
-//line app/vmalert/web.qtpl:652
-func streamseriesFetchedWarn(qw422016 *qt422016.Writer, prefix string, r apiRule) {
-//line app/vmalert/web.qtpl:652
+//line app/vmalert/web.qtpl:653
+func streamseriesFetchedWarn(qw422016 *qt422016.Writer, prefix string, r rule.ApiRule) {
+//line app/vmalert/web.qtpl:653
 	qw422016.N().S(`
 `)
-//line app/vmalert/web.qtpl:653
+//line app/vmalert/web.qtpl:654
 	if isNoMatch(r) {
-//line app/vmalert/web.qtpl:653
+//line app/vmalert/web.qtpl:654
 		qw422016.N().S(`
 <svg
     data-bs-toggle="tooltip"
@@ -2002,47 +2003,47 @@ func streamseriesFetchedWarn(qw422016 *qt422016.Writer, prefix string, r apiRule
     See more in Details."
     width="18" height="18" fill="currentColor" class="bi bi-exclamation-triangle-fill flex-shrink-0 me-2" role="img" aria-label="Warning:">
        <use href="`)
-//line app/vmalert/web.qtpl:660
+//line app/vmalert/web.qtpl:661
 		qw422016.E().S(prefix)
-//line app/vmalert/web.qtpl:660
+//line app/vmalert/web.qtpl:661
 		qw422016.N().S(`static/icons/icons.svg#exclamation"/>
 </svg>
 `)
-//line app/vmalert/web.qtpl:662
+//line app/vmalert/web.qtpl:663
 	}
-//line app/vmalert/web.qtpl:662
+//line app/vmalert/web.qtpl:663
 	qw422016.N().S(`
 `)
-//line app/vmalert/web.qtpl:663
+//line app/vmalert/web.qtpl:664
 }
 
-//line app/vmalert/web.qtpl:663
-func writeseriesFetchedWarn(qq422016 qtio422016.Writer, prefix string, r apiRule) {
-//line app/vmalert/web.qtpl:663
+//line app/vmalert/web.qtpl:664
+func writeseriesFetchedWarn(qq422016 qtio422016.Writer, prefix string, r rule.ApiRule) {
+//line app/vmalert/web.qtpl:664
 	qw422016 := qt422016.AcquireWriter(qq422016)
-//line app/vmalert/web.qtpl:663
+//line app/vmalert/web.qtpl:664
 	streamseriesFetchedWarn(qw422016, prefix, r)
-//line app/vmalert/web.qtpl:663
+//line app/vmalert/web.qtpl:664
 	qt422016.ReleaseWriter(qw422016)
-//line app/vmalert/web.qtpl:663
+//line app/vmalert/web.qtpl:664
 }
 
-//line app/vmalert/web.qtpl:663
-func seriesFetchedWarn(prefix string, r apiRule) string {
-//line app/vmalert/web.qtpl:663
+//line app/vmalert/web.qtpl:664
+func seriesFetchedWarn(prefix string, r rule.ApiRule) string {
+//line app/vmalert/web.qtpl:664
 	qb422016 := qt422016.AcquireByteBuffer()
-//line app/vmalert/web.qtpl:663
+//line app/vmalert/web.qtpl:664
 	writeseriesFetchedWarn(qb422016, prefix, r)
-//line app/vmalert/web.qtpl:663
+//line app/vmalert/web.qtpl:664
 	qs422016 := string(qb422016.B)
-//line app/vmalert/web.qtpl:663
+//line app/vmalert/web.qtpl:664
 	qt422016.ReleaseByteBuffer(qb422016)
-//line app/vmalert/web.qtpl:663
+//line app/vmalert/web.qtpl:664
 	return qs422016
-//line app/vmalert/web.qtpl:663
+//line app/vmalert/web.qtpl:664
 }
 
-//line app/vmalert/web.qtpl:666
-func isNoMatch(r apiRule) bool {
+//line app/vmalert/web.qtpl:667
+func isNoMatch(r rule.ApiRule) bool {
 	return r.LastSamples == 0 && r.LastSeriesFetched != nil && *r.LastSeriesFetched == 0
 }

--- a/app/vmalert/web_test.go
+++ b/app/vmalert/web_test.go
@@ -82,22 +82,22 @@ func TestHandler(t *testing.T) {
 	})
 
 	t.Run("/vmalert/rule", func(t *testing.T) {
-		a := ruleToAPI(ar)
+		a := rule.RuleToAPI(ar)
 		getResp(t, ts.URL+"/vmalert/"+a.WebLink(), nil, 200)
-		r := ruleToAPI(rr)
+		r := rule.RuleToAPI(rr)
 		getResp(t, ts.URL+"/vmalert/"+r.WebLink(), nil, 200)
 	})
 	t.Run("/vmalert/alert", func(t *testing.T) {
-		alerts := ruleToAPIAlert(ar)
+		alerts := rule.RuleToAPIAlert(ar)
 		for _, a := range alerts {
 			getResp(t, ts.URL+"/vmalert/"+a.WebLink(), nil, 200)
 		}
 	})
 	t.Run("/vmalert/rule?badParam", func(t *testing.T) {
-		params := fmt.Sprintf("?%s=0&%s=1", paramGroupID, paramRuleID)
+		params := fmt.Sprintf("?%s=0&%s=1", rule.ParamGroupID, rule.ParamRuleID)
 		getResp(t, ts.URL+"/vmalert/rule"+params, nil, 404)
 
-		params = fmt.Sprintf("?%s=1&%s=0", paramGroupID, paramRuleID)
+		params = fmt.Sprintf("?%s=1&%s=0", rule.ParamGroupID, rule.ParamRuleID)
 		getResp(t, ts.URL+"/vmalert/rule"+params, nil, 404)
 	})
 
@@ -124,14 +124,14 @@ func TestHandler(t *testing.T) {
 		}
 	})
 	t.Run("/api/v1/alert?alertID&groupID", func(t *testing.T) {
-		expAlert := newAlertAPI(ar, ar.GetAlerts()[0])
-		alert := &apiAlert{}
+		expAlert := rule.NewAlertAPI(ar, ar.GetAlerts()[0])
+		alert := &rule.ApiAlert{}
 		getResp(t, ts.URL+"/"+expAlert.APILink(), alert, 200)
 		if !reflect.DeepEqual(alert, expAlert) {
 			t.Fatalf("expected %v is equal to %v", alert, expAlert)
 		}
 
-		alert = &apiAlert{}
+		alert = &rule.ApiAlert{}
 		getResp(t, ts.URL+"/vmalert/"+expAlert.APILink(), alert, 200)
 		if !reflect.DeepEqual(alert, expAlert) {
 			t.Fatalf("expected %v is equal to %v", alert, expAlert)
@@ -139,16 +139,16 @@ func TestHandler(t *testing.T) {
 	})
 
 	t.Run("/api/v1/alert?badParams", func(t *testing.T) {
-		params := fmt.Sprintf("?%s=0&%s=1", paramGroupID, paramAlertID)
+		params := fmt.Sprintf("?%s=0&%s=1", rule.ParamGroupID, rule.ParamAlertID)
 		getResp(t, ts.URL+"/api/v1/alert"+params, nil, 404)
 		getResp(t, ts.URL+"/vmalert/api/v1/alert"+params, nil, 404)
 
-		params = fmt.Sprintf("?%s=1&%s=0", paramGroupID, paramAlertID)
+		params = fmt.Sprintf("?%s=1&%s=0", rule.ParamGroupID, rule.ParamAlertID)
 		getResp(t, ts.URL+"/api/v1/alert"+params, nil, 404)
 		getResp(t, ts.URL+"/vmalert/api/v1/alert"+params, nil, 404)
 
 		// bad request, alertID is missing
-		params = fmt.Sprintf("?%s=1", paramGroupID)
+		params = fmt.Sprintf("?%s=1", rule.ParamGroupID)
 		getResp(t, ts.URL+"/api/v1/alert"+params, nil, 400)
 		getResp(t, ts.URL+"/vmalert/api/v1/alert"+params, nil, 400)
 	})
@@ -167,22 +167,22 @@ func TestHandler(t *testing.T) {
 		}
 	})
 	t.Run("/api/v1/rule?ruleID&groupID", func(t *testing.T) {
-		expRule := ruleToAPI(ar)
-		gotRule := apiRule{}
+		expRule := rule.RuleToAPI(ar)
+		gotRule := rule.ApiRule{}
 		getResp(t, ts.URL+"/"+expRule.APILink(), &gotRule, 200)
 
 		if expRule.ID != gotRule.ID {
 			t.Fatalf("expected to get Rule %q; got %q instead", expRule.ID, gotRule.ID)
 		}
 
-		gotRule = apiRule{}
+		gotRule = rule.ApiRule{}
 		getResp(t, ts.URL+"/vmalert/"+expRule.APILink(), &gotRule, 200)
 
 		if expRule.ID != gotRule.ID {
 			t.Fatalf("expected to get Rule %q; got %q instead", expRule.ID, gotRule.ID)
 		}
 
-		gotRuleWithUpdates := apiRuleWithUpdates{}
+		gotRuleWithUpdates := rule.ApiRuleWithUpdates{}
 		getResp(t, ts.URL+"/"+expRule.APILink(), &gotRuleWithUpdates, 200)
 		if len(gotRuleWithUpdates.StateUpdates) < 1 {
 			t.Fatalf("expected %+v to have state updates field not empty", gotRuleWithUpdates.StateUpdates)


### PR DESCRIPTION
fix https://github.com/VictoriaMetrics/VictoriaMetrics/issues/9551.

To speed up the rule update process, we don't lock the `m.groupsMu` during the [group updates](https://github.com/VictoriaMetrics/VictoriaMetrics/blob/fd928a0f5b5bf9542438330f3bb0f547fb73dbcf/app/vmalert/manager.go#L100). 
And to avoid group changes during related API calls, a [DeepCopy](https://github.com/VictoriaMetrics/VictoriaMetrics/blob/61c5e8185c5b09941b6e92fbc66b2bce6d2a2fb5/app/vmalert/web_types.go#L341) was used to copy needed group info, but it was not implemented correctly and can't be implemented efficiently. This pull request splits rule-related web types into sub-packages, which should be clearer and easier to maintain.