### PR TITLE
lib/promscrape: revert 69760f1

### DIFF
--- a/lib/promscrape/discovery/kubernetes/api_watcher.go
+++ b/lib/promscrape/discovery/kubernetes/api_watcher.go
@@ -356,11 +356,7 @@ func groupWatchersCleaner() {
 		time.Sleep(7 * time.Second)
 		groupWatchersLock.Lock()
 		for key, gw := range groupWatchers {
-			if !gw.mu.TryLock() {
-				// This gw is likely in use, skip it to avoid blocking the loop
-				// Try again in the next cleanup cycle
-				continue
-			}
+			gw.mu.Lock()
 			// Calculate the number of apiWatcher instances subscribed to gw.
 			awsTotal := 0
 			for _, uw := range gw.m {


### PR DESCRIPTION
Due to high concurrency TryLock could be never obtained and it may result in higher memory usage

### Describe Your Changes

Please provide a brief description of the changes you made. Be as specific as possible to help others understand the purpose and impact of your modifications.

### Checklist

The following checks are **mandatory**:

- [ ] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [ ] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
