### PR TITLE
docs/vmbackupmanager: add docs to clarify unsafe usage of lifecycle rules

### DIFF
--- a/docs/victoriametrics/vmbackupmanager.md
+++ b/docs/victoriametrics/vmbackupmanager.md
@@ -158,9 +158,9 @@ Backup retention policy is controlled by:
 
 > `0` value in every `keepLast*` flag results into deletion of ALL backups for particular type (hourly, daily, weekly and monthly)
 
-> Retention policy does not enforce removing previous versions of objects in object storages if versioning is enabled. See [these docs](https://docs.victoriametrics.com/victoriametrics/vmbackup/#permanent-deletion-of-objects-in-s3-compatible-storages) for more details.
+> Retention policy does not enforce removing previous versions of objects in object storages if versioning is enabled. See [permanent deletion of objects in s3 compatible-storages](https://docs.victoriametrics.com/victoriametrics/vmbackup/#permanent-deletion-of-objects-in-s3-compatible-storages) for more details.
 
-> It is possible enforce retention by using object storage lifecycle rules. Please, see [these docs](https://docs.victoriametrics.com/victoriametrics/vmbackupmanager/#retention-by-using-object-storage-lifecycle-rules) for more details.
+> It is possible enforce retention by using object storage lifecycle rules. Please, see [retention by using object storage lifecycle rules](https://docs.victoriametrics.com/victoriametrics/vmbackupmanager/#retention-by-using-object-storage-lifecycle-rules) for more details.
 
 Let’s assume we have a backup manager collecting daily backups for the past 10 days.
 
@@ -193,7 +193,7 @@ The result on the GCS bucket. We see only 3 daily backups:
 
 #### Retention by using object storage lifecycle rules
 
-It is possible to enforce retention by using object storage lifecycle rules.
+It is possible to enforce retention by using [object storage lifecycle rules](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-lifecycle-mgmt.html).
 In order to do that it is required not use `keepLast*` flags in `vmbackupmanager` and configure lifecycle rules
 in your object storage to remove objects under `/hourly/`, `/daily/`, `/weekly/` and `/monthly/` prefixes.
 

--- a/docs/victoriametrics/vmbackupmanager.md
+++ b/docs/victoriametrics/vmbackupmanager.md
@@ -156,9 +156,13 @@ Backup retention policy is controlled by:
 * `-keepLastWeekly` - keep the last N weekly backups. Disabled by default
 * `-keepLastMonthly` - keep the last N monthly backups. Disabled by default
 
-> *Note*: 0 value in every keepLast flag results into deletion of ALL backups for particular type (hourly, daily, weekly and monthly)
+> `0` value in every `keepLast*` flag results into deletion of ALL backups for particular type (hourly, daily, weekly and monthly)
 
-> *Note*: retention policy does not enforce removing previous versions of objects in object storages such if versioning is enabled. See [these docs](https://docs.victoriametrics.com/victoriametrics/vmbackup/#permanent-deletion-of-objects-in-s3-compatible-storages) for more details.
+> Retention policy does not enforce removing previous versions of objects in object storages such if versioning is enabled. See [these docs](https://docs.victoriametrics.com/victoriametrics/vmbackup/#permanent-deletion-of-objects-in-s3-compatible-storages) for more details.
+
+> It is not safe to use object lifecycle rules provided by object storage for backup retention.
+> `vmbackupmanager` and `vmbackup` preserve original creation dates of the files when uploading data to object storage. Lifecycle rules of the object storage will be applied to original partition creation dates and not to the backup creation dates.
+> This may lead to deleting data which is still required for restoring from backup.
 
 Let’s assume we have a backup manager collecting daily backups for the past 10 days.
 
@@ -187,7 +191,7 @@ info    app/vmbackupmanager/retention.go:106    daily backups to delete [daily/2
 
 The result on the GCS bucket. We see only 3 daily backups:
 
-[retention policy daily after retention cycle](vmbackupmanager_rp_daily_2.webp "retention policy daily after retention cycle")
+![retention policy daily after retention cycle](vmbackupmanager_rp_daily_2.webp "retention policy daily after retention cycle")
 
 #### Protection backups against deletion by retention policy
 
@@ -235,7 +239,7 @@ For example:
   ```json
   [{"name":"daily/2023-04-07","size_bytes":318837,"size":"311.4ki","created_at":"2023-04-07T16:15:07+00:00"},{"name":"hourly/2023-04-07:11","size_bytes":318837,"size":"311.4ki","created_at":"2023-04-07T16:15:06+00:00"},{"name":"latest","size_bytes":318837,"size":"311.4ki","created_at":"2023-04-07T16:15:04+00:00"},{"name":"monthly/2023-04","size_bytes":318837,"size":"311.4ki","created_at":"2023-04-07T16:15:10+00:00"},{"name":"weekly/2023-14","size_bytes":318837,"size":"311.4ki","created_at":"2023-04-07T16:15:09+00:00"}]
   ```
-  > Note: `created_at` field is in RFC3339 format.
+  > `created_at` field is in RFC3339 format.
   
 * PUT `/api/v1/backups/<BACKUP_NAME>` - update "locked" attribute for backup by name.
   Example request body:

--- a/docs/victoriametrics/vmbackupmanager.md
+++ b/docs/victoriametrics/vmbackupmanager.md
@@ -158,7 +158,7 @@ Backup retention policy is controlled by:
 
 > `0` value in every `keepLast*` flag results into deletion of ALL backups for particular type (hourly, daily, weekly and monthly)
 
-> Retention policy does not enforce removing previous versions of objects in object storages such if versioning is enabled. See [these docs](https://docs.victoriametrics.com/victoriametrics/vmbackup/#permanent-deletion-of-objects-in-s3-compatible-storages) for more details.
+> Retention policy does not enforce removing previous versions of objects in object storages if versioning is enabled. See [these docs](https://docs.victoriametrics.com/victoriametrics/vmbackup/#permanent-deletion-of-objects-in-s3-compatible-storages) for more details.
 
 > It is not safe to use object lifecycle rules provided by object storage for backup retention.
 > `vmbackupmanager` and `vmbackup` preserve original creation dates of the files when uploading data to object storage. Lifecycle rules of the object storage will be applied to original partition creation dates and not to the backup creation dates.

--- a/docs/victoriametrics/vmbackupmanager.md
+++ b/docs/victoriametrics/vmbackupmanager.md
@@ -160,9 +160,7 @@ Backup retention policy is controlled by:
 
 > Retention policy does not enforce removing previous versions of objects in object storages if versioning is enabled. See [these docs](https://docs.victoriametrics.com/victoriametrics/vmbackup/#permanent-deletion-of-objects-in-s3-compatible-storages) for more details.
 
-> It is not safe to use object lifecycle rules provided by object storage for backup retention.
-> `vmbackupmanager` and `vmbackup` preserve original creation dates of the files when uploading data to object storage. Lifecycle rules of the object storage will be applied to original partition creation dates and not to the backup creation dates.
-> This may lead to deleting data which is still required for restoring from backup.
+> It is possible enforce retention by using object storage lifecycle rules. Please, see [these docs](https://docs.victoriametrics.com/victoriametrics/vmbackupmanager/#retention-by-using-object-storage-lifecycle-rules) for more details.
 
 Let’s assume we have a backup manager collecting daily backups for the past 10 days.
 
@@ -192,6 +190,15 @@ info    app/vmbackupmanager/retention.go:106    daily backups to delete [daily/2
 The result on the GCS bucket. We see only 3 daily backups:
 
 ![retention policy daily after retention cycle](vmbackupmanager_rp_daily_2.webp "retention policy daily after retention cycle")
+
+#### Retention by using object storage lifecycle rules
+
+It is possible to enforce retention by using object storage lifecycle rules.
+In order to do that it is required not use `keepLast*` flags in `vmbackupmanager` and configure lifecycle rules
+in your object storage to remove objects under `/hourly/`, `/daily/`, `/weekly/` and `/monthly/` prefixes.
+
+Note that `/latest/` prefix must be excluded from lifecycle rules as it saves files with original modification time.
+This means that files under `/latest/` prefix will be removed by lifecycle rules if they are older than specified in the rules.
 
 #### Protection backups against deletion by retention policy
 


### PR DESCRIPTION
- state that it is unsafe to use lifecycle rules and describe the reason
- update formatting according latest changes in docs


<details> 
<summary>Updated formatting</summary>
<img width="917" height="571" alt="image" src="https://github.com/user-attachments/assets/360fe462-9405-4b01-bb1f-7bd3e5f52224" />

<img width="913" height="101" alt="image" src="https://github.com/user-attachments/assets/307690d6-ea6a-4509-acc8-a1d8534721a6" />

</details>