### PR TITLE
Build multiarch base image and publish it

### DIFF
--- a/deployment/docker/Makefile
+++ b/deployment/docker/Makefile
@@ -3,14 +3,12 @@
 DOCKER_REGISTRIES ?= docker.io quay.io
 DOCKER_NAMESPACE ?= victoriametrics
 
-ROOT_IMAGE ?= alpine:3.22.1
 ROOT_IMAGE_SCRATCH ?= scratch
-CERTS_IMAGE := alpine:3.22.1
 
 GO_BUILDER_IMAGE := golang:1.25.1
 
 BUILDER_IMAGE := local/builder:2.0.0-$(shell echo $(GO_BUILDER_IMAGE) | tr :/ __)-1
-BASE_IMAGE := local/base:1.1.4-$(shell echo $(ROOT_IMAGE) | tr :/ __)-$(shell echo $(CERTS_IMAGE) | tr :/ __)
+BASE_IMAGE := victoriametrics/base:$(shell git log -1 --format="%h" -- deployment/docker/base/Dockerfile)$(shell git diff-index --quiet HEAD -- deployment/docker/base/Dockerfile || echo '-dirty-'$$(git diff-index -u HEAD -- deployment/docker/base/Dockerfile | openssl sha1 | cut -d' ' -f2 | cut -c 1-8))
 DOCKER ?= docker
 DOCKER_RUN ?= $(DOCKER) run
 DOCKER_BUILD ?= $(DOCKER) build
@@ -20,8 +18,16 @@ DOCKER_IMAGE_LS ?= $(DOCKER) image ls --format '{{.Repository}}:{{.Tag}}'
 package-base:
 	($(DOCKER_IMAGE_LS) | grep -q '$(BASE_IMAGE)$$') \
 		|| $(DOCKER_BUILD) \
-			--build-arg root_image=$(ROOT_IMAGE) \
-			--build-arg certs_image=$(CERTS_IMAGE) \
+			--tag $(BASE_IMAGE) \
+			deployment/docker/base
+
+publish-base:
+	($(DOCKER_IMAGE_LS) | grep -q '$(BASE_IMAGE)$$') \
+		|| $(DOCKER) buildx build \
+			-o type=image \
+			--provenance=false \
+			--platform=linux/amd64,linux/arm,linux/arm64,linux/ppc64le,linux/386 \
+			--push \
 			--tag $(BASE_IMAGE) \
 			deployment/docker/base
 
@@ -77,7 +83,7 @@ package-via-docker: package-base
 			--tag $(DOCKER_NAMESPACE)/$(APP_NAME):$(PKG_TAG)$(APP_SUFFIX)$(RACE) \
 			-f app/$(APP_NAME)/deployment/Dockerfile bin)
 
-publish-via-docker:
+publish-via-docker: publish-base
 	$(MAKE_PARALLEL) app-via-docker-linux-amd64 \
 		app-via-docker-linux-arm \
 		app-via-docker-linux-arm64 \
@@ -85,8 +91,8 @@ publish-via-docker:
 		app-via-docker-linux-386
 	$(DOCKER) buildx build \
 		--platform=linux/amd64,linux/arm,linux/arm64,linux/ppc64le,linux/386 \
-		--build-arg certs_image=$(CERTS_IMAGE) \
-		--build-arg root_image=$(ROOT_IMAGE) \
+		--build-arg certs_image=$(BASE_IMAGE) \
+		--build-arg root_image=$(BASE_IMAGE) \
 		--build-arg APP_NAME=$(APP_NAME) \
 		--build-arg BINARY_SUFFIX="" \
 		--label "org.opencontainers.image.source=https://github.com/VictoriaMetrics/VictoriaMetrics" \
@@ -105,7 +111,7 @@ publish-via-docker:
 		bin
 	$(DOCKER) buildx build \
 		--platform=linux/amd64,linux/arm,linux/arm64,linux/ppc64le,linux/386 \
-		--build-arg certs_image=$(CERTS_IMAGE) \
+		--build-arg certs_image=$(BASE_IMAGE) \
 		--build-arg root_image=$(ROOT_IMAGE_SCRATCH) \
 		--build-arg APP_NAME=$(APP_NAME) \
 		--build-arg BINARY_SUFFIX="" \

--- a/deployment/docker/base/Dockerfile
+++ b/deployment/docker/base/Dockerfile
@@ -1,11 +1,11 @@
+# NOTE: Once the changes made in this file commited, run make publish-base
+
 # See https://medium.com/on-docker/use-multi-stage-builds-to-inject-ca-certs-ad1e8f01de1b
-ARG certs_image=non-existing
-ARG root_image=non-existing
-FROM $certs_image AS certs
+FROM alpine:3.22.1 AS certs
 
 RUN apk update && apk upgrade && apk --update --no-cache add ca-certificates
 
-FROM $root_image
+FROM alpine:3.22.1
 
 # Temporary fix for CVE-2025-9230, CVE-2025-9231, CVE-2025-9232 until Alpine releases a fixed image.
 RUN apk add --no-cache 'libcrypto3=3.5.4-r0' 'libssl3=3.5.4-r0'


### PR DESCRIPTION
### Describe Your Changes

It turned out that the release-xxx commands [do not rely on the base image](https://github.com/VictoriaMetrics/VictoriaMetrics/blob/31adbf909431fc85e5b2eddc350adc99f268d161/deployment/docker/Makefile#L88-L89), so the security fix introduced in https://github.com/VictoriaMetrics/VictoriaMetrics/pull/9805 was not applied.

Attempted to build a multi-architecture Docker image locally. While building per-architecture images worked, creating a manifest failed.

Docker does not support creating manifests purely from local images. It always attempts to contact a remote registry, resulting in an authentication error:
```
docker manifest create local/base:alpine_3.22.1-alpine_3.22.1-17ca1ba8c4 local/base:alpine_3.22.1-alpine_3.22.1-17ca1ba8c4-amd64 local/base:alpine_3.22.1-alpine_3.22.1-17ca1ba8c4-arm --amend
...
denied: requested access to the resource is denied
unauthorized: authentication required
```

As a result, the only viable approach is to build and push the multi-arch base image to our registry first (same way as we do for apps), and then use it as the ROOT_IMAGE\ CERTS_IMAGE in release-xxx builds.

### Checklist

The following checks are **mandatory**:

- [ ] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [ ] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
