### PR TITLE
vmui: fix useSearchParamsFromObject not updating searchParams

### DIFF
--- a/app/vmui/packages/vmui/src/hooks/useSearchParamsFromObject.ts
+++ b/app/vmui/packages/vmui/src/hooks/useSearchParamsFromObject.ts
@@ -30,7 +30,7 @@ const useSearchParamsFromObject = () => {
     if (hasSearchParams) {
       setSearchParams(newSearchParams);
     } else {
-      navigate(`?${searchParams.toString()}`, { replace: true });
+      navigate(`?${newSearchParams.toString()}`, { replace: true });
     }
   }, [searchParams, navigate]);
 

--- a/docs/victoriametrics/changelog/CHANGELOG.md
+++ b/docs/victoriametrics/changelog/CHANGELOG.md
@@ -27,6 +27,7 @@ See also [LTS releases](https://docs.victoriametrics.com/victoriametrics/lts-rel
 ## tip
 
 * BUGFIX: `vmselect` in [VictoriaMetrics cluster](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/): properly route requests for `prometheus/vmui/config.json` API. Follow-up after 7f15e9f64cb8dd2b2f0f1c10d178fd06ac7c636c.
+* BUGFIX: [vmui](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#vmui): fix the issue where filtering on click does not work on the Explorer Cardinality page.
 
 ## [v1.125.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.125.0)
 


### PR DESCRIPTION
### Describe Your Changes

Fix bug in `useSearchParamsFromObject` hook that prevented filtering on the *Explore Cardinality* page.

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
