### PR TITLE
lib/storage: minor metricNameSearch fixes

### DIFF
--- a/lib/storage/metric_name_search.go
+++ b/lib/storage/metric_name_search.go
@@ -37,7 +37,7 @@ type metricNameSearch struct {
 func (s *metricNameSearch) search(dst []byte, metricID uint64) ([]byte, bool) {
 	if !s.useSparseCache {
 		n := len(dst)
-		dst := s.storage.getMetricNameFromCache(dst, metricID)
+		dst = s.storage.getMetricNameFromCache(dst, metricID)
 		if len(dst) > n {
 			return dst, true
 		}


### PR DESCRIPTION
- Fix comment
- Re-use dst instead introducing a new variable.

This change has been requested to be in a separated PR during the pt-index (#8134) code review.
