### PR TITLE
lib/storage: use lrucache to implement tagFilters loops cache

### DIFF
--- a/lib/storage/index_db.go
+++ b/lib/storage/index_db.go
@@ -2977,7 +2977,7 @@ func (is *indexSearch) getLoopsCountAndTimestampForDateFilter(date uint64, tf *t
 	is.kb.B = appendDateTagFilterCacheKey(is.kb.B[:0], is.db.name, date, tf)
 	kb := kbPool.Get()
 	defer kbPool.Put(kb)
-	e := is.db.loopsPerDateTagFilterCache.GetEntry(string(is.kb.B))
+	e := is.db.loopsPerDateTagFilterCache.GetEntry(bytesutil.ToUnsafeString(is.kb.B))
 	if e == nil {
 		return 0, 0, 0
 	}
@@ -3002,7 +3002,7 @@ func (is *indexSearch) storeLoopsCountForDateFilter(date uint64, tf *tagFilter, 
 		timestamp:        fasttime.UnixTimestamp(),
 	}
 	is.kb.B = appendDateTagFilterCacheKey(is.kb.B[:0], is.db.name, date, tf)
-	is.db.loopsPerDateTagFilterCache.PutEntry(bytesutil.ToUnsafeString(is.kb.B), &v)
+	is.db.loopsPerDateTagFilterCache.PutEntry(string(is.kb.B), &v)
 }
 
 func appendDateTagFilterCacheKey(dst []byte, indexDBName string, date uint64, tf *tagFilter) []byte {


### PR DESCRIPTION
The tagFilters loop cache is per-indexDB which means that currently there are two instances, one for idbCurr and one for idbPrev. When the partition index (#8134) is released, there will be as many instances of this cache as there will be partitions.

The cache is implemented using workingsetcache. Which occupies at least 30MB even when unused. Given that only the latest indexDB is used most of the time, a lot of memory can be wasted.

Therefore the cache implementation is changed to lrucache because it does not consume memory when it is unused and also has timeout-based eviction.

This is a follow-up for 4cd727a511 (https://github.com/VictoriaMetrics/VictoriaMetrics/pull/10072).