### PR TITLE
lib/promb: run 1000 iterations for write request benchmark

### DIFF
--- a/lib/prompb/prompb_timing_test.go
+++ b/lib/prompb/prompb_timing_test.go
@@ -33,7 +33,7 @@ func BenchmarkWriteRequestMarshalProtobuf(b *testing.B) {
 
 var benchWriteRequest = func() *WriteRequest {
 	var tss []TimeSeries
-	for i := 0; i < 10_000; i++ {
+	for i := 0; i < 1_000; i++ {
 		ts := TimeSeries{
 			Labels: []Label{
 				{


### PR DESCRIPTION
### Describe Your Changes

Initially, this benchmark was running 1000 iterations. Later in c005245741fc3d7d744f258959be2a5ae388f8ec it was refactored and bumped to 10_000. This alerts continuous benchmark systems, so this commit brings it back to 1000
### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
