### PR TITLE
lib/streamaggr: use keepFirstSample value from process startup

### DIFF
--- a/lib/streamaggr/total.go
+++ b/lib/streamaggr/total.go
@@ -25,8 +25,7 @@ type totalAggrValue struct {
 
 func (av *totalAggrValue) pushSample(c aggrConfig, sample *pushSample, key string, deleteDeadline int64) {
 	ac := c.(*totalAggrConfig)
-	currentTime := fasttime.UnixTimestamp()
-	keepFirstSample := ac.keepFirstSample && currentTime >= ac.ignoreFirstSampleDeadline
+	keepFirstSample := ac.keepFirstSample
 	lv, ok := av.shared.lastValues[key]
 	if ok || keepFirstSample {
 		if sample.timestamp < lv.timestamp {


### PR DESCRIPTION
### Describe Your Changes

The `total` aggregation should always keep the first sample to use in the aggregation. The `total_prometheus` aggregation does not. The existing logic will set `keepFirstSample` to `false` for `total` aggregation when data is received within roughly 1 [staleness interval](https://docs.victoriametrics.com/victoriametrics/stream-aggregation/index.html#staleness) after the process is started.

### Checklist

The following checks are **mandatory**:

- [ ] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [ ] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
