### PR TITLE
vmalert: add `-rule.resultLimit` command-line flag to allow limiting …

### DIFF
--- a/app/vmalert/config/config.go
+++ b/app/vmalert/config/config.go
@@ -31,7 +31,7 @@ type Group struct {
 	// EvalDelay will adjust the `time` parameter of rule evaluation requests to compensate intentional query delay from datasource.
 	// see https://github.com/VictoriaMetrics/VictoriaMetrics/issues/5155
 	EvalDelay   *promutil.Duration `yaml:"eval_delay,omitempty"`
-	Limit       int                `yaml:"limit,omitempty"`
+	Limit       *int               `yaml:"limit,omitempty"`
 	Rules       []Rule             `yaml:"rules"`
 	Concurrency int                `yaml:"concurrency"`
 	// Labels is a set of label value pairs, that will be added to every rule.
@@ -91,8 +91,8 @@ func (g *Group) Validate(validateTplFn ValidateTplFn, validateExpressions bool) 
 	if g.EvalOffset != nil && g.EvalDelay != nil {
 		return fmt.Errorf("eval_offset cannot be used with eval_delay")
 	}
-	if g.Limit < 0 {
-		return fmt.Errorf("invalid limit %d, shouldn't be less than 0", g.Limit)
+	if g.Limit != nil && *g.Limit < 0 {
+		return fmt.Errorf("invalid limit %d, shouldn't be less than 0", *g.Limit)
 	}
 	if g.Concurrency < 0 {
 		return fmt.Errorf("invalid concurrency %d, shouldn't be less than 0", g.Concurrency)

--- a/app/vmalert/config/config_test.go
+++ b/app/vmalert/config/config_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/VictoriaMetrics/VictoriaMetrics/app/vmalert/notifier"
 	"github.com/VictoriaMetrics/VictoriaMetrics/app/vmalert/templates"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/promutil"
-	"github.com/aws/smithy-go/ptr"
 	"gopkg.in/yaml.v2"
 )
 
@@ -182,9 +181,10 @@ func TestGroupValidate_Failure(t *testing.T) {
 		EvalOffset: promutil.NewDuration(2 * time.Minute),
 	}, false, "eval_offset should be smaller than interval")
 
+	limit := -1
 	f(&Group{
 		Name:  "wrong limit",
-		Limit: ptr.Int(-1),
+		Limit: &limit,
 	}, false, "invalid limit")
 
 	f(&Group{

--- a/app/vmalert/config/config_test.go
+++ b/app/vmalert/config/config_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/VictoriaMetrics/VictoriaMetrics/app/vmalert/notifier"
 	"github.com/VictoriaMetrics/VictoriaMetrics/app/vmalert/templates"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/promutil"
+	"github.com/aws/smithy-go/ptr"
 	"gopkg.in/yaml.v2"
 )
 
@@ -183,7 +184,7 @@ func TestGroupValidate_Failure(t *testing.T) {
 
 	f(&Group{
 		Name:  "wrong limit",
-		Limit: -1,
+		Limit: ptr.Int(-1),
 	}, false, "invalid limit")
 
 	f(&Group{

--- a/app/vmalert/rule/group.go
+++ b/app/vmalert/rule/group.go
@@ -24,7 +24,8 @@ import (
 )
 
 var (
-	ruleResultLimit = flag.Int("rule.resultLimit", 0, "Limits the number of alerts or recording results a single rule can produce. "+
+	ruleResultsLimit = flag.Int("rule.resultsLimit", 0, "Limits the number of alerts or recording results a single rule can produce. "+
+		"Can be overridden by the limit option under group if specified. "+
 		"If exceeded, the rule will be marked with an error and all its results will be discarded. "+
 		"0 means no limit.")
 	ruleUpdateEntriesLimit = flag.Int("rule.updateEntriesLimit", 20, "Defines the max number of rule's state updates stored in-memory. "+
@@ -133,7 +134,7 @@ func NewGroup(cfg config.Group, qb datasource.QuerierBuilder, defaultInterval ti
 	if cfg.Limit != nil {
 		g.Limit = *cfg.Limit
 	} else {
-		g.Limit = *ruleResultLimit
+		g.Limit = *ruleResultsLimit
 	}
 	if g.Concurrency < 1 {
 		g.Concurrency = 1

--- a/app/vmalert/rule/group.go
+++ b/app/vmalert/rule/group.go
@@ -24,6 +24,9 @@ import (
 )
 
 var (
+	ruleResultLimit = flag.Int("rule.resultLimit", 0, "Limits the number of alerts or recording results a single rule can produce. "+
+		"If exceeded, the rule will be marked with an error and all its results will be discarded. "+
+		"0 means no limit.")
 	ruleUpdateEntriesLimit = flag.Int("rule.updateEntriesLimit", 20, "Defines the max number of rule's state updates stored in-memory. "+
 		"Rule's updates are available on rule's Details page and are used for debugging purposes. The number of stored updates can be overridden per rule via update_entries_limit param.")
 	resendDelay        = flag.Duration("rule.resendDelay", 0, "MiniMum amount of time to wait before resending an alert to notifier.")
@@ -111,7 +114,6 @@ func NewGroup(cfg config.Group, qb datasource.QuerierBuilder, defaultInterval ti
 		Name:            cfg.Name,
 		File:            cfg.File,
 		Interval:        cfg.Interval.Duration(),
-		Limit:           cfg.Limit,
 		Concurrency:     cfg.Concurrency,
 		checksum:        cfg.Checksum,
 		Params:          cfg.Params,
@@ -127,6 +129,11 @@ func NewGroup(cfg config.Group, qb datasource.QuerierBuilder, defaultInterval ti
 	}
 	if g.Interval == 0 {
 		g.Interval = defaultInterval
+	}
+	if cfg.Limit != nil {
+		g.Limit = *cfg.Limit
+	} else {
+		g.Limit = *ruleResultLimit
 	}
 	if g.Concurrency < 1 {
 		g.Concurrency = 1

--- a/docs/victoriametrics/changelog/CHANGELOG.md
+++ b/docs/victoriametrics/changelog/CHANGELOG.md
@@ -29,7 +29,7 @@ See also [LTS releases](https://docs.victoriametrics.com/victoriametrics/lts-rel
 * SECURITY: upgrade Go builder from Go1.25.0 to Go1.25.1. See [the list of issues addressed in Go1.25.1](https://github.com/golang/go/issues?q=milestone%3AGo1.25.1%20label%3ACherryPickApproved).
 
 * FEATURE: [vmauth](https://docs.victoriametrics.com/victoriametrics/vmauth/): stream responses from backends to clients without delays. Previously the backend data could be buffered at `vmauth` side for indefinite amounts of time. This was preventing from using `vmauth` for streaming the data from backends in [live tailing mode](https://docs.victoriametrics.com/victorialogs/querying/#live-tailing). See [VictoriaLogs#667](https://github.com/VictoriaMetrics/VictoriaLogs/issues/667).
-* FEATURE: [vmalert](https://docs.victoriametrics.com/victoriametrics/vmalert/): add `-rule.resultLimit` command-line flag to allow limiting the number of alerts or recording results a single rule can produce. See [#5792](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/5792).
+* FEATURE: [vmalert](https://docs.victoriametrics.com/victoriametrics/vmalert/): add `-rule.resultsLimit` command-line flag to allow limiting the number of alerts or recording results a single rule can produce. See [#5792](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/5792).
 
 * BUGFIX: [vmagent](https://docs.victoriametrics.com/victoriametrics/vmagent/): remove the error log when marshaling an invalid comment or an empty HELP metadata line during scraping, if [metadata processing](https://docs.victoriametrics.com/victoriametrics/vmagent/#metric-metadata) is enabled. See [#9710](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/9710).
 

--- a/docs/victoriametrics/changelog/CHANGELOG.md
+++ b/docs/victoriametrics/changelog/CHANGELOG.md
@@ -29,6 +29,7 @@ See also [LTS releases](https://docs.victoriametrics.com/victoriametrics/lts-rel
 * SECURITY: upgrade Go builder from Go1.25.0 to Go1.25.1. See [the list of issues addressed in Go1.25.1](https://github.com/golang/go/issues?q=milestone%3AGo1.25.1%20label%3ACherryPickApproved).
 
 * FEATURE: [vmauth](https://docs.victoriametrics.com/victoriametrics/vmauth/): stream responses from backends to clients without delays. Previously the backend data could be buffered at `vmauth` side for indefinite amounts of time. This was preventing from using `vmauth` for streaming the data from backends in [live tailing mode](https://docs.victoriametrics.com/victorialogs/querying/#live-tailing). See [VictoriaLogs#667](https://github.com/VictoriaMetrics/VictoriaLogs/issues/667).
+* FEATURE: [vmalert](https://docs.victoriametrics.com/victoriametrics/vmalert/): add `-rule.resultLimit` command-line flag to allow limiting the number of alerts or recording results a single rule can produce. See [#5792](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/5792).
 
 * BUGFIX: [vmagent](https://docs.victoriametrics.com/victoriametrics/vmagent/): remove the error log when marshaling an invalid comment or an empty HELP metadata line during scraping, if [metadata processing](https://docs.victoriametrics.com/victoriametrics/vmagent/#metric-metadata) is enabled. See [#9710](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/9710).
 

--- a/docs/victoriametrics/vmalert.md
+++ b/docs/victoriametrics/vmalert.md
@@ -158,7 +158,7 @@ name: <string>
 # Limit limits the number of alerts or recording results a single rule within this group can produce.
 # If exceeded, the rule will be marked with an error and all its results will be discarded.
 # 0 means no limit.
-[ limit: <integer> | default = -rule.resultLimit flag]
+[ limit: <integer> | default = -rule.resultsLimit flag]
 
 # How many rules execute at once within a group. Increasing concurrency may speed
 # up group's evaluation duration (exposed via `vmalert_iteration_duration_seconds` metric).

--- a/docs/victoriametrics/vmalert.md
+++ b/docs/victoriametrics/vmalert.md
@@ -155,10 +155,10 @@ name: <string>
 # See https://github.com/VictoriaMetrics/VictoriaMetrics/issues/5155 and https://docs.victoriametrics.com/victoriametrics/keyconcepts/#query-latency.
 [ eval_delay: <duration> ]
 
-# Limit limits the number of alerts or recording results the rule within this group can produce.
-# On exceeding the limit, rule will be marked with an error and all its results will be discarded.
-# 0 is no limit.
-[ limit: <integer> | default 0]
+# Limit limits the number of alerts or recording results a single rule within this group can produce.
+# If exceeded, the rule will be marked with an error and all its results will be discarded.
+# 0 means no limit.
+[ limit: <integer> | default = -rule.resultLimit flag]
 
 # How many rules execute at once within a group. Increasing concurrency may speed
 # up group's evaluation duration (exposed via `vmalert_iteration_duration_seconds` metric).

--- a/docs/victoriametrics/vmalert_flags.md
+++ b/docs/victoriametrics/vmalert_flags.md
@@ -450,8 +450,8 @@ See the docs at https://docs.victoriametrics.com/victoriametrics/vmalert/ .
      Limits the maxiMum duration for automatic alert expiration, which by default is 4 times evaluationInterval of the parent group
   -rule.resendDelay duration
      MiniMum amount of time to wait before resending an alert to notifier.
-  -rule.resultLimit int
-     Limits the number of alerts or recording results a single rule can produce. If exceeded, the rule will be marked with an error and all its results will be discarded. 0 means no limit. (default 0)
+  -rule.resultsLimit int
+     Limits the number of alerts or recording results a single rule can produce. Can be overridden by the limit option under group if specified. If exceeded, the rule will be marked with an error and all its results will be discarded. 0 means no limit. (default 0)
   -rule.stripFilePath
      Whether to strip file path in responses from the api/v1/rules API for files configured via -rule cmd-line flag. For example, the file path '/path/to/tenant_id/rules.yml' will be stripped to just 'rules.yml'. This flag might be useful to hide sensitive information in file path such as tenant ID. This flag is available only in Enterprise binaries. See https://docs.victoriametrics.com/victoriametrics/enterprise/
   -rule.templates array

--- a/docs/victoriametrics/vmalert_flags.md
+++ b/docs/victoriametrics/vmalert_flags.md
@@ -450,6 +450,8 @@ See the docs at https://docs.victoriametrics.com/victoriametrics/vmalert/ .
      Limits the maxiMum duration for automatic alert expiration, which by default is 4 times evaluationInterval of the parent group
   -rule.resendDelay duration
      MiniMum amount of time to wait before resending an alert to notifier.
+  -rule.resultLimit int
+     Limits the number of alerts or recording results a single rule can produce. If exceeded, the rule will be marked with an error and all its results will be discarded. 0 means no limit. (default 0)
   -rule.stripFilePath
      Whether to strip file path in responses from the api/v1/rules API for files configured via -rule cmd-line flag. For example, the file path '/path/to/tenant_id/rules.yml' will be stripped to just 'rules.yml'. This flag might be useful to hide sensitive information in file path such as tenant ID. This flag is available only in Enterprise binaries. See https://docs.victoriametrics.com/victoriametrics/enterprise/
   -rule.templates array


### PR DESCRIPTION
…the number of alerts or recording results a single rule can produce

fix https://github.com/VictoriaMetrics/VictoriaMetrics/issues/5792