### PR TITLE
lib/streamaggr: aggregation output for summing series

### DIFF
--- a/docs/victoriametrics/stream-aggregation/configuration.md
+++ b/docs/victoriametrics/stream-aggregation/configuration.md
@@ -220,6 +220,7 @@ Below are aggregation functions that can be put in the `outputs` list at [stream
 * [stddev](#stddev)
 * [stdvar](#stdvar)
 * [sum_samples](#sum_samples)
+* [sum_series](#sum_series)
 * [total](#total)
 * [total_prometheus](#total_prometheus)
 * [unique_samples](#unique_samples)
@@ -506,6 +507,26 @@ See also:
 
 - [count_samples](#count_samples)
 - [count_series](#count_series)
+
+### sum_series
+
+`sum_series` sums the last values of unique [time series](https://docs.victoriametrics.com/victoriametrics/keyconcepts/#time-series) over the given `interval`.
+`sum_series` makes sense only for aggregating [gauges](https://docs.victoriametrics.com/victoriametrics/keyconcepts/#gauge).
+
+The results of `sum_series` is equal to the following [MetricsQL](https://docs.victoriametrics.com/victoriametrics/metricsql/) query:
+
+```metricsql
+sum(last_over_time(some_metric[interval]))
+```
+
+`sum_series` tracks unique time series by their labels and stores the last seen value for each series.
+At flush time, it sums all the stored values. This is useful for calculating totals across distinct instances
+or pods, where each time series represents a different entity.
+
+See also:
+
+- [count_series](#count_series)
+- [sum_samples](#sum_samples)
 
 ### total
 

--- a/lib/streamaggr/streamaggr.go
+++ b/lib/streamaggr/streamaggr.go
@@ -48,6 +48,7 @@ var supportedOutputs = []string{
 	"stddev",
 	"stdvar",
 	"sum_samples",
+	"sum_series",
 	"total",
 	"total_prometheus",
 	"unique_samples",
@@ -204,6 +205,7 @@ type Config struct {
 	// - stddev - standard deviation across all the samples
 	// - stdvar - standard variance across all the samples
 	// - sum_samples - sums the input sample values
+	// - sum_series - sums the last value across unique input series
 	// - total - aggregates input counters
 	// - total_prometheus - aggregates input counters, ignoring the first sample in new time series
 	// - unique_samples - counts the number of unique sample values
@@ -792,6 +794,8 @@ func newOutputConfig(output string, outputsSeen map[string]struct{}, useSharedSt
 		return newStdvarAggrConfig(), nil
 	case "sum_samples":
 		return newSumSamplesAggrConfig(), nil
+	case "sum_series":
+		return newSumSeriesAggrConfig(), nil
 	case "total":
 		return newTotalAggrConfig(ignoreFirstSampleIntervalSecs, false, true), nil
 	case "total_prometheus":

--- a/lib/streamaggr/streamaggr_synctest_test.go
+++ b/lib/streamaggr/streamaggr_synctest_test.go
@@ -559,6 +559,35 @@ foo:1m_stdvar{abc="456",de="fg"} 0
   outputs: [stdvar]
 `, "1111")
 
+	// sum_series output
+	f([]string{`
+foo{abc="123"} 4
+bar 5
+foo{abc="123"} 8.5
+foo{abc="456",de="fg"} 8
+`}, time.Minute, `bar:1m_sum_series 5
+foo:1m_sum_series 16.5
+`, `
+- interval: 1m
+  by: [__name__]
+  outputs: [sum_series]
+`, "1111")
+
+	// sum_series output with by label
+	f([]string{`
+foo{abc="123"} 4
+bar 5
+foo{abc="123"} 8.5
+foo{abc="456",de="fg"} 8
+`}, time.Minute, `bar:1m_by_abc_sum_series 5
+foo:1m_by_abc_sum_series{abc="123"} 8.5
+foo:1m_by_abc_sum_series{abc="456"} 8
+`, `
+- interval: 1m
+  by: [abc]
+  outputs: [sum_series]
+`, "1111")
+
 	// histogram_bucket output
 	f([]string{`
 cpu_usage{cpu="1"} 12.5

--- a/lib/streamaggr/streamaggr_timing_test.go
+++ b/lib/streamaggr/streamaggr_timing_test.go
@@ -27,6 +27,7 @@ var benchOutputs = []string{
 	"stddev",
 	"stdvar",
 	"sum_samples",
+	"sum_series",
 	"total",
 	"total_prometheus",
 	"unique_samples",

--- a/lib/streamaggr/sum_series.go
+++ b/lib/streamaggr/sum_series.go
@@ -1,0 +1,44 @@
+package streamaggr
+
+import (
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/bytesutil"
+	"github.com/cespare/xxhash/v2"
+)
+
+type sumSeriesAggrValue struct {
+	samples map[uint64]float64
+}
+
+func (av *sumSeriesAggrValue) pushSample(_ aggrConfig, sample *pushSample, key string, _ int64) {
+	// Store the last value for unique hashes over the keys instead of unique key values.
+	// This reduces memory usage at the cost of possible hash collisions for distinct key values.
+	h := xxhash.Sum64(bytesutil.ToUnsafeBytes(key))
+	av.samples[h] = sample.value
+}
+
+func (av *sumSeriesAggrValue) flush(_ aggrConfig, ctx *flushCtx, key string, _ bool) {
+	if len(av.samples) > 0 {
+		sum := float64(0)
+		for _, v := range av.samples {
+			sum += v
+		}
+		ctx.appendSeries(key, "sum_series", sum)
+		clear(av.samples)
+	}
+}
+
+func (*sumSeriesAggrValue) state() any {
+	return nil
+}
+
+func newSumSeriesAggrConfig() aggrConfig {
+	return &sumSeriesAggrConfig{}
+}
+
+type sumSeriesAggrConfig struct{}
+
+func (*sumSeriesAggrConfig) getValue(_ any) aggrValue {
+	return &sumSeriesAggrValue{
+		samples: make(map[uint64]float64),
+	}
+}


### PR DESCRIPTION
### Describe Your Changes

An aggregation output method `sum_series` allows summing over the last values of timeseries within the aggregation interval.
@valyala 

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
