### PR TITLE
app/vmui: add `minDate` and `maxDate` parameters for DatePicker to allow limiting available dates to select

### DIFF
--- a/app/vmui/packages/vmui/src/components/Main/DatePicker/Calendar/Calendar.tsx
+++ b/app/vmui/packages/vmui/src/components/Main/DatePicker/Calendar/Calendar.tsx
@@ -13,6 +13,8 @@ import Button from "../../Button/Button";
 interface DatePickerProps {
   date: Date | Dayjs
   format?: string
+  minDate?: Date | Dayjs
+  maxDate?: Date | Dayjs
   onChange: (date: string) => void
 }
 
@@ -24,6 +26,8 @@ enum CalendarTypeView {
 
 const Calendar: FC<DatePickerProps> = ({
   date,
+  minDate,
+  maxDate,
   format = DATE_TIME_FORMAT,
   onChange,
 }) => {
@@ -34,6 +38,8 @@ const Calendar: FC<DatePickerProps> = ({
   const today = dayjs.tz();
   const viewDateIsToday = today.format(DATE_FORMAT) === viewDate.format(DATE_FORMAT);
   const { isMobile } = useDeviceDetect();
+  const min = minDate ? dayjs(minDate) : undefined;
+  const max = maxDate ? dayjs(maxDate) : undefined;
 
   const toggleDisplayYears = () => {
     setViewType(prev => prev === CalendarTypeView.years ? CalendarTypeView.days : CalendarTypeView.years);
@@ -75,9 +81,13 @@ const Calendar: FC<DatePickerProps> = ({
         onChangeViewDate={handleChangeViewDate}
         toggleDisplayYears={toggleDisplayYears}
         showArrowNav={viewType === CalendarTypeView.days}
+        hasPrev={viewType === CalendarTypeView.days && (!min || viewDate.startOf("month").isAfter(min))}
+        hasNext={viewType === CalendarTypeView.days && (!max || viewDate.endOf("month").isBefore(max))}
       />
       {viewType === CalendarTypeView.days && (
         <CalendarBody
+          minDate={min}
+          maxDate={max}
           viewDate={viewDate}
           selectDate={selectDate}
           onChangeSelectDate={handleChangeSelectDate}
@@ -85,12 +95,16 @@ const Calendar: FC<DatePickerProps> = ({
       )}
       {viewType === CalendarTypeView.years && (
         <YearsList
+          minDate={min}
+          maxDate={max}
           viewDate={viewDate}
           onChangeViewDate={handleChangeViewDate}
         />
       )}
       {viewType === CalendarTypeView.months && (
         <MonthsList
+          minDate={min}
+          maxDate={max}
           selectDate={selectDate}
           viewDate={viewDate}
           onChangeViewDate={handleChangeViewDate}

--- a/app/vmui/packages/vmui/src/components/Main/DatePicker/Calendar/CalendarBody/CalendarBody.tsx
+++ b/app/vmui/packages/vmui/src/components/Main/DatePicker/Calendar/CalendarBody/CalendarBody.tsx
@@ -4,6 +4,8 @@ import classNames from "classnames";
 import Tooltip from "../../../Tooltip/Tooltip";
 
 interface CalendarBodyProps {
+  minDate?: Dayjs
+  maxDate?: Dayjs
   viewDate: Dayjs
   selectDate: Dayjs
   onChangeSelectDate: (date: Dayjs) => void
@@ -11,7 +13,7 @@ interface CalendarBodyProps {
 
 const weekday = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
 
-const CalendarBody: FC<CalendarBodyProps> = ({ viewDate: date, selectDate, onChangeSelectDate }) => {
+const CalendarBody: FC<CalendarBodyProps> = ({ minDate, maxDate, viewDate: date, selectDate, onChangeSelectDate }) => {
   const format = "YYYY-MM-DD";
   const today = dayjs.tz();
   const viewDate = dayjs(date.format(format));
@@ -44,21 +46,25 @@ const CalendarBody: FC<CalendarBodyProps> = ({ viewDate: date, selectDate, onCha
         </Tooltip>
       ))}
 
-      {days.map((d, i) => (
-        <div
-          className={classNames({
-            "vm-calendar-body-cell": true,
-            "vm-calendar-body-cell_day": true,
-            "vm-calendar-body-cell_day_empty": !d,
-            "vm-calendar-body-cell_day_active": (d && d.format(format)) === selectDate.format(format),
-            "vm-calendar-body-cell_day_today": (d && d.format(format)) === today.format(format)
-          })}
-          key={d ? d.format(format) : i}
-          onClick={createHandlerSelectDate(d)}
-        >
-          {d && d.format("D")}
-        </div>
-      ))}
+      {days.map((d, i) => {
+        const isDisabled = d && ((minDate && d.isBefore(minDate)) || (maxDate && d.isAfter(maxDate)));
+        return (
+          <div
+            className={classNames({
+              "vm-calendar-body-cell": true,
+              "vm-calendar-body-cell_day": true,
+              "vm-calendar-body-cell_day_empty": !d,
+              "vm-calendar-body-cell_day_active": (d && d.format(format)) === selectDate.format(format),
+              "vm-calendar-body-cell_day_today": (d && d.format(format)) === today.format(format),
+              "vm-calendar-body-cell_day_disabled": isDisabled,
+            })}
+            key={d ? d.format(format) : i}
+            onClick={createHandlerSelectDate(d)}
+          >
+            {d && d.format("D")}
+          </div>
+        );
+      })}
     </div>
   );
 };

--- a/app/vmui/packages/vmui/src/components/Main/DatePicker/Calendar/CalendarHeader/CalendarHeader.tsx
+++ b/app/vmui/packages/vmui/src/components/Main/DatePicker/Calendar/CalendarHeader/CalendarHeader.tsx
@@ -1,15 +1,18 @@
 import { FC } from "preact/compat";
 import { Dayjs } from "dayjs";
 import { ArrowDownIcon, ArrowDropDownIcon } from "../../../Icons";
+import classNames from "classnames";
 
 interface CalendarHeaderProps {
   viewDate: Dayjs
   onChangeViewDate: (date: Dayjs) => void
   showArrowNav: boolean
   toggleDisplayYears: () => void
+  hasNext: boolean
+  hasPrev: boolean
 }
 
-const CalendarHeader: FC<CalendarHeaderProps> = ({ viewDate, showArrowNav, onChangeViewDate, toggleDisplayYears }) => {
+const CalendarHeader: FC<CalendarHeaderProps> = ({ hasPrev, hasNext, viewDate, showArrowNav, onChangeViewDate, toggleDisplayYears }) => {
 
   const setPrevMonth = () => {
     onChangeViewDate(viewDate.subtract(1, "month"));
@@ -35,14 +38,20 @@ const CalendarHeader: FC<CalendarHeaderProps> = ({ viewDate, showArrowNav, onCha
       {showArrowNav && (
         <div className="vm-calendar-header-right">
           <div
-            className="vm-calendar-header-right__prev"
-            onClick={setPrevMonth}
+            className={classNames({
+              "vm-calendar-header-right__prev": true,
+              "vm-calendar-header-right_disabled": !hasPrev,
+            })}
+            onClick={hasPrev ? setPrevMonth : undefined}
           >
             <ArrowDownIcon/>
           </div>
           <div
-            className="vm-calendar-header-right__next"
-            onClick={setNextMonth}
+            className={classNames({
+              "vm-calendar-header-right__next": true,
+              "vm-calendar-header-right_disabled": !hasNext,
+            })}
+            onClick={hasNext ? setNextMonth : undefined}
           >
             <ArrowDownIcon/>
           </div>

--- a/app/vmui/packages/vmui/src/components/Main/DatePicker/Calendar/MonthsList/MonthsList.tsx
+++ b/app/vmui/packages/vmui/src/components/Main/DatePicker/Calendar/MonthsList/MonthsList.tsx
@@ -3,13 +3,14 @@ import dayjs, { Dayjs } from "dayjs";
 import classNames from "classnames";
 
 interface CalendarMonthsProps {
+  minDate?: Dayjs
+  maxDate?: Dayjs
   viewDate: Dayjs,
   selectDate: Dayjs
-
   onChangeViewDate: (date: Dayjs) => void
 }
 
-const MonthsList: FC<CalendarMonthsProps> = ({ viewDate, selectDate, onChangeViewDate }) => {
+const MonthsList: FC<CalendarMonthsProps> = ({ minDate, maxDate, viewDate, selectDate, onChangeViewDate }) => {
 
   const today = dayjs().format("MM");
   const currentMonths = useMemo(() => selectDate.format("MM"), [selectDate]);
@@ -29,20 +30,24 @@ const MonthsList: FC<CalendarMonthsProps> = ({ viewDate, selectDate, onChangeVie
 
   return (
     <div className="vm-calendar-years">
-      {months.map(m => (
-        <div
-          className={classNames({
-            "vm-calendar-years__year": true,
-            "vm-calendar-years__year_selected": m.format("MM") === currentMonths,
-            "vm-calendar-years__year_today": m.format("MM") === today
-          })}
-          id={`vm-calendar-year-${m.format("MM")}`}
-          key={m.format("MM")}
-          onClick={createHandlerClick(m)}
-        >
-          {m.format("MMMM")}
-        </div>
-      ))}
+      {months.map(m => {
+        const isDisabled = m && ((minDate && m.isBefore(minDate)) || (maxDate && m.isAfter(maxDate)));
+        return (
+          <div
+            className={classNames({
+              "vm-calendar-years__year": true,
+              "vm-calendar-years__year_selected": m.format("MM") === currentMonths,
+              "vm-calendar-years__year_today": m.format("MM") === today,
+              "vm-calendar-years__year_disabled": isDisabled,
+            })}
+            id={`vm-calendar-year-${m.format("MM")}`}
+            key={m.format("MM")}
+            onClick={isDisabled ? undefined : createHandlerClick(m)}
+          >
+            {m.format("MMMM")}
+          </div>
+        );
+      })}
     </div>
   );
 };

--- a/app/vmui/packages/vmui/src/components/Main/DatePicker/Calendar/YearsList/YearsList.tsx
+++ b/app/vmui/packages/vmui/src/components/Main/DatePicker/Calendar/YearsList/YearsList.tsx
@@ -3,11 +3,13 @@ import dayjs, { Dayjs } from "dayjs";
 import classNames from "classnames";
 
 interface CalendarYearsProps {
+  minDate?: Dayjs
+  maxDate?: Dayjs
   viewDate: Dayjs
   onChangeViewDate: (date: Dayjs) => void
 }
 
-const YearsList: FC<CalendarYearsProps> = ({ viewDate, onChangeViewDate }) => {
+const YearsList: FC<CalendarYearsProps> = ({ minDate, maxDate, viewDate, onChangeViewDate }) => {
 
   const today = dayjs().format("YYYY");
   const currentYear = useMemo(() => viewDate.format("YYYY"), [viewDate]);
@@ -30,20 +32,24 @@ const YearsList: FC<CalendarYearsProps> = ({ viewDate, onChangeViewDate }) => {
 
   return (
     <div className="vm-calendar-years">
-      {years.map(y => (
-        <div
-          className={classNames({
-            "vm-calendar-years__year": true,
-            "vm-calendar-years__year_selected": y.format("YYYY") === currentYear,
-            "vm-calendar-years__year_today": y.format("YYYY") === today
-          })}
-          id={`vm-calendar-year-${y.format("YYYY")}`}
-          key={y.format("YYYY")}
-          onClick={createHandlerClick(y)}
-        >
-          {y.format("YYYY")}
-        </div>
-      ))}
+      {years.map(y => {
+        const isDisabled = y && (minDate && y.isBefore(minDate)) || (maxDate && y.isAfter(maxDate));
+        return (
+          <div
+            className={classNames({
+              "vm-calendar-years__year": true,
+              "vm-calendar-years__year_selected": y.format("YYYY") === currentYear,
+              "vm-calendar-years__year_today": y.format("YYYY") === today,
+              "vm-calendar-years__year_disabled": isDisabled,
+            })}
+            id={`vm-calendar-year-${y.format("YYYY")}`}
+            key={y.format("YYYY")}
+            onClick={isDisabled ? undefined : createHandlerClick(y)}
+          >
+            {y.format("YYYY")}
+          </div>
+        );
+      })}
     </div>
   );
 };

--- a/app/vmui/packages/vmui/src/components/Main/DatePicker/Calendar/style.scss
+++ b/app/vmui/packages/vmui/src/components/Main/DatePicker/Calendar/style.scss
@@ -69,6 +69,10 @@
         }
       }
 
+      &_disabled {
+        color: $color-text-disabled;
+      }
+
       &__prev {
         transform: rotate(90deg);
       }
@@ -108,7 +112,12 @@
         cursor: pointer;
         transition: color 200ms ease, background-color 300ms ease-in-out;
 
-        &:hover {
+        &_disabled {
+          cursor: unset;
+          color: $color-text-disabled;
+        }
+
+        &:not(&_disabled):hover {
           background-color: $color-hover-black;
         }
 
@@ -148,7 +157,12 @@
       cursor: pointer;
       transition: color 200ms ease, background-color 300ms ease-in-out;
 
-      &:hover {
+      &_disabled {
+        cursor: unset;
+        color: $color-text-disabled;
+      }
+
+      &:not(&_disabled):hover {
         background-color: $color-hover-black;
       }
 

--- a/app/vmui/packages/vmui/src/components/Main/DatePicker/DatePicker.tsx
+++ b/app/vmui/packages/vmui/src/components/Main/DatePicker/DatePicker.tsx
@@ -10,8 +10,10 @@ import useEventListener from "../../../hooks/useEventListener";
 interface DatePickerProps {
   date: string | Date | Dayjs,
   targetRef: React.RefObject<HTMLElement>;
-  format?: string
-  label?: string
+  format?: string;
+  label?: string;
+  minDate?: Date | Dayjs;
+  maxDate?: Date | Dayjs;
   onChange: (val: string) => void
 }
 
@@ -20,7 +22,9 @@ const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(({
   targetRef,
   format = DATE_TIME_FORMAT,
   onChange,
-  label
+  label,
+  minDate,
+  maxDate
 }, ref) => {
   const dateDayjs = useMemo(() => dayjs(date).isValid() ? dayjs.tz(date) : dayjs().tz(), [date]);
   const { isMobile } = useDeviceDetect();
@@ -56,6 +60,8 @@ const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(({
           date={dateDayjs}
           format={format}
           onChange={handleChangeDate}
+          minDate={minDate}
+          maxDate={maxDate}
         />
       </div>
     </Popper>

--- a/app/vmui/packages/vmui/src/components/Main/DatePicker/DateTimeInput/DateTimeInput.tsx
+++ b/app/vmui/packages/vmui/src/components/Main/DatePicker/DateTimeInput/DateTimeInput.tsx
@@ -3,29 +3,39 @@ import { ChangeEvent, KeyboardEvent } from "react";
 import { CalendarIcon } from "../../Icons";
 import DatePicker from "../DatePicker";
 import Button from "../../Button/Button";
-import { DATE_TIME_FORMAT } from "../../../../constants/date";
+import { DATE_ISO_FORMAT, DATE_FORMAT, DATE_TIME_FORMAT } from "../../../../constants/date";
 import InputMask from "react-input-mask";
-import dayjs from "dayjs";
+import dayjs, { Dayjs } from "dayjs";
 import classNames from "classnames";
 import "./style.scss";
 
-const formatStringDate = (val: string) => {
-  return dayjs(val).isValid() ? dayjs.tz(val).format(DATE_TIME_FORMAT) : val;
+const formatStringDate = (val: string, format: string) => {
+  return dayjs(val).isValid() ? dayjs.tz(val).format(format) : val;
 };
 
 interface DateTimeInputProps {
   value?:  string;
   label: string;
   pickerLabel: string;
-  dateOnly?: boolean;
+  format?: string;
   pickerRef: React.RefObject<HTMLDivElement>;
   onChange: (date: string) => void;
   onEnter: () => void;
+  minDate?: Date | Dayjs;
+  maxDate?: Date | Dayjs;
 }
+
+const masks: Record<string, string> = {
+  [DATE_ISO_FORMAT]: "9999-99-99T99:99:99",
+  [DATE_FORMAT]: "9999-99-99",
+  [DATE_TIME_FORMAT]: "9999-99-99 99:99:99"
+};
 
 const DateTimeInput: FC<DateTimeInputProps> = ({
   value = "",
-  dateOnly = false,
+  format = DATE_TIME_FORMAT,
+  minDate,
+  maxDate,
   label,
   pickerLabel,
   pickerRef,
@@ -34,8 +44,9 @@ const DateTimeInput: FC<DateTimeInputProps> = ({
 }) => {
   const wrapperRef = useRef<HTMLDivElement>(null);
   const [inputRef, setInputRef] = useState<HTMLInputElement | null>(null);
+  const mask = masks[format];
 
-  const [maskedValue, setMaskedValue] = useState(formatStringDate(value));
+  const [maskedValue, setMaskedValue] = useState(formatStringDate(value, format));
   const [focusToTime, setFocusToTime] = useState(false);
   const [awaitChangeForEnter, setAwaitChangeForEnter] = useState(false);
   const error = dayjs(maskedValue).isValid() ? "" : "Invalid date format";
@@ -55,16 +66,13 @@ const DateTimeInput: FC<DateTimeInputProps> = ({
     }
   };
 
-  const mask = dateOnly ? "9999-99-99" : "9999-99-99 99:99:99";
-  const placeholder = dateOnly ? "YYYY-MM-DD" : "YYYY-MM-DD HH:mm:ss";
-
   const handleChangeDate = (val: string) => {
     setMaskedValue(val);
     setFocusToTime(true);
   };
 
   useEffect(() => {
-    const newValue = formatStringDate(value);
+    const newValue = formatStringDate(value, format);
     if (newValue !== maskedValue) {
       setMaskedValue(newValue);
     }
@@ -95,7 +103,7 @@ const DateTimeInput: FC<DateTimeInputProps> = ({
         tabIndex={1}
         inputRef={setInputRef}
         mask={mask}
-        placeholder={placeholder}
+        placeholder={format}
         value={maskedValue}
         autoCapitalize={"none"}
         inputMode={"numeric"}
@@ -125,6 +133,9 @@ const DateTimeInput: FC<DateTimeInputProps> = ({
         date={maskedValue}
         onChange={handleChangeDate}
         targetRef={wrapperRef}
+        minDate={minDate}
+        maxDate={maxDate}
+        format={format}
       />
     </div>
   );


### PR DESCRIPTION
add ability to limit available in datePicker dates using `minDate` and `maxDate` parameters. all dates before `minDate` and after `maxDate` cannot be picked. lower and upper bounds can be set independently.

<img width="261" height="299" alt="image" src="https://github.com/user-attachments/assets/71700843-4f68-40df-a861-e445f702734a" />
<img width="245" height="285" alt="image" src="https://github.com/user-attachments/assets/433ef2f8-5058-434f-817e-4b374cc6c504" />
<img width="356" height="205" alt="image" src="https://github.com/user-attachments/assets/920fd13a-aceb-454b-baf9-844d8d79ecd3" />


### Describe Your Changes

Please provide a brief description of the changes you made. Be as specific as possible to help others understand the purpose and impact of your modifications.

### Checklist

The following checks are **mandatory**:

- [ ] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [ ] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
