### PR TITLE
integration test: prevent GetMetric from interrupting the test when metric not found

### DIFF
--- a/apptest/client.go
+++ b/apptest/client.go
@@ -150,7 +150,7 @@ func (app *ServesMetrics) GetMetric(t *testing.T, metricName string) float64 {
 			return res
 		}
 	}
-	t.Fatalf("metric not found: %s", metricName)
+	t.Logf("warn: metric not found: %s", metricName)
 	return 0
 }
 


### PR DESCRIPTION
### Describe Your Changes

Previously, `GetMetric` do `t.Fatalf` immediately when the target metric not exist in `/metrics` page.

However, some metrics may start to appear after the process has been running for a while. `t.Fatalf` invalidates the retry mechanism of assertions, if the metric is not found the first time, the test case will terminate.

This pull request changes `t.Fatalf` to `t.Logf` (instead of `t.Errorf`, because error output may be considered a test case failure in some scenarios).

The CHANGELOG is left blank intentionally, as:
1. users do not need to be aware of this change
2. the original issue was found in VictoriaTraces, this issue does not affect the test in VictoriaMetrics.

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
