### PR TITLE
app/vmui: fix incorrect median value calculation in series

### DIFF
--- a/app/vmui/packages/vmui/src/components/Views/GraphView/GraphView.tsx
+++ b/app/vmui/packages/vmui/src/components/Views/GraphView/GraphView.tsx
@@ -15,7 +15,7 @@ import {
 } from "../../../utils/uplot";
 import { TimeParams, SeriesItem, LegendItemType } from "../../../types";
 import { AxisRange, YaxisState } from "../../../state/graph/reducer";
-import { getAvgFromArray, getMaxFromArray, getMinFromArray } from "../../../utils/math";
+import { getMathStats } from "../../../utils/math";
 import classNames from "classnames";
 import { useTimeState } from "../../../state/time/TimeStateContext";
 import HeatmapChart from "../../Chart/Heatmap/HeatmapChart/HeatmapChart";
@@ -169,8 +169,9 @@ const GraphView: FC<GraphViewProps> = ({
 
       // stabilize float numbers
       const resultAsNumber = results.filter(s => s !== null) as number[];
-      const avg = Math.abs(getAvgFromArray(resultAsNumber));
-      const range = getMinMaxBuffer(getMinFromArray(resultAsNumber), getMaxFromArray(resultAsNumber));
+      const { min, max, avg: avgRaw } = getMathStats(resultAsNumber, { min: true, max: true, avg: true });
+      const avg = Math.abs(Number(avgRaw));
+      const range = getMinMaxBuffer(min, max);
       const rangeStep = Math.abs(range[1] - range[0]);
 
       return (avg > rangeStep * 1e10) && !isAnomalyView ? results.map(() => avg) : results;

--- a/app/vmui/packages/vmui/src/types/uplot.ts
+++ b/app/vmui/packages/vmui/src/types/uplot.ts
@@ -14,7 +14,6 @@ export interface SeriesItemStatsFormatted {
     min: string,
     max: string,
     median: string,
-    last: string
 }
 
 export interface SeriesItem extends Series {

--- a/app/vmui/packages/vmui/src/utils/math.test.ts
+++ b/app/vmui/packages/vmui/src/utils/math.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect } from "vitest";
+import { getMathStats } from "./math";
+
+const finite = (x: number) => Number.isFinite(x);
+
+const expectedMin = (arr: number[]): number | null => {
+  const vals = arr.filter(finite);
+  return vals.length ? Math.min(...vals) : null;
+};
+
+const expectedMax = (arr: number[]): number | null => {
+  const vals = arr.filter(finite);
+  return vals.length ? Math.max(...vals) : null;
+};
+
+const expectedAvg = (arr: number[]): number | null => {
+  const vals = arr.filter(finite);
+  if (!vals.length) return null;
+  const sum = vals.reduce((s, x) => s + x, 0);
+  return sum / vals.length;
+};
+
+const expectedMedian = (arr: number[]): number | null => {
+  const vals = arr.filter(finite).slice().sort((a, b) => a - b);
+  const m = vals.length;
+  if (!m) return null;
+  const k = m >> 1;
+  return m & 1 ? vals[k] : (vals[k - 1] + vals[k]) / 2;
+};
+
+describe("getMathStats — basics", () => {
+  it("returns all nulls when no options are requested", () => {
+    const a = [1, 2, 3];
+    const r = getMathStats(a, {});
+    expect(r).toEqual({ min: null, max: null, median: null, avg: null });
+  });
+
+  it("does not mutate the input array", () => {
+    const a = [7, 3, 10, -2, 5];
+    const before = a.slice();
+    getMathStats(a, { min: true, max: true, median: true, avg: true });
+    expect(a).toEqual(before);
+  });
+});
+
+describe("getMathStats — individual metrics", () => {
+  const arrays = [
+    [7, 3, 10, -2, 5],
+    [0, -0, 0, 0.5, 0.25, -1.25],
+    [100],
+    [NaN, Infinity, -Infinity, 42],
+    [NaN, Infinity, -Infinity],
+    [],
+  ];
+
+  it("min only", () => {
+    for (const a of arrays) {
+      const r = getMathStats(a, { min: true });
+      expect(r.min).toBe(expectedMin(a));
+      expect(r.max).toBeNull();
+      expect(r.avg).toBeNull();
+      expect(r.median).toBeNull();
+    }
+  });
+
+  it("max only", () => {
+    for (const a of arrays) {
+      const r = getMathStats(a, { max: true });
+      expect(r.max).toBe(expectedMax(a));
+      expect(r.min).toBeNull();
+      expect(r.avg).toBeNull();
+      expect(r.median).toBeNull();
+    }
+  });
+
+  it("average only", () => {
+    for (const a of arrays) {
+      const r = getMathStats(a, { avg: true });
+      const exp = expectedAvg(a);
+      if (exp == null) {
+        expect(r.avg).toBeNull();
+      } else {
+        expect(r.avg!).toBeCloseTo(exp, 12);
+      }
+      expect(r.min).toBeNull();
+      expect(r.max).toBeNull();
+      expect(r.median).toBeNull();
+    }
+  });
+
+  it("median only (odd/even, with non-finite filtered)", () => {
+    const cases = [
+      [7, 3, 10, -2, 5],              // odd
+      [7, 3, 10, -2, 5, 8],           // even
+      [NaN, Infinity, 3, 3, 3, 1],    // duplicates + non-finite
+      [100],                          // single
+      [],                             // empty
+      [NaN, Infinity, -Infinity],     // only non-finite
+    ];
+    for (const a of cases) {
+      const r = getMathStats(a, { median: true });
+      const exp = expectedMedian(a);
+      if (exp == null) {
+        expect(r.median).toBeNull();
+      } else {
+        expect(r.median!).toBeCloseTo(exp, 12);
+      }
+      expect(r.min).toBeNull();
+      expect(r.max).toBeNull();
+      expect(r.avg).toBeNull();
+    }
+  });
+});
+
+describe("getMathStats — combined metrics", () => {
+  it("all metrics together", () => {
+    const a = [7, 3, 10, -2, 5, NaN, Infinity];
+    const r = getMathStats(a, { min: true, max: true, avg: true, median: true });
+
+    // expected values computed independently
+    const expMin = expectedMin(a);
+    const expMax = expectedMax(a);
+    const expAvg = expectedAvg(a);
+    const expMedian = expectedMedian(a);
+
+    expect(r.min).toBe(expMin);
+    expect(r.max).toBe(expMax);
+    if (expAvg == null) expect(r.avg).toBeNull();
+    else expect(r.avg!).toBeCloseTo(expAvg, 12);
+    if (expMedian == null) expect(r.median).toBeNull();
+    else expect(r.median!).toBeCloseTo(expMedian, 12);
+  });
+
+  it("does not return median when not requested", () => {
+    const a = [9, 1, 5, 3, 7, 2, 11, 4];
+    const r = getMathStats(a, { min: true, max: true, avg: true /* median: false */ });
+    expect(r.min).toBe(expectedMin(a));
+    expect(r.max).toBe(expectedMax(a));
+    const expAvg = expectedAvg(a)!;
+    expect(r.avg!).toBeCloseTo(expAvg, 12);
+    // IMPORTANT: median should be null if not requested
+    expect(r.median).toBeNull();
+  });
+});

--- a/app/vmui/packages/vmui/src/utils/quickselect.test.ts
+++ b/app/vmui/packages/vmui/src/utils/quickselect.test.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect } from "vitest";
+import quickselect from "./quickselect";
+
+// Helper: verifies partition property around k using given comparator
+function checkPartition<T>(
+  arr: T[],
+  k: number,
+  compare: (a: T, b: T) => number
+) {
+  const pivot = arr[k];
+  for (let i = 0; i < arr.length; i++) {
+    if (i < k) {
+      expect(compare(arr[i], pivot)).toBeLessThanOrEqual(0);
+    } else if (i > k) {
+      expect(compare(arr[i], pivot)).toBeGreaterThanOrEqual(0);
+    }
+  }
+}
+
+const numCmp = (a: number, b: number) => (a < b ? -1 : a > b ? 1 : 0);
+
+describe("quickselect (numbers)", () => {
+  it("finds k-th smallest on small array", () => {
+    const arr = [7, 2, 9, 1, 5, 3];
+    const k = 3;
+    const orig = arr.slice();
+    quickselect(arr, k);
+    const sorted = orig.slice().sort(numCmp);
+    expect(arr[k]).toBe(sorted[k]);
+    checkPartition(arr, k, numCmp);
+  });
+
+  it("works for k = 0 (minimum)", () => {
+    const arr = [10, -1, 4, 4, 2];
+    const orig = arr.slice();
+    quickselect(arr, 0);
+    expect(arr[0]).toBe(Math.min(...orig));
+    checkPartition(arr, 0, numCmp);
+  });
+
+  it("works for k = n-1 (maximum)", () => {
+    const arr = [10, -1, 4, 4, 2];
+    const k = arr.length - 1;
+    const orig = arr.slice();
+    quickselect(arr, k);
+    expect(arr[k]).toBe(Math.max(...orig));
+    checkPartition(arr, k, numCmp);
+  });
+
+  it("handles duplicates correctly", () => {
+    const arr = [5, 1, 3, 3, 3, 2, 5, 4];
+    const k = 4;
+    const orig = arr.slice();
+    quickselect(arr, k);
+    const sorted = orig.slice().sort(numCmp);
+    expect(arr[k]).toBe(sorted[k]);
+    checkPartition(arr, k, numCmp);
+  });
+
+  it("handles negative numbers and mixed values", () => {
+    const arr = [0, -100, 50, -3, 7, 7, 2, -1];
+    const k = 2;
+    const orig = arr.slice();
+    quickselect(arr, k);
+    const sorted = orig.slice().sort(numCmp);
+    expect(arr[k]).toBe(sorted[k]);
+    checkPartition(arr, k, numCmp);
+  });
+
+  it("matches fully sorted array at many random ks", () => {
+    for (let t = 0; t < 25; t++) {
+      const n = 50;
+      const arr = Array.from({ length: n }, () => Math.floor(Math.random() * 1000) - 500);
+      const k = Math.floor(Math.random() * n);
+      const orig = arr.slice();
+      quickselect(arr, k);
+      const sorted = orig.slice().sort(numCmp);
+      expect(arr[k]).toBe(sorted[k]);
+      checkPartition(arr, k, numCmp);
+    }
+  });
+
+  it("handles already sorted and reverse-sorted", () => {
+    const asc = [1, 2, 3, 4, 5, 6, 7, 8, 9];
+    const k1 = 4;
+    const origAsc = asc.slice();
+    quickselect(asc, k1);
+    expect(asc[k1]).toBe(origAsc[k1]);
+    checkPartition(asc, k1, numCmp);
+
+    const desc = [9, 8, 7, 6, 5, 4, 3, 2, 1];
+    const k2 = 3;
+    const origDesc = desc.slice();
+    quickselect(desc, k2);
+    const sortedDesc = origDesc.slice().sort(numCmp);
+    expect(desc[k2]).toBe(sortedDesc[k2]);
+    checkPartition(desc, k2, numCmp);
+  });
+
+  it("handles all-equal values", () => {
+    const arr = Array(100).fill(42);
+    const k = 50;
+    quickselect(arr, k);
+    expect(arr[k]).toBe(42);
+    checkPartition(arr, k, numCmp);
+  });
+});
+
+describe("quickselect (custom comparator)", () => {
+  it("works with strings (lexicographic)", () => {
+    const arr = ["pear", "apple", "banana", "apricot", "kiwi"];
+    const k = 2;
+    const cmp = (a: string, b: string) => a.localeCompare(b);
+    const orig = arr.slice();
+    quickselect(arr, k, 0, arr.length - 1, cmp);
+    const sorted = orig.slice().sort(cmp);
+    expect(arr[k]).toBe(sorted[k]);
+    checkPartition(arr, k, cmp);
+  });
+
+  it("works with objects via custom comparator (by score asc)", () => {
+    type Item = { id: string; score: number };
+    const items: Item[] = [
+      { id: "a", score: 10 },
+      { id: "b", score: -3 },
+      { id: "c", score: 7 },
+      { id: "d", score: 7 },
+      { id: "e", score: 0 },
+    ];
+    const k = 3;
+    const cmp = (x: Item, y: Item) => (x.score < y.score ? -1 : x.score > y.score ? 1 : 0);
+
+    const orig = items.slice();
+    quickselect(items, k, 0, items.length - 1, cmp);
+
+    const sorted = orig.slice().sort(cmp);
+    expect(items[k].score).toBe(sorted[k].score);
+    checkPartition(items, k, cmp);
+  });
+});
+
+describe("quickselect (bounds/segments)", () => {
+  it("respects left/right boundaries (partial region)", () => {
+    const arr = [9, 8, 7, 6, 5, 4, 3, 2, 1];
+    // We'll only work inside [2..6], so k=4 is within that range.
+    const left = 2;
+    const right = 6;
+    const k = 4;
+
+    const before = arr.slice();
+    quickselect(arr, k, left, right);
+
+    // Elements outside [left..right] remain untouched
+    expect(arr.slice(0, left)).toEqual(before.slice(0, left));
+    expect(arr.slice(right + 1)).toEqual(before.slice(right + 1));
+
+    // Inside the segment, property holds
+    const seg = arr.slice(left, right + 1);
+    const segCmp = numCmp;
+    checkPartition(seg, k - left, segCmp);
+
+    // And k-th inside the segment matches the k-th of the sorted segment
+    const segSorted = before.slice(left, right + 1).sort(segCmp);
+    expect(arr[k]).toBe(segSorted[k - left]);
+  });
+
+  it("single-element segment is a no-op", () => {
+    const arr = [5, 4, 3, 2, 1];
+    const left = 2, right = 2, k = 2;
+    const before = arr.slice();
+    quickselect(arr, k, left, right);
+    expect(arr).toEqual(before);
+  });
+
+  it("k at segment boundaries (left/right)", () => {
+    const arr1 = [7, 4, 6, 1, 9, 2, 5, 0];
+    const left1 = 2, right1 = 6, k1 = left1;
+    const segSorted1 = arr1.slice(left1, right1 + 1).slice().sort(numCmp);
+    quickselect(arr1, k1, left1, right1);
+    expect(arr1[k1]).toBe(segSorted1[0]);
+    checkPartition(arr1.slice(left1, right1 + 1), k1 - left1, numCmp);
+
+    const arr2 = [7, 4, 6, 1, 9, 2, 5, 0];
+    const left2 = 1, right2 = 5, k2 = right2;
+    const segSorted2 = arr2.slice(left2, right2 + 1).slice().sort(numCmp);
+    quickselect(arr2, k2, left2, right2);
+    expect(arr2[k2]).toBe(segSorted2[segSorted2.length - 1]);
+    checkPartition(arr2.slice(left2, right2 + 1), k2 - left2, numCmp);
+  });
+});
+
+describe("quickselect (Floyd–Rivest path)", () => {
+  it("covers the large-array acceleration branch", () => {
+    const n = 2000; // right - left = 1999 > 600 -> triggers acceleration
+    const base = 2654435761; // Knuth multiplicative hash (32-bit after >>> 0)
+    const arr = Array.from({ length: n }, (_, i) => ((i * base) >>> 0))
+      .map(x => (x % 2000) - 1000); // keep numbers in a small range to include duplicates
+    const k = Math.floor(n * 0.63);
+
+    const orig = arr.slice();
+    quickselect(arr, k);
+    const sorted = orig.slice().sort(numCmp);
+
+    expect(arr[k]).toBe(sorted[k]);
+    checkPartition(arr, k, numCmp);
+  });
+});

--- a/app/vmui/packages/vmui/src/utils/quickselect.ts
+++ b/app/vmui/packages/vmui/src/utils/quickselect.ts
@@ -1,0 +1,58 @@
+// In-place quickselect: reorders the array so arr[k] is the k-th smallest (avg O(n));
+// uses a Floyd–Rivest speedup.
+
+export default function quickselect<T>(
+  arr: T[],
+  k: number,
+  left: number = 0,
+  right: number = arr.length - 1,
+  compare: (a: T, b: T) => number = defaultCompare as (a: T, b: T) => number
+): void {
+  while (right > left) {
+    if (right - left > 600) {
+      const n = right - left + 1;
+      const m = k - left + 1;
+      const z = Math.log(n);
+      const s = 0.5 * Math.exp((2 * z) / 3);
+      const sd = 0.5 * Math.sqrt((z * s * (n - s)) / n) * (m - n / 2 < 0 ? -1 : 1);
+      const newLeft = Math.max(left, Math.floor(k - (m * s) / n + sd));
+      const newRight = Math.min(right, Math.floor(k + ((n - m) * s) / n + sd));
+      quickselect(arr, k, newLeft, newRight, compare);
+    }
+
+    const t = arr[k];
+    let i = left;
+    let j: number = right;
+
+    swap(arr, left, k);
+    if (compare(arr[right], t) > 0) swap(arr, left, right);
+
+    while (i < j) {
+      swap(arr, i, j);
+      i++;
+      j--;
+      while (compare(arr[i], t) < 0) i++;
+      while (compare(arr[j], t) > 0) j--;
+    }
+
+    if (compare(arr[left], t) === 0) {
+      swap(arr, left, j);
+    } else {
+      j++;
+      swap(arr, j, right);
+    }
+
+    if (j <= k) left = j + 1;
+    if (k <= j) right = j - 1;
+  }
+}
+
+function swap<T>(arr: T[], i: number, j: number): void {
+  const tmp = arr[i];
+  arr[i] = arr[j];
+  arr[j] = tmp;
+}
+
+function defaultCompare(a: number, b: number): number {
+  return a < b ? -1 : a > b ? 1 : 0;
+}

--- a/app/vmui/packages/vmui/src/utils/uplot/axes.ts
+++ b/app/vmui/packages/vmui/src/utils/uplot/axes.ts
@@ -1,5 +1,5 @@
 import uPlot, { Axis, Series } from "uplot";
-import { getMaxFromArray, getMinFromArray } from "../math";
+import { getMathStats } from "../math";
 import { getSecondsFromDuration, roundToMilliseconds } from "../time";
 import { AxisRange } from "../../state/graph/reducer";
 import { formatTicks, getTextWidth } from "./helpers";
@@ -73,9 +73,8 @@ export const getLimitsYAxis = (values: { [key: string]: number[] }, buffer: bool
   const result: AxisRange = {};
   const numbers = Object.values(values).flat();
   const key = "1";
-  const min = getMinFromArray(numbers) || 0;
-  const max = getMaxFromArray(numbers) || 1;
-  result[key] = buffer ? getMinMaxBuffer(min, max) : [min, max];
+  const { min, max } = getMathStats(numbers, {min: true, max: true})
+  result[key] = buffer ? getMinMaxBuffer(min, max) : [min || -1, max || 1];
   return result;
 };
 

--- a/app/vmui/packages/vmui/src/utils/uplot/series.ts
+++ b/app/vmui/packages/vmui/src/utils/uplot/series.ts
@@ -3,7 +3,7 @@ import uPlot, { Series as uPlotSeries } from "uplot";
 import { getNameForMetric, promValueToNumber } from "../metric";
 import { BarSeriesItem, Disp, Fill, ForecastType, HideSeriesArgs, LegendItemType, SeriesItem, Stroke } from "../../types";
 import { anomalyColors, baseContrastColors, getColorFromString } from "../color";
-import { getLastFromArray, getMaxFromArray, getMedianFromArray, getMinFromArray } from "../math";
+import { getMathStats } from "../math";
 import { formatPrettyNumber } from "./helpers";
 
 // Helper function to extract freeFormFields values as a comma-separated string
@@ -65,19 +65,13 @@ export const getSeriesItemContext = (data: MetricResult[], hideSeries: string[],
 
 const getSeriesStatistics = (d: MetricResult) => {
   const values = d.values.map(v => promValueToNumber(v[1]));
-  const { min, max, median, last } = {
-    min: getMinFromArray(values),
-    max: getMaxFromArray(values),
-    median: getMedianFromArray(values),
-    last: getLastFromArray(values),
-  };
+  const { min, max, median } = getMathStats(values, { min: true, max: true, median: true });
   return {
-    median,
+    median: Number(median),
     statsFormatted: {
       min: formatPrettyNumber(min, min, max),
       max: formatPrettyNumber(max, min, max),
       median: formatPrettyNumber(median, min, max),
-      last: formatPrettyNumber(last, min, max),
     },
   };
 };

--- a/docs/victoriametrics/changelog/CHANGELOG.md
+++ b/docs/victoriametrics/changelog/CHANGELOG.md
@@ -28,6 +28,8 @@ See also [LTS releases](https://docs.victoriametrics.com/victoriametrics/lts-rel
 
 * FEATURE: [vmagent](https://docs.victoriametrics.com/victoriametrics/vmagent/): add ability to set `attach_metadata.namespace=true` option for all the [`kubernetes_sd_configs`](https://docs.victoriametrics.com/victoriametrics/sd_configs/#kubernetes_sd_configs) defined at [`-promscrape.config`](https://docs.victoriametrics.com/victoriametrics/vmagent/#quick-start), or via `-promscrape.kubernetes.attachNamespaceMetadataAll` command-line flag. This allows attaching namespace labels and annotations to discovered targets for `pod`, `service`, `endpoints`, `endpointslice`, and `ingress` roles. See [#9880](https://github.com/VictoriaMetrics/VictoriaMetrics/pull/9880) for more details. Thank you, @clementnuss, for the contribution. 
 
+* BUGFIX: [vmui](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#vmui): fix median value calculation displayed below series graph. See [#9926](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/9926).
+
 ## [v1.129.1](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.129.1)
 
 Released at 2025-11-04


### PR DESCRIPTION
### Describe Your Changes

This PR fixes incorrect median calculation in metric series.

* Switched median algorithm to Quickselect (Floyd–Rivest).
* Unified array stats functions (`min`, `max`, `avg`, `median`) into a single pass.
* Removed unused `last` value from series.

**Note**: Duplicated from PR #9946 for isolated testing and review.

Related issue: #9926

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
