### PR TITLE
app/vmui: rename "Reset" to "Reset filters" and disable when no filters are modified

### DIFF
--- a/app/vmui/packages/vmui/src/pages/CardinalityPanel/CardinalityConfigurator/CardinalityConfigurator.tsx
+++ b/app/vmui/packages/vmui/src/pages/CardinalityPanel/CardinalityConfigurator/CardinalityConfigurator.tsx
@@ -13,6 +13,8 @@ import useSearchParamsFromObject from "../../../hooks/useSearchParamsFromObject"
 import useStateSearchParams from "../../../hooks/useStateSearchParams";
 import Hyperlink from "../../../components/Main/Hyperlink/Hyperlink";
 
+const DEFAULT_TOP_N = 10;
+
 const CardinalityConfigurator: FC<CardinalityTotalsProps> = ({ isPrometheus, isCluster, ...props }) => {
   const { isMobile } = useDeviceDetect();
   const [searchParams] = useSearchParams();
@@ -21,7 +23,8 @@ const CardinalityConfigurator: FC<CardinalityTotalsProps> = ({ isPrometheus, isC
   const showTips = searchParams.get("tips") || "";
   const [match, setMatch] = useStateSearchParams("", "match");
   const [focusLabel, setFocusLabel] = useStateSearchParams("", "focusLabel");
-  const [topN, setTopN] = useStateSearchParams(10, "topN");
+  const [topN, setTopN] = useStateSearchParams(DEFAULT_TOP_N, "topN");
+  const hasChanges = !!(match || focusLabel || (topN !== DEFAULT_TOP_N && !isPrometheus));
 
   const errorTopN = useMemo(() => topN < 0 ? "Number must be bigger than zero" : "", [topN]);
 
@@ -35,7 +38,10 @@ const CardinalityConfigurator: FC<CardinalityTotalsProps> = ({ isPrometheus, isC
   };
 
   const handleResetQuery = () => {
-    setSearchParamsFromKeys({ match: "", focusLabel: "" });
+    setSearchParamsFromKeys({ match: "", focusLabel: "", topN: "" });
+    setMatch("");
+    setFocusLabel("");
+    setTopN(DEFAULT_TOP_N);
   };
 
   const handleToggleTips = () => {
@@ -45,7 +51,7 @@ const CardinalityConfigurator: FC<CardinalityTotalsProps> = ({ isPrometheus, isC
 
   useEffect(() => {
     const matchQuery = searchParams.get("match");
-    const topNQuery = +(searchParams.get("topN") || 10);
+    const topNQuery = +(searchParams.get("topN") || DEFAULT_TOP_N);
     const focusLabelQuery = searchParams.get("focusLabel");
     if (matchQuery !== match) setMatch(matchQuery || "");
     if (topNQuery !== topN) setTopN(topNQuery);
@@ -94,7 +100,7 @@ const CardinalityConfigurator: FC<CardinalityTotalsProps> = ({ isPrometheus, isC
         <TextField
           label="Limit entries"
           type="number"
-          value={isPrometheus ? 10 : topN}
+          value={isPrometheus ? DEFAULT_TOP_N : topN}
           error={errorTopN}
           disabled={isPrometheus}
           helperText={isPrometheus ? "not available for Prometheus" : ""}
@@ -145,8 +151,9 @@ const CardinalityConfigurator: FC<CardinalityTotalsProps> = ({ isPrometheus, isC
           variant="text"
           startIcon={<RestartIcon/>}
           onClick={handleResetQuery}
+          disabled={!hasChanges}
         >
-          Reset
+          Reset filters
         </Button>
         <Button
           startIcon={<PlayIcon/>}

--- a/docs/victoriametrics/changelog/CHANGELOG.md
+++ b/docs/victoriametrics/changelog/CHANGELOG.md
@@ -29,6 +29,7 @@ See also [LTS releases](https://docs.victoriametrics.com/victoriametrics/lts-rel
 * SECURITY: upgrade Go builder from Go1.25.1 to Go1.25.2. See [the list of issues addressed in Go1.25.2](https://github.com/golang/go/issues?q=milestone%3AGo1.25.2%20label%3ACherryPickApproved).
 
 * FEATURE: [vmagent](https://docs.victoriametrics.com/victoriametrics/vmagent/), [vmalert](https://docs.victoriametrics.com/victoriametrics/vmalert/): add `-secret.flags` command-line flag to configure flags to be hidden in logs and on `/metrics`. This is useful for protecting sensitive flag values (for example `-remoteWrite.headers`) from being exposed in logs or metrics. See [#6938](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/6938). Thank you @truepele for the issue and PR
+* FEATURE: [vmui](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#vmui): on the [Cardinality Explorer](https://docs.victoriametrics.com/victoriametrics/#cardinality-explorer) page, rename `Reset` to `Reset filters` and disable the button when no filters are modified. See [#9609](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/9609).
 
 * BUGFIX: [vmui](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#vmui): fix issue where updating one query parameter removed others. See [#9816](https://github.com/VictoriaMetrics/VictoriaMetrics/pull/9816) for details.
 


### PR DESCRIPTION
### Describe Your Changes

This PR updates the **Cardinality Explorer** page in `vmui`:

* Renames the `Reset` button to `Reset filters`.
* Disables the button when no filters are modified.

Related issue: #9609

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
