### PR TITLE
lib/ingestserver: Actually close the first vminsert connection

### DIFF
--- a/lib/ingestserver/conns_map.go
+++ b/lib/ingestserver/conns_map.go
@@ -94,7 +94,7 @@ func (cm *ConnsMap) CloseAll(shutdownDuration time.Duration) {
 	shutdownInterval := shutdownDuration / time.Duration(len(conns)-1)
 	startTime := time.Now()
 	logger.Infof("closing %d %s connections with %dms interval between them", len(conns), cm.clientName, shutdownInterval.Milliseconds())
-	_ = conns[0].closeAll
+	conns[0].closeAll()
 	for _, c := range conns[1:] {
 		time.Sleep(shutdownInterval)
 		c.closeAll()


### PR DESCRIPTION
Since the first connection is not closed, the vmstorage will never terminate gracefully which will cause the reset of all caches on the start-up.

Follow-up for 244769a00d12ce6f31f33b69ac15a4230e8485e0 (#10136)