### PR TITLE
httpserver: add http2 option

### DIFF
--- a/lib/httpserver/httpserver.go
+++ b/lib/httpserver/httpserver.go
@@ -158,19 +158,22 @@ func serveWithListener(addr string, ln net.Listener, rh RequestHandler, disableB
 	// Disable HTTP/2 by default, since it doesn't give any advantages for VictoriaMetrics services.
 	// But for external projects that import `httpserver` package,
 	// the `enableHTTP2` arg provides the flexibility to use HTTP/2.
-	var protocols *http.Protocols
-	tlsNextProto := make(map[string]func(*http.Server, *tls.Conn, http.Handler))
+	var (
+		protocols    *http.Protocols
+		tlsNextProto map[string]func(*http.Server, *tls.Conn, http.Handler)
+	)
 	if enableHTTP2 {
 		protocols = &http.Protocols{}
 		protocols.SetHTTP2(true)
 		protocols.SetUnencryptedHTTP2(true)
-		tlsNextProto = nil
+	} else {
+		tlsNextProto = make(map[string]func(*http.Server, *tls.Conn, http.Handler))
 	}
 
 	s.s = &http.Server{
 		Protocols:    protocols,
 		TLSNextProto: tlsNextProto,
-		
+
 		ReadHeaderTimeout: 5 * time.Second,
 		IdleTimeout:       *idleConnTimeout,
 


### PR DESCRIPTION
### Describe Your Changes

Currently, the `httpserver` disabled HTTP/2 support by design, because:
```
// Disable http/2, since it doesn't give any advantages for VictoriaMetrics services.
```

As VictoriaLogs and VictoriaTraces rely on `httpserver`, in order to support gRPC over HTTP/2, an option to support HTTP/2 is required.

This change is not reflected in VictoriaMetrics, and no public function call is changed. So the CHANGELOG is left empty.

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
