### PR TITLE
app/vmui: make TextField box height constant regardless error message presence

### DIFF
--- a/app/vmui/packages/vmui/eslint.config.js
+++ b/app/vmui/packages/vmui/eslint.config.js
@@ -79,15 +79,13 @@ export default [...compat.extends(
     }],
 
     "react/jsx-first-prop-new-line": [1, "multiline"],
-    "object-curly-spacing": [2, "always"],
 
-    indent: ["error", 2, {
-      SwitchCase: 1,
-    }],
+    // Disable core indent rule due to recursion issues in ESLint 9; use JSX-specific rules instead
+    indent: "off",
+    "react/jsx-indent": ["error", 2],
+    "react/jsx-indent-props": ["error", 2],
 
-    "linebreak-style": ["error", "unix"],
-    quotes: ["error", "double"],
-    semi: ["error", "always"],
+    // Formatting rules moved out of ESLint core; omit here to avoid deprecation noise
     "react/prop-types": 0,
     "react/react-in-jsx-scope": "off",
 

--- a/app/vmui/packages/vmui/src/components/Chart/Line/Legend/LegendConfigs/LegendConfigs.tsx
+++ b/app/vmui/packages/vmui/src/components/Chart/Line/Legend/LegendConfigs/LegendConfigs.tsx
@@ -116,7 +116,7 @@ const LegendConfigs: FC<Props> = ({ data, isCompact }) => {
               onEnter={onApplyFormat}
             />
             <span className="vm-legend-configs-item__info vm-legend-configs-item__info_input">
-          Customize legend labels with text and &#123;&#123;label_name&#125;&#125; placeholders.
+              Customize legend labels with text and &#123;&#123;label_name&#125;&#125; placeholders.
             </span>
           </div>
 
@@ -130,7 +130,7 @@ const LegendConfigs: FC<Props> = ({ data, isCompact }) => {
               searchable
             />
             <span className="vm-legend-configs-item__info">
-          Choose a label to group the legend. By default, legends are grouped by query.
+              Choose a label to group the legend. By default, legends are grouped by query.
             </span>
           </div>
         </>

--- a/app/vmui/packages/vmui/src/components/Configurators/StepConfigurator/StepConfigurator.tsx
+++ b/app/vmui/packages/vmui/src/components/Configurators/StepConfigurator/StepConfigurator.tsx
@@ -142,7 +142,7 @@ const StepConfigurator: FC = () => {
           startIcon={<TimelineIcon/>}
           onClick={toggleOpenOptions}
         >
-            Step: {isAutoStep ? `auto (${customStep})` : customStep}
+          Step: {isAutoStep ? `auto (${customStep})` : customStep}
         </Button>
       )}
       <Popper

--- a/app/vmui/packages/vmui/src/components/ExploreMetrics/ExploreMetricItemHeader/ExploreMetricItemHeader.tsx
+++ b/app/vmui/packages/vmui/src/components/ExploreMetrics/ExploreMetricItemHeader/ExploreMetricItemHeader.tsx
@@ -106,7 +106,7 @@ const ExploreMetricItemHeader: FC<ExploreMetricItemControlsProps> = ({
                 onClick={handleClickRemove}
                 fullWidth
               >
-                  Remove graph
+                Remove graph
               </Button>
             </div>
           </Modal>

--- a/app/vmui/packages/vmui/src/components/Main/DatePicker/Calendar/Calendar.tsx
+++ b/app/vmui/packages/vmui/src/components/Main/DatePicker/Calendar/Calendar.tsx
@@ -117,7 +117,7 @@ const Calendar: FC<DatePickerProps> = ({
             size="small"
             onClick={handleToday}
           >
-              show today
+            show today
           </Button>
         </div>
       )}

--- a/app/vmui/packages/vmui/src/components/Main/DatePicker/Calendar/CalendarBody/CalendarBody.tsx
+++ b/app/vmui/packages/vmui/src/components/Main/DatePicker/Calendar/CalendarBody/CalendarBody.tsx
@@ -59,7 +59,7 @@ const CalendarBody: FC<CalendarBodyProps> = ({ minDate, maxDate, viewDate: date,
               "vm-calendar-body-cell_day_disabled": isDisabled,
             })}
             key={d ? d.format(format) : i}
-            onClick={createHandlerSelectDate(d)}
+            onClick={isDisabled ? undefined : createHandlerSelectDate(d)}
           >
             {d && d.format("D")}
           </div>

--- a/app/vmui/packages/vmui/src/components/Main/DatePicker/DatePicker.tsx
+++ b/app/vmui/packages/vmui/src/components/Main/DatePicker/DatePicker.tsx
@@ -8,13 +8,13 @@ import useBoolean from "../../../hooks/useBoolean";
 import useEventListener from "../../../hooks/useEventListener";
 
 interface DatePickerProps {
-  date: string | Date | Dayjs,
+  date: string | Date | Dayjs;
   targetRef: React.RefObject<HTMLElement>;
   format?: string;
   label?: string;
   minDate?: Date | Dayjs;
   maxDate?: Date | Dayjs;
-  onChange: (val: string) => void
+  onChange: (val: string) => void;
 }
 
 const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(({

--- a/app/vmui/packages/vmui/src/components/Main/TextField/TextField.tsx
+++ b/app/vmui/packages/vmui/src/components/Main/TextField/TextField.tsx
@@ -142,6 +142,7 @@ const TextField: FC<TextFieldProps> = ({
   >
     {startIcon && <div className="vm-text-field__icon-start">{startIcon}</div>}
     {endIcon && <div className="vm-text-field__icon-end">{endIcon}</div>}
+    {label && <span className="vm-text-field__label">{label}</span>}
     {type === "textarea"
       ? (
         <textarea
@@ -180,7 +181,6 @@ const TextField: FC<TextFieldProps> = ({
         />
       )
     }
-    {label && <span className="vm-text-field__label">{label}</span>}
     <TextFieldMessage
       error={error}
       warning={warning}

--- a/app/vmui/packages/vmui/src/components/Main/TextField/style.scss
+++ b/app/vmui/packages/vmui/src/components/Main/TextField/style.scss
@@ -1,7 +1,6 @@
 @use "src/styles/variables" as *;
 
 .vm-text-field {
-  position: relative;
   display: grid;
   margin: 6px 0;
   width: 100%;
@@ -31,7 +30,7 @@
     background-color: transparent;
     font-size: $font-size;
     line-height: 18px;
-    grid-area: 1 / 1 / 2 / 2;
+    grid-area: 2 / 1 / 2 / 2;
     overflow: hidden;
     box-sizing: border-box;
   }
@@ -40,8 +39,10 @@
   &__error,
   &__warning,
   &__helper-text, {
-    position: absolute;
-    left: calc($padding-global/2);
+    width: fit-content;
+    margin-top: calc(($font-size-small/-2) - 1px);
+    margin-bottom: calc(($font-size-small/-2) - 1px);
+    margin-left: calc($padding-global/2);
     max-width: calc(100% - $padding-global);
     padding: 0 3px;
     font-size: $font-size-small;
@@ -59,16 +60,12 @@
   }
 
   &__label {
-    top: calc(($font-size-small/-2) - 2px);
     color: $color-text-secondary;
   }
 
   &__helper-text,
   &__warning,
   &__error {
-    position: relative;
-    top: calc($font-size-small/-2);
-    width: fit-content;
     overflow-wrap: anywhere;
     pointer-events: auto;
     user-select: text;
@@ -152,28 +149,17 @@
 
   &__icon-start,
   &__icon-end {
-    display: flex;
-    align-items: center;
-    justify-content: center;
+    align-self: center;
     max-width: 15px;
-    top: 0;
-    left: $padding-small;
-    height: 36px;
     position: absolute;
     color: $color-text-secondary;
+  }
+
+  &__icon-start {
+    left: $padding-small;
   }
 
   &__icon-end {
-    left: auto;
     right: $padding-small;
-  }
-
-  &__controls-info {
-    position: absolute;
-    bottom: $padding-small;
-    right: $padding-global;
-    color: $color-text-secondary;
-    font-size: $font-size-small;
-    opacity: 0.8;
   }
 }

--- a/app/vmui/packages/vmui/src/components/Table/TableSettings/TableSettings.tsx
+++ b/app/vmui/packages/vmui/src/components/Table/TableSettings/TableSettings.tsx
@@ -198,7 +198,7 @@ const TableSettings: FC<TableSettingsProps> = ({
           {toggleTableCompact && tableCompact !== undefined && (
             <div className="vm-table-settings-modal-section">
               <div className="vm-table-settings-modal-section__title">
-              Table view
+                Table view
               </div>
               <div className="vm-table-settings-modal-columns-list__item">
                 <Switch

--- a/app/vmui/packages/vmui/src/components/TraceQuery/TracingsView.tsx
+++ b/app/vmui/packages/vmui/src/components/TraceQuery/TracingsView.tsx
@@ -75,7 +75,7 @@ const TracingsView: FC<TraceViewProps> = ({ traces, jsonEditor = false, onDelete
           >
             <div className="vm-tracings-view-trace-header">
               <h3 className="vm-tracings-view-trace-header-title">
-              Trace for <b className="vm-tracings-view-trace-header-title__query">{trace.queryValue}</b>
+                Trace for <b className="vm-tracings-view-trace-header-title__query">{trace.queryValue}</b>
               </h3>
               <Tooltip title={expandedTraces.includes(trace.idValue) ? "Collapse All" : "Expand All"}>
                 <Button

--- a/app/vmui/packages/vmui/src/components/Views/TableView/TableView.tsx
+++ b/app/vmui/packages/vmui/src/components/Views/TableView/TableView.tsx
@@ -128,7 +128,7 @@ const TableView: FC<GraphViewProps> = ({ data, displayColumns }) => {
                 >
                   <ArrowDropDownIcon/>
                 </div>
-            Value
+                Value
               </div>
             </td>
             {hasCopyValue && <td className="vm-table-cell vm-table-cell_header"/>}

--- a/app/vmui/packages/vmui/src/hooks/useCopyToClipboard.tsx
+++ b/app/vmui/packages/vmui/src/hooks/useCopyToClipboard.tsx
@@ -61,7 +61,7 @@ const DebugInfoClipboardApi = () => (
             target="_blank"
             rel="noopener noreferrer"
           >
-          Clipboard API documentation
+            Clipboard API documentation
           </a>
         </p>
       </p>

--- a/app/vmui/packages/vmui/src/pages/CardinalityPanel/CardinalityConfigurator/CardinalityConfigurator.tsx
+++ b/app/vmui/packages/vmui/src/pages/CardinalityPanel/CardinalityConfigurator/CardinalityConfigurator.tsx
@@ -116,7 +116,7 @@ const CardinalityConfigurator: FC<CardinalityTotalsProps> = ({ isPrometheus, isC
             withIcon={true}
           >
             <WikiIcon/>
-          Statistic inaccuracy explanation
+            Statistic inaccuracy explanation
           </Hyperlink>
         </div>
       }

--- a/app/vmui/packages/vmui/src/pages/CustomPanel/WarningHeatmapToLine/WarningHeatmapToLine.tsx
+++ b/app/vmui/packages/vmui/src/pages/CustomPanel/WarningHeatmapToLine/WarningHeatmapToLine.tsx
@@ -17,8 +17,8 @@ const WarningHeatmapToLine:FC = () => {
     <Alert variant="warning">
       <div className="vm-warning-heatmap-to-line">
         <p className="vm-warning-heatmap-to-line__text">
-         The expression cannot be displayed as a heatmap.
-         To make the graph work, disable the heatmap in the &quot;Graph settings&quot; or modify the expression.
+          The expression cannot be displayed as a heatmap.
+          To make the graph work, disable the heatmap in the &quot;Graph settings&quot; or modify the expression.
         </p>
 
         <Button

--- a/app/vmui/packages/vmui/src/pages/CustomPanel/WarningLimitSeries/WarningLimitSeries.tsx
+++ b/app/vmui/packages/vmui/src/pages/CustomPanel/WarningLimitSeries/WarningLimitSeries.tsx
@@ -40,7 +40,7 @@ const WarningLimitSeries: FC<Props> = ({ warning, query, onChange }) => {
           variant="outlined"
           onClick={handleShowAll}
         >
-        Show all
+          Show all
         </Button>
       </div>
     </Alert>


### PR DESCRIPTION
TextField component has ability to show error message and depending on it's presence text field height changes, which may cause visibility issues if this field is vertically aligned with some neighbour components. This PR makes textfield height constant and its input box horizontally symmetrical

before:
<img width="618" height="58" alt="image" src="https://github.com/user-attachments/assets/86204cc2-1515-462b-afd2-7d3ec1c34d88" />
<img width="621" height="62" alt="image" src="https://github.com/user-attachments/assets/2e49b527-45dd-4c51-b51d-5fe75de8c303" />


after:

<img width="618" height="58" alt="image" src="https://github.com/user-attachments/assets/86204cc2-1515-462b-afd2-7d3ec1c34d88" />
<img width="622" height="64" alt="image" src="https://github.com/user-attachments/assets/220e86aa-9ffb-4ced-9976-6d5318b79685" />

<img width="1394" height="98" alt="image" src="https://github.com/user-attachments/assets/8989e4f3-efb2-47b9-b404-f8a1436ad690" />


### Describe Your Changes

Please provide a brief description of the changes you made. Be as specific as possible to help others understand the purpose and impact of your modifications.

### Checklist

The following checks are **mandatory**:

- [ ] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [ ] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
