### PR TITLE
docs/stream-aggregation: Add deduplication common mistake

### DIFF
--- a/docs/victoriametrics/stream-aggregation/README.md
+++ b/docs/victoriametrics/stream-aggregation/README.md
@@ -728,6 +728,13 @@ Stream aggregation allows keeping original metric names after aggregation by usi
 But the "meaning" of aggregated metrics is usually different to original ones after the aggregation.
 Make sure that you updated queries in your alerting rules and dashboards accordingly if you used `keep_metric_names` setting.
 
+### Use different deduplication intervals on storage and vmagent
+
+If the storage uses `-dedup.minScrapeInterval` but `vmagent` has no deduplication configured, aggregation results may not match queries on the storage. 
+For example, `sum(rate(foo[1m])) by (instance)` query result can differ from the [rate_sum](https://docs.victoriametrics.com/victoriametrics/stream-aggregation/configuration/#rate_sum) aggregation result `foo:1m_by_instance_rate_sum`.
+This happens because vmagent aggregates all samples, while queries on the storage use deduplicated samples. 
+To avoid this, set `-streamAggr.dedupInterval` or `-remoteWrite.streamAggr.dedupInterval` on `vmagent` to match the storage interval.
+
 ---
 
 Section below contains backward-compatible anchors for links that were moved or renamed.


### PR DESCRIPTION
### Describe Your Changes

Fix a stream aggregation pitfall when deduplication intervals differ between storage and vmagent.

Follow up on https://github.com/VictoriaMetrics/VictoriaMetrics/issues/9581

### Checklist

The following checks are **mandatory**:

- [ ] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [ ] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
