### PR TITLE
lib/storage: fix loading nextDayMetricIDs cache from a file for different indexDB generation

### DIFF
--- a/lib/storage/storage.go
+++ b/lib/storage/storage.go
@@ -1060,6 +1060,7 @@ func (s *Storage) mustLoadNextDayMetricIDs(generation, date uint64) *byDateMetri
 	src = src[8:]
 	if generationLoaded != generation {
 		logger.Infof("discarding %s, since it contains data for stale generation; got %d; want %d", path, generationLoaded, generation)
+		return e
 	}
 	dateLoaded := encoding.UnmarshalUint64(src)
 	src = src[8:]

--- a/lib/storage/storage_synctest_test.go
+++ b/lib/storage/storage_synctest_test.go
@@ -568,3 +568,101 @@ func TestStorageAddRows_nextDayIndexPrefill(t *testing.T) {
 		s.MustClose()
 	})
 }
+
+func TestStorageMustLoadNextDayMetricIDs(t *testing.T) {
+	defer testRemoveAll(t)
+
+	assertNextDayMetricIDs := func(t *testing.T, gotNextDayMetricIDs *byDateMetricIDEntry, wantGen, wantDate uint64, wantLen int) {
+		t.Helper()
+
+		if got, want := gotNextDayMetricIDs.k.generation, wantGen; got != want {
+			t.Fatalf("unexpected nextDayMetricIDs idb generation: got %d, want %d", got, want)
+		}
+		if got, want := gotNextDayMetricIDs.k.date, wantDate; got != want {
+			t.Fatalf("unexpected nextDayMetricIDs date: got %d, want %d", got, want)
+		}
+		if got, want := gotNextDayMetricIDs.v.Len(), wantLen; got != want {
+			t.Fatalf("unexpected nextDayMetricIDs count: got %d, want %d", got, want)
+		}
+	}
+
+	synctest.Test(t, func(t *testing.T) {
+		// synctest starts at 2000-01-01T00:00:00Z.
+		// Advance time to 23:30 to enable next day prefill.
+		time.Sleep(23*time.Hour + 30*time.Minute) // 2000-01-01T23:30:00Z
+		date := uint64(time.Now().UnixMilli() / msecPerDay)
+
+		const numSeries = 1000
+		s := MustOpenStorage(t.Name(), OpenOptions{})
+		idbPrev, idbCurr := s.getPrevAndCurrIndexDBs()
+		genCurr := idbCurr.generation
+		s.putPrevAndCurrIndexDBs(idbPrev, idbCurr)
+
+		rng := rand.New(rand.NewSource(1))
+		mrs := testGenerateMetricRowsWithPrefix(rng, numSeries, "metric", TimeRange{
+			MinTimestamp: time.Now().Add(-15 * time.Minute).UnixMilli(),
+			MaxTimestamp: time.Now().UnixMilli(),
+		})
+		s.AddRows(mrs, defaultPrecisionBits)
+		s.DebugFlush()
+
+		// After the initial ingestion, the metricIDs are not in
+		// currHourMetricIDs cache yet, so no timeseries will be registered in
+		// next day index.
+		if got := s.pendingNextDayMetricIDs.Len(); got != 0 {
+			t.Fatalf("unexpected pendingNextDayMetricIDs count: got %d, want 0", got)
+		}
+		assertNextDayMetricIDs(t, s.nextDayMetricIDs.Load(), genCurr, date, 0)
+
+		// Wait for currHourMetricIDs cache to populate and ingest the same data
+		// again.
+		time.Sleep(15 * time.Second)
+		synctest.Wait()
+		s.AddRows(mrs, defaultPrecisionBits)
+		s.DebugFlush()
+
+		// The next day metricIDs must now appear in pendingNextDayMetricIDs cache.
+		if s.pendingNextDayMetricIDs.Len() == 0 {
+			t.Fatalf("unexpected pendingNextDayMetricIDs count: got 0, want > 0")
+		}
+		numNextDayMetricIDs := s.pendingNextDayMetricIDs.Len()
+		// But not in the nextDayMetricIDs cache. The pending metrics will be
+		// moved to it by a bg process a few seconds later.
+		assertNextDayMetricIDs(t, s.nextDayMetricIDs.Load(), genCurr, date, 0)
+
+		// Wait for nextDayMetricIDs cache to populate.
+		time.Sleep(15 * time.Second)
+		synctest.Wait()
+
+		// At this point, pending metricIDs must have been moved to
+		// nextDayMetricIDs cache and the pendingNextDayMetricIDs must be empty.
+		if got := s.pendingNextDayMetricIDs.Len(); got != 0 {
+			t.Fatalf("unexpected pendingNextDayMetricIDs count: got %d, want 0", got)
+		}
+		// While the actual cache, must contain the exact number of metricIDs
+		// that once were pending.
+		assertNextDayMetricIDs(t, s.nextDayMetricIDs.Load(), genCurr, date, numNextDayMetricIDs)
+
+		// Close the storage to persist nextDayMetricIDs cache to a file.
+		s.MustClose()
+		// Open the storage again to enrure that the cache is populated
+		// correctly.
+		s = MustOpenStorage(t.Name(), OpenOptions{})
+		if got := s.pendingNextDayMetricIDs.Len(); got != 0 {
+			t.Fatalf("unexpected pendingNextDayMetricIDs count: got %d, want 0", got)
+		}
+		assertNextDayMetricIDs(t, s.nextDayMetricIDs.Load(), genCurr, date, numNextDayMetricIDs)
+
+		// Try loading the cache file contents for a different indexDB.
+		genOther := genCurr + 1
+		gotNextDayMetricIDs := s.mustLoadNextDayMetricIDs(genOther, date)
+		assertNextDayMetricIDs(t, gotNextDayMetricIDs, genOther, date, 0)
+
+		// Try loading the cache file contents for a different date.
+		dateOther := date + 1
+		gotNextDayMetricIDs = s.mustLoadNextDayMetricIDs(genCurr, dateOther)
+		assertNextDayMetricIDs(t, gotNextDayMetricIDs, genCurr, dateOther, 0)
+
+		s.MustClose()
+	})
+}


### PR DESCRIPTION
Previously, if a storage started with curr indexDB different from one stored in nextDayMetricIDs cache file, the cache would still be loaded into memory possibly affecting the next day prefill.

This is an unlikely case but it is still possible when:

- A programmer makes a mistake in the code and uses something else instead of idbCurr.generation.
- Downgrading from pt-index to previous version

Related to #7599 and #8134.

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
