### PR TITLE
app/vmalert: preserve html formatting in annotations

### DIFF
--- a/app/vmalert/static/css/custom.css
+++ b/app/vmalert/static/css/custom.css
@@ -111,3 +111,9 @@ textarea.curl-area {
 .w-60 {
   width: 60%;
 }
+
+.annotations {
+  white-space: pre-wrap;
+  color: gray;
+  word-wrap: break-word;
+}

--- a/app/vmalert/web.qtpl
+++ b/app/vmalert/web.qtpl
@@ -435,7 +435,7 @@
         <div class="col">
            {% for _, k := range annotationKeys %}
                 <b>{%s k %}:</b><br>
-                <p>{%s alert.Annotations[k] %}</p>
+                <p class="annotations">{%s alert.Annotations[k] %}</p>
           {% endfor %}
         </div>
       </div>
@@ -549,7 +549,7 @@
         <div class="col">
           {% for _, k := range annotationKeys %}
                 <b>{%s k %}:</b><br>
-                <p>{%s rule.Annotations[k] %}</p>
+                <p class="annotations">{%s rule.Annotations[k] %}</p>
           {% endfor %}
         </div>
       </div>

--- a/app/vmalert/web.qtpl.go
+++ b/app/vmalert/web.qtpl.go
@@ -1349,7 +1349,7 @@ func StreamAlert(qw422016 *qt422016.Writer, r *http.Request, alert *rule.ApiAler
 		qw422016.E().S(k)
 //line app/vmalert/web.qtpl:437
 		qw422016.N().S(`:</b><br>
-                <p>`)
+                <p class="annotations">`)
 //line app/vmalert/web.qtpl:438
 		qw422016.E().S(alert.Annotations[k])
 //line app/vmalert/web.qtpl:438
@@ -1608,7 +1608,7 @@ func StreamRuleDetails(qw422016 *qt422016.Writer, r *http.Request, rule rule.Api
 			qw422016.E().S(k)
 //line app/vmalert/web.qtpl:551
 			qw422016.N().S(`:</b><br>
-                <p>`)
+                <p class="annotations">`)
 //line app/vmalert/web.qtpl:552
 			qw422016.E().S(rule.Annotations[k])
 //line app/vmalert/web.qtpl:552


### PR DESCRIPTION
The change is purely visual. It preserves html formatting in annotations when rendering them on rule or alert details page. The css change is clumsy, but demonstrates the point.

--------

Before:
<img width="1179" height="297" alt="image" src="https://github.com/user-attachments/assets/c30e2222-7b0f-4f28-bf6e-c546cc5bb2fc" />


After:
<img width="1196" height="321" alt="image" src="https://github.com/user-attachments/assets/2c6d9530-7ae9-47fd-b4ba-87fe6f44c625" />


-------

p.s. @AndrewChubatiuk I sure know that you could make this change in more elegant or stylish way than I did. Please do so, if you want. Please port this change to vmui too. Thanks!