### PR TITLE
refactor: use b.Loop() to simplify the code and improve performance

### DIFF
--- a/app/vmselect/promql/parse_cache_timing_test.go
+++ b/app/vmselect/promql/parse_cache_timing_test.go
@@ -141,7 +141,7 @@ var testSimpleQueries = []string{
 
 func BenchmarkParsePromQLWithCacheSimple(b *testing.B) {
 	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		for j := 0; j < len(testSimpleQueries); j++ {
 			_, err := parsePromQLWithCache(testSimpleQueries[j])
 			if err != nil {
@@ -210,7 +210,7 @@ var testComplexQueries = []string{
 
 func BenchmarkParsePromQLWithCacheComplex(b *testing.B) {
 	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		for j := 0; j < len(testComplexQueries); j++ {
 			_, err := parsePromQLWithCache(testComplexQueries[j])
 			if err != nil {


### PR DESCRIPTION
### Describe Your Changes

These changes use b.Loop() to simplify the code and improve performance

Supported by Go Team, more info: https://go.dev/blog/testing-b-loop and https://go.dev/issue/73137.



Before this pr:

```shell
go test -run=^$ -bench=. ./app/vmselect/promql
goos: darwin
goarch: arm64
pkg: github.com/VictoriaMetrics/VictoriaMetrics/app/vmselect/promql
cpu: Apple M4
BenchmarkBinaryOpOr/tss:1_or_tss:1-10              	 4977340	       228.9 ns/op
BenchmarkBinaryOpOr/tss:1_or_tss:1000-10           	   48272	     24802 ns/op
BenchmarkBinaryOpOr/tss:1000_or_tss:1-10           	   26131	     45986 ns/op
BenchmarkBinaryOpOr/tss:1000_or_tss:1000-10        	     402	   2891872 ns/op
BenchmarkBinaryOpOr/tss:1000_or_on()_vector(0)-10  	   26504	     43122 ns/op
BenchmarkCachePutNoOverFlow-10                     	   10000	    110068 ns/op	       0 B/op	       0 allocs/op
BenchmarkCacheGetNoOverflow-10                     	   22642	     53382 ns/op	       0 B/op	       0 allocs/op
BenchmarkCachePutGetNoOverflow-10                  	    7728	    145035 ns/op	       0 B/op	       0 allocs/op
BenchmarkCachePutOverflow-10                       	   10000	    114732 ns/op	       0 B/op	       0 allocs/op
BenchmarkCachePutGetOverflow-10                    	    7514	    160221 ns/op	       0 B/op	       0 allocs/op
BenchmarkParsePromQLWithCacheSimple-10             	 6500893	       161.8 ns/op	       0 B/op	       0 allocs/op
BenchmarkParsePromQLWithCacheSimpleParallel-10     	 3761550	       319.1 ns/op	       0 B/op	       0 allocs/op
BenchmarkParsePromQLWithCacheComplex-10            	 4382840	       273.5 ns/op	       0 B/op	       0 allocs/op
BenchmarkParsePromQLWithCacheComplexParallel-10    	 5029287	       238.4 ns/op	       0 B/op	       0 allocs/op
BenchmarkRollupAvg-10                              	17115258	        70.21 ns/op	14242.27 MB/s	       0 B/op	       0 allocs/op
PASS
ok  	github.com/VictoriaMetrics/VictoriaMetrics/app/vmselect/promql	21.303s

```

After:

```shell
go test -run=^$ -bench=. ./app/vmselect/promql               
goos: darwin
goarch: arm64
pkg: github.com/VictoriaMetrics/VictoriaMetrics/app/vmselect/promql
cpu: Apple M4
BenchmarkBinaryOpOr/tss:1_or_tss:1-10              	 4991538	       225.7 ns/op
BenchmarkBinaryOpOr/tss:1_or_tss:1000-10           	   48792	     24483 ns/op
BenchmarkBinaryOpOr/tss:1000_or_tss:1-10           	   26686	     44787 ns/op
BenchmarkBinaryOpOr/tss:1000_or_tss:1000-10        	     420	   2573115 ns/op
BenchmarkBinaryOpOr/tss:1000_or_on()_vector(0)-10  	   29323	     41275 ns/op
BenchmarkCachePutNoOverFlow-10                     	   10000	    108337 ns/op	       0 B/op	       0 allocs/op
BenchmarkCacheGetNoOverflow-10                     	   22525	     53244 ns/op	       0 B/op	       0 allocs/op
BenchmarkCachePutGetNoOverflow-10                  	    7620	    147218 ns/op	       0 B/op	       0 allocs/op
BenchmarkCachePutOverflow-10                       	   10000	    113560 ns/op	       0 B/op	       0 allocs/op
BenchmarkCachePutGetOverflow-10                    	    7545	    157304 ns/op	       0 B/op	       0 allocs/op
BenchmarkParsePromQLWithCacheSimple-10             	 6723859	       168.8 ns/op	       0 B/op	       0 allocs/op
BenchmarkParsePromQLWithCacheSimpleParallel-10     	 3790436	       317.9 ns/op	       0 B/op	       0 allocs/op
BenchmarkParsePromQLWithCacheComplex-10            	 4582118	       262.0 ns/op	       0 B/op	       0 allocs/op
BenchmarkParsePromQLWithCacheComplexParallel-10    	 4920531	       262.5 ns/op	       0 B/op	       0 allocs/op
BenchmarkRollupAvg-10                              	14927608	        74.30 ns/op	13459.84 MB/s	       0 B/op	       0 allocs/op
PASS
ok  	github.com/VictoriaMetrics/VictoriaMetrics/app/vmselect/promql	20.773s

```



### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
