### PR TITLE
lib/storage: Restore prefetch metric names

### DIFF
--- a/app/vmstorage/main.go
+++ b/app/vmstorage/main.go
@@ -582,6 +582,7 @@ func writeStorageMetrics(w io.Writer, strg *storage.Storage) {
 	metrics.WriteCounterUint64(w, `vm_new_timeseries_created_total`, m.NewTimeseriesCreated)
 	metrics.WriteCounterUint64(w, `vm_slow_row_inserts_total`, m.SlowRowInserts)
 	metrics.WriteCounterUint64(w, `vm_slow_per_day_index_inserts_total`, m.SlowPerDayIndexInserts)
+	metrics.WriteCounterUint64(w, `vm_slow_metric_name_loads_total`, m.SlowMetricNameLoads)
 
 	if *maxHourlySeries > 0 {
 		metrics.WriteGaugeUint64(w, `vm_hourly_series_limit_current_series`, m.HourlySeriesLimitCurrentSeries)
@@ -626,6 +627,7 @@ func writeStorageMetrics(w io.Writer, strg *storage.Storage) {
 	metrics.WriteGaugeUint64(w, `vm_cache_entries{type="indexdb/tagFiltersToMetricIDs"}`, idbm.TagFiltersToMetricIDsCacheSize)
 	metrics.WriteGaugeUint64(w, `vm_cache_entries{type="storage/regexps"}`, uint64(storage.RegexpCacheSize()))
 	metrics.WriteGaugeUint64(w, `vm_cache_entries{type="storage/regexpPrefixes"}`, uint64(storage.RegexpPrefixesCacheSize()))
+	metrics.WriteGaugeUint64(w, `vm_cache_entries{type="storage/prefetchedMetricIDs"}`, m.PrefetchedMetricIDsSize)
 
 	metrics.WriteGaugeUint64(w, `vm_cache_size_bytes{type="storage/tsid"}`, m.TSIDCacheSizeBytes)
 	metrics.WriteGaugeUint64(w, `vm_cache_size_bytes{type="storage/metricIDs"}`, m.MetricIDCacheSizeBytes)
@@ -640,6 +642,7 @@ func writeStorageMetrics(w io.Writer, strg *storage.Storage) {
 	metrics.WriteGaugeUint64(w, `vm_cache_size_bytes{type="indexdb/tagFiltersToMetricIDs"}`, idbm.TagFiltersToMetricIDsCacheSizeBytes)
 	metrics.WriteGaugeUint64(w, `vm_cache_size_bytes{type="storage/regexps"}`, uint64(storage.RegexpCacheSizeBytes()))
 	metrics.WriteGaugeUint64(w, `vm_cache_size_bytes{type="storage/regexpPrefixes"}`, uint64(storage.RegexpPrefixesCacheSizeBytes()))
+	metrics.WriteGaugeUint64(w, `vm_cache_size_bytes{type="storage/prefetchedMetricIDs"}`, m.PrefetchedMetricIDsSizeBytes)
 
 	metrics.WriteGaugeUint64(w, `vm_cache_size_max_bytes{type="storage/tsid"}`, m.TSIDCacheSizeMaxBytes)
 	metrics.WriteGaugeUint64(w, `vm_cache_size_max_bytes{type="storage/metricIDs"}`, m.MetricIDCacheSizeMaxBytes)

--- a/lib/storage/index_db.go
+++ b/lib/storage/index_db.go
@@ -1834,7 +1834,7 @@ func (db *indexDB) prefetchMetricNames(qt *querytracer.Tracer, srcMetricIDs []ui
 	qt = qt.NewChild("prefetch metric names for %d metricIDs", len(srcMetricIDs))
 	defer qt.Done()
 
-	if len(srcMetricIDs) < 500 {
+	if len(srcMetricIDs) < 100_000 {
 		qt.Printf("skip pre-fetching metric names for low number of metric ids=%d", len(srcMetricIDs))
 		return nil
 	}
@@ -1851,7 +1851,7 @@ func (db *indexDB) prefetchMetricNames(qt *querytracer.Tracer, srcMetricIDs []ui
 	db.s.prefetchedMetricIDsLock.Unlock()
 
 	qt.Printf("%d out of %d metric names must be pre-fetched", len(metricIDs), len(srcMetricIDs))
-	if len(metricIDs) < 500 {
+	if len(metricIDs) < 100_000 {
 		// It is cheaper to skip pre-fetching and obtain metricNames inline.
 		qt.Printf("skip pre-fetching metric names for low number of missing metric ids=%d", len(metricIDs))
 		return nil

--- a/lib/storage/index_db.go
+++ b/lib/storage/index_db.go
@@ -30,6 +30,7 @@ import (
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/mergeset"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/querytracer"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/slicesutil"
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/timeutil"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/uint64set"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/workingsetcache"
 )
@@ -1783,6 +1784,9 @@ func (db *indexDB) SearchMetricNames(qt *querytracer.Tracer, tfss []*TagFilters,
 	if len(metricIDs) == 0 {
 		return nil, nil
 	}
+	if err = db.prefetchMetricNames(qt, metricIDs, deadline); err != nil {
+		return nil, err
+	}
 
 	is := db.getIndexSearch(noDeadline)
 	defer db.putIndexSearch(is)
@@ -1819,6 +1823,70 @@ func (db *indexDB) SearchMetricNames(qt *querytracer.Tracer, tfss []*TagFilters,
 
 	qt.Printf("loaded %d metric names", len(metricNames))
 	return metricNames, nil
+}
+
+// prefetchMetricNames pre-fetches metric names for the given srcMetricIDs into metricID->metricName cache.
+//
+// This should speed-up further searchMetricNameWithCache calls for srcMetricIDs from tsids.
+//
+// It is expected that srcMetricIDs are already sorted by the caller. Otherwise the pre-fetching may be slow.
+func (db *indexDB) prefetchMetricNames(qt *querytracer.Tracer, srcMetricIDs []uint64, deadline uint64) error {
+	qt = qt.NewChild("prefetch metric names for %d metricIDs", len(srcMetricIDs))
+	defer qt.Done()
+
+	if len(srcMetricIDs) < 500 {
+		qt.Printf("skip pre-fetching metric names for low number of metric ids=%d", len(srcMetricIDs))
+		return nil
+	}
+
+	var metricIDs []uint64
+	db.s.prefetchedMetricIDsLock.Lock()
+	prefetchedMetricIDs := db.s.prefetchedMetricIDs
+	for _, metricID := range srcMetricIDs {
+		if prefetchedMetricIDs.Has(metricID) {
+			continue
+		}
+		metricIDs = append(metricIDs, metricID)
+	}
+	db.s.prefetchedMetricIDsLock.Unlock()
+
+	qt.Printf("%d out of %d metric names must be pre-fetched", len(metricIDs), len(srcMetricIDs))
+	if len(metricIDs) < 500 {
+		// It is cheaper to skip pre-fetching and obtain metricNames inline.
+		qt.Printf("skip pre-fetching metric names for low number of missing metric ids=%d", len(metricIDs))
+		return nil
+	}
+	db.s.slowMetricNameLoads.Add(uint64(len(metricIDs)))
+
+	// Pre-fetch metric names.
+	var metricName []byte
+	is := db.getIndexSearch(deadline)
+	defer db.putIndexSearch(is)
+	for loops, metricID := range metricIDs {
+		if loops&paceLimiterSlowIterationsMask == 0 {
+			if err := checkSearchDeadlineAndPace(is.deadline); err != nil {
+				return err
+			}
+		}
+		metricName, _ = is.searchMetricNameWithCache(metricName[:0], metricID)
+	}
+	qt.Printf("pre-fetch metric names for %d metric ids", len(metricIDs))
+
+	// Store the pre-fetched metricIDs, so they aren't pre-fetched next time.
+	db.s.prefetchedMetricIDsLock.Lock()
+	// TODO(@rtm0): Move resetting to Storage.
+	if fasttime.UnixTimestamp() > db.s.prefetchedMetricIDsDeadline.Load() {
+		// Periodically reset the prefetchedMetricIDs in order to limit its size.
+		db.s.prefetchedMetricIDs = &uint64set.Set{}
+		d := timeutil.AddJitterToDuration(time.Second * 20 * 60)
+		metricIDsDeadline := fasttime.UnixTimestamp() + uint64(d.Seconds())
+		db.s.prefetchedMetricIDsDeadline.Store(metricIDsDeadline)
+	}
+	db.s.prefetchedMetricIDs.AddMulti(metricIDs)
+	db.s.prefetchedMetricIDsLock.Unlock()
+
+	qt.Printf("cache metric ids for pre-fetched metric names")
+	return nil
 }
 
 var tagFiltersKeyBufPool bytesutil.ByteBufferPool

--- a/lib/storage/search.go
+++ b/lib/storage/search.go
@@ -200,6 +200,9 @@ func (s *Search) searchTSIDs(qt *querytracer.Tracer, tfss []*TagFilters, tr Time
 		metricIDs, err := idb.searchMetricIDs(qt, tfss, tr, maxMetrics, deadline)
 		if err == nil {
 			tsids, err = idb.getTSIDsFromMetricIDs(qt, metricIDs, deadline)
+			if err == nil {
+				err = idb.prefetchMetricNames(qt, metricIDs, deadline)
+			}
 		}
 		return tsids, err
 	}


### PR DESCRIPTION
### Describe Your Changes

In #9137, the `prefetchMetricNames()` has been removed because it did not improve performance. This change was included into `v1.123.0`. The benchmarks used to prove it used 10k metricIDs per response and showed no difference in performance with and without this method. However, it appears that prefetching does make sense for len(metricIDs) > 100k. And new benchmarks clearly show that.

Many deployments we are aware of have `>100k` timeseries per response. In addition we suspect that #9602 is the first reported issue related to this. Hence, prefetching metric names needs to be restored but with the necessary changes to account for new concurrent search implementation introduced in #9431. Additionally, new benchmarks show that the threshold of 500 metricIDs is no longer relevant and needs to be changed to 100k (a number found empirically by running benchmarks on various machines).

TODO: Add benchmark results  

### Checklist

The following checks are **mandatory**:

- [ ] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [ ] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
