### PR TITLE
app/vmselect: add more context for bad URL error

### DIFF
--- a/app/vmselect/main.go
+++ b/app/vmselect/main.go
@@ -282,6 +282,13 @@ func requestHandler(w http.ResponseWriter, r *http.Request) bool {
 		httpserver.Errorf(w, r, "cannot parse path %q: %s", path, err)
 		return true
 	}
+	switch p.Prefix {
+	case "select":
+	case "delete":
+	default:
+		httpserver.Errorf(w, r, "unsupported URL format for path %q. Make sure you're using cluster URL format https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/#url-format.", path)
+		return true
+	}
 	at, err := auth.NewTokenPossibleMultitenant(p.AuthToken)
 	if err != nil {
 		httpserver.Errorf(w, r, "auth error: %s", err)


### PR DESCRIPTION
It was multiple times already for users to get confused with Single-node and Cluster URL formats for VictoriaMetrics. This is an attempt to bring more context to the error message, if request doesn't contain expected "/select" or "/delete" prefix. Which is usually a sign of using wrong API.

This commit is only an attempt to fix it. But it demonstrates the idea.