### PR TITLE
app/vmui: removed home page hack

### DIFF
--- a/app/vmui/packages/vmui/src/layouts/AnomalyLayout/AnomalyLayout.tsx
+++ b/app/vmui/packages/vmui/src/layouts/AnomalyLayout/AnomalyLayout.tsx
@@ -1,12 +1,11 @@
 import Header from "../Header/Header";
 import { FC, useEffect } from "preact/compat";
-import { Outlet, useLocation, useSearchParams } from "react-router-dom";
+import { Outlet, useSearchParams } from "react-router-dom";
 import qs from "qs";
 import "../MainLayout/style.scss";
 import { getAppModeEnable } from "../../utils/app-mode";
 import classNames from "classnames";
 import Footer from "../Footer/Footer";
-import { routerOptions } from "../../router";
 import useFetchDefaultTimezone from "../../hooks/useFetchDefaultTimezone";
 import useDeviceDetect from "../../hooks/useDeviceDetect";
 import ControlsAnomalyLayout from "./ControlsAnomalyLayout";
@@ -14,16 +13,9 @@ import ControlsAnomalyLayout from "./ControlsAnomalyLayout";
 const AnomalyLayout: FC = () => {
   const appModeEnable = getAppModeEnable();
   const { isMobile } = useDeviceDetect();
-  const { pathname } = useLocation();
   const [searchParams, setSearchParams] = useSearchParams();
 
   useFetchDefaultTimezone();
-
-  const setDocumentTitle = () => {
-    const defaultTitle = "vmui for vmanomaly";
-    const routeTitle = routerOptions[pathname]?.title;
-    document.title = routeTitle ? `${routeTitle} - ${defaultTitle}` : defaultTitle;
-  };
 
   // for support old links with search params
   const redirectSearchToHashParams = () => {
@@ -38,7 +30,6 @@ const AnomalyLayout: FC = () => {
     if (newHref !== href) window.location.replace(newHref);
   };
 
-  useEffect(setDocumentTitle, [pathname]);
   useEffect(redirectSearchToHashParams, []);
 
   return <section className="vm-container">

--- a/app/vmui/packages/vmui/src/router/index.ts
+++ b/app/vmui/packages/vmui/src/router/index.ts
@@ -1,3 +1,5 @@
+import { APP_TYPE, AppType } from "../constants/appType";
+
 const router = {
   home: "/",
   metrics: "/metrics",
@@ -51,11 +53,23 @@ const routerOptionsDefault = {
   },
 };
 
+const getDefaultOptions = (appType: AppType) => {
+  switch (appType) {
+    case AppType.vmanomaly:
+      return {
+        title: "Anomaly exploration",
+        ...routerOptionsDefault,
+      };
+    default:
+      return {
+        title: "Query",
+        ...routerOptionsDefault,
+      };
+  }
+};
+
 export const routerOptions: { [key: string]: RouterOptions } = {
-  [router.home]: {
-    title: "Query",
-    ...routerOptionsDefault,
-  },
+  [router.home]: getDefaultOptions(APP_TYPE),
   [router.rawQuery]: {
     title: "Raw query",
     ...routerOptionsDefault,
@@ -127,10 +141,7 @@ export const routerOptions: { [key: string]: RouterOptions } = {
     title: "Icons",
     header: {},
   },
-  [router.anomaly]: {
-    title: "Anomaly exploration",
-    ...routerOptionsDefault,
-  },
+  [router.anomaly]: getDefaultOptions(AppType.vmanomaly),
   [router.query]: {
     title: "Query",
     ...routerOptionsDefault,


### PR DESCRIPTION
### Describe Your Changes

`router.home` represents `/` path, which is the same for all UI apps, but content and title for root path differs depending on application type. added `getDefaultOptions` function, which returns proper home route configuration depending on application type, which allows to remove renamings in respective layouts 

### Checklist

The following checks are **mandatory**:

- [ ] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [ ] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
