### PR TITLE
flag: update RetentionDuration to Duration for clearer, reusable naming

### DIFF
--- a/lib/flagutil/duration.go
+++ b/lib/flagutil/duration.go
@@ -110,12 +110,12 @@ func (d *RetentionDuration) Set(value string) error {
 //
 // Requires explicit unit suffixes (s, m, h, d, w, y). Bare numbers without units will cause errors (except 0).
 func NewExtendedDuration(name string, defaultValue string, description string) *ExtendedDuration {
-    description += "\nThe following unit suffixes are required: s (second), m (minute), h (hour), d (day), w (week), y (year). " +
-        "Bare numbers without units are not allowed (except 0)"
-    d := &ExtendedDuration{}
-    if err := d.Set(defaultValue); err != nil {
-        panic(fmt.Sprintf("BUG: can not parse default value %s for flag %s", defaultValue, name))
-    }
+	description += "\nThe following unit suffixes are required: s (second), m (minute), h (hour), d (day), w (week), y (year). " +
+		"Bare numbers without units are not allowed (except 0)"
+	d := &ExtendedDuration{}
+	if err := d.Set(defaultValue); err != nil {
+		panic(fmt.Sprintf("BUG: can not parse default value %s for flag %s", defaultValue, name))
+	}
 	flag.Var(d, name, description)
 	return d
 }
@@ -164,34 +164,34 @@ func (d *ExtendedDuration) String() string {
 	return d.valueString
 }
 
-    // Set implements flag.Value interface
-    // It requires explicit unit suffixes and rejects bare numbers (except 0).
-    func (d *ExtendedDuration) Set(value string) error {
+// Set implements flag.Value interface
+// It requires explicit unit suffixes and rejects bare numbers (except 0).
+func (d *ExtendedDuration) Set(value string) error {
 	if value == "" {
 		d.msecs = 0
 		d.valueString = ""
 		return nil
 	}
-	
+
 	// Check for bare numbers first
-        if f, err := strconv.ParseFloat(value, 64); err == nil {
-            // It's a bare number
-            if f != 0 {
-                return fmt.Errorf("duration value must have a unit suffix (s, m, h, d, w, y); got bare number %q (0 is allowed)", value)
-            }
-            // Allow 0 as it's unambiguous
-            d.msecs = 0
-            d.valueString = value
-            return nil
-        }
-	
+	if f, err := strconv.ParseFloat(value, 64); err == nil {
+		// It's a bare number
+		if f != 0 {
+			return fmt.Errorf("duration value must have a unit suffix (s, m, h, d, w, y); got bare number %q (0 is allowed)", value)
+		}
+		// Allow 0 as it's unambiguous
+		d.msecs = 0
+		d.valueString = value
+		return nil
+	}
+
 	// Parse duration with units using metricsql
 	value = strings.ToLower(value)
 	msecs, err := metricsql.PositiveDurationValue(value, 0)
 	if err != nil {
 		return fmt.Errorf("cannot parse duration %q: %w", value, err)
 	}
-	
+
 	d.msecs = msecs
 	d.valueString = value
 	return nil

--- a/lib/flagutil/duration.go
+++ b/lib/flagutil/duration.go
@@ -106,5 +106,95 @@ func (d *RetentionDuration) Set(value string) error {
 	return nil
 }
 
+// NewExtendedDuration returns new `duration` flag with the given name, defaultValue and description.
+//
+// Requires explicit unit suffixes (s, h, d, w, y). Bare numbers without units will cause errors (except 0).
+func NewExtendedDuration(name string, defaultValue string, description string) *ExtendedDuration {
+	description += "\nThe following unit suffixes are required: s (second), h (hour), d (day), w (week), y (year). " +
+		"Bare numbers without units are not allowed (except 0)"
+	d := &ExtendedDuration{}
+	if err := d.Set(defaultValue); err != nil {
+		panic(fmt.Sprintf("BUG: can not parse default value %s for flag %s", defaultValue, name))
+	}
+	flag.Var(d, name, description)
+	return d
+}
+
+// ExtendedDuration is a flag for specifying time durations with extended units (d, w, y).
+// Unlike RetentionDuration, it requires explicit unit suffixes and doesn't treat bare numbers as months.
+type ExtendedDuration struct {
+	// msecs contains parsed duration in milliseconds.
+	msecs int64
+
+	valueString string
+}
+
+var (
+	_ json.Marshaler   = (*ExtendedDuration)(nil)
+	_ json.Unmarshaler = (*ExtendedDuration)(nil)
+)
+
+// MarshalJSON implements json.Marshaler interface
+func (d *ExtendedDuration) MarshalJSON() ([]byte, error) {
+	return json.Marshal(d.valueString)
+}
+
+// UnmarshalJSON implements json.Unmarshaler interface
+func (d *ExtendedDuration) UnmarshalJSON(data []byte) error {
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return err
+	}
+	return d.Set(s)
+}
+
+// Duration returns d as time.Duration
+func (d *ExtendedDuration) Duration() time.Duration {
+	return time.Millisecond * time.Duration(d.msecs)
+}
+
+// Milliseconds returns d in milliseconds
+func (d *ExtendedDuration) Milliseconds() int64 {
+	return d.msecs
+}
+
+// String implements flag.Value interface
+func (d *ExtendedDuration) String() string {
+	return d.valueString
+}
+
+// Set implements flag.Value interface
+// It requires explicit unit suffixes and rejects bare numbers (except 0).
+func (d *ExtendedDuration) Set(value string) error {
+	if value == "" {
+		d.msecs = 0
+		d.valueString = ""
+		return nil
+	}
+	
+	// Check for bare numbers first
+	if f, err := strconv.ParseFloat(value, 64); err == nil {
+		// It's a bare number
+		if f != 0 {
+			return fmt.Errorf("duration value must have a unit suffix (s, h, d, w, y); got bare number %q (0 is allowed)", value)
+		}
+		// Allow 0 as it's unambiguous
+		d.msecs = 0
+		d.valueString = value
+		return nil
+	}
+	
+	// Parse duration with units using metricsql
+	value = strings.ToLower(value)
+	msecs, err := metricsql.PositiveDurationValue(value, 0)
+	if err != nil {
+		return fmt.Errorf("cannot parse duration %q: %w", value, err)
+	}
+	
+	d.msecs = msecs
+	d.valueString = value
+	return nil
+}
+
 const maxMonths = 12 * 100
 const msecsPer31Days = 31 * 24 * 3600 * 1000

--- a/lib/flagutil/duration_test.go
+++ b/lib/flagutil/duration_test.go
@@ -130,14 +130,14 @@ func TestExtendedDurationSetSuccess(t *testing.T) {
 	// Empty and zero values
 	f("", 0)
 	f("0", 0)
-	
+
 	// Time units
 	f("1s", 1000)
 	f("30s", 30*1000)
 	f("1h", 3600*1000)
 	f("2h", 2*3600*1000)
 	f("1.5h", 1.5*3600*1000)
-	
+
 	// Extended units
 	f("1d", 24*3600*1000)
 	f("1.5d", 1.5*24*3600*1000)
@@ -146,12 +146,12 @@ func TestExtendedDurationSetSuccess(t *testing.T) {
 	f("2w", 2*7*24*3600*1000)
 	f("1y", 365*24*3600*1000)
 	f("0.25y", 0.25*365*24*3600*1000)
-	
+
 	// Case insensitive
 	f("1D", 24*3600*1000)
 	f("1W", 7*24*3600*1000)
 	f("1Y", 365*24*3600*1000)
-	
+
 	// Minutes are allowed (no ambiguity like in RetentionDuration)
 	f("1m", 60*1000)
 	f("30m", 30*60*1000)
@@ -185,19 +185,19 @@ func TestExtendedDurationJSON(t *testing.T) {
 		if err := d.Set(value); err != nil {
 			t.Fatalf("unexpected error in d.Set(%q): %s", value, err)
 		}
-		
+
 		// Test MarshalJSON
 		data, err := d.MarshalJSON()
 		if err != nil {
 			t.Fatalf("unexpected error in MarshalJSON(): %s", err)
 		}
-		
+
 		// Test UnmarshalJSON
 		var d2 ExtendedDuration
 		if err := d2.UnmarshalJSON(data); err != nil {
 			t.Fatalf("unexpected error in UnmarshalJSON(): %s", err)
 		}
-		
+
 		if d.Milliseconds() != d2.Milliseconds() {
 			t.Fatalf("unexpected result after JSON roundtrip; got %d; want %d", d2.Milliseconds(), d.Milliseconds())
 		}

--- a/lib/flagutil/duration_test.go
+++ b/lib/flagutil/duration_test.go
@@ -81,3 +81,133 @@ func TestDurationDuration(t *testing.T) {
 	f("1w", 7*24*time.Hour)
 	f("0.25y", 0.25*365*24*time.Hour)
 }
+
+func TestExtendedDurationSetFailure(t *testing.T) {
+	f := func(value string) {
+		t.Helper()
+		var d ExtendedDuration
+		if err := d.Set(value); err == nil {
+			t.Fatalf("expecting non-nil error in d.Set(%q)", value)
+		}
+	}
+	// Invalid format
+	f("foobar")
+	f("5foobar")
+	f("ah")
+	f("134xd")
+	f("2.43sdfw")
+
+	// Bare numbers are not allowed (except 0)
+	f("1")
+	f("5")
+	f("123.456")
+
+	// Negative duration
+	f("-1h")
+	f("-34d")
+
+	// Invalid duration syntax
+	f("1x")
+	f("abc5d")
+}
+
+func TestExtendedDurationSetSuccess(t *testing.T) {
+	f := func(value string, expectedMsecs int64) {
+		t.Helper()
+		var d ExtendedDuration
+		if err := d.Set(value); err != nil {
+			t.Fatalf("unexpected error in d.Set(%q): %s", value, err)
+		}
+		if d.Milliseconds() != expectedMsecs {
+			t.Fatalf("unexpected result; got %d; want %d", d.Milliseconds(), expectedMsecs)
+		}
+		valueString := d.String()
+		valueExpected := strings.ToLower(value)
+		if valueString != valueExpected {
+			t.Fatalf("unexpected valueString; got %q; want %q", valueString, valueExpected)
+		}
+	}
+	// Empty and zero values
+	f("", 0)
+	f("0", 0)
+	
+	// Time units
+	f("1s", 1000)
+	f("30s", 30*1000)
+	f("1h", 3600*1000)
+	f("2h", 2*3600*1000)
+	f("1.5h", 1.5*3600*1000)
+	
+	// Extended units
+	f("1d", 24*3600*1000)
+	f("1.5d", 1.5*24*3600*1000)
+	f("7d", 7*24*3600*1000)
+	f("1w", 7*24*3600*1000)
+	f("2w", 2*7*24*3600*1000)
+	f("1y", 365*24*3600*1000)
+	f("0.25y", 0.25*365*24*3600*1000)
+	
+	// Case insensitive
+	f("1D", 24*3600*1000)
+	f("1W", 7*24*3600*1000)
+	f("1Y", 365*24*3600*1000)
+	
+	// Minutes are allowed (no ambiguity like in RetentionDuration)
+	f("1m", 60*1000)
+	f("30m", 30*60*1000)
+}
+
+func TestExtendedDurationDuration(t *testing.T) {
+	f := func(value string, expected time.Duration) {
+		t.Helper()
+		var d ExtendedDuration
+		if err := d.Set(value); err != nil {
+			t.Fatalf("unexpected error in d.Set(%q): %s", value, err)
+		}
+		if d.Duration() != expected {
+			t.Fatalf("unexpected result; got %v; want %v", d.Duration().String(), expected.String())
+		}
+	}
+	f("0", 0)
+	f("1s", time.Second)
+	f("1m", time.Minute)
+	f("1h", time.Hour)
+	f("1d", 24*time.Hour)
+	f("1w", 7*24*time.Hour)
+	f("1y", 365*24*time.Hour)
+	f("1.5d", 1.5*24*time.Hour)
+}
+
+func TestExtendedDurationJSON(t *testing.T) {
+	f := func(value string) {
+		t.Helper()
+		var d ExtendedDuration
+		if err := d.Set(value); err != nil {
+			t.Fatalf("unexpected error in d.Set(%q): %s", value, err)
+		}
+		
+		// Test MarshalJSON
+		data, err := d.MarshalJSON()
+		if err != nil {
+			t.Fatalf("unexpected error in MarshalJSON(): %s", err)
+		}
+		
+		// Test UnmarshalJSON
+		var d2 ExtendedDuration
+		if err := d2.UnmarshalJSON(data); err != nil {
+			t.Fatalf("unexpected error in UnmarshalJSON(): %s", err)
+		}
+		
+		if d.Milliseconds() != d2.Milliseconds() {
+			t.Fatalf("unexpected result after JSON roundtrip; got %d; want %d", d2.Milliseconds(), d.Milliseconds())
+		}
+		if d.String() != d2.String() {
+			t.Fatalf("unexpected string after JSON roundtrip; got %q; want %q", d2.String(), d.String())
+		}
+	}
+	f("0")
+	f("1h")
+	f("1d")
+	f("1w")
+	f("1y")
+}


### PR DESCRIPTION
Related: https://github.com/VictoriaMetrics/VictoriaLogs/issues/50