### PR TITLE
lib/storage: introduce metricNameSearch type

### DIFF
--- a/lib/storage/block_stream_merger.go
+++ b/lib/storage/block_stream_merger.go
@@ -21,9 +21,6 @@ type blockStreamMerger struct {
 
 	// The last error
 	err error
-
-	// A flag to indicate which cache to use: sparse or regular.
-	useSparseCache bool
 }
 
 func (bsm *blockStreamMerger) reset() {
@@ -37,11 +34,10 @@ func (bsm *blockStreamMerger) reset() {
 	bsm.retentionDeadline = 0
 	bsm.nextBlockNoop = false
 	bsm.err = nil
-	bsm.useSparseCache = false
 }
 
 // Init initializes bsm with the given bsrs.
-func (bsm *blockStreamMerger) Init(bsrs []*blockStreamReader, retentionDeadline int64, useSparseCache bool) {
+func (bsm *blockStreamMerger) Init(bsrs []*blockStreamReader, retentionDeadline int64) {
 	bsm.reset()
 	bsm.retentionDeadline = retentionDeadline
 	for _, bsr := range bsrs {
@@ -63,7 +59,6 @@ func (bsm *blockStreamMerger) Init(bsrs []*blockStreamReader, retentionDeadline 
 	heap.Init(&bsm.bsrHeap)
 	bsm.Block = &bsm.bsrHeap[0].Block
 	bsm.nextBlockNoop = true
-	bsm.useSparseCache = useSparseCache
 }
 
 func (bsm *blockStreamMerger) getRetentionDeadline(_ *blockHeader) int64 {

--- a/lib/storage/merge.go
+++ b/lib/storage/merge.go
@@ -16,12 +16,11 @@ import (
 // mergeBlockStreams returns immediately if stopCh is closed.
 //
 // rowsMerged is atomically updated with the number of merged rows during the merge.
-func mergeBlockStreams(ph *partHeader, bsw *blockStreamWriter, bsrs []*blockStreamReader, stopCh <-chan struct{}, dmis *uint64set.Set, retentionDeadline int64,
-	rowsMerged, rowsDeleted *atomic.Uint64, useSparseCache bool) error {
+func mergeBlockStreams(ph *partHeader, bsw *blockStreamWriter, bsrs []*blockStreamReader, stopCh <-chan struct{}, dmis *uint64set.Set, retentionDeadline int64, rowsMerged, rowsDeleted *atomic.Uint64) error {
 	ph.Reset()
 
 	bsm := bsmPool.Get().(*blockStreamMerger)
-	bsm.Init(bsrs, retentionDeadline, useSparseCache)
+	bsm.Init(bsrs, retentionDeadline)
 	err := mergeBlockStreamsInternal(ph, bsw, bsm, stopCh, dmis, rowsMerged, rowsDeleted)
 	bsm.reset()
 	bsmPool.Put(bsm)

--- a/lib/storage/merge_timing_test.go
+++ b/lib/storage/merge_timing_test.go
@@ -26,8 +26,9 @@ func BenchmarkMergeBlockStreamsFourSourcesBestCase(b *testing.B) {
 }
 
 func benchmarkMergeBlockStreams(b *testing.B, mps []*inmemoryPart, rowsPerLoop int64) {
-	var rowsMerged, rowsDeleted atomic.Uint64
 	dmis := &uint64set.Set{}
+	const retentionDeadline = 0
+	var rowsMerged, rowsDeleted atomic.Uint64
 
 	b.ReportAllocs()
 	b.SetBytes(rowsPerLoop)
@@ -45,7 +46,7 @@ func benchmarkMergeBlockStreams(b *testing.B, mps []*inmemoryPart, rowsPerLoop i
 			}
 			mpOut.Reset()
 			bsw.MustInitFromInmemoryPart(&mpOut, -5)
-			if err := mergeBlockStreams(&mpOut.ph, &bsw, bsrs, nil, dmis, 0, &rowsMerged, &rowsDeleted, true); err != nil {
+			if err := mergeBlockStreams(&mpOut.ph, &bsw, bsrs, nil, dmis, retentionDeadline, &rowsMerged, &rowsDeleted); err != nil {
 				panic(fmt.Errorf("cannot merge block streams: %w", err))
 			}
 		}

--- a/lib/storage/metric_name_search.go
+++ b/lib/storage/metric_name_search.go
@@ -1,0 +1,91 @@
+package storage
+
+import (
+	"sync"
+)
+
+// metricNameSearch is used for for searching a metricName by a metricID in curr
+// and prev indexDBs. If useSparseCache is false the name is first searched in
+// metricNameCache and also stored in that cache when found in one of the
+// indexDBs.
+//
+// Most index search methods invoked only once per API call. For example, one
+// request to /api/v1/series results in one invocation of
+// Storage.SearchMetricNames() method. However, searching is metricName by
+// metricID is done multiple times per API call. For example, data search
+// performs the the metricName search for each data block (see search.go).
+//
+// Additionally, each search method must get a snapshot of idbs so that they
+// don't get rotated in the middle of the search. This works for methods that
+// are invoked only once per API call. But for searching metricName by metricID
+// happens many times per API call and the idb snapshot must be taken
+// outside the search method.
+//
+// To address this, the state of the metricNameSearch type holds the search
+// context: the idb snapshot along with other options. This not only ensures
+// that idbs won't change during the API call but also avoids performance
+// degradation that may be caused by getting the idb snapshot every time the
+// search method is invoked (due do mutex locks).
+type metricNameSearch struct {
+	storage        *Storage
+	idbPrev        *indexDB
+	idbCurr        *indexDB
+	useSparseCache bool
+}
+
+// search searches the metricName of a metricID.
+func (s *metricNameSearch) search(dst []byte, metricID uint64) ([]byte, bool) {
+	if !s.useSparseCache {
+		metricName := s.storage.getMetricNameFromCache(dst, metricID)
+		if len(metricName) > len(dst) {
+			return metricName, true
+		}
+	}
+
+	dst, found := s.idbCurr.searchMetricName(dst, metricID, s.useSparseCache)
+	if found {
+		if !s.useSparseCache {
+			s.storage.putMetricNameToCache(metricID, dst)
+		}
+		return dst, true
+	}
+
+	// Fallback to previous indexDB.
+	dst, found = s.idbPrev.searchMetricName(dst, metricID, s.useSparseCache)
+	if found {
+		if !s.useSparseCache {
+			s.storage.putMetricNameToCache(metricID, dst)
+		}
+		return dst, true
+	}
+
+	// Not deleting metricID if no corresponding metricName has been found
+	// because it is not known which indexDB metricID belongs to.
+	// For cases when this does happen see indexDB.SearchMetricNames() and
+	// indexDB.getTSIDsFromMetricIDs()).
+
+	return dst, false
+}
+
+var mnsPool = &sync.Pool{
+	New: func() any {
+		return &metricNameSearch{}
+	},
+}
+
+func getMetricNameSearch(storage *Storage, useSparseCache bool) *metricNameSearch {
+	s := mnsPool.Get().(*metricNameSearch)
+	s.storage = storage
+	s.idbPrev, s.idbCurr = storage.getPrevAndCurrIndexDBs()
+	s.useSparseCache = useSparseCache
+	return s
+}
+
+func putMetricNameSearch(s *metricNameSearch) {
+	s.storage.putPrevAndCurrIndexDBs(s.idbPrev, s.idbCurr)
+	s.storage = nil
+	s.idbPrev = nil
+	s.idbCurr = nil
+	s.useSparseCache = false
+	mnsPool.Put(s)
+}

--- a/lib/storage/partition.go
+++ b/lib/storage/partition.go
@@ -1447,6 +1447,7 @@ func (pt *partition) mergeParts(pws []*partWrapper, stopCh <-chan struct{}, isFi
 		bsw.MustInitFromFilePart(dstPartPath, nocache, compressLevel)
 	}
 
+	// Merge source parts to destination part.
 	ph, err := pt.mergePartsInternal(dstPartPath, bsw, bsrs, dstPartType, stopCh, currentTimestamp, useSparseCache)
 	putBlockStreamWriter(bsw)
 	for _, bsr := range bsrs {
@@ -1586,8 +1587,9 @@ func (pt *partition) mergePartsInternal(dstPartPath string, bsw *blockStreamWrit
 	}
 	retentionDeadline := currentTimestamp - pt.s.retentionMsecs
 	activeMerges.Add(1)
+	_ = useSparseCache // unused in OSS version.
 	dmis := pt.s.getDeletedMetricIDs()
-	err := mergeBlockStreams(&ph, bsw, bsrs, stopCh, dmis, retentionDeadline, rowsMerged, rowsDeleted, useSparseCache)
+	err := mergeBlockStreams(&ph, bsw, bsrs, stopCh, dmis, retentionDeadline, rowsMerged, rowsDeleted)
 	activeMerges.Add(-1)
 	mergesCount.Add(1)
 	if err != nil {

--- a/lib/storage/search.go
+++ b/lib/storage/search.go
@@ -99,9 +99,8 @@ type Search struct {
 	// data blocks.
 	storage *Storage
 
-	// idbCurr and idbPrev are used for MetricName lookup for the found data blocks.
-	idbCurr *indexDB
-	idbPrev *indexDB
+	// mns is used for searching metricName by metricID.
+	mns *metricNameSearch
 
 	// retentionDeadline is used for filtering out blocks outside the configured retention.
 	retentionDeadline int64
@@ -137,8 +136,7 @@ func (s *Search) reset() {
 	s.MetricBlockRef.BlockRef = nil
 
 	s.storage = nil
-	s.idbPrev = nil
-	s.idbCurr = nil
+	s.mns = nil
 	s.retentionDeadline = 0
 	s.ts.reset()
 	s.tr = TimeRange{}
@@ -170,7 +168,7 @@ func (s *Search) Init(qt *querytracer.Tracer, storage *Storage, tfss []*TagFilte
 
 	s.reset()
 	s.storage = storage
-	s.idbPrev, s.idbCurr = storage.getPrevAndCurrIndexDBs()
+	s.mns = getMetricNameSearch(storage, false)
 	s.retentionDeadline = retentionDeadline
 	s.metricsTracker = storage.metricsTracker
 	s.tr = tr
@@ -198,7 +196,7 @@ func (s *Search) MustClose() {
 		logger.Panicf("BUG: missing Init call before MustClose")
 	}
 	s.ts.MustClose()
-	s.storage.putPrevAndCurrIndexDBs(s.idbPrev, s.idbCurr)
+	putMetricNameSearch(s.mns)
 	s.reset()
 }
 
@@ -230,7 +228,7 @@ func (s *Search) NextMetricBlock() bool {
 				continue
 			}
 			var ok bool
-			s.MetricBlockRef.MetricName, ok = s.storage.searchMetricName(s.idbPrev, s.idbCurr, s.MetricBlockRef.MetricName[:0], tsid.MetricID, false)
+			s.MetricBlockRef.MetricName, ok = s.mns.search(s.MetricBlockRef.MetricName[:0], tsid.MetricID)
 			if !ok {
 				// Skip missing metricName for tsid.MetricID.
 				// It should be automatically fixed. See indexDB.searchMetricNameWithCache for details.

--- a/lib/storage/storage.go
+++ b/lib/storage/storage.go
@@ -1404,50 +1404,6 @@ func (s *Storage) searchTSIDs(qt *querytracer.Tracer, tfss []*TagFilters, tr Tim
 	return tsids, nil
 }
 
-// searchMetricName searches the name of a metric by id in curr and prev
-// indexDBs. If cache is enabled (noCache is false), the name is first
-// searched in metricNameCache and also stored in that cache when found in one
-// of the indexDBs.
-//
-// Unlike other index search methods, this one requires getting the prev and
-// curr indexDBs before calling it. This is because this method is supposed to
-// be called multiple times quickly and on the same indexDBs. While getting the
-// indexDBs everytime the method is called 1) may be much slower because of the
-// locks and 2) the set of indexDBs may change between the calls due to indexDB
-// rotation.
-func (s *Storage) searchMetricName(idbPrev, idbCurr *indexDB, dst []byte, metricID uint64, noCache bool) ([]byte, bool) {
-	if !noCache {
-		metricName := s.getMetricNameFromCache(dst, metricID)
-		if len(metricName) > len(dst) {
-			return metricName, true
-		}
-	}
-
-	dst, found := idbCurr.searchMetricName(dst, metricID, noCache)
-	if found {
-		if !noCache {
-			s.putMetricNameToCache(metricID, dst)
-		}
-		return dst, true
-	}
-
-	// Fallback to previous indexDB.
-	dst, found = idbPrev.searchMetricName(dst, metricID, noCache)
-	if found {
-		if !noCache {
-			s.putMetricNameToCache(metricID, dst)
-		}
-		return dst, true
-	}
-
-	// Not deleting metricID if no corresponding metricName has been found
-	// because it is not known which indexDB metricID belongs to.
-	// For cases when this does happen see indexDB.SearchMetricNames() and
-	// indexDB.getTSIDsFromMetricIDs()).
-
-	return dst, false
-}
-
 // SearchMetricNames returns marshaled metric names matching the given tfss on
 // the given tr.
 //


### PR DESCRIPTION
Searching metricName by metricID happens many times during a single API call. This requires getting the current set of idbs before those calls happen. Which is fine but requires propagating idbs across the code base. This is also fine in case of OSS version as it is used in Search only.

Propagating idbs across the code base becomes a problem in Enterprise version as it is used in at least 3 places. As a result it becomes very difficult to merge things from OSS to Ent.

Localizing the all the dependencies in one searchMetricName type and reusing this type everywhere should make things simpler.

Related enterprise changes: https://github.com/VictoriaMetrics/VictoriaMetrics-enterprise/compare/search-metric-name-ent?expand=1

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
