### PR TITLE
lib/promscrape/config: change promscrape.dropOriginalLabels default value to false

### DIFF
--- a/docs/victoriametrics/changelog/CHANGELOG.md
+++ b/docs/victoriametrics/changelog/CHANGELOG.md
@@ -29,6 +29,7 @@ See also [LTS releases](https://docs.victoriametrics.com/victoriametrics/lts-rel
 * SECURITY: upgrade Go builder from Go1.25.0 to Go1.25.1. See [the list of issues addressed in Go1.25.1](https://github.com/golang/go/issues?q=milestone%3AGo1.25.1%20label%3ACherryPickApproved).
 
 * FEATURE: [vmauth](https://docs.victoriametrics.com/victoriametrics/vmauth/): stream responses from backends to clients without delays. Previously the backend data could be buffered at `vmauth` side for indefinite amounts of time. This was preventing from using `vmauth` for streaming the data from backends in [live tailing mode](https://docs.victoriametrics.com/victorialogs/querying/#live-tailing). See [VictoriaLogs#667](https://github.com/VictoriaMetrics/VictoriaLogs/issues/667).
+* FEATURE: [vmagent](https://docs.victoriametrics.com/victoriametrics/vmagent/): reduce CPU and Memory usage by dropping service-discovery original labels by default. Default value of the flag `-promscrape.dropOriginalLabels` changed from `false` to `true`. See this issue [#9665](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/9665) for details.
 
 * BUGFIX: [vmagent](https://docs.victoriametrics.com/victoriametrics/vmagent/): remove the error log when marshaling an invalid comment or an empty HELP metadata line during scraping, if [metadata processing](https://docs.victoriametrics.com/victoriametrics/vmagent/#metric-metadata) is enabled. See [#9710](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/9710).
 

--- a/docs/victoriametrics/relabeling.md
+++ b/docs/victoriametrics/relabeling.md
@@ -351,8 +351,8 @@ see two types of targets:
   service discovery, before any relabeling rules are applied. This includes
   targets that may later be dropped.
 
-_This option is not available when the component is started with the
-`-promscrape.dropOriginalLabels` flag._
+_This option is only available when the component is started with the
+`-promscrape.dropOriginalLabels=false` flag._
 
 {{% collapse name="How to use `/targets` page?" %}}
 
@@ -373,8 +373,8 @@ to all metrics scraped from that target.
 You can click the label column of the target to see the original labels
 **before** any relabeling was applied.
 
-_This option is not available when the component is started with the
-`-promscrape.dropOriginalLabels` flag._
+_This option is only available when the component is started with the
+`-promscrape.dropOriginalLabels=false` flag._
 
 **3. Why does a target have a certain set of labels?**
 
@@ -382,8 +382,8 @@ Click the `target` link in the `debug relabeling` column. This opens a
 step-by-step view of how the relabeling rules were applied to the original
 labels.
 
-_This option is not available when the component is started with the
-`-promscrape.dropOriginalLabels` flag._
+_This option is only available when the component is started with the
+`-promscrape.dropOriginalLabels=false` flag._
 
 **4. How are metric relabeling rules applied to scraped metrics?**
 
@@ -407,8 +407,8 @@ Each column on the page shows important details:
 This page shows all
 [discovered targets](https://docs.victoriametrics.com/victoriametrics/sd_configs/).
 
-_This option is not available when the component is started with the
-`-promscrape.dropOriginalLabels` flag._
+_This option is only available when the component is started with the
+`-promscrape.dropOriginalLabels=false` flag._
 
 It helps answer the following questions:
 

--- a/lib/promscrape/config.go
+++ b/lib/promscrape/config.go
@@ -59,7 +59,7 @@ var (
 		"Returns non-zero exit code on parsing errors and emits these errors to stderr. "+
 		"See also -promscrape.config.strictParse command-line flag. "+
 		"Pass -loggerLevel=ERROR if you don't need to see info messages in the output.")
-	dropOriginalLabels = flag.Bool("promscrape.dropOriginalLabels", false, "Whether to drop original labels for scrape targets at /targets and /api/v1/targets pages. "+
+	dropOriginalLabels = flag.Bool("promscrape.dropOriginalLabels", true, "Whether to drop original labels for scrape targets at /targets and /api/v1/targets pages. "+
 		"This may be needed for reducing memory usage when original labels for big number of scrape targets occupy big amounts of memory. "+
 		"Note that this reduces debuggability for improper per-target relabeling configs")
 	clusterMembersCount = flag.Int("promscrape.cluster.membersCount", 1, "The number of members in a cluster of scrapers. "+


### PR DESCRIPTION
 Tracking original labels requires storing a copy of labels obtained
from service discovery. It adds extra Garbage Collection pressure and as a result increased CPU usage.

 While dropOriginalLabels has almost no impact at test and small installations.
Impact grows with a scale. And especially is impactful at Kubernetes based installations.

 In addition, this flag is disabled by default for `k8s-stack` helm
chart, which is our main Kubernetes monitoring solution.

 An also, we recommend at vmagent optimisation guide to disable original
 labels storing.

 This commit changes default value to true and disables tracking of
dropped targets by default. In case of debugging, it could be easily enabled back by providing `false` value to the flag: `promscrape.dropOriginalLabels`. It should improve resource usage out of box by reducing user-experience for minority of users.

Related issue:
https://github.com/VictoriaMetrics/VictoriaMetrics/issues/9665

### Describe Your Changes

Please provide a brief description of the changes you made. Be as specific as possible to help others understand the purpose and impact of your modifications.

### Checklist

The following checks are **mandatory**:

- [ ] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [ ] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
