### PR TITLE
app/vmui: fixed backend URL for multitenant endpoints

### DIFF
--- a/app/vmui/packages/vmui/src/utils/default-server-url.test.ts
+++ b/app/vmui/packages/vmui/src/utils/default-server-url.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+import { getDefaultURL } from "./default-server-url";
+
+describe("test server urls", () => {
+  describe("getDefaultURL()", () => {
+    it("/select/0/vmui/", () => {
+      const result = getDefaultURL("https://localhost:1111/select/0/vmui/");
+      expect(result).toBe("https://localhost:1111/select/0/prometheus");
+    });
+
+    it("/any/path/prefix/select/multitenant/vmui/#/rules?q=test", () => {
+      const result = getDefaultURL("http://test/any/path/prefix/select/multitenant/vmui/#/rules?q=test");
+      expect(result).toBe("http://test/any/path/prefix/select/multitenant/prometheus");
+    });
+
+    it("/test/select/1:1/prometheus/graph/", () => {
+      const result = getDefaultURL("https://domain.com/test/select/1:1/prometheus/graph/");
+      expect(result).toBe("https://domain.com/test/select/1:1/prometheus");
+    });
+
+    it("https://play.vm.com/#/rules?q=test", () => {
+      const result = getDefaultURL("https://play.vm.com/#/rules?q=test");
+      expect(result).toBe("https://play.vm.com");
+    });
+  });
+});

--- a/app/vmui/packages/vmui/src/utils/default-server-url.ts
+++ b/app/vmui/packages/vmui/src/utils/default-server-url.ts
@@ -3,12 +3,15 @@ import { replaceTenantId } from "./tenants";
 import { APP_TYPE, AppType } from "../constants/appType";
 import { getFromStorage } from "./storage";
 
+export const getDefaultURL = (u: string) => {
+  return u.replace(/(\/(?:prometheus\/)?(?:graph|vmui)\/.*|\/#\/.*)/, "").replace(/(\/select\/[^/]+)$/, "$1/prometheus");
+};
+
 export const getDefaultServer = (tenantId?: string): string => {
   const { serverURL } = getAppModeParams();
   const storageURL = getFromStorage("SERVER_URL") as string;
   const anomalyURL = `${window.location.origin}${window.location.pathname.replace(/^\/vmui/, "")}`;
-  const baseURL = window.location.href.replace(/(\/(?:prometheus\/)?(?:graph|vmui)\/.*|\/#\/.*)/, "");
-  const defaultURL = baseURL.replace(/(\/select\/[\d:]+)$/, "$1/prometheus");
+  const defaultURL = getDefaultURL(window.location.href);
   const url = serverURL || storageURL || defaultURL;
 
   switch (APP_TYPE) {

--- a/app/vmui/packages/vmui/src/utils/tenants.ts
+++ b/app/vmui/packages/vmui/src/utils/tenants.ts
@@ -1,4 +1,4 @@
-const regexp = /(\/select\/)(\d+|\d.+)(\/)(.+)/;
+const regexp = /(\/select\/)([^/])(\/)(.+)/;
 
 export const replaceTenantId = (serverUrl: string, tenantId: string) => {
   return serverUrl.replace(regexp, `$1${tenantId}/$4`);

--- a/docs/victoriametrics/changelog/CHANGELOG.md
+++ b/docs/victoriametrics/changelog/CHANGELOG.md
@@ -34,6 +34,7 @@ See also [LTS releases](https://docs.victoriametrics.com/victoriametrics/lts-rel
 * BUGFIX: [vmalert](https://docs.victoriametrics.com/victoriametrics/vmalert/): fix possible partial rule update responses in group-related APIs during group updates in hot config reload. See [#9551](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/9551)
 * BUGFIX: [vmui](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#vmui): properly apply rollup functions to metrics based on their name in vmui's [metrics explorer](https://docs.victoriametrics.com/victoriametrics/#metrics-explorer). See [#9655](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/9655) for details. Thanks to @wbwren-eric for the fix. 
 * BUGFIX: all VictoriaMetrics [enterprise](https://docs.victoriametrics.com/enterprise/) components: fix support for automatic issuing of TLS certificates for HTTPS server via [Let's Encrypt service](https://letsencrypt.org/) using [TLS-ALPN-01 challenge](https://letsencrypt.org/docs/challenge-types/#tls-alpn-01). See [Automatic issuing of TLS certificates](https://docs.victoriametrics.com/victoriametrics/#automatic-issuing-of-tls-certificates) for more info.
+* BUGFIX: [vmui](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#vmui): fix VMUI backend URL, while using multitenant API. See more in [#9703](https://github.com/VictoriaMetrics/VictoriaMetrics/pull/9703).
 
 ## [v1.125.1](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.125.1)
 


### PR DESCRIPTION
### Describe Your Changes

vmui builds incorrect endpoint, while using multitenant API. bug was introduced in PR #8989

### Checklist

The following checks are **mandatory**:

- [ ] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [ ] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
