### PR TITLE
lib/timerpool: removed unneeded code, unified package usage

### DIFF
--- a/app/vmselect/graphite/eval.go
+++ b/app/vmselect/graphite/eval.go
@@ -197,13 +197,13 @@ func newNextSeriesForSearchQuery(ec *evalConfig, sq *storage.SearchQuery, expr g
 			}
 			s.summarize(aggrAvg, ec.startTime, ec.endTime, ec.storageStep, 0)
 			t := timerpool.Get(30 * time.Second)
+			defer timerpool.Put(t)
 			select {
 			case seriesCh <- s:
 			case <-t.C:
 				logger.Errorf("resource leak when processing the %s (full query: %s); please report this error to VictoriaMetrics developers",
 					expr.AppendString(nil), ec.originalQuery)
 			}
-			timerpool.Put(t)
 			return nil
 		})
 		close(seriesCh)

--- a/lib/streamaggr/streamaggr.go
+++ b/lib/streamaggr/streamaggr.go
@@ -802,7 +802,7 @@ func (a *aggregator) runFlusher(pushFunc PushFunc, alignFlushToInterval, skipInc
 			return
 		}
 		timer := timerpool.Get(dSleep)
-		defer timer.Stop()
+		defer timerpool.Put(timer)
 		select {
 		case <-a.stopCh:
 		case <-timer.C:

--- a/lib/timerpool/timerpool.go
+++ b/lib/timerpool/timerpool.go
@@ -25,13 +25,7 @@ func Get(d time.Duration) *time.Timer {
 //
 // t cannot be accessed after returning to the pool.
 func Put(t *time.Timer) {
-	if !t.Stop() {
-		// Drain t.C if it wasn't obtained by the caller yet.
-		select {
-		case <-t.C:
-		default:
-		}
-	}
+	t.Stop()
 	timerPool.Put(t)
 }
 

--- a/lib/writeconcurrencylimiter/concurrencylimiter.go
+++ b/lib/writeconcurrencylimiter/concurrencylimiter.go
@@ -115,12 +115,11 @@ func incConcurrency() bool {
 
 	concurrencyLimitReached.Inc()
 	t := timerpool.Get(*maxQueueDuration)
+	defer timerpool.Put(t)
 	select {
 	case concurrencyLimitCh <- struct{}{}:
-		timerpool.Put(t)
 		return true
 	case <-t.C:
-		timerpool.Put(t)
 		concurrencyLimitTimeout.Inc()
 		return false
 	}


### PR DESCRIPTION
### Describe Your Changes

after golang 1.23 it's enough just to stop timer, no need to drain a channel

related issue https://github.com/VictoriaMetrics/VictoriaMetrics/issues/9721, but this is not a fix for it

### Checklist

The following checks are **mandatory**:

- [ ] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [ ] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
