### PR TITLE
docs: Correct statement about precision in FAQ

### DIFF
--- a/docs/victoriametrics/FAQ.md
+++ b/docs/victoriametrics/FAQ.md
@@ -479,7 +479,7 @@ Please use the [whisper-to-graphite](https://github.com/bzed/whisper-to-graphite
 
 ## Why do the same metrics have differences in VictoriaMetrics' and Prometheus' dashboards?
 
-There could be a slight difference in stored values for time series. Due to different compression algorithms, VM may reduce the precision for float values with more than 12 significant decimal digits.
+There could be a slight difference in stored values for time series. Due to different compression algorithms, VM may reduce the precision for float values with more than 0 significant decimal digits.
 Please see [this article](https://valyala.medium.com/evaluating-performance-and-correctness-victoriametrics-response-e27315627e87).
 
 The query engine may behave differently for some functions. Please see [this article](https://medium.com/@romanhavronenko/victoriametrics-promql-compliance-d4318203f51e).


### PR DESCRIPTION
As demonstrated in #9448, in certain scenarios compression may result in values being stored with 0 significant digits.