### PR TITLE
document: guide users to use --data-binary in curl when import multi lines influx data

### DIFF
--- a/docs/victoriametrics/integrations/influxdb.md
+++ b/docs/victoriametrics/integrations/influxdb.md
@@ -57,7 +57,7 @@ Here's an example writing data with `curl`:
 curl --data-binary 'measurement1,tag1=value1,tag2=value2 field1=123,field2=1.23' -X POST 'http://<victoriametrics-addr>:8428/api/v2/write'
 ```
 
-And to write multiple lines of data at once, prepare a file (e.g., `influx.data`) with your data
+And to write multiple lines of data at once, prepare a file (e.g., `influx.data`) with your data:
 ```text
 measurement2,tag1=value1,tag2=value2 field1=456,field2=4.56
 measurement3,tag1=value1,tag2=value2 field1=789,field2=7.89


### PR DESCRIPTION
### Describe Your Changes

fix https://github.com/VictoriaMetrics/VictoriaMetrics/issues/10165.

Refer to [curl docs](https://curl.se/docs/manpage.html#--data).

> When --data is told to read from a file like that, carriage returns, newlines and null bytes are stripped out

If users import multiple lines of data in file via `/api/v2/write`, he may follow the example we gave to use `-d` to instruct curl, then newlines will be stripped out, hence the parse error in VictoriaMetrics.

It's not VictoriaMetrics' bug, but it will be better to guide users to use `--data-binary` just like how [/api/v1/import](https://docs.victoriametrics.com/victoriametrics/url-examples/#apiv1import) did.

### Checklist

The following checks are **mandatory**:

- [ ] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [ ] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
