### PR TITLE
lib/backup/s3remote: properly extend http client if it is present

### DIFF
--- a/docs/victoriametrics/changelog/CHANGELOG.md
+++ b/docs/victoriametrics/changelog/CHANGELOG.md
@@ -26,6 +26,8 @@ See also [LTS releases](https://docs.victoriametrics.com/victoriametrics/lts-rel
 
 ## tip
 
+* BUGFIX: [vmbackup](https://docs.victoriametrics.com/victoriametrics/vmbackup/), [vmrestore](https://docs.victoriametrics.com/victoriametrics/vmrestore/), [vmbackupmanager](https://docs.victoriametrics.com/victoriametrics/vmbackupmanager/): complete a fix of environment variables configuration parsing for connection to AWS S3. Previously, such settings were ignored starting from [v1.115.0](https://docs.victoriametrics.com/victoriametrics/changelog/#v11150) and releases [v1.128.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.128.0), [v1.122.6](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.122.6) and [v1.110.21](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.110.21) did not fix an issue completely. See this issue [#9858](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/9858) for details.
+
 ## [v1.128.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.128.0)
 
 Released at 2025-10-17

--- a/lib/backup/s3remote/s3.go
+++ b/lib/backup/s3remote/s3.go
@@ -174,6 +174,12 @@ func (fs *FS) Init(ctx context.Context) error {
 	// based on additional configuration from environment variables.
 	// See: https://github.com/VictoriaMetrics/VictoriaMetrics/issues/9858
 	c := awshttp.NewBuildableClient()
+	if cfg.HTTPClient != nil {
+		trOpts, ok := cfg.HTTPClient.(*awshttp.BuildableClient)
+		if ok {
+			c = trOpts
+		}
+	}
 	cfg.HTTPClient = c.WithTransportOptions(func(t *http.Transport) {
 		if fs.TLSInsecureSkipVerify {
 			if t.TLSClientConfig == nil {


### PR DESCRIPTION
fb1344b5 replaced an HTTP client unconditionally which overrides configurations which were loaded by AWS SDK. This leads to AWS env variables to being overwritten.

See: https://github.com/VictoriaMetrics/VictoriaMetrics/issues/9858