### PR TITLE
app/vmselect: encode application version into manifest

### DIFF
--- a/app/vmselect/main.go
+++ b/app/vmselect/main.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/VictoriaMetrics/metrics"
+
 	"github.com/VictoriaMetrics/VictoriaMetrics/app/vmselect/graphite"
 	"github.com/VictoriaMetrics/VictoriaMetrics/app/vmselect/netstorage"
 	"github.com/VictoriaMetrics/VictoriaMetrics/app/vmselect/prometheus"
@@ -18,6 +20,7 @@ import (
 	"github.com/VictoriaMetrics/VictoriaMetrics/app/vmselect/searchutil"
 	"github.com/VictoriaMetrics/VictoriaMetrics/app/vmselect/stats"
 	"github.com/VictoriaMetrics/VictoriaMetrics/app/vmstorage"
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/buildinfo"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/cgroup"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/flagutil"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/fs"
@@ -27,7 +30,6 @@ import (
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/promscrape"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/querytracer"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/timerpool"
-	"github.com/VictoriaMetrics/metrics"
 )
 
 var (
@@ -740,6 +742,7 @@ var (
 
 func initVMUIConfig() {
 	var cfg struct {
+		Version string `json:"version"`
 		License struct {
 			Type string `json:"type"`
 		} `json:"license"`
@@ -754,6 +757,11 @@ func initVMUIConfig() {
 	err = json.Unmarshal(data, &cfg)
 	if err != nil {
 		logger.Fatalf("cannot parse vmui default config: %s", err)
+	}
+	cfg.Version = buildinfo.ShortVersion()
+	if cfg.Version == "" {
+		// buildinfo.ShortVersion() may return empty result for builds without tags
+		cfg.Version = buildinfo.Version
 	}
 	cfg.VMAlert.Enabled = len(*vmalertProxyURL) != 0
 	data, err = json.Marshal(&cfg)

--- a/lib/appmetrics/appmetrics.go
+++ b/lib/appmetrics/appmetrics.go
@@ -4,7 +4,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"regexp"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -27,8 +26,6 @@ var exposeMetadataOnce sync.Once
 func initExposeMetadata() {
 	metrics.ExposeMetadata(*exposeMetadata)
 }
-
-var versionRe = regexp.MustCompile(`v\d+\.\d+\.\d+(?:-enterprise)?(?:-cluster)?`)
 
 // WritePrometheusMetrics writes all the registered metrics to w in Prometheus exposition format.
 func WritePrometheusMetrics(w io.Writer) {
@@ -58,7 +55,7 @@ func writePrometheusMetrics(w io.Writer) {
 	metrics.WritePrometheus(w, true)
 	metrics.WriteFDMetrics(w)
 
-	metrics.WriteGaugeUint64(w, fmt.Sprintf("vm_app_version{version=%q, short_version=%q}", buildinfo.Version, versionRe.FindString(buildinfo.Version)), 1)
+	metrics.WriteGaugeUint64(w, fmt.Sprintf("vm_app_version{version=%q, short_version=%q}", buildinfo.Version, buildinfo.ShortVersion()), 1)
 	metrics.WriteGaugeUint64(w, "vm_allowed_memory_bytes", uint64(memory.Allowed()))
 	metrics.WriteGaugeUint64(w, "vm_available_memory_bytes", uint64(memory.Allowed()+memory.Remaining()))
 	metrics.WriteGaugeUint64(w, "vm_available_cpu_cores", uint64(cgroup.AvailableCPUs()))

--- a/lib/buildinfo/version.go
+++ b/lib/buildinfo/version.go
@@ -4,12 +4,20 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"regexp"
 )
 
 var version = flag.Bool("version", false, "Show VictoriaMetrics version")
 
 // Version must be set via -ldflags '-X'
 var Version string
+
+var shortVersionRe = regexp.MustCompile(`v\d+\.\d+\.\d+(?:-enterprise)?(?:-cluster)?`)
+
+// ShortVersion returns a shortened version
+func ShortVersion() string {
+	return shortVersionRe.FindString(Version)
+}
 
 // Init must be called after flag.Parse call.
 func Init() {


### PR DESCRIPTION
The application version can be then displayed in the vmui. Showing the application version in vmui should make it easier to determine currently used VM version (at least vmselect version).

------------

@Loori-R it would be could to add the app version in vmui in a follow-up PR or by pushing a commit to this branch.