### PR TITLE
apptest: Fix flaky TestSingleVMAuthRouterWithAuth

### DIFF
--- a/apptest/vmagent.go
+++ b/apptest/vmagent.go
@@ -123,9 +123,7 @@ func (app *Vmagent) ReloadRelabelConfigs(t *testing.T) {
 		time.Sleep(100 * time.Millisecond)
 	}
 
-	if currTotal <= prevTotal {
-		t.Fatalf("relabel configs were not reloaded after SIGHUP signal; previous total: %f, current total: %f", prevTotal, currTotal)
-	}
+	t.Fatalf("relabel configs were not reloaded after SIGHUP signal; previous total: %f, current total: %f", prevTotal, currTotal)
 }
 
 // sendBlocking sends the data to vmstorage by executing `send` function and


### PR DESCRIPTION
### Describe Your Changes

Do not check vmauth_config_last_reload_success_timestamp_seconds since it may contain the timestamp < time.Now() due to how lib/fasttime works.

Instead, compare the number of config reloads.

follow up on https://github.com/VictoriaMetrics/VictoriaMetrics/pull/9369 and https://github.com/VictoriaMetrics/VictoriaMetrics/pull/9572

Also, split the config update and reload into two separate functions. 

master:
```
$gotest -race ./apptest/tests/ -run=TestSingleVMAuthRouterWithInternalAddr -count=40
ok  	github.com/VictoriaMetrics/VictoriaMetrics/apptest/tests	90.176s
```

pr:
```
$gotest -race ./apptest/tests/ -run=TestSingleVMAuthRouterWithInternalAddr -count=40
ok  	github.com/VictoriaMetrics/VictoriaMetrics/apptest/tests	46.130s
```

### Checklist

The following checks are **mandatory**:

- [ ] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [ ] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
