### PR TITLE
lib/storage: add overlapsWith() and contains() methods to TimeRange

### DIFF
--- a/lib/storage/partition.go
+++ b/lib/storage/partition.go
@@ -872,7 +872,7 @@ func newPartWrapperFromInmemoryPart(mp *inmemoryPart, flushToDiskDeadline time.T
 
 // HasTimestamp returns true if the pt contains the given timestamp.
 func (pt *partition) HasTimestamp(timestamp int64) bool {
-	return timestamp >= pt.tr.MinTimestamp && timestamp <= pt.tr.MaxTimestamp
+	return pt.tr.contains(timestamp)
 }
 
 // GetParts appends parts snapshot to dst and returns it.

--- a/lib/storage/partition_search.go
+++ b/lib/storage/partition_search.go
@@ -75,7 +75,7 @@ func (pts *partitionSearch) Init(pt *partition, tsids []TSID, tr TimeRange) {
 		return
 	}
 
-	if pt.tr.MinTimestamp > tr.MaxTimestamp || pt.tr.MaxTimestamp < tr.MinTimestamp {
+	if !pt.tr.overlapsWith(tr) {
 		// Fast path - the partition doesn't contain rows for the given time range.
 		pts.err = io.EOF
 		return

--- a/lib/storage/time.go
+++ b/lib/storage/time.go
@@ -104,6 +104,18 @@ func (tr *TimeRange) fromPartitionTime(t time.Time) {
 	tr.MaxTimestamp = maxTime.Unix()*1e3 - 1
 }
 
-const msecPerDay = 24 * 3600 * 1000
+// overlapsWith returns true if the time range overlaps with the given time
+// range.
+func (tr *TimeRange) overlapsWith(v TimeRange) bool {
+	return tr.MinTimestamp <= v.MaxTimestamp && tr.MaxTimestamp >= v.MinTimestamp
+}
 
-const msecPerHour = 3600 * 1000
+// contains returns true if the time range contains the given timestamp.
+func (tr *TimeRange) contains(timestamp int64) bool {
+	return tr.MinTimestamp <= timestamp && timestamp <= tr.MaxTimestamp
+}
+
+const (
+	msecPerDay  = 24 * 3600 * 1000
+	msecPerHour = 3600 * 1000
+)


### PR DESCRIPTION
The change was introduced in pt-index PR (#8134) and is extracted into a separate PR.

Currently used in partition_search and partition. If you see more places like this, please let me know.