### PR TITLE
app/vmui: set rateEnabled default value to false for probe_success

### DIFF
--- a/app/vmui/packages/vmui/src/components/ExploreMetrics/ExploreMetricItem/ExploreMetricItem.tsx
+++ b/app/vmui/packages/vmui/src/components/ExploreMetrics/ExploreMetricItem/ExploreMetricItem.tsx
@@ -27,7 +27,7 @@ const ExploreMetricItem: FC<ExploreMetricItemProps> = ({
   onChangeOrder,
 }) => {
 
-  const isCounter = useMemo(() => /_sum?|_total?|_count?/.test(name), [name]);
+  const isCounter = useMemo(() => /_sum$|_total$|_count$/.test(name), [name]);
   const isBucket = useMemo(() => /_bucket?/.test(name), [name]);
 
   const [rateEnabled, setRateEnabled] = useState(isCounter);


### PR DESCRIPTION
### Describe Your Changes

Set rateEnabled to false for probe_success in VMUI

Problem:
probe_success is incorrectly initialized with rateEnabled = true because the regex detecting counters (/_sum?|_total?|_count?/) matches partial strings like _su. This causes probe_success (a gauge) to be treated as a counter, producing slightly misleading graphs. For example, when rateEnabled is set to true, probe_success often shows as 0 in VMUI when the probe is actually succeding.
It is not intuative for users to have to disable rateEnabled manually just to get the correct value for probe_success in VMUI.


### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
