### PR TITLE
docs: update examples to use proper license flags

### DIFF
--- a/docs/victoriametrics/vmbackupmanager.md
+++ b/docs/victoriametrics/vmbackupmanager.md
@@ -110,7 +110,7 @@ Backup manager launched with the following configuration:
 ```sh
 export NODE_IP=192.168.0.10
 export VMSTORAGE_ENDPOINT=http://127.0.0.1:8428
-./vmbackupmanager -dst=gs://vmstorage-data/$NODE_IP -credsFilePath=credentials.json -storageDataPath=/vmstorage-data -snapshot.createURL=$VMSTORAGE_ENDPOINT/snapshot/create -eula
+./vmbackupmanager -dst=gs://vmstorage-data/$NODE_IP -credsFilePath=credentials.json -storageDataPath=/vmstorage-data -snapshot.createURL=$VMSTORAGE_ENDPOINT/snapshot/create -licenseFile=/path/to/vm-license
 ```
 
 Expected logs in vmbackupmanager:
@@ -170,7 +170,7 @@ We enable backup retention policy for backup manager by using following configur
 export NODE_IP=192.168.0.10
 export VMSTORAGE_ENDPOINT=http://127.0.0.1:8428
 ./vmbackupmanager -dst=gs://vmstorage-data/$NODE_IP -credsFilePath=credentials.json -storageDataPath=/vmstorage-data -snapshot.createURL=$VMSTORAGE_ENDPOINT/snapshot/create
--keepLastDaily=3 -eula
+-keepLastDaily=3 -licenseFile=/path/to/vm-license
 ```
 
 Expected logs in backup manager on start:
@@ -196,14 +196,14 @@ You can protect any backup against deletion by retention policy with the `vmback
 For instance:
 
 ```sh
-./vmbackupmanager backup lock daily/2021-02-13 -dst=<DST_PATH> -storageDataPath=/vmstorage-data -eula
+./vmbackupmanager backup lock daily/2021-02-13 -dst=<DST_PATH> -storageDataPath=/vmstorage-data
 ```
 
 After that the backup won't be deleted by retention policy.
 You can view the `locked` attribute in backup list:
 
 ```sh
-./vmbackupmanager backup list -dst=<DST_PATH> -storageDataPath=/vmstorage-data -eula
+./vmbackupmanager backup list -dst=<DST_PATH> -storageDataPath=/vmstorage-data
 ```
 
 To remove protection, you can use the command `vmbackupmanager backups unlock`.
@@ -211,7 +211,7 @@ To remove protection, you can use the command `vmbackupmanager backups unlock`.
 For example:
 
 ```sh
-./vmbackupmanager backup unlock daily/2021-02-13 -dst=<DST_PATH> -storageDataPath=/vmstorage-data -eula
+./vmbackupmanager backup unlock daily/2021-02-13 -dst=<DST_PATH> -storageDataPath=/vmstorage-data
 ```
 
 ## API methods

--- a/docs/victoriametrics/vmgateway.md
+++ b/docs/victoriametrics/vmgateway.md
@@ -88,7 +88,7 @@ Start the single version of VictoriaMetrics
 Start vmgateway
 
 ```sh
-./bin/vmgateway -eula -enable.auth -read.url http://localhost:8428 --write.url http://localhost:8428
+./bin/vmgateway -licenseFile=/path/to/vm-license -enable.auth -read.url http://localhost:8428 --write.url http://localhost:8428
 ```
 
 Retrieve data from the database
@@ -163,9 +163,9 @@ EOF
 # start cluster
 
 # start vmstorage, vmselect and vminsert
-./bin/vmstorage -eula
-./bin/vmselect -eula -storageNode 127.0.0.1:8401
-./bin/vminsert -eula -storageNode 127.0.0.1:8400
+./bin/vmstorage -licenseFile=/path/to/vm-license
+./bin/vmselect -licenseFile=/path/to/vm-license -storageNode 127.0.0.1:8401
+./bin/vminsert -licenseFile=/path/to/vm-license -storageNode 127.0.0.1:8400
 
 # create base rate limiting config:
 cat << EOF > limit.yaml
@@ -184,7 +184,7 @@ limits:
 EOF
 
 # start gateway with `-clusterMode`
-./bin/vmgateway -eula -enable.rateLimit -ratelimit.config limit.yaml -datasource.url http://localhost:8428 -enable.auth -clusterMode -write.url=http://localhost:8480 --read.url=http://localhost:8481
+./bin/vmgateway -licenseFile=/path/to/vm-license -enable.rateLimit -ratelimit.config limit.yaml -datasource.url http://localhost:8428 -enable.auth -clusterMode -write.url=http://localhost:8480 --read.url=http://localhost:8481
 
 # ingest simple metric to tenant 1:5
 curl 'http://localhost:8431/api/v1/import/prometheus' -X POST  -d 'foo{bar="baz1"} 123' -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE2MjAxNjIwMDAwMDAsInZtX2FjY2VzcyI6eyJ0ZW5hbnRfaWQiOnsiYWNjb3VudF9pZCI6MTV9fX0.PB1_KXDKPUp-40pxOGk6lt_jt9Yq80PIMpWVJqSForQ'
@@ -210,7 +210,7 @@ Note that both flags support passing multiple keys and also can be used together
 
 Example usage:
 ```sh
-./bin/vmgateway -eula \
+./bin/vmgateway -licenseFile=/path/to/vm-license \
   -enable.auth \
   -write.url=http://localhost:8480 \
   -read.url=http://localhost:8481 \
@@ -238,7 +238,7 @@ When `auth.oidcDiscoveryEndpoints` is specified `vmgateway` will fetch JWKS keys
 
 Example usage for tokens issued by Azure Active Directory:
 ```sh
-/bin/vmgateway -eula \
+/bin/vmgateway -licenseFile=/path/to/vm-license \
   -enable.auth \
   -write.url=http://localhost:8480 \
   -read.url=http://localhost:8481 \
@@ -247,7 +247,7 @@ Example usage for tokens issued by Azure Active Directory:
 
 Example usage for tokens issued by Google:
 ```sh
-/bin/vmgateway -eula \
+/bin/vmgateway -licenseFile=/path/to/vm-license \
   -enable.auth \
   -write.url=http://localhost:8480 \
   -read.url=http://localhost:8481 \
@@ -263,7 +263,7 @@ When `auth.jwksEndpoints` is specified `vmgateway` will fetch public keys from t
 
 Example usage for tokens issued by Azure Active Directory:
 ```sh
-/bin/vmgateway -eula \
+/bin/vmgateway -licenseFile=/path/to/vm-license \
   -enable.auth \
   -write.url=http://localhost:8480 \
   -read.url=http://localhost:8481 \
@@ -272,7 +272,7 @@ Example usage for tokens issued by Azure Active Directory:
 
 Example usage for tokens issued by Google:
 ```sh
-/bin/vmgateway -eula \
+/bin/vmgateway -licenseFile=/path/to/vm-license \
   -enable.auth \
   -write.url=http://localhost:8480 \
   -read.url=http://localhost:8481 \


### PR DESCRIPTION
`-eula` was deprecated and made no-op in v1.123.0, so examples with `-eula` will no longer work.
Replace those with proper license configuration.

While at it, remove license flags from vmbackupmanager CLI commands as it is not required when using CLI.
