### PR TITLE
app/vmui: prevent removing other query params when updating one

### DIFF
--- a/app/vmui/packages/vmui/src/hooks/useSearchParamsFromObject.ts
+++ b/app/vmui/packages/vmui/src/hooks/useSearchParamsFromObject.ts
@@ -1,42 +1,39 @@
-import { useNavigate, useSearchParams } from "react-router-dom";
+import { useSearchParams } from "react-router-dom";
 import { useCallback } from "preact/compat";
 
+type ParamValue = string | number | boolean | null | undefined;
 
 const useSearchParamsFromObject = () => {
-  const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
 
-  const setSearchParamsFromKeys = useCallback((objectParams: Record<string, string | number>) => {
-    const hasSearchParams = !!searchParams.size;
-    let hasChanged = false;
+  const setSearchParamsFromKeys = useCallback((objectParams: Record<string, ParamValue>) => {
+    const hadParams = !!searchParams.size;
 
     const newSearchParams = new URLSearchParams(searchParams);
-    searchParams.keys().forEach(key => {
-      if (!(key in objectParams)) {
+    const beforeParams = searchParams.toString();
+
+    for (const [key, newValue] of Object.entries(objectParams)) {
+      const isEmpty = newValue === null || newValue === undefined || newValue === "";
+
+      if (isEmpty) {
         newSearchParams.delete(key);
-        hasChanged = true;
+        continue;
       }
-    });
 
-    Object.entries(objectParams).forEach(([key, value]) => {
-      if (newSearchParams.get(key) !== `${value}`) {
-        newSearchParams.set(key, `${value}`);
-        hasChanged = true;
+      const next = String(newValue);
+      if (newSearchParams.get(key) !== next) {
+        newSearchParams.set(key, next);
       }
-    });
-
-    if (!hasChanged) return;
-
-    if (hasSearchParams) {
-      setSearchParams(newSearchParams);
-    } else {
-      navigate(`?${newSearchParams.toString()}`, { replace: true });
     }
-  }, [searchParams, navigate]);
 
-  return {
-    setSearchParamsFromKeys
-  };
+    if (beforeParams === newSearchParams.toString()) return;
+
+    setSearchParams(newSearchParams, { replace: !hadParams });
+  },
+  [searchParams, setSearchParams]
+  );
+
+  return { setSearchParamsFromKeys };
 };
 
 export default useSearchParamsFromObject;

--- a/docs/victoriametrics/changelog/CHANGELOG.md
+++ b/docs/victoriametrics/changelog/CHANGELOG.md
@@ -30,6 +30,8 @@ See also [LTS releases](https://docs.victoriametrics.com/victoriametrics/lts-rel
 
 * FEATURE: [vmagent](https://docs.victoriametrics.com/victoriametrics/vmagent/), [vmalert](https://docs.victoriametrics.com/victoriametrics/vmalert/): add `-secret.flags` command-line flag to configure flags to be hidden in logs and on `/metrics`. This is useful for protecting sensitive flag values (for example `-remoteWrite.headers`) from being exposed in logs or metrics. See [#6938](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/6938). Thank you @truepele for the issue and PR
 
+* BUGFIX: [vmui](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#vmui): fix issue where updating one query parameter removed others. See [#9816](https://github.com/VictoriaMetrics/VictoriaMetrics/pull/9816) for details.
+
 ## [v1.127.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.127.0)
 
 Released at 2025-10-03


### PR DESCRIPTION
### Describe Your Changes

Prevents removal of unrelated query parameters when updating a single one in `vmui`.
Previously, changing one search parameter could unintentionally clear others.

Related issue: #9816

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
