### PR TITLE
lib/backup/actions: improve progress logging

### DIFF
--- a/lib/backup/actions/backup.go
+++ b/lib/backup/actions/backup.go
@@ -8,13 +8,13 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/VictoriaMetrics/VictoriaMetrics/lib/formatutil"
 	"github.com/VictoriaMetrics/metrics"
 
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/backup/backupnames"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/backup/common"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/backup/fslocal"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/backup/fsnil"
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/formatutil"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/logger"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/snapshot/snapshotutil"
 )

--- a/lib/backup/actions/restore.go
+++ b/lib/backup/actions/restore.go
@@ -9,12 +9,12 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/VictoriaMetrics/VictoriaMetrics/lib/formatutil"
 	"github.com/VictoriaMetrics/metrics"
 
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/backup/backupnames"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/backup/common"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/backup/fslocal"
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/formatutil"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/fs"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/logger"
 )


### PR DESCRIPTION
Currently, it is hard to make sense of progress based on logging as it requires manual calculation of progress and ETA.
Solve this by:
- making data units humanly readable
- adding an estimation of completion for the operation

Log examples:

<details>
<summary>vmrestore</summary>

Before:
```
2025-10-08T14:24:08.554Z	info	VictoriaMetrics/lib/backup/actions/restore.go:185	downloaded 3420512905 out of 6913250661 bytes (49.48%) from S3{bucket: "b", dir: "vmstorage-victoria-metrics-k8s-stack-0/daily/2025-10-07/"} to fslocal "/tmp/vmrestore" in 5m50.000744082s
```

After:
```
2025-10-08T14:34:34.575Z        info    ib/backup/actions/restore.go:192  downloaded 4.499Gi out of 5.477Gi bytes (82.15%) from S3{bucket: "b", dir: "vmstorage-victoria-metrics-k8s-stack-0/daily/2025-10-07/"} to fslocal "/tmp/vmrestore" in 8m40.000867958s; estimated time to completion: 1m51.999132042s
```
</details>


<details>
<summary>vmbackup</summary>

Before:
```
2025-10-08T15:15:57.611Z	info	VictoriaMetrics/lib/backup/actions/backup.go:170	uploaded 86596228 out of 10873215340 bytes (0.80%) from fslocal "/tmp/vmrestore/snapshots/20251008151543-186C8C8F5628B604" to S3{bucket: "b", dir: "testing/"} in 13.074306684s
```

After:
```
2025-10-08T15:08:48.110Z        info    lib/backup/actions/backup.go:176   uploaded 88.17Mi out of 10.13Gi bytes (0.85%) from fslocal "/tmp/vmrestore/snapshots/20251008150830-186C8C8F5628B603" to S3{bucket: "b", dir: "testing/"} in 17.504908135s; estimated time to completion: 34m1.495091865s
```
</details>


`vmbackupmanager` uses `lib/backup/actions`, so updated logging will also be propagated there.

Not sure if it worth a changelog entry, lmk if you'd prefer to have one for this.