### PR TITLE
lib/workingsetcache: Fix bytesSize metric calculation

### DIFF
--- a/lib/workingsetcache/cache.go
+++ b/lib/workingsetcache/cache.go
@@ -457,7 +457,7 @@ func (c *Cache) UpdateStats(fcs *fastcache.Stats) {
 
 	// Track the total number of entries across prev and curr, since they all occupy memory.
 	fcs.EntriesCount += csPrev.EntriesCount + csCurr.EntriesCount
-	fcs.BytesSize += csPrev.EntriesCount + csCurr.EntriesCount
+	fcs.BytesSize += csPrev.BytesSize + csCurr.BytesSize
 	fcs.MaxBytesSize += csPrev.MaxBytesSize + csCurr.MaxBytesSize
 }
 


### PR DESCRIPTION
Follow-up for 3e6fc445a96eebafbb840f8f5d06af51008ff56f

cc: @valyala 