### PR TITLE
app/vmui: fix points display; add option to show all points

### DIFF
--- a/app/vmui/packages/vmui/src/components/Chart/Line/LineChart/LineChart.tsx
+++ b/app/vmui/packages/vmui/src/components/Chart/Line/LineChart/LineChart.tsx
@@ -42,6 +42,7 @@ export interface LineChartProps {
   height?: number;
   isAnomalyView?: boolean;
   spanGaps?: boolean;
+  showAllPoints?: boolean;
 }
 
 const LineChart: FC<LineChartProps> = ({
@@ -55,7 +56,8 @@ const LineChart: FC<LineChartProps> = ({
   layoutSize,
   height,
   isAnomalyView,
-  spanGaps = false
+  spanGaps = false,
+  showAllPoints = false,
 }) => {
   const { isDarkTheme } = useAppState();
 
@@ -108,10 +110,10 @@ const LineChart: FC<LineChartProps> = ({
   useEffect(() => {
     if (!uPlotInst) return;
     delSeries(uPlotInst);
-    addSeries(uPlotInst, series, spanGaps);
+    addSeries(uPlotInst, series, spanGaps, showAllPoints);
     setBand(uPlotInst, series);
     uPlotInst.redraw();
-  }, [series, spanGaps]);
+  }, [series, spanGaps, showAllPoints]);
 
   useEffect(() => {
     if (!uPlotInst) return;

--- a/app/vmui/packages/vmui/src/components/Configurators/GraphSettings/GraphSettings.tsx
+++ b/app/vmui/packages/vmui/src/components/Configurators/GraphSettings/GraphSettings.tsx
@@ -14,6 +14,7 @@ import LegendConfigs from "../../Chart/Line/Legend/LegendConfigs/LegendConfigs";
 import Modal from "../../Main/Modal/Modal";
 import { useGraphDispatch, useGraphState } from "../../../state/graph/GraphStateContext";
 import { useEffect } from "react";
+import PointsConfigurator from "./PointsConfigurator/PointsConfigurator";
 
 const title = "Graph & Legend Settings";
 
@@ -26,10 +27,14 @@ interface GraphSettingsProps {
     value: boolean,
     onChange: (value: boolean) => void,
   },
+  showAllPoints: {
+    value: boolean,
+    onChange: (value: boolean) => void,
+  },
   isHistogram?: boolean,
 }
 
-const GraphSettings: FC<GraphSettingsProps> = ({ data, yaxis, setYaxisLimits, toggleEnableLimits, spanGaps }) => {
+const GraphSettings: FC<GraphSettingsProps> = ({ data, yaxis, setYaxisLimits, toggleEnableLimits, spanGaps, showAllPoints }) => {
   const { openSettings } = useGraphState();
   const graphDispatch = useGraphDispatch();
 
@@ -83,6 +88,10 @@ const GraphSettings: FC<GraphSettingsProps> = ({ data, yaxis, setYaxisLimits, to
                 <LinesConfigurator
                   spanGaps={spanGaps.value}
                   onChange={spanGaps.onChange}
+                />
+                <PointsConfigurator
+                  showAllPoints={showAllPoints.value}
+                  onChangeShow={showAllPoints.onChange}
                 />
                 {displayHistogramMode && <GraphTypeSwitcher onChange={handleClose}/>}
               </div>

--- a/app/vmui/packages/vmui/src/components/Configurators/GraphSettings/LinesConfigurator/LinesConfigurator.tsx
+++ b/app/vmui/packages/vmui/src/components/Configurators/GraphSettings/LinesConfigurator/LinesConfigurator.tsx
@@ -20,7 +20,7 @@ const LinesConfigurator: FC<Props> = ({ spanGaps, onChange }) => {
         fullWidth={isMobile}
       />
       <span className="vm-legend-configs-item__info">
-        Connects data points by skipping null values instead of creating gaps.
+        Connects data points by skipping null values instead of gaps.
       </span>
     </div>
   );

--- a/app/vmui/packages/vmui/src/components/Configurators/GraphSettings/PointsConfigurator/PointsConfigurator.tsx
+++ b/app/vmui/packages/vmui/src/components/Configurators/GraphSettings/PointsConfigurator/PointsConfigurator.tsx
@@ -1,0 +1,31 @@
+import { FC } from "preact/compat";
+import Switch from "../../../Main/Switch/Switch";
+import useDeviceDetect from "../../../../hooks/useDeviceDetect";
+
+interface Props {
+  showAllPoints: boolean;
+  onChangeShow: (value: boolean) => void;
+}
+
+const PointsConfigurator: FC<Props> = ({ showAllPoints, onChangeShow }) => {
+  const { isMobile } = useDeviceDetect();
+
+  return (
+    <>
+      <div className="vm-graph-settings-row">
+        <span className="vm-graph-settings-row__label">Show all data points</span>
+        <Switch
+          value={showAllPoints}
+          onChange={onChangeShow}
+          label={showAllPoints ? "Enabled" : "Disabled"}
+          fullWidth={isMobile}
+        />
+        <span className="vm-legend-configs-item__info">
+          Display every data point, even when no line can be drawn.
+        </span>
+      </div>
+    </>
+  );
+};
+
+export default PointsConfigurator;

--- a/app/vmui/packages/vmui/src/components/Configurators/GraphSettings/style.scss
+++ b/app/vmui/packages/vmui/src/components/Configurators/GraphSettings/style.scss
@@ -46,5 +46,6 @@
     align-items: center;
     justify-content: stretch;
     grid-template-columns: 1fr 100px;
+    gap: 0 $padding-large;
   }
 }

--- a/app/vmui/packages/vmui/src/components/Main/Alert/style.scss
+++ b/app/vmui/packages/vmui/src/components/Main/Alert/style.scss
@@ -1,9 +1,7 @@
 @use "src/styles/variables" as *;
 
 .vm-alert {
-  z-index: 20;
-  position: sticky;
-  top: $padding-global;
+  position: relative;
   display: grid;
   grid-template-columns: 20px 1fr;
   align-items: center;

--- a/app/vmui/packages/vmui/src/components/Views/GraphView/GraphView.tsx
+++ b/app/vmui/packages/vmui/src/components/Views/GraphView/GraphView.tsx
@@ -45,6 +45,7 @@ export interface GraphViewProps {
   isAnomalyView?: boolean;
   isPredefinedPanel?: boolean;
   spanGaps?: boolean;
+  showAllPoints?: boolean;
 }
 
 const GraphView: FC<GraphViewProps> = ({
@@ -63,7 +64,8 @@ const GraphView: FC<GraphViewProps> = ({
   isHistogram,
   isAnomalyView,
   isPredefinedPanel,
-  spanGaps
+  spanGaps,
+  showAllPoints
 }) => {
   const graphDispatch = useGraphDispatch();
 
@@ -80,8 +82,8 @@ const GraphView: FC<GraphViewProps> = ({
   const [legendValue, setLegendValue] = useState<ChartTooltipProps | null>(null);
 
   const getSeriesItem = useMemo(() => {
-    return getSeriesItemContext(data, hideSeries, alias, isAnomalyView);
-  }, [data, hideSeries, alias, isAnomalyView]);
+    return getSeriesItemContext(data, hideSeries, alias, showAllPoints, isAnomalyView);
+  }, [data, hideSeries, alias, showAllPoints, isAnomalyView]);
 
   const setLimitsYaxis = (values: { [key: string]: number[] }) => {
     const limits = getLimitsYAxis(values, !isHistogram);
@@ -243,6 +245,7 @@ const GraphView: FC<GraphViewProps> = ({
           height={height}
           isAnomalyView={isAnomalyView}
           spanGaps={spanGaps}
+          showAllPoints={showAllPoints}
         />
       )}
       {isHistogram && (

--- a/app/vmui/packages/vmui/src/pages/CustomPanel/CustomPanelTabs/GraphTab.tsx
+++ b/app/vmui/packages/vmui/src/pages/CustomPanel/CustomPanelTabs/GraphTab.tsx
@@ -20,7 +20,7 @@ type Props = {
 const GraphTab: FC<Props> = ({ isHistogram, graphData, controlsRef, isAnomalyView }) => {
   const { isMobile } = useDeviceDetect();
 
-  const { customStep, yaxis, spanGaps } = useGraphState();
+  const { customStep, yaxis, spanGaps, showAllPoints } = useGraphState();
   const { period } = useTimeState();
   const { query } = useQueryState();
 
@@ -39,6 +39,10 @@ const GraphTab: FC<Props> = ({ isHistogram, graphData, controlsRef, isAnomalyVie
     graphDispatch({ type: "SET_SPAN_GAPS", payload: value });
   };
 
+  const setShowPoints = (value: boolean) => {
+    graphDispatch({ type: "SET_SHOW_POINTS", payload: value });
+  };
+
   const setPeriod = ({ from, to }: {from: Date, to: Date}) => {
     timeDispatch({ type: "SET_PERIOD", payload: { from, to } });
   };
@@ -53,6 +57,7 @@ const GraphTab: FC<Props> = ({ isHistogram, graphData, controlsRef, isAnomalyVie
         setYaxisLimits={setYaxisLimits}
         toggleEnableLimits={toggleEnableLimits}
         spanGaps={{ value: spanGaps, onChange: setSpanGaps }}
+        showAllPoints={{ value: showAllPoints, onChange: setShowPoints }}
       />
     </div>
   );
@@ -72,6 +77,7 @@ const GraphTab: FC<Props> = ({ isHistogram, graphData, controlsRef, isAnomalyVie
         isHistogram={isHistogram}
         isAnomalyView={isAnomalyView}
         spanGaps={spanGaps}
+        showAllPoints={showAllPoints}
       />
     </>
   );

--- a/app/vmui/packages/vmui/src/pages/PredefinedPanels/PredefinedPanel/PredefinedPanel.tsx
+++ b/app/vmui/packages/vmui/src/pages/PredefinedPanels/PredefinedPanel/PredefinedPanel.tsx
@@ -35,6 +35,7 @@ const PredefinedPanel: FC<PredefinedPanelsProps> = ({
   const containerRef = useRef<HTMLDivElement>(null);
   const [visible, setVisible] = useState(false);
   const [spanGaps, setSpanGaps] = useState(false);
+  const [showAllPoints, setShowPoints] = useState(false);
   const [yaxis, setYaxis] = useState<YaxisState>({
     limits: {
       enable: false,
@@ -124,6 +125,7 @@ const PredefinedPanel: FC<PredefinedPanelsProps> = ({
         setYaxisLimits={setYaxisLimits}
         toggleEnableLimits={toggleEnableLimits}
         spanGaps={{ value: spanGaps, onChange: setSpanGaps }}
+        showAllPoints={{ value: showAllPoints, onChange: setShowPoints }}
       />
     </div>
     <div className="vm-predefined-panel-body">
@@ -145,6 +147,7 @@ const PredefinedPanel: FC<PredefinedPanelsProps> = ({
         fullWidth={false}
         height={isMobile ? window.innerHeight * 0.5 : 500}
         spanGaps={spanGaps}
+        showAllPoints={showAllPoints}
       />
       }
     </div>

--- a/app/vmui/packages/vmui/src/pages/QueryAnalyzer/QueryAnalyzerView/QueryAnalyzerView.tsx
+++ b/app/vmui/packages/vmui/src/pages/QueryAnalyzer/QueryAnalyzerView/QueryAnalyzerView.tsx
@@ -53,7 +53,7 @@ const QueryAnalyzerView: FC<Props> = ({ data, period }) => {
   }, [data]);
   const [displayType, setDisplayType] = useState(tabs[0].value);
 
-  const { yaxis, spanGaps } = useGraphState();
+  const { yaxis, spanGaps, showAllPoints } = useGraphState();
   const graphDispatch = useGraphDispatch();
 
   const setYaxisLimits = (limits: AxisRange) => {
@@ -66,6 +66,10 @@ const QueryAnalyzerView: FC<Props> = ({ data, period }) => {
 
   const setSpanGaps = (value: boolean) => {
     graphDispatch({ type: "SET_SPAN_GAPS", payload: value });
+  };
+
+  const setShowPoints = (value: boolean) => {
+    graphDispatch({ type: "SET_SHOW_POINTS", payload: value });
   };
 
   const handleChangeDisplayType = (newValue: string) => {
@@ -154,6 +158,7 @@ const QueryAnalyzerView: FC<Props> = ({ data, period }) => {
                 setYaxisLimits={setYaxisLimits}
                 toggleEnableLimits={toggleEnableLimits}
                 spanGaps={{ value: spanGaps, onChange: setSpanGaps }}
+                showAllPoints={{ value: showAllPoints, onChange: setShowPoints }}
               />
             )}
             {displayType === "table" && (
@@ -179,6 +184,7 @@ const QueryAnalyzerView: FC<Props> = ({ data, period }) => {
             height={isMobile ? window.innerHeight * 0.5 : 500}
             isHistogram={isHistogram}
             spanGaps={spanGaps}
+            showAllPoints={showAllPoints}
           />
         )}
         {liveData && (displayType === "code") && (

--- a/app/vmui/packages/vmui/src/state/graph/reducer.ts
+++ b/app/vmui/packages/vmui/src/state/graph/reducer.ts
@@ -1,4 +1,5 @@
 import { getQueryStringValue } from "../../utils/query-string";
+import { getFromStorage, saveToStorage } from "../../utils/storage";
 
 export interface AxisRange {
   [key: string]: [number, number]
@@ -18,6 +19,7 @@ export interface GraphState {
   isEmptyHistogram: boolean
   /** when true, null data values will not cause line breaks */
   spanGaps: boolean
+  showAllPoints: boolean
   openSettings: boolean
 }
 
@@ -28,6 +30,7 @@ export type GraphAction =
   | { type: "SET_IS_HISTOGRAM", payload: boolean }
   | { type: "SET_IS_EMPTY_HISTOGRAM", payload: boolean }
   | { type: "SET_SPAN_GAPS", payload: boolean }
+  | { type: "SET_SHOW_POINTS", payload: boolean }
   | { type: "SET_OPEN_SETTINGS", payload: boolean }
 
 export const initialGraphState: GraphState = {
@@ -38,6 +41,7 @@ export const initialGraphState: GraphState = {
   isHistogram: false,
   isEmptyHistogram: false,
   spanGaps: false,
+  showAllPoints: Boolean(getFromStorage("POINTS_SHOW_ALL")),
   openSettings: false
 };
 
@@ -84,6 +88,12 @@ export function reducer(state: GraphState, action: GraphAction): GraphState {
       return {
         ...state,
         spanGaps: action.payload
+      };
+    case "SET_SHOW_POINTS":
+      saveToStorage("POINTS_SHOW_ALL", action.payload);
+      return {
+        ...state,
+        showAllPoints: action.payload
       };
     case "SET_OPEN_SETTINGS":
       return {

--- a/app/vmui/packages/vmui/src/utils/storage.ts
+++ b/app/vmui/packages/vmui/src/utils/storage.ts
@@ -16,6 +16,7 @@ export type StorageKeys = "AUTOCOMPLETE"
   | "METRICS_QUERY_HISTORY"
   | "SERVER_URL"
   | "RAW_JSON_LIVE_VIEW"
+  | "POINTS_SHOW_ALL"
   | DeprecatedStorageKeys;
 
 

--- a/app/vmui/packages/vmui/src/utils/uplot/series.ts
+++ b/app/vmui/packages/vmui/src/utils/uplot/series.ts
@@ -31,7 +31,7 @@ export const isForecast = (metric: MetricBase["metric"]): ForecastMetricInfo => 
   };
 };
 
-export const getSeriesItemContext = (data: MetricResult[], hideSeries: string[], alias: string[], isAnomalyUI?: boolean) => {
+export const getSeriesItemContext = (data: MetricResult[], hideSeries: string[], alias: string[], showPoints?: boolean, isAnomalyUI?: boolean) => {
   const colorState: {[key: string]: string} = {};
   const maxColors = isAnomalyUI ? 0 : Math.min(data.length, baseContrastColors.length);
 
@@ -51,7 +51,7 @@ export const getSeriesItemContext = (data: MetricResult[], hideSeries: string[],
       dash: getDashSeries(metricInfo),
       width: getWidthSeries(metricInfo),
       stroke: getStrokeSeries({ metricInfo, label, isAnomalyUI, colorState }),
-      points: getPointsSeries(metricInfo),
+      points: getPointsSeries(metricInfo, showPoints),
       spanGaps: false,
       forecast: metricInfo?.value,
       forecastGroup: metricInfo?.group,
@@ -146,9 +146,10 @@ export const delSeries = (u: uPlot) => {
   }
 };
 
-export const addSeries = (u: uPlot, series: uPlotSeries[], spanGaps = false) => {
+export const addSeries = (u: uPlot, series: uPlotSeries[], spanGaps = false, showPoints = false) => {
   series.forEach((s,i) => {
     if (s.label) s.spanGaps = spanGaps;
+    if (s.points) s.points.filter = showPoints ? undefined : filterPoints;
     i && u.addSeries(s);
   });
 };
@@ -184,7 +185,7 @@ const getWidthSeries = (metricInfo: ForecastMetricInfo | null): number => {
   return 1.4;
 };
 
-const getPointsSeries = (metricInfo: ForecastMetricInfo | null): uPlotSeries.Points => {
+const getPointsSeries = (metricInfo: ForecastMetricInfo | null, showPoints: boolean = false): uPlotSeries.Points => {
   const isAnomalyMetric = metricInfo?.value === ForecastType.anomaly;
 
   if (isAnomalyMetric) {
@@ -194,7 +195,7 @@ const getPointsSeries = (metricInfo: ForecastMetricInfo | null): uPlotSeries.Poi
     size: 4,
     width: 0,
     show: true,
-    filter: filterPoints,
+    filter: showPoints ? null : filterPoints,
   };
 };
 
@@ -205,7 +206,7 @@ const filterPoints = (self: uPlot, seriesIdx: number): number[] | null => {
   for (let i = 0; i < data.length; i++) {
     const prev = data[i - 1];
     const next = data[i + 1];
-    if (prev === null && next === null) {
+    if (prev === null || next === null) {
       indices.push(i);
     }
   }

--- a/docs/victoriametrics/changelog/CHANGELOG.md
+++ b/docs/victoriametrics/changelog/CHANGELOG.md
@@ -26,6 +26,10 @@ See also [LTS releases](https://docs.victoriametrics.com/victoriametrics/lts-rel
 
 ## tip
 
+* FEATURE: [vmui](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#vmui): add option to always show all points on the chart.
+
+* BUGFIX: [vmui](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#vmui): fix display of isolated points on the chart. See [#9666](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/9666).
+
 ## [v1.127.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.127.0)
 
 Released at 2025-10-03


### PR DESCRIPTION
### Describe Your Changes

* Fix rendering of isolated points at gaps.
* Add toggle to always show all points (even when connected by a line).

Related issue: #9666

| Before | After |
|---|---|
| <img width="600" alt="Before – isolated points" src="https://github.com/user-attachments/assets/9cbb4405-0569-471d-b4fb-2c31421be3f4" /> | <img width="600" alt="After – isolated points" src="https://github.com/user-attachments/assets/7e893314-4cc4-4a74-a70e-e2155150f63c" /> |

| Switch show all points | Chart all points visible |
|---|---|
| <img width="575" alt="image" src="https://github.com/user-attachments/assets/e689e79e-0295-446d-9176-d7fc2730cb6c" /> | <img width="600" alt="image" src="https://github.com/user-attachments/assets/4240ebb0-2249-4275-8ba5-f450952983fb" /> |

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
