### PR TITLE
lib/backup/s3remote: use http client from AWS instead of custom implementation

### DIFF
--- a/docs/victoriametrics/changelog/CHANGELOG.md
+++ b/docs/victoriametrics/changelog/CHANGELOG.md
@@ -40,6 +40,7 @@ It disables `Discovered targets` debug IU by default.
 
 * BUGFIX: [vmui](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#vmui): fix issue where updating one query parameter removed others. See [#9816](https://github.com/VictoriaMetrics/VictoriaMetrics/pull/9816) for details.
 * BUGFIX: [vmui](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#vmui) alerting tab: update the search filter if the corresponding query argument was passed. Reset selected items in dropdown filters if they are not available anymore after the update.
+* BUGFIX: [vmbackup](https://docs.victoriametrics.com/victoriametrics/vmbackup/), [vmrestore](https://docs.victoriametrics.com/victoriametrics/vmrestore/), [vmbackupmanager](https://docs.victoriametrics.com/victoriametrics/vmbackupmanager/): properly apply additional configuration of connection provided via environment variables (such as `AWS_CA_BUNDLE`). Previously, such settings were ignored starting from [v1.115.0](https://docs.victoriametrics.com/victoriametrics/changelog/#v11150). See this issue [#9858](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/9858) for details.
 
 ## [v1.127.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.127.0)
 


### PR DESCRIPTION
AWS SDK [does not modify](https://github.com/VictoriaMetrics/VictoriaMetrics/blob/0eb465782a813e1e7b367e1b31dfb007a80e587a/vendor/github.com/aws/aws-sdk-go-v2/aws/config.go#L51-L52) custom http client configuration if it was provided. This leads to additional configuration such as environment variables being ignored.

Use AWS http client builder instead of custom implementation and override DialContext to preserve metrics exposed by custom transport.

See: https://github.com/VictoriaMetrics/VictoriaMetrics/issues/9858