### PR TITLE
Revert "lib/storage: after deleting series, reset tsid only once"

### DIFF
--- a/lib/storage/index_db.go
+++ b/lib/storage/index_db.go
@@ -1554,6 +1554,9 @@ func (db *indexDB) saveDeletedMetricIDs(metricIDs *uint64set.Set) {
 	// Reset TagFilters -> TSIDS cache, since it may contain deleted TSIDs.
 	db.tagFiltersToMetricIDsCache.Reset()
 
+	// Reset MetricName -> TSID cache, since it may contain deleted TSIDs.
+	db.s.resetAndSaveTSIDCache()
+
 	// Store the metricIDs as deleted.
 	// Make this after updating the deletedMetricIDs and resetting caches
 	// in order to exclude the possibility of the inconsistent state when the deleted metricIDs

--- a/lib/storage/storage.go
+++ b/lib/storage/storage.go
@@ -1480,9 +1480,6 @@ func (s *Storage) DeleteSeries(qt *querytracer.Tracer, tfss []*TagFilters, maxMe
 	qt.Printf("deleted %d metricIDs from current indexDB", dmisCurr.Len())
 	deletedMetricIDs.UnionMayOwn(dmisCurr)
 
-	// Reset MetricName -> TSID cache, since it may contain deleted TSIDs.
-	s.resetAndSaveTSIDCache()
-
 	// Do not reset MetricID->MetricName cache, since it must be used only
 	// after filtering out deleted metricIDs.
 


### PR DESCRIPTION
This reverts commit dbe71700b5d3e2a84292eb84e64aa1a8e14aeb29.

tsidCache is persistent and must be reset before deletedMetricID records are added to the index. THis is needed to handle ungraceful shutdowns properly.