### PR TITLE
app/vmalert: simplify delayBeforeStart func

### DIFF
--- a/app/vmalert/rule/group.go
+++ b/app/vmalert/rule/group.go
@@ -336,7 +336,7 @@ func (g *Group) Start(ctx context.Context, nts func() []notifier.Notifier, rw re
 	// sleep random duration to spread group rules evaluation
 	// over time to reduce the load on datasource.
 	if !SkipRandSleepOnGroupStart {
-		sleepBeforeStart := delayBeforeStart(evalTS, g.GetID(), g.Interval, g.EvalOffset)
+		sleepBeforeStart := g.delayBeforeStart(evalTS)
 		g.infof("will start in %v", sleepBeforeStart)
 
 		sleepTimer := time.NewTimer(sleepBeforeStart)
@@ -475,10 +475,13 @@ func (g *Group) UpdateWith(newGroup *Group) {
 	g.updateCh <- newGroup
 }
 
-// if offset is specified, delayBeforeStart returns a duration to help aligning timestamp with offset;
-// otherwise, it returns a random duration between [0..interval] based on group key.
-func delayBeforeStart(ts time.Time, key uint64, interval time.Duration, offset *time.Duration) time.Duration {
+// delayBeforeStart returns duration for delaying the evaluation start
+// based on given ts and Group settings.
+func (g *Group) delayBeforeStart(ts time.Time) time.Duration {
+	interval := g.Interval
+	offset := g.EvalOffset
 	if offset != nil {
+		// if offset is specified, return a duration aligned with offset
 		currentOffsetPoint := ts.Truncate(interval).Add(*offset)
 		if currentOffsetPoint.Before(ts) {
 			// wait until the next offset point
@@ -487,8 +490,9 @@ func delayBeforeStart(ts time.Time, key uint64, interval time.Duration, offset *
 		return currentOffsetPoint.Sub(ts)
 	}
 
+	// otherwise, return a random duration between [0..interval] based on group ID
 	var randSleep time.Duration
-	randSleep = time.Duration(float64(interval) * (float64(key) / (1 << 64)))
+	randSleep = time.Duration(float64(interval) * (float64(g.GetID()) / (1 << 64)))
 	sleepOffset := time.Duration(ts.UnixNano() % interval.Nanoseconds())
 	if randSleep < sleepOffset {
 		randSleep += interval

--- a/app/vmalert/rule/group_test.go
+++ b/app/vmalert/rule/group_test.go
@@ -573,7 +573,7 @@ func TestGroupStartDelay(t *testing.T) {
 	g := &Group{}
 	// interval of 5min and key generate a static delay of 30s
 	g.Interval = time.Minute * 5
-	key := uint64(math.MaxUint64 / 10)
+	g.id = uint64(math.MaxUint64 / 10)
 
 	f := func(atS, expS string) {
 		t.Helper()
@@ -585,7 +585,7 @@ func TestGroupStartDelay(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		delay := delayBeforeStart(at, key, g.Interval, g.EvalOffset)
+		delay := g.delayBeforeStart(at)
 		gotStart := at.Add(delay)
 		if expTS != gotStart {
 			t.Fatalf("expected to get %v; got %v instead", expTS, gotStart)


### PR DESCRIPTION
It is a cosmetic change: it simplifies function signature by making it a method of the Group struct.