### PR TITLE
TSDB: support for all query types

### DIFF
--- a/benchmarks/Makefile
+++ b/benchmarks/Makefile
@@ -32,7 +32,7 @@
 #
 # See https://github.com/timescale/tsbs/blob/master/docs/victoriametrics.md
 # for details
-tsbs: tsbs-build tsbs-generate-data tsbs-load-data tsbs-generate-queries tsbs-run-queries
+tsbs: tsbs-build tsbs-generate-data tsbs-load-data tsbs-generate-queries-all tsbs-run-queries-all
 
 TSBS_SCALE ?= 100000
 TSBS_END ?= $(shell date -u +%Y-%m-%dT00:00:00Z)
@@ -45,8 +45,9 @@ TSBS_START ?= $(shell \
 TSBS_STEP ?= 80s
 TSBS_QUERIES ?= 1000
 TSBS_WORKERS ?= 4
+TSBS_QUERY_TYPE := cpu-max-all-8
 TSBS_DATA_FILE := /tmp/tsbs-data-$(TSBS_SCALE)-$(TSBS_START)-$(TSBS_END)-$(TSBS_STEP).gz
-TSBS_QUERY_FILE := /tmp/tsbs-queries-$(TSBS_SCALE)-$(TSBS_START)-$(TSBS_END)-$(TSBS_QUERIES).gz
+TSBS_QUERY_FILE := /tmp/tsbs-queries-$(TSBS_QUERY_TYPE)-$(TSBS_SCALE)-$(TSBS_START)-$(TSBS_END)-$(TSBS_QUERIES).gz
 # For cluster setup use http://vminsert:8480/insert/0/influx/write
 TSBS_WRITE_URLS ?= http://localhost:8428/write
 # For cluster setup use http://vmselect:8481/select/0/prometheus
@@ -86,7 +87,7 @@ tsbs-load-data:
 		-e process_io_written_bytes_total || true
 
 
-# Generate benchmark queries
+# Generate benchmark queries of a given type
 tsbs-generate-queries:
 	test -f $(TSBS_QUERY_FILE) || /tmp/tsbs/bin/tsbs_generate_queries \
 		--format=victoriametrics \
@@ -95,10 +96,40 @@ tsbs-generate-queries:
 		--scale=$(TSBS_SCALE) \
 		--timestamp-start=$(TSBS_START) \
 		--timestamp-end=$(TSBS_END) \
-		--query-type=cpu-max-all-8 \
+		--query-type=$(TSBS_QUERY_TYPE) \
 		--queries=1000 \
 		| gzip > $(TSBS_QUERY_FILE)
 
-# Run benchmark queries against VictoriaMetrics
+# Generate all types of benchmark queries
+tsbs-generate-queries-all:
+	$(MAKE) tsbs-generate-queries TSBS_QUERY_TYPE=single-groupby-1-1-1
+	$(MAKE) tsbs-generate-queries TSBS_QUERY_TYPE=single-groupby-1-1-12
+	$(MAKE) tsbs-generate-queries TSBS_QUERY_TYPE=single-groupby-1-8-1
+	$(MAKE) tsbs-generate-queries TSBS_QUERY_TYPE=single-groupby-5-1-1
+	$(MAKE) tsbs-generate-queries TSBS_QUERY_TYPE=single-groupby-5-1-12
+	$(MAKE) tsbs-generate-queries TSBS_QUERY_TYPE=single-groupby-5-8-1
+	$(MAKE) tsbs-generate-queries TSBS_QUERY_TYPE=cpu-max-all-1
+	$(MAKE) tsbs-generate-queries TSBS_QUERY_TYPE=cpu-max-all-8
+	$(MAKE) tsbs-generate-queries TSBS_QUERY_TYPE=double-groupby-1
+	$(MAKE) tsbs-generate-queries TSBS_QUERY_TYPE=double-groupby-5
+	$(MAKE) tsbs-generate-queries TSBS_QUERY_TYPE=double-groupby-all
+
+# Run benchmark queries of a given type against VictoriaMetrics
 tsbs-run-queries:
 	cat $(TSBS_QUERY_FILE) | gunzip | /tmp/tsbs/bin/tsbs_run_queries_victoriametrics --workers=$(TSBS_WORKERS) --urls=$(TSBS_READ_URLS)
+
+# Run all types of benchmark queries against VictoriaMetrics
+tsbs-run-queries-all:
+	$(MAKE) tsbs-run-queries TSBS_QUERY_TYPE=single-groupby-1-1-1
+	$(MAKE) tsbs-run-queries TSBS_QUERY_TYPE=single-groupby-1-1-12
+	$(MAKE) tsbs-run-queries TSBS_QUERY_TYPE=single-groupby-1-8-1
+	$(MAKE) tsbs-run-queries TSBS_QUERY_TYPE=single-groupby-5-1-1
+	$(MAKE) tsbs-run-queries TSBS_QUERY_TYPE=single-groupby-5-1-12
+	$(MAKE) tsbs-run-queries TSBS_QUERY_TYPE=single-groupby-5-8-1
+	$(MAKE) tsbs-run-queries TSBS_QUERY_TYPE=cpu-max-all-1
+	$(MAKE) tsbs-run-queries TSBS_QUERY_TYPE=cpu-max-all-8
+	$(MAKE) tsbs-run-queries TSBS_QUERY_TYPE=double-groupby-1
+	$(MAKE) tsbs-run-queries TSBS_QUERY_TYPE=double-groupby-5
+
+	# Too heavy: retrieves 1B samples
+	# $(MAKE) tsbs-run-queries TSBS_QUERY_TYPE=double-groupby-all


### PR DESCRIPTION
### Describe Your Changes

Add the support of all standard TSDB query types that can be executed against VictoriaMetrics. `double-groupby-all` is commented out as it attempts to retrieve all 1B samples and fails. While this can be fixed by setting the `-search.maxSamplesPerQuery` this query is left disabled anyway because it will consume way too much memory and cpu time. 

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
