### PR TITLE
lib/lrucache: do not reset requests and misses after cache reset

### DIFF
--- a/lib/lrucache/lrucache.go
+++ b/lib/lrucache/lrucache.go
@@ -223,8 +223,6 @@ func (c *cache) Reset() {
 
 	c.m = make(map[string]*cacheEntry)
 	c.lah = nil
-	c.requests.Store(0)
-	c.misses.Store(0)
 	c.sizeBytes.Store(0)
 }
 

--- a/lib/lrucache/lrucache_test.go
+++ b/lib/lrucache/lrucache_test.go
@@ -107,10 +107,10 @@ func TestCache(t *testing.T) {
 	if n := c.SizeBytes(); n != 0 {
 		t.Fatalf("unexpected SizeBytes(); got %d; want %d", n, 0)
 	}
-	if n := c.Requests(); n != 0 {
+	if n := c.Requests(); n != 3 {
 		t.Fatalf("unexpected number of requests; got %d; want %d", n, 0)
 	}
-	if n := c.Misses(); n != 0 {
+	if n := c.Misses(); n != 1 {
 		t.Fatalf("unexpected number of misses; got %d; want %d", n, 0)
 	}
 	if n := c.Resets(); n != 1 {


### PR DESCRIPTION
Follow-up for #10072.

Do not reset requests and misses metrics since cache reset implies the reset of the storage only.