### PR TITLE
app/vmalert: add new type `vtraces` for VictoriaTraces

### DIFF
--- a/app/vmalert/config/config.go
+++ b/app/vmalert/config/config.go
@@ -18,7 +18,7 @@ import (
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/promutil"
 )
 
-var defaultRuleType = flag.String("rule.defaultRuleType", "prometheus", `Default type for rule expressions, can be overridden via "type" parameter on the group level, see https://docs.victoriametrics.com/victoriametrics/vmalert/#groups. Supported values: "graphite", "prometheus" and "vlogs".`)
+var defaultRuleType = flag.String("rule.defaultRuleType", "prometheus", `Default type for rule expressions, can be overridden via "type" parameter on the group level, see https://docs.victoriametrics.com/victoriametrics/vmalert/#groups. Supported values: "graphite", "prometheus", "vlogs" and "vtraces".`)
 
 // Group contains list of Rules grouped into
 // entity with one name and evaluation interval

--- a/app/vmalert/config/config_test.go
+++ b/app/vmalert/config/config_test.go
@@ -343,6 +343,34 @@ func TestGroupValidate_Failure(t *testing.T) {
 			},
 		},
 	}, true, "bad prometheus expr")
+
+	f(&Group{
+		Name: "test vtraces expr",
+		Type: NewVTracesType(),
+		Rules: []Rule{
+			{Alert: "alert", Expr: "stats count(*) as requests"},
+		},
+	}, true, "bad LogsQL expr")
+
+	f(&Group{
+		Name: "test vtraces expr",
+		Type: NewVTracesType(),
+		Rules: []Rule{
+			{Alert: "alert", Expr: "_time: 1m | stats by (path, _time: 1m) count(*) as requests"},
+		},
+	}, true, "bad LogsQL expr")
+
+	f(&Group{
+		Name: "test vtraces with prometheus exp",
+		Type: NewVTracesType(),
+		Rules: []Rule{
+			{
+				Record: "r1",
+				Expr:   "sum(up == 0 ) by (host)",
+				For:    promutil.NewDuration(10 * time.Millisecond),
+			},
+		},
+	}, true, "bad LogsQL expr")
 }
 
 func TestGroupValidate_Success(t *testing.T) {
@@ -412,6 +440,15 @@ func TestGroupValidate_Success(t *testing.T) {
 	f(&Group{
 		Name: "test victorialogs",
 		Type: NewVLogsType(),
+		Rules: []Rule{
+			{Alert: "alert", Expr: " _time: 1m | stats count(*) as requests", Labels: map[string]string{
+				"description": "{{ value|query }}",
+			}},
+		},
+	}, false, true)
+	f(&Group{
+		Name: "test victoriatraces",
+		Type: NewVTracesType(),
 		Rules: []Rule{
 			{Alert: "alert", Expr: " _time: 1m | stats count(*) as requests", Labels: map[string]string{
 				"description": "{{ value|query }}",

--- a/app/vmalert/config/types.go
+++ b/app/vmalert/config/types.go
@@ -36,6 +36,13 @@ func NewVLogsType() Type {
 	}
 }
 
+// NewVTracesType returns victoriatraces datasource type
+func NewVTracesType() Type {
+	return Type{
+		Name: "vtraces",
+	}
+}
+
 // NewRawType returns datasource type from raw string
 // without validation.
 func NewRawType(d string) Type {
@@ -71,7 +78,7 @@ func (t *Type) ValidateExpr(expr string) error {
 		if _, err := metricsql.Parse(expr); err != nil {
 			return fmt.Errorf("bad prometheus expr: %q, err: %w", expr, err)
 		}
-	case "vlogs":
+	case "vlogs", "vtraces":
 		q, err := logstorage.ParseStatsQuery(expr, 0)
 		if err != nil {
 			return fmt.Errorf("bad LogsQL expr: %q, err: %w", expr, err)
@@ -92,7 +99,7 @@ func (t *Type) ValidateExpr(expr string) error {
 
 // SupportedType is true if given datasource type is supported
 func SupportedType(dsType string) bool {
-	return dsType == "graphite" || dsType == "prometheus" || dsType == "vlogs"
+	return dsType == "graphite" || dsType == "prometheus" || dsType == "vlogs" || dsType == "vtraces"
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.
@@ -102,7 +109,7 @@ func (t *Type) UnmarshalYAML(unmarshal func(any) error) error {
 		return err
 	}
 	if !SupportedType(s) {
-		return fmt.Errorf("unknown datasource type=%q, want prometheus, graphite or vlogs", s)
+		return fmt.Errorf("unknown datasource type=%q, want prometheus, graphite, vlogs or vtraces", s)
 	}
 	t.Name = s
 	return nil

--- a/app/vmalert/datasource/client.go
+++ b/app/vmalert/datasource/client.go
@@ -29,7 +29,7 @@ func toDatasourceType(s string) datasourceType {
 		return datasourcePrometheus
 	case string(datasourceGraphite):
 		return datasourceGraphite
-	case string(datasourceVLogs):
+	case string(datasourceVLogs), "vtraces":
 		return datasourceVLogs
 	default:
 		logger.Panicf("BUG: unknown datasource type %q", s)


### PR DESCRIPTION
Fixes #10126

## Changes
- Add `vtraces` as an alias for `vlogs` type in vmalert
- Update `ValidateExpr` to handle both vlogs and vtraces with same LogsQL validation
- Add `NewVTracesType()` constructor function
- Update datasource client to map `vtraces` to vlogs datasource type
- Add corresponding tests for vtraces type validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)