### PR TITLE
lib/storage: check indexDB refCount at MustClose

### DIFF
--- a/lib/storage/index_db.go
+++ b/lib/storage/index_db.go
@@ -279,6 +279,10 @@ func (db *indexDB) UpdateMetrics(m *IndexDBMetrics) {
 
 // MustClose closes db.
 func (db *indexDB) MustClose() {
+	rc := db.refCount.Load()
+	if rc != 1 {
+		logger.Fatalf("BUG: %q unexpected indexDB refCount: %d", db.name, rc)
+	}
 	db.decRef()
 }
 


### PR DESCRIPTION
 In order to gracefully stop indexDB, refCount must be checked during
storage graceful shutdown.

Related issue: https://github.com/VictoriaMetrics/VictoriaMetrics/issues/10063
