### PR TITLE
app/vmbakcup: support custom SSE KMS key id and ACL

### DIFF
--- a/docs/victoriametrics/changelog/CHANGELOG.md
+++ b/docs/victoriametrics/changelog/CHANGELOG.md
@@ -38,6 +38,7 @@ See also [LTS releases](https://docs.victoriametrics.com/victoriametrics/lts-rel
 * BUGFIX: all components: restore sorting order of summary and quantile metrics exposed by VictoriaMetrics components on `/metrics` page. See [metrics#105](https://github.com/VictoriaMetrics/metrics/pull/105) for details.
 * BUGFIX: [vmsingle](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/) and `vmselect` in [VictoriaMetrics cluster](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/): avoid applying offset modifier twice to the request time when an instant query uses rollup functions `rate()` or `avg_over_time()` with cache enabled. See [#9762](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/9762).
 * BUGFIX: [vmalert](https://docs.victoriametrics.com/victoriametrics/vmalert/): restore support for `query` templates in alert rule labels after the regression introduced in [#9543](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/9543). See [#9783](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/9783) for details.
+* BUGFIX: [vmbackup](https://docs.victoriametrics.com/victoriametrics/vmbackup/), [vmrestore](https://docs.victoriametrics.com/victoriametrics/vmrestore/), [vmbackupmanager](https://docs.victoriametrics.com/victoriametrics/vmbackupmanager/): add support for SSE KMS Key ID and ACLfor use with S3-compatible storages.
 
 ## [v1.126.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.126.0)
 

--- a/docs/victoriametrics/vmbackup.md
+++ b/docs/victoriametrics/vmbackup.md
@@ -487,10 +487,14 @@ Run `vmbackup -help` in order to see all the available options:
      Optional URL to push metrics exposed at /metrics page. See https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#push-metrics . By default, metrics exposed at /metrics page aren't pushed to any remote storage
      Supports an array of values separated by comma or specified via multiple flags.
      Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
+  -s3ACL string
+     ACL to be set for uploaded objects to S3. Supported values are: private, public-read, public-read-write, authenticated-read, aws-exec-read, bucket-owner-read, bucket-owner-full-control
   -s3ForcePathStyle
      Prefixing endpoint with bucket name when set false, true by default. (default true)
   -s3ObjectTags string
      S3 tags to be set for uploaded objects. Must be set in JSON format: {"param1":"value1",...,"paramN":"valueN"}.
+  -s3SSEKMSKeyId string
+     SSE KMS Key ID for use with S3-compatible storages.
   -s3StorageClass string
      The Storage Class applied to objects uploaded to AWS S3. Supported values are: GLACIER, DEEP_ARCHIVE, GLACIER_IR, INTELLIGENT_TIERING, ONEZONE_IA, OUTPOSTS, REDUCED_REDUNDANCY, STANDARD, STANDARD_IA.
      See https://docs.aws.amazon.com/AmazonS3/latest/userguide/storage-class-intro.html

--- a/docs/victoriametrics/vmbackupmanager.md
+++ b/docs/victoriametrics/vmbackupmanager.md
@@ -649,10 +649,14 @@ command-line flags:
      Disable validation of source backup presence and completeness when creating a restore mark.
   -runOnStart
      Upload backups immediately after start of the service. Otherwise the backup starts on new hour
+  -s3ACL string
+     ACL to be set for uploaded objects to S3. Supported values are: private, public-read, public-read-write, authenticated-read, aws-exec-read, bucket-owner-read, bucket-owner-full-control
   -s3ForcePathStyle
      Prefixing endpoint with bucket name when set false, true by default. (default true)
   -s3ObjectTags string
      S3 tags to be set for uploaded objects. Must be set in JSON format: {"param1":"value1",...,"paramN":"valueN"}.
+  -s3SSEKMSKeyId string
+     SSE KMS Key ID for use with S3-compatible storages.
   -s3StorageClass string
      The Storage Class applied to objects uploaded to AWS S3. Supported values are: GLACIER, DEEP_ARCHIVE, GLACIER_IR, INTELLIGENT_TIERING, ONEZONE_IA, OUTPOSTS, REDUCED_REDUNDANCY, STANDARD, STANDARD_IA.
      See https://docs.aws.amazon.com/AmazonS3/latest/userguide/storage-class-intro.html

--- a/docs/victoriametrics/vmrestore.md
+++ b/docs/victoriametrics/vmrestore.md
@@ -187,6 +187,8 @@ Run `vmrestore -help` in order to see all the available options:
      Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
   -s3ForcePathStyle
      Prefixing endpoint with bucket name when set false, true by default. (default true)
+  -s3SSEKMSKeyId string
+     SSE KMS Key ID for use with S3-compatible storages.
   -s3StorageClass string
      The Storage Class applied to objects uploaded to AWS S3. Supported values are: GLACIER, DEEP_ARCHIVE, GLACIER_IR, INTELLIGENT_TIERING, ONEZONE_IA, OUTPOSTS, REDUCED_REDUNDANCY, STANDARD, STANDARD_IA.
      See https://docs.aws.amazon.com/AmazonS3/latest/userguide/storage-class-intro.html

--- a/lib/backup/actions/util.go
+++ b/lib/backup/actions/util.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"path/filepath"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -15,6 +16,7 @@ import (
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/backup/gcsremote"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/backup/s3remote"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/flagutil"
+	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
 )
 
 var (
@@ -27,12 +29,15 @@ var (
 	configProfile = flag.String("configProfile", "", "Profile name for S3 configs. If no set, the value of the environment variable will be loaded (AWS_PROFILE or AWS_DEFAULT_PROFILE), "+
 		"or if both not set, DefaultSharedConfigProfile is used")
 	customS3Endpoint = flag.String("customS3Endpoint", "", "Custom S3 endpoint for use with S3-compatible storages (e.g. MinIO). S3 is used if not set")
+	s3ACL            = flag.String("s3ACL", "bucket-owner-full-control", "ACL to be set for uploaded objects to S3.")
 	s3ForcePathStyle = flag.Bool("s3ForcePathStyle", true, "Prefixing endpoint with bucket name when set false, true by default.")
 	s3StorageClass   = flag.String("s3StorageClass", "", "The Storage Class applied to objects uploaded to AWS S3. Supported values are: GLACIER, "+
 		"DEEP_ARCHIVE, GLACIER_IR, INTELLIGENT_TIERING, ONEZONE_IA, OUTPOSTS, REDUCED_REDUNDANCY, STANDARD, STANDARD_IA.\n"+
 		"See https://docs.aws.amazon.com/AmazonS3/latest/userguide/storage-class-intro.html")
 	s3ChecksumAlgorithm = flag.String("s3ChecksumAlgorithm", "", "Objects integrity checksum algorithm which is applied while uploading objects to AWS S3. "+
 		"Supported values are: SHA256, SHA1, CRC32C, CRC32")
+	s3SSEKMSKeyId           = flag.String("s3SSEKMSKeyId", "", "SSE KMS Key ID for use with S3-compatible storages.")
+	s3SSEAlgorithm          = flag.String("s3SSEAlgorithm", "aws:kms", "SSE KMS Key Algorithm for use with S3-compatible storages.")
 	s3TLSInsecureSkipVerify = flag.Bool("s3TLSInsecureSkipVerify", false, "Whether to skip TLS verification when connecting to the S3 endpoint.")
 	s3Tags                  = flag.String("s3ObjectTags", "", `S3 tags to be set for uploaded objects. Must be set in JSON format: {"param1":"value1",...,"paramN":"valueN"}.`)
 )
@@ -259,6 +264,22 @@ func NewRemoteFS(ctx context.Context, path string) (common.RemoteFS, error) {
 			return nil, fmt.Errorf("cannot parse s3 tags %q: %w", *s3Tags, err)
 		}
 
+		sseAlgorithm := s3types.ServerSideEncryptionAwsKms
+		if s3SSEAlgorithm != nil && *s3SSEAlgorithm != "" {
+			if !slices.Contains(sseAlgorithm.Values(), s3types.ServerSideEncryption(*s3SSEAlgorithm)) {
+				return nil, fmt.Errorf("unsupported SSE algorithm: %s. Supported values: %v", *s3SSEAlgorithm, sseAlgorithm.Values())
+			}
+			sseAlgorithm = s3types.ServerSideEncryption(*s3SSEAlgorithm)
+		}
+
+		acl := s3types.ObjectCannedACL("")
+		if s3ACL != nil && *s3ACL != "" {
+			if !slices.Contains(acl.Values(), s3types.ObjectCannedACL(*s3ACL)) {
+				return nil, fmt.Errorf("unsupported ACL: %s. Supported values: %v", *s3ACL, acl.Values())
+			}
+			acl = s3types.ObjectCannedACL(*s3ACL)
+		}
+
 		fs := &s3remote.FS{
 			CredsFilePath:         *credsFilePath,
 			ConfigFilePath:        *configFilePath,
@@ -267,6 +288,9 @@ func NewRemoteFS(ctx context.Context, path string) (common.RemoteFS, error) {
 			StorageClass:          s3remote.StringToStorageClass(*s3StorageClass),
 			ChecksumAlgorithm:     s3remote.StringToChecksumAlgorithm(*s3ChecksumAlgorithm),
 			S3ForcePathStyle:      *s3ForcePathStyle,
+			ACL:                   acl,
+			SSEKMSKeyId:           *s3SSEKMSKeyId,
+			SSEAlgorithm:          sseAlgorithm,
 			ProfileName:           *configProfile,
 			Bucket:                bucket,
 			Dir:                   dir,

--- a/lib/backup/s3remote/s3.go
+++ b/lib/backup/s3remote/s3.go
@@ -89,6 +89,11 @@ type FS struct {
 	// Whether to use HTTP client with tls.InsecureSkipVerify setting
 	TLSInsecureSkipVerify bool
 
+	// SSEKMSKeyId
+	SSEKMSKeyId  string
+	SSEAlgorithm s3types.ServerSideEncryption
+	ACL          s3types.ObjectCannedACL
+
 	s3       *s3.Client
 	uploader *manager.Uploader
 
@@ -308,6 +313,13 @@ func (fs *FS) CopyPart(srcFS common.OriginFS, p common.Part) error {
 		MetadataDirective: s3types.MetadataDirectiveReplace,
 		Tagging:           fs.tags,
 	}
+	if len(fs.SSEKMSKeyId) > 0 {
+		input.SSEKMSKeyId = aws.String(fs.SSEKMSKeyId)
+		input.ServerSideEncryption = fs.SSEAlgorithm
+	}
+	if len(fs.ACL) > 0 {
+		input.ACL = fs.ACL
+	}
 
 	_, err := fs.s3.CopyObject(fs.ctx, input)
 	if err != nil {
@@ -355,6 +367,13 @@ func (fs *FS) UploadPart(p common.Part, r io.Reader) error {
 		Metadata:          fs.Metadata,
 		ChecksumAlgorithm: fs.ChecksumAlgorithm,
 		Tagging:           fs.tags,
+	}
+	if len(fs.SSEKMSKeyId) > 0 {
+		input.SSEKMSKeyId = aws.String(fs.SSEKMSKeyId)
+		input.ServerSideEncryption = fs.SSEAlgorithm
+	}
+	if len(fs.ACL) > 0 {
+		input.ACL = fs.ACL
 	}
 
 	_, err := fs.uploader.Upload(fs.ctx, input)
@@ -449,6 +468,14 @@ func (fs *FS) CreateFile(filePath string, data []byte) error {
 		ChecksumAlgorithm: fs.ChecksumAlgorithm,
 		Tagging:           fs.tags,
 	}
+	if len(fs.SSEKMSKeyId) > 0 {
+		input.SSEKMSKeyId = aws.String(fs.SSEKMSKeyId)
+		input.ServerSideEncryption = fs.SSEAlgorithm
+	}
+	if len(fs.ACL) > 0 {
+		input.ACL = fs.ACL
+	}
+
 	_, err := fs.uploader.Upload(fs.ctx, input)
 	if err != nil {
 		return fmt.Errorf("cannot upload data to %q at %s (remote path %q): %w", filePath, fs, path, err)


### PR DESCRIPTION
### Describe Your Changes

Add more S3 configurations.

- SSES3KeyID allows to push to a bucket that is another account as the KMS key it uses to encrypt data server side.
- ACL allows configure which permissions are given to the object uploaded on the bucket (usefull when bucket policy expect a given permission such as `bucket-owner-full-control`). 

### Checklist

The following checks are **mandatory**:

- [ ] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [ ] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
