### PR TITLE
lib/lrucache: use uint64 for SizeBytes() and SizeMaxBytes()

### DIFF
--- a/app/vmstorage/main.go
+++ b/app/vmstorage/main.go
@@ -656,8 +656,8 @@ func writeStorageMetrics(w io.Writer, strg *storage.Storage) {
 	metrics.WriteGaugeUint64(w, `vm_cache_size_bytes{type="storage/hour_metric_ids"}`, m.HourMetricIDCacheSizeBytes)
 	metrics.WriteGaugeUint64(w, `vm_cache_size_bytes{type="storage/next_day_metric_ids"}`, m.NextDayMetricIDCacheSizeBytes)
 	metrics.WriteGaugeUint64(w, `vm_cache_size_bytes{type="indexdb/tagFiltersToMetricIDs"}`, idbm.TagFiltersToMetricIDsCacheSizeBytes)
-	metrics.WriteGaugeUint64(w, `vm_cache_size_bytes{type="storage/regexps"}`, uint64(storage.RegexpCacheSizeBytes()))
-	metrics.WriteGaugeUint64(w, `vm_cache_size_bytes{type="storage/regexpPrefixes"}`, uint64(storage.RegexpPrefixesCacheSizeBytes()))
+	metrics.WriteGaugeUint64(w, `vm_cache_size_bytes{type="storage/regexps"}`, storage.RegexpCacheSizeBytes())
+	metrics.WriteGaugeUint64(w, `vm_cache_size_bytes{type="storage/regexpPrefixes"}`, storage.RegexpPrefixesCacheSizeBytes())
 
 	metrics.WriteGaugeUint64(w, `vm_cache_size_max_bytes{type="storage/tsid"}`, m.TSIDCacheSizeMaxBytes)
 	metrics.WriteGaugeUint64(w, `vm_cache_size_max_bytes{type="storage/metricIDs"}`, m.MetricIDCacheSizeMaxBytes)
@@ -667,8 +667,8 @@ func writeStorageMetrics(w io.Writer, strg *storage.Storage) {
 	metrics.WriteGaugeUint64(w, `vm_cache_size_max_bytes{type="indexdb/dataBlocksSparse"}`, idbm.DataBlocksSparseCacheSizeMaxBytes)
 	metrics.WriteGaugeUint64(w, `vm_cache_size_max_bytes{type="indexdb/indexBlocks"}`, idbm.IndexBlocksCacheSizeMaxBytes)
 	metrics.WriteGaugeUint64(w, `vm_cache_size_max_bytes{type="indexdb/tagFiltersToMetricIDs"}`, idbm.TagFiltersToMetricIDsCacheSizeMaxBytes)
-	metrics.WriteGaugeUint64(w, `vm_cache_size_max_bytes{type="storage/regexps"}`, uint64(storage.RegexpCacheMaxSizeBytes()))
-	metrics.WriteGaugeUint64(w, `vm_cache_size_max_bytes{type="storage/regexpPrefixes"}`, uint64(storage.RegexpPrefixesCacheMaxSizeBytes()))
+	metrics.WriteGaugeUint64(w, `vm_cache_size_max_bytes{type="storage/regexps"}`, storage.RegexpCacheMaxSizeBytes())
+	metrics.WriteGaugeUint64(w, `vm_cache_size_max_bytes{type="storage/regexpPrefixes"}`, storage.RegexpPrefixesCacheMaxSizeBytes())
 
 	metrics.WriteCounterUint64(w, `vm_cache_requests_total{type="storage/tsid"}`, m.TSIDCacheRequests)
 	metrics.WriteCounterUint64(w, `vm_cache_requests_total{type="storage/metricIDs"}`, m.MetricIDCacheRequests)

--- a/lib/lrucache/lrucache_test.go
+++ b/lib/lrucache/lrucache_test.go
@@ -9,13 +9,13 @@ import (
 )
 
 func TestCache(t *testing.T) {
-	sizeMaxBytes := 64 * 1024
+	sizeMaxBytes := uint64(64 * 1024)
 	// Multiply sizeMaxBytes by the square of available CPU cores
 	// in order to get proper distribution of sizes between cache shards.
 	// See https://github.com/VictoriaMetrics/VictoriaMetrics/issues/2204
 	cpus := cgroup.AvailableCPUs()
-	sizeMaxBytes *= cpus * cpus
-	getMaxSize := func() int {
+	sizeMaxBytes *= uint64(cpus * cpus)
+	getMaxSize := func() uint64 {
 		return sizeMaxBytes
 	}
 	c := NewCache(getMaxSize)
@@ -86,8 +86,8 @@ func TestCache(t *testing.T) {
 }
 
 func TestCacheConcurrentAccess(_ *testing.T) {
-	const sizeMaxBytes = 16 * 1024 * 1024
-	getMaxSize := func() int {
+	const sizeMaxBytes = uint64(16 * 1024 * 1024)
+	getMaxSize := func() uint64 {
 		return sizeMaxBytes
 	}
 	c := NewCache(getMaxSize)
@@ -121,6 +121,6 @@ func testCacheSetGet(c *Cache, worker int) {
 
 type testEntry struct{}
 
-func (tb *testEntry) SizeBytes() int {
+func (tb *testEntry) SizeBytes() uint64 {
 	return 42
 }

--- a/lib/storage/tag_filters.go
+++ b/lib/storage/tag_filters.go
@@ -513,12 +513,12 @@ func RegexpCacheSize() int {
 }
 
 // RegexpCacheSizeBytes returns an approximate size in bytes for the cached regexps for tag filters.
-func RegexpCacheSizeBytes() int {
+func RegexpCacheSizeBytes() uint64 {
 	return regexpCache.SizeBytes()
 }
 
 // RegexpCacheMaxSizeBytes returns the maximum size in bytes for the cached regexps for tag filters.
-func RegexpCacheMaxSizeBytes() int {
+func RegexpCacheMaxSizeBytes() uint64 {
 	return regexpCache.SizeMaxBytes()
 }
 
@@ -565,7 +565,7 @@ func getRegexpFromCache(expr string) (*regexpCacheValue, error) {
 	rcv.reCost = reCost
 	rcv.literalSuffix = literalSuffix
 	// heuristic for rcv in-memory size
-	rcv.sizeBytes = 8*len(exprOrig) + len(literalSuffix)
+	rcv.sizeBytes = uint64(8*len(exprOrig) + len(literalSuffix))
 	regexpCache.PutEntry(exprOrig, &rcv)
 
 	return &rcv, nil
@@ -853,15 +853,15 @@ var tagCharsReverseRegexpEscaper = strings.NewReplacer(
 	"\x002", "\x02", // kvSeparatorChar
 )
 
-func getMaxRegexpCacheSize() int {
+func getMaxRegexpCacheSize() uint64 {
 	maxRegexpCacheSizeOnce.Do(func() {
-		maxRegexpCacheSize = int(0.05 * float64(memory.Allowed()))
+		maxRegexpCacheSize = uint64(0.05 * float64(memory.Allowed()))
 	})
 	return maxRegexpCacheSize
 }
 
 var (
-	maxRegexpCacheSize     int
+	maxRegexpCacheSize     uint64
 	maxRegexpCacheSizeOnce sync.Once
 )
 
@@ -874,11 +874,11 @@ type regexpCacheValue struct {
 	reMatch       func(b []byte) bool
 	reCost        uint64
 	literalSuffix string
-	sizeBytes     int
+	sizeBytes     uint64
 }
 
 // SizeBytes implements lrucache.Entry interface
-func (rcv *regexpCacheValue) SizeBytes() int {
+func (rcv *regexpCacheValue) SizeBytes() uint64 {
 	return rcv.sizeBytes
 }
 
@@ -908,15 +908,15 @@ func simplifyRegexp(expr string) (string, string) {
 	return prefix, suffix
 }
 
-func getMaxPrefixesCacheSize() int {
+func getMaxPrefixesCacheSize() uint64 {
 	maxPrefixesCacheSizeOnce.Do(func() {
-		maxPrefixesCacheSize = int(0.05 * float64(memory.Allowed()))
+		maxPrefixesCacheSize = uint64(0.05 * float64(memory.Allowed()))
 	})
 	return maxPrefixesCacheSize
 }
 
 var (
-	maxPrefixesCacheSize     int
+	maxPrefixesCacheSize     uint64
 	maxPrefixesCacheSizeOnce sync.Once
 )
 
@@ -930,12 +930,12 @@ func RegexpPrefixesCacheSize() int {
 }
 
 // RegexpPrefixesCacheSizeBytes returns an approximate size in bytes for cached regexp prefixes for tag filters.
-func RegexpPrefixesCacheSizeBytes() int {
+func RegexpPrefixesCacheSizeBytes() uint64 {
 	return prefixesCache.SizeBytes()
 }
 
 // RegexpPrefixesCacheMaxSizeBytes returns the maximum size in bytes for cached regexp prefixes for tag filters in bytes.
-func RegexpPrefixesCacheMaxSizeBytes() int {
+func RegexpPrefixesCacheMaxSizeBytes() uint64 {
 	return prefixesCache.SizeMaxBytes()
 }
 
@@ -955,6 +955,6 @@ type prefixSuffix struct {
 }
 
 // SizeBytes implements lrucache.Entry interface
-func (ps *prefixSuffix) SizeBytes() int {
-	return len(ps.prefix) + len(ps.suffix) + int(unsafe.Sizeof(*ps))
+func (ps *prefixSuffix) SizeBytes() uint64 {
+	return uint64(len(ps.prefix) + len(ps.suffix) + int(unsafe.Sizeof(*ps)))
 }


### PR DESCRIPTION
Currently, `lrucache.Cache` `SizeBytes()` and `SizeMaxBytes()` return type is `int`. The cache `Entry.SizeBytes()` also returns `int` value. Changing the type to `uint64` will allow using `uint64set.Set` as the cache entry type (see #10072).

Please note that using `uint64` regardless the cpu architecture is set is not entirely correct, because in 32-bit systems the size won't ever get bigger than `2^32`, so the `uint64` will too much. However current type (`int`) is not correct either since it is signed and will only allow to store values up to `2^31`. Alternatively, all `SizeBytes()` methods should return `uint`. 