### PR TITLE
app/vmagent: add -promscrape.ignoreBrokenScrapeTargets flag  

### DIFF
--- a/lib/promscrape/config.go
+++ b/lib/promscrape/config.go
@@ -84,6 +84,8 @@ var (
 		"See https://docs.victoriametrics.com/victoriametrics/vmagent/#scraping-big-number-of-targets for more info")
 	maxScrapeSize = flagutil.NewBytes("promscrape.maxScrapeSize", 16*1024*1024, "The maximum size of scrape response in bytes to process from Prometheus targets. "+
 		"Bigger responses are rejected. See also max_scrape_size option at https://docs.victoriametrics.com/victoriametrics/sd_configs/#scrape_configs")
+	ignoreBrokenScrapeTargets = flag.Bool("promscrape.ignoreBrokenScrapeTargets", false, "If this flag is set, scrape work for job will be generated even"+
+		"if some scrape config targets where unavaliable. Default is false")
 )
 
 var clusterMemberID int
@@ -831,7 +833,9 @@ func (cfg *Config) getScrapeWorkGeneric(visitConfigs func(sc *ScrapeConfig, visi
 			targetLabels, err := sdc.GetLabels(cfg.baseDir)
 			if err != nil {
 				logger.Errorf("skipping %s targets for job_name=%s because of error: %s", discoveryType, sc.swc.jobName, err)
-				ok = false
+				if !*ignoreBrokenScrapeTargets {
+					ok = false
+				}
 				return
 			}
 			dst = appendScrapeWorkForTargetLabels(dst, sc.swc, targetLabels, discoveryType)


### PR DESCRIPTION
### Describe Your Changes

Fixes: #9375

With new flag enabled when generating scrapeWork for any job's sd_configs (for example http_sd_config as in issue), if any of the targets has an issue getting labels, all the other targets wont be skipped.

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
