### PR TITLE
app/vmui: fixed ability to select multiple metrics in explore metrics tab

### DIFF
--- a/app/vmui/packages/vmui/src/components/ExploreAlerts/NotifiersHeader/style.scss
+++ b/app/vmui/packages/vmui/src/components/ExploreAlerts/NotifiersHeader/style.scss
@@ -46,9 +46,6 @@
     .vm-text-field__input {
       padding: 11px 28px;
     }
-    .vm-text-field__icon-start {
-      height: 42px;
-    }
   }
 
   &__clear-icon {

--- a/app/vmui/packages/vmui/src/components/ExploreAlerts/RulesHeader/index.tsx
+++ b/app/vmui/packages/vmui/src/components/ExploreAlerts/RulesHeader/index.tsx
@@ -61,7 +61,7 @@ const RulesHeader: FC<RulesHeaderProps> = ({
             value={states}
             list={allStates}
             label="State"
-            placeholder="Please rule state"
+            placeholder="Please select rule state"
             onChange={onChangeStates}
             noOptionsText={noStateText}
             includeAll

--- a/app/vmui/packages/vmui/src/components/ExploreAlerts/RulesHeader/style.scss
+++ b/app/vmui/packages/vmui/src/components/ExploreAlerts/RulesHeader/style.scss
@@ -26,9 +26,6 @@
     .vm-text-field__input {
       padding: 11px 28px;
     }
-    .vm-text-field__icon-start {
-      height: 42px;
-    }
   }
 
   &__clear-icon {

--- a/app/vmui/packages/vmui/src/components/ExploreMetrics/ExploreMetricGraph/ExploreMetricItemGraph.tsx
+++ b/app/vmui/packages/vmui/src/components/ExploreMetrics/ExploreMetricGraph/ExploreMetricItemGraph.tsx
@@ -43,7 +43,7 @@ const ExploreMetricItem: FC<ExploreMetricItemGraphProps> = ({
   const step = isHeatmap && customStep === defaultStep ? heatmapStep : customStep;
 
 
-  const query = useMemo(() => {
+  const queries = useMemo(() => {
     const params = Object.entries({ job, instance })
       .filter(val => val[1])
       .map(([key, val]) => `${key}=${JSON.stringify(val)}`);
@@ -55,19 +55,19 @@ const ExploreMetricItem: FC<ExploreMetricItemGraphProps> = ({
 
     const base = `{${params.join(",")}}`;
     if (isBucket) {
-      return `sum(rate(${base})) by (vmrange, le)`;
+      return [`sum(rate(${base})) by (vmrange, le)`];
     }
     const queryBase = rateEnabled ? `rollup_rate(${base})` : `rollup(${base})`;
-    return `
+    return [`
 with (q = ${queryBase}) (
   alias(min(label_match(q, "rollup", "min")), "min"),
   alias(max(label_match(q, "rollup", "max")), "max"),
   alias(avg(label_match(q, "rollup", "avg")), "avg"),
-)`;
+)`];
   }, [name, job, instance, rateEnabled, isBucket]);
 
   const { isLoading, graphData, error, queryErrors, warning, isHistogram } = useFetchQuery({
-    predefinedQuery: [query],
+    predefinedQuery: queries,
     visible: true,
     customStep: step,
     showAllSeries
@@ -98,7 +98,7 @@ with (q = ${queryBase}) (
       {warning && (
         <WarningLimitSeries
           warning={warning}
-          query={[query]}
+          query={queries}
           onChange={setShowAllSeries}
         />
       )}
@@ -107,7 +107,7 @@ with (q = ${queryBase}) (
           data={graphData}
           period={period}
           customStep={step}
-          query={[query]}
+          query={queries}
           yaxis={yaxis}
           setYaxisLimits={setYaxisLimits}
           setPeriod={setPeriod}

--- a/app/vmui/packages/vmui/src/components/Main/Select/Select.tsx
+++ b/app/vmui/packages/vmui/src/components/Main/Select/Select.tsx
@@ -137,6 +137,7 @@ const Select: FC<SelectProps> = ({
         "vm-select_disabled": disabled
       })}
     >
+      {label && <span className="vm-text-field__label">{label}</span>}
       <div
         className="vm-select-input"
         onClick={handleToggleList}
@@ -150,7 +151,7 @@ const Select: FC<SelectProps> = ({
               onRemoveItem={handleSelected}
             />
           )}
-          {!hideInput && !selectedValues?.length && (
+          {!hideInput && (
             <input
               value={textFieldValue}
               type="text"
@@ -164,7 +165,6 @@ const Select: FC<SelectProps> = ({
             />
           )}
         </div>
-        {label && <span className="vm-text-field__label">{label}</span>}
         {clearable && value && (
           <div
             className="vm-select-input__icon"

--- a/app/vmui/packages/vmui/src/components/Main/Select/style.scss
+++ b/app/vmui/packages/vmui/src/components/Main/Select/style.scss
@@ -1,6 +1,8 @@
 @use "src/styles/variables" as *;
 
 .vm-select {
+  position: relative;
+  display: grid;
   &-input {
     position: relative;
     display: flex;

--- a/docs/victoriametrics/changelog/CHANGELOG.md
+++ b/docs/victoriametrics/changelog/CHANGELOG.md
@@ -34,6 +34,7 @@ See also [LTS releases](https://docs.victoriametrics.com/victoriametrics/lts-rel
 * BUGFIX: `vmselect` in [VictoriaMetrics cluster](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/): respect `replicationFactor` and `globalReplicationFactor` settings when some of vmstorage nodes are overloaded. See [#10030](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/10030) for details. Thanks to @tIGO for the contribution.
 * BUGFIX: [vmui](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#vmui): remove the “step” control from the Raw Query page, since it didn't affect the chart rendering. See [#9667](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/9667).
 * BUGFIX: [vmui](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#vmui): fix display of multiple points at the same timestamp on the Raw Query page. See [#9666](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/9666).
+* BUGFIX: [vmui](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#vmui): fix ability to select multiple metrics in `Explore Metrics` tab. See [#9995](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/9995).
 
 ## [v1.130.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.130.0)
 


### PR DESCRIPTION
fixes https://github.com/VictoriaMetrics/VictoriaMetrics/issues/9995

change in only `Select` component leads to infinite ExploreMetricsGraphItem component refresh since each time array has a new reference

### Describe Your Changes

Please provide a brief description of the changes you made. Be as specific as possible to help others understand the purpose and impact of your modifications.

### Checklist

The following checks are **mandatory**:

- [ ] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [ ] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
