### PR TITLE
app/vmselect/graphite: enforce search.maxQueryLen for Graphite queries

### DIFF
--- a/app/vmselect/graphite/eval_test.go
+++ b/app/vmselect/graphite/eval_test.go
@@ -4348,3 +4348,59 @@ func TestSafePathExpressionFromString(t *testing.T) {
 		}
 	})
 }
+
+func TestExecExprQueryLengthValidation(t *testing.T) {
+	// Create a test case that exceeds the default maxQueryLen (16KB)
+	longQuery := "sumSeries(" + strings.Repeat("metric.very.long.name.that.takes.space,", 500) + "metric.final)"
+
+	ec := &evalConfig{
+		at:        &auth.Token{},
+		startTime: 0,
+		endTime:   1000,
+	}
+
+	t.Run("query exceeding maxQueryLen should fail", func(t *testing.T) {
+		// This query should be longer than 16KB
+		if len(longQuery) <= 16*1024 {
+			t.Skipf("Test query is not long enough (%d bytes), skipping", len(longQuery))
+		}
+
+		_, err := execExpr(ec, longQuery)
+		if err == nil {
+			t.Fatalf("expected error for query exceeding maxQueryLen")
+		}
+
+		expectedMsg := "too long query"
+		if !strings.Contains(err.Error(), expectedMsg) {
+			t.Fatalf("expected error message to contain %q, got: %v", expectedMsg, err)
+		}
+
+		expectedMsg2 := "search.maxQueryLen"
+		if !strings.Contains(err.Error(), expectedMsg2) {
+			t.Fatalf("expected error message to mention maxQueryLen flag, got: %v", err)
+		}
+	})
+
+	t.Run("short query should succeed parsing", func(t *testing.T) {
+		shortQuery := "metric.cpu.usage"
+
+		// We expect this to fail later (no actual storage), but not from length validation
+		_, err := execExpr(ec, shortQuery)
+		if err != nil && strings.Contains(err.Error(), "too long query") {
+			t.Fatalf("unexpected query length error for short query: %v", err)
+		}
+	})
+}
+
+func TestGetMaxQueryLen(t *testing.T) {
+	// Test that the function returns a reasonable value
+	maxLen := getMaxQueryLen()
+	if maxLen <= 0 {
+		t.Fatalf("getMaxQueryLen() returned non-positive value: %d", maxLen)
+	}
+
+	// Should return at least the default value
+	if maxLen < 1024 {
+		t.Fatalf("getMaxQueryLen() returned unexpectedly small value: %d", maxLen)
+	}
+}


### PR DESCRIPTION
Description:

This PR ensures that the -search.maxQueryLen flag applies to Graphite queries, matching the behavior already present for Prometheus queries. Previously, Graphite queries could bypass this limit, creating an inconsistency and a potential vector for resource exhaustion.

Key changes:

Added getMaxQueryLen() to access the global query length limit.
Enforced query length validation in execExpr() for Graphite queries.
Added comprehensive tests for the new validation logic and edge cases.
Error messages are consistent with Prometheus query validation.
The default limit is 16KB (configurable via -search.maxQueryLen). Setting the limit to 0 disables validation.
This change closes the gap where Graphite queries could exceed configured length limits, providing consistent protection against excessively long queries across both query APIs.

Related to https://github.com/VictoriaMetrics/VictoriaMetrics/pull/9534