### PR TITLE
lib/storage: after deleting series, reset tsid only once

### DIFF
--- a/lib/storage/index_db.go
+++ b/lib/storage/index_db.go
@@ -1551,9 +1551,6 @@ func (db *indexDB) saveDeletedMetricIDs(metricIDs *uint64set.Set) {
 	// Reset TagFilters -> TSIDS cache, since it may contain deleted TSIDs.
 	db.tagFiltersToMetricIDsCache.Reset()
 
-	// Reset MetricName -> TSID cache, since it may contain deleted TSIDs.
-	db.s.resetAndSaveTSIDCache()
-
 	// Store the metricIDs as deleted.
 	// Make this after updating the deletedMetricIDs and resetting caches
 	// in order to exclude the possibility of the inconsistent state when the deleted metricIDs

--- a/lib/storage/storage.go
+++ b/lib/storage/storage.go
@@ -1480,6 +1480,9 @@ func (s *Storage) DeleteSeries(qt *querytracer.Tracer, tfss []*TagFilters, maxMe
 	qt.Printf("deleted %d metricIDs from current indexDB", dmisCurr.Len())
 	deletedMetricIDs.UnionMayOwn(dmisCurr)
 
+	// Reset MetricName -> TSID cache, since it may contain deleted TSIDs.
+	s.resetAndSaveTSIDCache()
+
 	// Do not reset MetricID->MetricName cache, since it must be used only
 	// after filtering out deleted metricIDs.
 


### PR DESCRIPTION
As indexDBs became independent from each other, the tsidCache is now reset more than once when the DeleteSeries() operation is performed. But it needs to be performed only once. Thus, move the deletion from indexDB to Storage.

Follow-up for 16d75ab0bd.
