### PR TITLE
deployment/docker: bump base image version

### DIFF
--- a/deployment/docker/Makefile
+++ b/deployment/docker/Makefile
@@ -10,7 +10,7 @@ CERTS_IMAGE := alpine:3.22.1
 GO_BUILDER_IMAGE := golang:1.25.1
 
 BUILDER_IMAGE := local/builder:2.0.0-$(shell echo $(GO_BUILDER_IMAGE) | tr :/ __)-1
-BASE_IMAGE := local/base:1.1.4-$(shell echo $(ROOT_IMAGE) | tr :/ __)-$(shell echo $(CERTS_IMAGE) | tr :/ __)
+BASE_IMAGE := local/base:1.1.5-$(shell echo $(ROOT_IMAGE) | tr :/ __)-$(shell echo $(CERTS_IMAGE) | tr :/ __)
 DOCKER ?= docker
 DOCKER_RUN ?= $(DOCKER) run
 DOCKER_BUILD ?= $(DOCKER) build


### PR DESCRIPTION
### Describe Your Changes

The image tag didn’t change in #9805. So Docker could reuse a cached image. This required manual cleanup with docker image rm or docker system prune to force building the fixed image.
With this change, the image tag is updated, guaranteeing that the new image with the security fix is used everywhere.

Follow up on https://github.com/VictoriaMetrics/VictoriaMetrics/pull/9805

### Checklist

The following checks are **mandatory**:

- [ ] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [ ] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
