### PR TITLE
app/vmui: reset select values, when 'ALL' selected

### DIFF
--- a/app/vmui/packages/vmui/src/components/Main/Select/Select.tsx
+++ b/app/vmui/packages/vmui/src/components/Main/Select/Select.tsx
@@ -46,6 +46,7 @@ const Select: FC<SelectProps> = ({
   const autocompleteAnchorEl = useRef<HTMLDivElement>(null);
   const [wrapperRef, setWrapperRef] = useState<React.RefObject<HTMLElement> | null>(null);
   const [openList, setOpenList] = useState(false);
+  const resultList = [...list];
 
   const inputRef = useRef<HTMLInputElement>(null);
 
@@ -77,7 +78,7 @@ const Select: FC<SelectProps> = ({
   };
 
   const handleBlur = () => {
-    list.includes(search) && onChange(search);
+    resultList.includes(search) && onChange(search);
   };
 
   const handleToggleList = (e: MouseEvent<HTMLDivElement>) => {
@@ -123,8 +124,11 @@ const Select: FC<SelectProps> = ({
   useEventListener("keyup", handleKeyUp);
   useClickOutside(autocompleteAnchorEl, handleCloseList, wrapperRef);
 
-  includeAll && !list.includes("All") && list.push("All");
-  includeAll && !selectedValues?.length && selectedValues.push("All");
+  if (includeAll && !resultList.includes("All")) resultList.push("All");
+  if (includeAll && (!selectedValues?.length || selectedValues?.length === resultList?.length)) {
+    selectedValues.splice(0, selectedValues?.length);
+    selectedValues.push("All");
+  }
 
   return (
     <div
@@ -182,7 +186,7 @@ const Select: FC<SelectProps> = ({
         itemClassName={itemClassName}
         label={label}
         value={autocompleteValue}
-        options={list.map(l => ({ value: l }))}
+        options={resultList.map(l => ({ value: l }))}
         anchor={autocompleteAnchorEl}
         selected={selectedValues}
         minLength={1}

--- a/app/vmui/packages/vmui/src/components/Main/Select/Select.tsx
+++ b/app/vmui/packages/vmui/src/components/Main/Select/Select.tsx
@@ -51,7 +51,7 @@ const Select: FC<SelectProps> = ({
   const inputRef = useRef<HTMLInputElement>(null);
 
   const isMultiple = Array.isArray(value);
-  const selectedValues = Array.isArray(value) ? value.slice() : [];
+  let selectedValues = Array.isArray(value) ? value.slice() : [];
   const hideInput = isMobile && isMultiple && !!selectedValues?.length;
 
   const textFieldValue = useMemo(() => {
@@ -126,8 +126,7 @@ const Select: FC<SelectProps> = ({
 
   if (includeAll && !resultList.includes("All")) resultList.push("All");
   if (includeAll && (!selectedValues?.length || selectedValues?.length === resultList?.length)) {
-    selectedValues.splice(0, selectedValues?.length);
-    selectedValues.push("All");
+    selectedValues = ["All"];
   }
 
   return (

--- a/app/vmui/packages/vmui/src/pages/ExploreAlerts/ExploreRules.tsx
+++ b/app/vmui/packages/vmui/src/pages/ExploreAlerts/ExploreRules.tsx
@@ -155,8 +155,8 @@ const ExploreRules: FC = () => {
     [groups, types, states, searchInput]
   );
 
-  if (allTypes.size === types.length) types.splice(0, types.length);
-  if (allStates.size === states.length) states.splice(0, states.length);
+  const selectedTypes = allTypes.size === types.length ? [] : types;
+  const selectedStates = allStates.size === states.length ? [] : states;
 
   return (
     <>
@@ -164,9 +164,9 @@ const ExploreRules: FC = () => {
       {(!modalOpen || !!allStates?.size) && (
         <div className="vm-explore-alerts">
           <RulesHeader
-            types={types}
+            types={selectedTypes}
             allTypes={Array.from(allTypes)}
-            states={states}
+            states={selectedStates}
             allStates={Array.from(allStates)}
             onChangeTypes={handleChangeTypes}
             onChangeStates={handleChangeStates}

--- a/app/vmui/packages/vmui/src/pages/ExploreAlerts/ExploreRules.tsx
+++ b/app/vmui/packages/vmui/src/pages/ExploreAlerts/ExploreRules.tsx
@@ -155,6 +155,9 @@ const ExploreRules: FC = () => {
     [groups, types, states, searchInput]
   );
 
+  if (allTypes.size === types.length) types.splice(0, types.length);
+  if (allStates.size === states.length) states.splice(0, states.length);
+
   return (
     <>
       {modalOpen && getModal()}


### PR DESCRIPTION
### Describe Your Changes

resetting Select component selected items, when all items are selected, this should speed up filtering on alerting page on VMUI

### Checklist

The following checks are **mandatory**:

- [ ] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [ ] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
