### PR TITLE
app/vmui: make sidebar scrollable and its items collapsible

### DIFF
--- a/app/vmui/packages/vmui/src/layouts/Header/Header.tsx
+++ b/app/vmui/packages/vmui/src/layouts/Header/Header.tsx
@@ -31,7 +31,7 @@ const Header: FC<HeaderProps> = ({ controlsComponent }) => {
   const { isMobile } = useDeviceDetect();
 
   const windowSize = useWindowSize();
-  const displaySidebar = useMemo(() => window.innerWidth < 1000, [windowSize]);
+  const displaySidebar = useMemo(() => window.innerWidth < 1230, [windowSize]);
 
   const { isDarkTheme } = useAppState();
   const appModeEnable = getAppModeEnable();

--- a/app/vmui/packages/vmui/src/layouts/Header/HeaderControls/HeaderControls.tsx
+++ b/app/vmui/packages/vmui/src/layouts/Header/HeaderControls/HeaderControls.tsx
@@ -53,7 +53,7 @@ const HeaderControls: FC<ControlsProps & HeaderProps> = ({
   if (isMobile) {
     return (
       <>
-        <div>
+        <div className="vm-header-controls">
           <Button
             className={classNames({
               "vm-header-button": !appModeEnable

--- a/app/vmui/packages/vmui/src/layouts/Header/HeaderNav/NavSubItem.tsx
+++ b/app/vmui/packages/vmui/src/layouts/Header/HeaderNav/NavSubItem.tsx
@@ -23,7 +23,7 @@ const NavSubItem: FC<NavItemProps> = ({
   color,
   background,
   submenu,
-  direction
+  direction = "row"
 }) => {
   const { pathname } = useLocation();
 
@@ -37,8 +37,9 @@ const NavSubItem: FC<NavItemProps> = ({
   } = useBoolean(false);
 
   const handleOpenSubmenu = () => {
-    setOpenSubmenu();
-    if (menuTimeout) clearTimeout(menuTimeout);
+    if (direction === "row" || !openSubmenu) setOpenSubmenu();
+    if (direction === "column" && openSubmenu) handleCloseSubmenu();
+    if (direction === "row" && menuTimeout) clearTimeout(menuTimeout);
   };
 
   const handleMouseLeave = () => {
@@ -55,50 +56,31 @@ const NavSubItem: FC<NavItemProps> = ({
     handleCloseSubmenu();
   }, [pathname]);
 
-  if (direction === "column") {
-    return (
-      <>
-        {submenu.map(sm => (
-          <NavItem
-            key={sm.value}
-            activeMenu={activeMenu}
-            value={sm.value || ""}
-            label={sm.label || ""}
-            type={sm.type || NavigationItemType.internalLink}
-          />
-        ))}
-      </>
-    );
-  }
-
   return (
     <div
       className={classNames({
-        "vm-header-nav-item": true,
-        "vm-header-nav-item_sub": true,
         "vm-header-nav-item_open": openSubmenu,
-        "vm-header-nav-item_active": submenu.find(m => m.value === activeMenu)
       })}
       style={{ color }}
-      onMouseEnter={handleOpenSubmenu}
-      onMouseLeave={handleMouseLeave}
+      onMouseEnter={direction === "column" ? undefined : handleOpenSubmenu}
+      onMouseLeave={direction === "column" ? undefined : handleMouseLeave}
+      onClick={direction === "column" ? handleOpenSubmenu : undefined}
       ref={buttonRef}
     >
-      {label}
-      <ArrowDropDownIcon/>
-
-      <Popper
-        open={openSubmenu}
-        placement="bottom-left"
-        offset={{ top: 12, left: 0 }}
-        onClose={handleCloseSubmenu}
-        buttonRef={buttonRef}
+      <div
+        className={classNames({
+          "vm-header-nav-item": true,
+          "vm-header-nav-item_sub": true,
+          "vm-header-nav-item_active": submenu.find(m => m.value === activeMenu),
+        })}
       >
+        {label}
+        <ArrowDropDownIcon/>
+      </div>
+      {direction === "column" ? (
         <div
           className="vm-header-nav-item-submenu"
           style={{ background }}
-          onMouseLeave={handleMouseLeave}
-          onMouseEnter={handleMouseEnterPopup}
         >
           {submenu.map(sm => (
             <NavItem
@@ -111,7 +93,33 @@ const NavSubItem: FC<NavItemProps> = ({
             />
           ))}
         </div>
-      </Popper>
+      ) : (
+        <Popper
+          open={openSubmenu}
+          placement="bottom-left"
+          offset={{ top: 12, left: 0 }}
+          onClose={handleCloseSubmenu}
+          buttonRef={buttonRef}
+        >
+          <div
+            className="vm-header-nav-item-submenu"
+            style={{ background }}
+            onMouseLeave={handleMouseLeave}
+            onMouseEnter={handleMouseEnterPopup}
+          >
+            {submenu.map(sm => (
+              <NavItem
+                key={sm.value}
+                activeMenu={activeMenu}
+                value={sm.value || ""}
+                label={sm.label || ""}
+                color={color}
+                type={sm.type || NavigationItemType.internalLink}
+              />
+            ))}
+          </div>
+        </Popper>
+      )}
     </div>
   );
 };

--- a/app/vmui/packages/vmui/src/layouts/Header/HeaderNav/style.scss
+++ b/app/vmui/packages/vmui/src/layouts/Header/HeaderNav/style.scss
@@ -20,6 +20,14 @@
     }
   }
 
+  &_column &-item-submenu {
+    display: none;
+  }
+
+  &_column &-item_open &-item-submenu {
+    display: grid;
+  }
+
   &-item {
     position: relative;
     padding: $padding-global $padding-small;
@@ -44,6 +52,7 @@
     }
 
     &_active {
+      padding: $padding-global $padding-small 10px $padding-small;
       border-bottom: 2px solid rgba($color-black, 0.2);
     }
 
@@ -60,7 +69,6 @@
 
     &-submenu {
       display: grid;
-      white-space: nowrap;
       padding: $padding-small;
       color: $color-white;
       border-radius: $border-radius-small;

--- a/app/vmui/packages/vmui/src/layouts/Header/SidebarNav/SidebarHeader.tsx
+++ b/app/vmui/packages/vmui/src/layouts/Header/SidebarNav/SidebarHeader.tsx
@@ -52,7 +52,7 @@ const SidebarHeader: FC<SidebarHeaderProps> = ({
         "vm-header-sidebar-menu_open": openMenu
       })}
     >
-      <div>
+      <div className="vm-header-sidebar-scrollable">
         <HeaderNav
           color={color}
           background={background}

--- a/app/vmui/packages/vmui/src/layouts/Header/SidebarNav/style.scss
+++ b/app/vmui/packages/vmui/src/layouts/Header/SidebarNav/style.scss
@@ -25,7 +25,13 @@ $sidebar-transition: cubic-bezier(0.280, 0.840, 0.420, 1);
       z-index: 102;
     }
   }
-
+  &-scrollable {
+    overflow-y: scroll;
+    scrollbar-width: none;
+  }
+  &-scrollable::-webkit-scrollbar {
+    display: none;
+  }
   &-menu {
     position: fixed;
     top: 0;

--- a/app/vmui/packages/vmui/src/layouts/Header/style.scss
+++ b/app/vmui/packages/vmui/src/layouts/Header/style.scss
@@ -22,15 +22,9 @@
   }
 
   &_sidebar {
-    display: grid;
-    grid-template-columns: 40px auto 1fr;
-    box-shadow: $color-background-body 0 1px 1px 0px;
-  }
-
-  &_mobile {
-    display: grid;
-    grid-template-columns: 33px 1fr 33px;
+    display: flex;
     justify-content: space-between;
+    box-shadow: $color-background-body 0 1px 1px 0px;
   }
 
   &_dark {


### PR DESCRIPTION
after adding Alerting section all menu items cannot be displayed on mobile devices in a sidebar. this PR:

- makes sidebar scrollable, when it's content overflows screen
- makes sidebar items collapsible
- fixes menu layout on mobile devices with big screens

before:

<img width="1074" height="57" alt="image" src="https://github.com/user-attachments/assets/6ae69487-d89a-4aaa-985b-de788be06cff" />

<img width="198" height="490" alt="image" src="https://github.com/user-attachments/assets/0a494c52-6db7-4160-a04d-df69b88604dc" />


after:

<img width="1170" height="55" alt="image" src="https://github.com/user-attachments/assets/57909536-0353-4be2-8d8f-4302b3bfe338" />

<img width="199" height="509" alt="image" src="https://github.com/user-attachments/assets/43f33536-86eb-41b1-91d8-5b8ca95faeca" />



### Describe Your Changes

Please provide a brief description of the changes you made. Be as specific as possible to help others understand the purpose and impact of your modifications.

### Checklist

The following checks are **mandatory**:

- [ ] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [ ] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
