### PR TITLE
app/vmagent/promscrape: add concurrency parameter to getScrapeWorkGeneric function

### DIFF
--- a/docs/victoriametrics/README.md
+++ b/docs/victoriametrics/README.md
@@ -2708,6 +2708,8 @@ Pass `-help` to VictoriaMetrics in order to see the list of supported command-li
      Interval for checking for changes in 'file_sd_config'. See https://docs.victoriametrics.com/victoriametrics/sd_configs/#file_sd_configs for details (default 1m0s)
   -promscrape.gceSDCheckInterval duration
      Interval for checking for changes in gce. This works only if gce_sd_configs is configured in '-promscrape.config' file. See https://docs.victoriametrics.com/victoriametrics/sd_configs/#gce_sd_configs for details (default 1m0s)
+  -promscrape.promscrape.getScrapeWorkConcurrency int
+     The maximum number of concurrent goroutines used to generate scrape work during service discovery (default 1)
   -promscrape.hetznerSDCheckInterval duration
      Interval for checking for changes in Hetzner API. This works only if hetzner_sd_configs is configured in '-promscrape.config' file. See https://docs.victoriametrics.com/victoriametrics/sd_configs/#hetzner_sd_configs for details (default 1m0s)
   -promscrape.httpSDCheckInterval duration

--- a/docs/victoriametrics/README.md
+++ b/docs/victoriametrics/README.md
@@ -2708,7 +2708,7 @@ Pass `-help` to VictoriaMetrics in order to see the list of supported command-li
      Interval for checking for changes in 'file_sd_config'. See https://docs.victoriametrics.com/victoriametrics/sd_configs/#file_sd_configs for details (default 1m0s)
   -promscrape.gceSDCheckInterval duration
      Interval for checking for changes in gce. This works only if gce_sd_configs is configured in '-promscrape.config' file. See https://docs.victoriametrics.com/victoriametrics/sd_configs/#gce_sd_configs for details (default 1m0s)
-  -promscrape.promscrape.getScrapeWorkConcurrency int
+  -promscrape.maxScrapeDiscoveryConcurrency int
      The maximum number of concurrent goroutines used to generate scrape work during service discovery (default 1)
   -promscrape.hetznerSDCheckInterval duration
      Interval for checking for changes in Hetzner API. This works only if hetzner_sd_configs is configured in '-promscrape.config' file. See https://docs.victoriametrics.com/victoriametrics/sd_configs/#hetzner_sd_configs for details (default 1m0s)

--- a/lib/promscrape/config_test.go
+++ b/lib/promscrape/config_test.go
@@ -1502,3 +1502,83 @@ scrape_configs:
 	})
 
 }
+
+func TestGetScrapeWorkGeneric(t *testing.T) {
+	baseDir := "/test"
+	discoveryType := "test_sd_config"
+	prev := []*ScrapeWork{}
+
+	f := func(t *testing.T, cfg *Config, visitConfigs func(*ScrapeConfig, func(targetLabelsGetter)), wantLen int) {
+		t.Helper()
+		sws := cfg.getScrapeWorkGeneric(visitConfigs, discoveryType, prev)
+		if len(sws) != wantLen {
+			t.Fatalf("unexpected number of scrape works; got %d; want %d", len(sws), wantLen)
+		}
+	}
+
+	t.Run("basic", func(t *testing.T) {
+		cfg := &Config{
+			baseDir: baseDir,
+			ScrapeConfigs: []*ScrapeConfig{
+				{
+					JobName: "test_job",
+					swc: &scrapeWorkConfig{
+						jobName: "test_job",
+					},
+				},
+			},
+		}
+
+		visitConfigs := func(sc *ScrapeConfig, visitor func(sdc targetLabelsGetter)) {
+			visitor(&mockTargetLabelsGetter{
+				labels: []*promutil.Labels{
+					promutil.NewLabelsFromMap(map[string]string{
+						"__address__": "test:1",
+					}),
+					promutil.NewLabelsFromMap(map[string]string{
+						"__address__": "test:2",
+					}),
+					promutil.NewLabelsFromMap(map[string]string{
+						"__address__": "test:3",
+					}),
+				},
+			})
+		}
+
+		f(t, cfg, visitConfigs, 3)
+	})
+
+	t.Run("error handling", func(t *testing.T) {
+		cfg := &Config{
+			baseDir: baseDir,
+			ScrapeConfigs: []*ScrapeConfig{
+				{
+					JobName: "test_job",
+					swc: &scrapeWorkConfig{
+						jobName: "test_job",
+					},
+				},
+			},
+		}
+
+		visitConfigs := func(sc *ScrapeConfig, visitor func(sdc targetLabelsGetter)) {
+			visitor(&mockTargetLabelsGetter{
+				err: "simulated error",
+			})
+		}
+
+		f(t, cfg, visitConfigs, 0)
+	})
+}
+
+type mockTargetLabelsGetter struct {
+	labels []*promutil.Labels
+	err    string
+}
+
+func (m *mockTargetLabelsGetter) GetLabels(baseDir string) ([]*promutil.Labels, error) {
+	if m.err != "" {
+		return nil, fmt.Errorf("%s", m.err)
+	}
+	return m.labels, nil
+}


### PR DESCRIPTION
add concurrency parameter to getScrapeWorkGeneric function

Describe Your Changes
add the promscrape.getScrapeWorkConcurrency parameter to control the concurrent execution of getScrapeWorkGeneric in vmagent, which will significantly accelerate service discovery when dealing with a large number of jobs.
Background reference link: https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8838
### Checklist

The following checks are **mandatory**:

- [ ✅] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
-  [ ✅] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
