### PR TITLE
vmalert: correct the end parameter when evaluating VictoriaLogs rules

### DIFF
--- a/app/vmalert/datasource/client_test.go
+++ b/app/vmalert/datasource/client_test.go
@@ -735,7 +735,7 @@ func TestRequestParams(t *testing.T) {
 		applyIntervalAsTimeFilter: true,
 	}, func(t *testing.T, r *http.Request) {
 		ts := timestamp.Format(time.RFC3339)
-		exp := url.Values{"query": {vlogsQuery}, "time": {ts}, "start": {timestamp.Add(-time.Minute).Format(time.RFC3339)}, "end": {ts}}
+		exp := url.Values{"query": {vlogsQuery}, "time": {ts}, "start": {timestamp.Add(-time.Minute).Format(time.RFC3339)}, "end": {timestamp.Add(-time.Second).Format(time.RFC3339)}}
 		checkEqualString(t, exp.Encode(), r.URL.RawQuery)
 	})
 

--- a/app/vmalert/datasource/client_vlogs.go
+++ b/app/vmalert/datasource/client_vlogs.go
@@ -18,7 +18,10 @@ func (c *Client) setVLogsInstantReqParams(r *http.Request, query string, timesta
 	// so the query will be executed in time range [timestamp - evaluationInterval, timestamp].
 	if c.applyIntervalAsTimeFilter && c.evaluationInterval > 0 {
 		q.Set("start", timestamp.Add(-c.evaluationInterval).Format(time.RFC3339))
-		q.Set("end", timestamp.Format(time.RFC3339))
+		// decrease end by one second in order to avoid capturing logs belonging
+		// to the next period of time.
+		// see https://github.com/VictoriaMetrics/VictoriaMetrics/issues/9753
+		q.Set("end", timestamp.Add(-1*time.Second).Format(time.RFC3339))
 	}
 	r.URL.RawQuery = q.Encode()
 	c.setReqParams(r, query)

--- a/docs/victoriametrics/changelog/CHANGELOG.md
+++ b/docs/victoriametrics/changelog/CHANGELOG.md
@@ -31,6 +31,7 @@ See also [LTS releases](https://docs.victoriametrics.com/victoriametrics/lts-rel
 * FEATURE: [vmauth](https://docs.victoriametrics.com/victoriametrics/vmauth/): stream responses from backends to clients without delays. Previously the backend data could be buffered at `vmauth` side for indefinite amounts of time. This was preventing from using `vmauth` for streaming the data from backends in [live tailing mode](https://docs.victoriametrics.com/victorialogs/querying/#live-tailing). See [VictoriaLogs#667](https://github.com/VictoriaMetrics/VictoriaLogs/issues/667).
 
 * BUGFIX: [vmagent](https://docs.victoriametrics.com/victoriametrics/vmagent/): remove the error log when marshaling an invalid comment or an empty HELP metadata line during scraping, if [metadata processing](https://docs.victoriametrics.com/victoriametrics/vmagent/#metric-metadata) is enabled. See [#9710](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/9710).
+* BUGFIX: [vmalert](https://docs.victoriametrics.com/victoriametrics/vmalert/): Correct the `end` parameter when evaluating [VictoriaLogs](https://docs.victoriametrics.com/victorialogs/vmalert/) rules. Previously, logs could be counted twice if their timestamps aligned with the evaluation request’s `end` parameter. See [#9753](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/9753).
 
 ## [v1.126.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.126.0)
 


### PR DESCRIPTION
Previously, logs could be counted twice if their timestamps aligned with the evaluation request’s end parameter.

It's ok for vmalert to subtract the `end` by one second instead of one nanosecond, since VictoriaLogs will adjust the `end` to the last nanosecond of the second, see codes [here](https://github.com/VictoriaMetrics/VictoriaLogs/blob/e9b92572d75ba87f327d29aed9631e59dd70685a/lib/logstorage/parser.go#L3400-L3405).

In VictoriaLogs, when query with `query=xxx, start="2006-01-02T15:03:05", end="2006-01-02T15:04:04"`, VictoriaLogs uses time range: `start="2006-01-02T15:03:05", end="2006-01-02T15:04:04.999999999"`(counting all logs older than `2006-01-02T15:04:05.000000000`).
When using [time filter](https://docs.victoriametrics.com/victorialogs/logsql/#time-filter) in expression like `query=_time: 1m xxx, time="2006-01-02T15:04:05"`, VictoriaLogs uses time range: `start="2006-01-02T15:03:04.999999999", end="2006-01-02T15:04:04.999999999"`.

[vmalert uses the first format when the time filter is omitted in the rule expression](https://docs.victoriametrics.com/victorialogs/vmalert/#time-filter).

There remains a minor difference in the `start` parameter between the two requests, but it is trivial and only problematic if logs were ingested at `2006-01-02T15:03:04.999999999` and the timestamp happens to match the `start` parameter.

fix https://github.com/VictoriaMetrics/VictoriaMetrics/issues/9753