### PR TITLE
lib/storage: introduce daily partitioning for parts

### DIFF
--- a/lib/storage/storage.go
+++ b/lib/storage/storage.go
@@ -91,6 +91,8 @@ type Storage struct {
 
 	disablePerDayIndex bool
 
+	enableDailyPartitioning bool
+
 	tb *table
 
 	// Series cardinality limiters.
@@ -204,12 +206,17 @@ func MustOpenStorage(path string, opts OpenOptions) *Storage {
 	if idbPrefillStart <= 0 {
 		idbPrefillStart = time.Hour
 	}
+	var enableDailyPartitioning bool
+	if retention < 30*24*time.Hour {
+		enableDailyPartitioning = true
+	}
 	s := &Storage{
-		path:                   path,
-		cachePath:              filepath.Join(path, cacheDirname),
-		retentionMsecs:         retention.Milliseconds(),
-		stopCh:                 make(chan struct{}),
-		idbPrefillStartSeconds: idbPrefillStart.Milliseconds() / 1000,
+		path:                    path,
+		cachePath:               filepath.Join(path, cacheDirname),
+		retentionMsecs:          retention.Milliseconds(),
+		stopCh:                  make(chan struct{}),
+		idbPrefillStartSeconds:  idbPrefillStart.Milliseconds() / 1000,
+		enableDailyPartitioning: enableDailyPartitioning,
 	}
 	s.logNewSeries.Store(opts.LogNewSeries)
 


### PR DESCRIPTION
 This commit adds new storage flag: `-storage.enableDailyPartitioning`.
Which instructs storage to perform merge operations with in a partition only on parts that belongs to the same day.

 It allows to apply more strict retention and reduce disk usage for
high-cardinality samples.

Fixes https://github.com/VictoriaMetrics/VictoriaMetrics/issues/9452

### Describe Your Changes

Please provide a brief description of the changes you made. Be as specific as possible to help others understand the purpose and impact of your modifications.

### Checklist

The following checks are **mandatory**:

- [ ] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [ ] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
