### PR TITLE
lib/promscrape: show (N/A) instead of hiding target response link when original labels are dropped

### DIFF
--- a/lib/promscrape/targetstatus.qtpl
+++ b/lib/promscrape/targetstatus.qtpl
@@ -242,6 +242,8 @@
                                   {% space %}
                                   (<a href="target_response?id={%s targetID %}" target="_blank"
                                     title="click to fetch target response on behalf of the scraper">response</a>)
+                                {% else %}
+                                  {% space %}(N/A)
                                 {% endif %}
                             </td>
                             <td>

--- a/lib/promscrape/targetstatus.qtpl.go
+++ b/lib/promscrape/targetstatus.qtpl.go
@@ -624,422 +624,428 @@ func streamscrapeJobTargets(qw422016 *qt422016.Writer, num int, jts *jobTargetsS
 //line lib/promscrape/targetstatus.qtpl:243
 			qw422016.N().S(`" target="_blank"title="click to fetch target response on behalf of the scraper">response</a>)`)
 //line lib/promscrape/targetstatus.qtpl:245
+		} else {
+//line lib/promscrape/targetstatus.qtpl:246
+			qw422016.N().S(` `)
+//line lib/promscrape/targetstatus.qtpl:246
+			qw422016.N().S(`(N/A)`)
+//line lib/promscrape/targetstatus.qtpl:247
 		}
-//line lib/promscrape/targetstatus.qtpl:245
+//line lib/promscrape/targetstatus.qtpl:247
 		qw422016.N().S(`</td><td>`)
-//line lib/promscrape/targetstatus.qtpl:248
+//line lib/promscrape/targetstatus.qtpl:250
 		if ts.up {
-//line lib/promscrape/targetstatus.qtpl:248
+//line lib/promscrape/targetstatus.qtpl:250
 			qw422016.N().S(`<span class="badge bg-success">UP</span>`)
-//line lib/promscrape/targetstatus.qtpl:250
+//line lib/promscrape/targetstatus.qtpl:252
 		} else {
-//line lib/promscrape/targetstatus.qtpl:250
+//line lib/promscrape/targetstatus.qtpl:252
 			qw422016.N().S(`<span class="badge bg-danger">DOWN</span>`)
-//line lib/promscrape/targetstatus.qtpl:252
+//line lib/promscrape/targetstatus.qtpl:254
 		}
-//line lib/promscrape/targetstatus.qtpl:252
+//line lib/promscrape/targetstatus.qtpl:254
 		qw422016.N().S(`</td><td class="labels"><div`)
-//line lib/promscrape/targetstatus.qtpl:256
+//line lib/promscrape/targetstatus.qtpl:258
 		if hasOriginalLabels {
-//line lib/promscrape/targetstatus.qtpl:257
+//line lib/promscrape/targetstatus.qtpl:259
 			qw422016.N().S(` `)
-//line lib/promscrape/targetstatus.qtpl:257
+//line lib/promscrape/targetstatus.qtpl:259
 			qw422016.N().S(`title="click to show original labels"onclick="document.getElementById('original-labels-`)
-//line lib/promscrape/targetstatus.qtpl:258
+//line lib/promscrape/targetstatus.qtpl:260
 			qw422016.E().S(targetID)
-//line lib/promscrape/targetstatus.qtpl:258
+//line lib/promscrape/targetstatus.qtpl:260
 			qw422016.N().S(`').style.display='block'"`)
-//line lib/promscrape/targetstatus.qtpl:259
+//line lib/promscrape/targetstatus.qtpl:261
 		}
-//line lib/promscrape/targetstatus.qtpl:259
+//line lib/promscrape/targetstatus.qtpl:261
 		qw422016.N().S(`>`)
-//line lib/promscrape/targetstatus.qtpl:261
+//line lib/promscrape/targetstatus.qtpl:263
 		streamformatLabels(qw422016, ts.sw.Config.Labels)
-//line lib/promscrape/targetstatus.qtpl:261
+//line lib/promscrape/targetstatus.qtpl:263
 		qw422016.N().S(`</div>`)
-//line lib/promscrape/targetstatus.qtpl:263
+//line lib/promscrape/targetstatus.qtpl:265
 		if hasOriginalLabels {
-//line lib/promscrape/targetstatus.qtpl:263
+//line lib/promscrape/targetstatus.qtpl:265
 			qw422016.N().S(`<div style="display:none" id="original-labels-`)
-//line lib/promscrape/targetstatus.qtpl:264
+//line lib/promscrape/targetstatus.qtpl:266
 			qw422016.E().S(targetID)
-//line lib/promscrape/targetstatus.qtpl:264
+//line lib/promscrape/targetstatus.qtpl:266
 			qw422016.N().S(`">`)
-//line lib/promscrape/targetstatus.qtpl:265
+//line lib/promscrape/targetstatus.qtpl:267
 			streamformatLabels(qw422016, originalLabels)
-//line lib/promscrape/targetstatus.qtpl:265
+//line lib/promscrape/targetstatus.qtpl:267
 			qw422016.N().S(`</div>`)
-//line lib/promscrape/targetstatus.qtpl:267
+//line lib/promscrape/targetstatus.qtpl:269
 		}
-//line lib/promscrape/targetstatus.qtpl:267
+//line lib/promscrape/targetstatus.qtpl:269
 		qw422016.N().S(`</td><td>`)
-//line lib/promscrape/targetstatus.qtpl:270
+//line lib/promscrape/targetstatus.qtpl:272
 		if hasOriginalLabels {
-//line lib/promscrape/targetstatus.qtpl:270
+//line lib/promscrape/targetstatus.qtpl:272
 			qw422016.N().S(`<a href="target-relabel-debug?id=`)
-//line lib/promscrape/targetstatus.qtpl:271
+//line lib/promscrape/targetstatus.qtpl:273
 			qw422016.E().S(targetID)
-//line lib/promscrape/targetstatus.qtpl:271
+//line lib/promscrape/targetstatus.qtpl:273
 			qw422016.N().S(`" target="_blank">target</a>`)
-//line lib/promscrape/targetstatus.qtpl:271
+//line lib/promscrape/targetstatus.qtpl:273
 			qw422016.N().S(` `)
-//line lib/promscrape/targetstatus.qtpl:271
+//line lib/promscrape/targetstatus.qtpl:273
 			qw422016.N().S(`<a href="metric-relabel-debug?id=`)
-//line lib/promscrape/targetstatus.qtpl:272
+//line lib/promscrape/targetstatus.qtpl:274
 			qw422016.E().S(targetID)
-//line lib/promscrape/targetstatus.qtpl:272
+//line lib/promscrape/targetstatus.qtpl:274
 			qw422016.N().S(`" target="_blank">metrics</a>`)
-//line lib/promscrape/targetstatus.qtpl:273
+//line lib/promscrape/targetstatus.qtpl:275
 		} else {
-//line lib/promscrape/targetstatus.qtpl:273
+//line lib/promscrape/targetstatus.qtpl:275
 			qw422016.N().S(`N/A`)
-//line lib/promscrape/targetstatus.qtpl:275
-		}
-//line lib/promscrape/targetstatus.qtpl:275
-		qw422016.N().S(`</td><td>`)
 //line lib/promscrape/targetstatus.qtpl:277
+		}
+//line lib/promscrape/targetstatus.qtpl:277
+		qw422016.N().S(`</td><td>`)
+//line lib/promscrape/targetstatus.qtpl:279
 		qw422016.N().D(ts.scrapesTotal)
-//line lib/promscrape/targetstatus.qtpl:277
+//line lib/promscrape/targetstatus.qtpl:279
 		qw422016.N().S(`</td><td>`)
-//line lib/promscrape/targetstatus.qtpl:278
+//line lib/promscrape/targetstatus.qtpl:280
 		qw422016.N().D(ts.scrapesFailed)
-//line lib/promscrape/targetstatus.qtpl:278
+//line lib/promscrape/targetstatus.qtpl:280
 		qw422016.N().S(`</td><td>`)
-//line lib/promscrape/targetstatus.qtpl:279
+//line lib/promscrape/targetstatus.qtpl:281
 		qw422016.E().S(ts.getDurationFromLastScrape())
-//line lib/promscrape/targetstatus.qtpl:279
+//line lib/promscrape/targetstatus.qtpl:281
 		qw422016.N().S(`</td><td>`)
-//line lib/promscrape/targetstatus.qtpl:280
+//line lib/promscrape/targetstatus.qtpl:282
 		qw422016.N().D(int(ts.scrapeDuration))
-//line lib/promscrape/targetstatus.qtpl:280
+//line lib/promscrape/targetstatus.qtpl:282
 		qw422016.N().S(`ms</td><td>`)
-//line lib/promscrape/targetstatus.qtpl:281
+//line lib/promscrape/targetstatus.qtpl:283
 		qw422016.E().S(ts.getSizeFromLastScrape())
-//line lib/promscrape/targetstatus.qtpl:281
+//line lib/promscrape/targetstatus.qtpl:283
 		qw422016.N().S(`</td><td>`)
-//line lib/promscrape/targetstatus.qtpl:282
+//line lib/promscrape/targetstatus.qtpl:284
 		qw422016.N().D(ts.samplesScraped)
-//line lib/promscrape/targetstatus.qtpl:282
+//line lib/promscrape/targetstatus.qtpl:284
 		qw422016.N().S(`</td><td>`)
-//line lib/promscrape/targetstatus.qtpl:283
+//line lib/promscrape/targetstatus.qtpl:285
 		if ts.err != nil {
-//line lib/promscrape/targetstatus.qtpl:283
+//line lib/promscrape/targetstatus.qtpl:285
 			qw422016.E().S(ts.err.Error())
-//line lib/promscrape/targetstatus.qtpl:283
+//line lib/promscrape/targetstatus.qtpl:285
 		}
-//line lib/promscrape/targetstatus.qtpl:283
+//line lib/promscrape/targetstatus.qtpl:285
 		qw422016.N().S(`</td></tr>`)
-//line lib/promscrape/targetstatus.qtpl:285
+//line lib/promscrape/targetstatus.qtpl:287
 	}
-//line lib/promscrape/targetstatus.qtpl:285
+//line lib/promscrape/targetstatus.qtpl:287
 	qw422016.N().S(`</tbody></table></div></div></div>`)
-//line lib/promscrape/targetstatus.qtpl:291
-}
-
-//line lib/promscrape/targetstatus.qtpl:291
-func writescrapeJobTargets(qq422016 qtio422016.Writer, num int, jts *jobTargetsStatuses, hasOriginalLabels bool) {
-//line lib/promscrape/targetstatus.qtpl:291
-	qw422016 := qt422016.AcquireWriter(qq422016)
-//line lib/promscrape/targetstatus.qtpl:291
-	streamscrapeJobTargets(qw422016, num, jts, hasOriginalLabels)
-//line lib/promscrape/targetstatus.qtpl:291
-	qt422016.ReleaseWriter(qw422016)
-//line lib/promscrape/targetstatus.qtpl:291
-}
-
-//line lib/promscrape/targetstatus.qtpl:291
-func scrapeJobTargets(num int, jts *jobTargetsStatuses, hasOriginalLabels bool) string {
-//line lib/promscrape/targetstatus.qtpl:291
-	qb422016 := qt422016.AcquireByteBuffer()
-//line lib/promscrape/targetstatus.qtpl:291
-	writescrapeJobTargets(qb422016, num, jts, hasOriginalLabels)
-//line lib/promscrape/targetstatus.qtpl:291
-	qs422016 := string(qb422016.B)
-//line lib/promscrape/targetstatus.qtpl:291
-	qt422016.ReleaseByteBuffer(qb422016)
-//line lib/promscrape/targetstatus.qtpl:291
-	return qs422016
-//line lib/promscrape/targetstatus.qtpl:291
+//line lib/promscrape/targetstatus.qtpl:293
 }
 
 //line lib/promscrape/targetstatus.qtpl:293
+func writescrapeJobTargets(qq422016 qtio422016.Writer, num int, jts *jobTargetsStatuses, hasOriginalLabels bool) {
+//line lib/promscrape/targetstatus.qtpl:293
+	qw422016 := qt422016.AcquireWriter(qq422016)
+//line lib/promscrape/targetstatus.qtpl:293
+	streamscrapeJobTargets(qw422016, num, jts, hasOriginalLabels)
+//line lib/promscrape/targetstatus.qtpl:293
+	qt422016.ReleaseWriter(qw422016)
+//line lib/promscrape/targetstatus.qtpl:293
+}
+
+//line lib/promscrape/targetstatus.qtpl:293
+func scrapeJobTargets(num int, jts *jobTargetsStatuses, hasOriginalLabels bool) string {
+//line lib/promscrape/targetstatus.qtpl:293
+	qb422016 := qt422016.AcquireByteBuffer()
+//line lib/promscrape/targetstatus.qtpl:293
+	writescrapeJobTargets(qb422016, num, jts, hasOriginalLabels)
+//line lib/promscrape/targetstatus.qtpl:293
+	qs422016 := string(qb422016.B)
+//line lib/promscrape/targetstatus.qtpl:293
+	qt422016.ReleaseByteBuffer(qb422016)
+//line lib/promscrape/targetstatus.qtpl:293
+	return qs422016
+//line lib/promscrape/targetstatus.qtpl:293
+}
+
+//line lib/promscrape/targetstatus.qtpl:295
 func streamdiscoveredTargets(qw422016 *qt422016.Writer, tsr *targetsStatusResult) {
-//line lib/promscrape/targetstatus.qtpl:294
+//line lib/promscrape/targetstatus.qtpl:296
 	if !tsr.hasOriginalLabels {
-//line lib/promscrape/targetstatus.qtpl:294
+//line lib/promscrape/targetstatus.qtpl:296
 		qw422016.N().S(`<div class="alert alert-warning" role="alert">Discovered targets are unavailable, set <b>-promscrape.dropOriginalLabels=false</b> command-line flag to enable it</div>`)
-//line lib/promscrape/targetstatus.qtpl:298
+//line lib/promscrape/targetstatus.qtpl:300
 		return
-//line lib/promscrape/targetstatus.qtpl:299
-	}
 //line lib/promscrape/targetstatus.qtpl:301
+	}
+//line lib/promscrape/targetstatus.qtpl:303
 	if n := droppedTargetsMap.getTotalTargets(); n > *maxDroppedTargets {
-//line lib/promscrape/targetstatus.qtpl:301
+//line lib/promscrape/targetstatus.qtpl:303
 		qw422016.N().S(`<div class="alert alert-warning" role="alert">Dropped targets' list below is incomplete, because the number of dropped targets exceeds <b>-promscrape.maxDroppedTargets=`)
-//line lib/promscrape/targetstatus.qtpl:303
+//line lib/promscrape/targetstatus.qtpl:305
 		qw422016.N().D(*maxDroppedTargets)
-//line lib/promscrape/targetstatus.qtpl:303
+//line lib/promscrape/targetstatus.qtpl:305
 		qw422016.N().S(`</b>.<br/>If you want to see the full list of dropped targets, then increase <b>-promscrape.maxDroppedTargets</b> command-line flag value to at least`)
-//line lib/promscrape/targetstatus.qtpl:304
+//line lib/promscrape/targetstatus.qtpl:306
 		qw422016.N().S(` `)
-//line lib/promscrape/targetstatus.qtpl:304
+//line lib/promscrape/targetstatus.qtpl:306
 		qw422016.N().S(`<b>`)
-//line lib/promscrape/targetstatus.qtpl:304
+//line lib/promscrape/targetstatus.qtpl:306
 		qw422016.N().D(n)
-//line lib/promscrape/targetstatus.qtpl:304
+//line lib/promscrape/targetstatus.qtpl:306
 		qw422016.N().S(`</b>.<br/>Note that this may increase memory usage.</div>`)
-//line lib/promscrape/targetstatus.qtpl:307
-	}
 //line lib/promscrape/targetstatus.qtpl:309
+	}
+//line lib/promscrape/targetstatus.qtpl:311
 	tljs := tsr.getTargetLabelsByJob()
 
-//line lib/promscrape/targetstatus.qtpl:309
+//line lib/promscrape/targetstatus.qtpl:311
 	qw422016.N().S(`<div class="row mt-4"><div class="col-12">`)
-//line lib/promscrape/targetstatus.qtpl:312
+//line lib/promscrape/targetstatus.qtpl:314
 	for i, tlj := range tljs {
-//line lib/promscrape/targetstatus.qtpl:313
+//line lib/promscrape/targetstatus.qtpl:315
 		streamdiscoveredJobTargets(qw422016, i, tlj)
-//line lib/promscrape/targetstatus.qtpl:314
+//line lib/promscrape/targetstatus.qtpl:316
 	}
-//line lib/promscrape/targetstatus.qtpl:314
+//line lib/promscrape/targetstatus.qtpl:316
 	qw422016.N().S(`</div></div>`)
-//line lib/promscrape/targetstatus.qtpl:317
+//line lib/promscrape/targetstatus.qtpl:319
 }
 
-//line lib/promscrape/targetstatus.qtpl:317
+//line lib/promscrape/targetstatus.qtpl:319
 func writediscoveredTargets(qq422016 qtio422016.Writer, tsr *targetsStatusResult) {
-//line lib/promscrape/targetstatus.qtpl:317
+//line lib/promscrape/targetstatus.qtpl:319
 	qw422016 := qt422016.AcquireWriter(qq422016)
-//line lib/promscrape/targetstatus.qtpl:317
+//line lib/promscrape/targetstatus.qtpl:319
 	streamdiscoveredTargets(qw422016, tsr)
-//line lib/promscrape/targetstatus.qtpl:317
+//line lib/promscrape/targetstatus.qtpl:319
 	qt422016.ReleaseWriter(qw422016)
-//line lib/promscrape/targetstatus.qtpl:317
+//line lib/promscrape/targetstatus.qtpl:319
 }
 
-//line lib/promscrape/targetstatus.qtpl:317
+//line lib/promscrape/targetstatus.qtpl:319
 func discoveredTargets(tsr *targetsStatusResult) string {
-//line lib/promscrape/targetstatus.qtpl:317
+//line lib/promscrape/targetstatus.qtpl:319
 	qb422016 := qt422016.AcquireByteBuffer()
-//line lib/promscrape/targetstatus.qtpl:317
+//line lib/promscrape/targetstatus.qtpl:319
 	writediscoveredTargets(qb422016, tsr)
-//line lib/promscrape/targetstatus.qtpl:317
+//line lib/promscrape/targetstatus.qtpl:319
 	qs422016 := string(qb422016.B)
-//line lib/promscrape/targetstatus.qtpl:317
+//line lib/promscrape/targetstatus.qtpl:319
 	qt422016.ReleaseByteBuffer(qb422016)
-//line lib/promscrape/targetstatus.qtpl:317
+//line lib/promscrape/targetstatus.qtpl:319
 	return qs422016
-//line lib/promscrape/targetstatus.qtpl:317
+//line lib/promscrape/targetstatus.qtpl:319
 }
 
-//line lib/promscrape/targetstatus.qtpl:319
+//line lib/promscrape/targetstatus.qtpl:321
 func streamdiscoveredJobTargets(qw422016 *qt422016.Writer, num int, tlj *targetLabelsByJob) {
-//line lib/promscrape/targetstatus.qtpl:319
+//line lib/promscrape/targetstatus.qtpl:321
 	qw422016.N().S(`<h4><span class="me-2">`)
-//line lib/promscrape/targetstatus.qtpl:321
+//line lib/promscrape/targetstatus.qtpl:323
 	qw422016.E().S(tlj.jobName)
-//line lib/promscrape/targetstatus.qtpl:321
+//line lib/promscrape/targetstatus.qtpl:323
 	qw422016.N().S(` `)
-//line lib/promscrape/targetstatus.qtpl:321
+//line lib/promscrape/targetstatus.qtpl:323
 	qw422016.N().S(`(`)
-//line lib/promscrape/targetstatus.qtpl:321
+//line lib/promscrape/targetstatus.qtpl:323
 	qw422016.N().D(tlj.activeTargets)
-//line lib/promscrape/targetstatus.qtpl:321
+//line lib/promscrape/targetstatus.qtpl:323
 	qw422016.N().S(`/`)
-//line lib/promscrape/targetstatus.qtpl:321
+//line lib/promscrape/targetstatus.qtpl:323
 	qw422016.N().D(tlj.activeTargets + tlj.droppedTargets)
-//line lib/promscrape/targetstatus.qtpl:321
+//line lib/promscrape/targetstatus.qtpl:323
 	qw422016.N().S(` `)
-//line lib/promscrape/targetstatus.qtpl:321
+//line lib/promscrape/targetstatus.qtpl:323
 	qw422016.N().S(`active)</span>`)
-//line lib/promscrape/targetstatus.qtpl:322
+//line lib/promscrape/targetstatus.qtpl:324
 	streamshowHideScrapeJobButtons(qw422016, num)
-//line lib/promscrape/targetstatus.qtpl:322
+//line lib/promscrape/targetstatus.qtpl:324
 	qw422016.N().S(`</h4><div id="scrape-job-`)
-//line lib/promscrape/targetstatus.qtpl:324
+//line lib/promscrape/targetstatus.qtpl:326
 	qw422016.N().D(num)
-//line lib/promscrape/targetstatus.qtpl:324
+//line lib/promscrape/targetstatus.qtpl:326
 	qw422016.N().S(`" class="scrape-job table-responsive"><table class="table table-striped table-hover table-bordered table-sm"><thead><tr><th scope="col" style="width: 5%">Status</th><th scope="col" style="width: 60%">Discovered Labels</th><th scope="col" style="width: 30%">Target Labels</th><th scope="col" stile="width: 5%">Debug relabeling</a></tr></thead><tbody>`)
-//line lib/promscrape/targetstatus.qtpl:335
-	for _, t := range tlj.targets {
-//line lib/promscrape/targetstatus.qtpl:335
-		qw422016.N().S(`<tr`)
 //line lib/promscrape/targetstatus.qtpl:337
+	for _, t := range tlj.targets {
+//line lib/promscrape/targetstatus.qtpl:337
+		qw422016.N().S(`<tr`)
+//line lib/promscrape/targetstatus.qtpl:339
 		if !t.up {
-//line lib/promscrape/targetstatus.qtpl:338
+//line lib/promscrape/targetstatus.qtpl:340
 			qw422016.N().S(` `)
-//line lib/promscrape/targetstatus.qtpl:338
+//line lib/promscrape/targetstatus.qtpl:340
 			qw422016.N().S(`role="alert"`)
-//line lib/promscrape/targetstatus.qtpl:338
+//line lib/promscrape/targetstatus.qtpl:340
 			qw422016.N().S(` `)
-//line lib/promscrape/targetstatus.qtpl:339
+//line lib/promscrape/targetstatus.qtpl:341
 			if t.labels.Len() > 0 {
-//line lib/promscrape/targetstatus.qtpl:339
+//line lib/promscrape/targetstatus.qtpl:341
 				qw422016.N().S(`class="alert alert-danger"`)
-//line lib/promscrape/targetstatus.qtpl:341
-			} else {
-//line lib/promscrape/targetstatus.qtpl:341
-				qw422016.N().S(`class="alert alert-warning"`)
 //line lib/promscrape/targetstatus.qtpl:343
+			} else {
+//line lib/promscrape/targetstatus.qtpl:343
+				qw422016.N().S(`class="alert alert-warning"`)
+//line lib/promscrape/targetstatus.qtpl:345
 			}
-//line lib/promscrape/targetstatus.qtpl:344
+//line lib/promscrape/targetstatus.qtpl:346
 		}
-//line lib/promscrape/targetstatus.qtpl:344
+//line lib/promscrape/targetstatus.qtpl:346
 		qw422016.N().S(`><td>`)
-//line lib/promscrape/targetstatus.qtpl:347
+//line lib/promscrape/targetstatus.qtpl:349
 		if t.up {
-//line lib/promscrape/targetstatus.qtpl:347
+//line lib/promscrape/targetstatus.qtpl:349
 			qw422016.N().S(`<span class="badge bg-success">UP</span>`)
-//line lib/promscrape/targetstatus.qtpl:349
+//line lib/promscrape/targetstatus.qtpl:351
 		} else if t.labels.Len() > 0 {
-//line lib/promscrape/targetstatus.qtpl:349
+//line lib/promscrape/targetstatus.qtpl:351
 			qw422016.N().S(`<span class="badge bg-danger">DOWN</span>`)
-//line lib/promscrape/targetstatus.qtpl:351
+//line lib/promscrape/targetstatus.qtpl:353
 		} else {
-//line lib/promscrape/targetstatus.qtpl:351
+//line lib/promscrape/targetstatus.qtpl:353
 			qw422016.N().S(`<span class="badge bg-warning">DROPPED (`)
-//line lib/promscrape/targetstatus.qtpl:352
+//line lib/promscrape/targetstatus.qtpl:354
 			qw422016.E().S(string(t.dropReason))
-//line lib/promscrape/targetstatus.qtpl:352
+//line lib/promscrape/targetstatus.qtpl:354
 			qw422016.N().S(`)</span>`)
-//line lib/promscrape/targetstatus.qtpl:353
+//line lib/promscrape/targetstatus.qtpl:355
 			if len(t.clusterMemberNums) > 0 {
-//line lib/promscrape/targetstatus.qtpl:353
+//line lib/promscrape/targetstatus.qtpl:355
 				qw422016.N().S(`<br/><span title="The target exists at vmagent instances with the given -promscrape.cluster.memberNum values">exists at`)
-//line lib/promscrape/targetstatus.qtpl:356
+//line lib/promscrape/targetstatus.qtpl:358
 				qw422016.N().S(` `)
-//line lib/promscrape/targetstatus.qtpl:357
-				for i, memberNum := range t.clusterMemberNums {
-//line lib/promscrape/targetstatus.qtpl:358
-					if *clusterMemberURLTemplate == "" {
-//line lib/promscrape/targetstatus.qtpl:358
-						qw422016.N().S(`shard-`)
 //line lib/promscrape/targetstatus.qtpl:359
-						qw422016.N().D(memberNum)
+				for i, memberNum := range t.clusterMemberNums {
 //line lib/promscrape/targetstatus.qtpl:360
-					} else {
+					if *clusterMemberURLTemplate == "" {
 //line lib/promscrape/targetstatus.qtpl:360
-						qw422016.N().S(`<a href="`)
-//line lib/promscrape/targetstatus.qtpl:361
-						qw422016.E().S(strings.ReplaceAll(*clusterMemberURLTemplate, "%d", strconv.Itoa(memberNum)))
-//line lib/promscrape/targetstatus.qtpl:361
-						qw422016.N().S(`" target="_blank">shard-`)
+						qw422016.N().S(`shard-`)
 //line lib/promscrape/targetstatus.qtpl:361
 						qw422016.N().D(memberNum)
-//line lib/promscrape/targetstatus.qtpl:361
-						qw422016.N().S(`</a>`)
 //line lib/promscrape/targetstatus.qtpl:362
-					}
+					} else {
+//line lib/promscrape/targetstatus.qtpl:362
+						qw422016.N().S(`<a href="`)
 //line lib/promscrape/targetstatus.qtpl:363
-					if i+1 < len(t.clusterMemberNums) {
+						qw422016.E().S(strings.ReplaceAll(*clusterMemberURLTemplate, "%d", strconv.Itoa(memberNum)))
 //line lib/promscrape/targetstatus.qtpl:363
-						qw422016.N().S(`,`)
+						qw422016.N().S(`" target="_blank">shard-`)
 //line lib/promscrape/targetstatus.qtpl:363
-						qw422016.N().S(` `)
+						qw422016.N().D(memberNum)
 //line lib/promscrape/targetstatus.qtpl:363
-					}
+						qw422016.N().S(`</a>`)
 //line lib/promscrape/targetstatus.qtpl:364
-				}
+					}
 //line lib/promscrape/targetstatus.qtpl:365
+					if i+1 < len(t.clusterMemberNums) {
+//line lib/promscrape/targetstatus.qtpl:365
+						qw422016.N().S(`,`)
+//line lib/promscrape/targetstatus.qtpl:365
+						qw422016.N().S(` `)
+//line lib/promscrape/targetstatus.qtpl:365
+					}
+//line lib/promscrape/targetstatus.qtpl:366
+				}
+//line lib/promscrape/targetstatus.qtpl:367
 			}
-//line lib/promscrape/targetstatus.qtpl:366
+//line lib/promscrape/targetstatus.qtpl:368
 		}
-//line lib/promscrape/targetstatus.qtpl:366
+//line lib/promscrape/targetstatus.qtpl:368
 		qw422016.N().S(`</td><td class="labels">`)
-//line lib/promscrape/targetstatus.qtpl:369
+//line lib/promscrape/targetstatus.qtpl:371
 		streamformatLabels(qw422016, t.originalLabels)
-//line lib/promscrape/targetstatus.qtpl:369
+//line lib/promscrape/targetstatus.qtpl:371
 		qw422016.N().S(`</td><td class="labels">`)
-//line lib/promscrape/targetstatus.qtpl:372
+//line lib/promscrape/targetstatus.qtpl:374
 		streamformatLabels(qw422016, t.labels)
-//line lib/promscrape/targetstatus.qtpl:372
+//line lib/promscrape/targetstatus.qtpl:374
 		qw422016.N().S(`</td><td>`)
-//line lib/promscrape/targetstatus.qtpl:375
+//line lib/promscrape/targetstatus.qtpl:377
 		targetID := getLabelsID(t.originalLabels)
 
-//line lib/promscrape/targetstatus.qtpl:375
+//line lib/promscrape/targetstatus.qtpl:377
 		qw422016.N().S(`<a href="target-relabel-debug?id=`)
-//line lib/promscrape/targetstatus.qtpl:376
+//line lib/promscrape/targetstatus.qtpl:378
 		qw422016.E().S(targetID)
-//line lib/promscrape/targetstatus.qtpl:376
+//line lib/promscrape/targetstatus.qtpl:378
 		qw422016.N().S(`" target="_blank">debug</a></td></tr>`)
-//line lib/promscrape/targetstatus.qtpl:379
+//line lib/promscrape/targetstatus.qtpl:381
 	}
-//line lib/promscrape/targetstatus.qtpl:379
+//line lib/promscrape/targetstatus.qtpl:381
 	qw422016.N().S(`</tbody></table></div>`)
-//line lib/promscrape/targetstatus.qtpl:383
+//line lib/promscrape/targetstatus.qtpl:385
 }
 
-//line lib/promscrape/targetstatus.qtpl:383
+//line lib/promscrape/targetstatus.qtpl:385
 func writediscoveredJobTargets(qq422016 qtio422016.Writer, num int, tlj *targetLabelsByJob) {
-//line lib/promscrape/targetstatus.qtpl:383
+//line lib/promscrape/targetstatus.qtpl:385
 	qw422016 := qt422016.AcquireWriter(qq422016)
-//line lib/promscrape/targetstatus.qtpl:383
+//line lib/promscrape/targetstatus.qtpl:385
 	streamdiscoveredJobTargets(qw422016, num, tlj)
-//line lib/promscrape/targetstatus.qtpl:383
+//line lib/promscrape/targetstatus.qtpl:385
 	qt422016.ReleaseWriter(qw422016)
-//line lib/promscrape/targetstatus.qtpl:383
+//line lib/promscrape/targetstatus.qtpl:385
 }
 
-//line lib/promscrape/targetstatus.qtpl:383
+//line lib/promscrape/targetstatus.qtpl:385
 func discoveredJobTargets(num int, tlj *targetLabelsByJob) string {
-//line lib/promscrape/targetstatus.qtpl:383
+//line lib/promscrape/targetstatus.qtpl:385
 	qb422016 := qt422016.AcquireByteBuffer()
-//line lib/promscrape/targetstatus.qtpl:383
+//line lib/promscrape/targetstatus.qtpl:385
 	writediscoveredJobTargets(qb422016, num, tlj)
-//line lib/promscrape/targetstatus.qtpl:383
+//line lib/promscrape/targetstatus.qtpl:385
 	qs422016 := string(qb422016.B)
-//line lib/promscrape/targetstatus.qtpl:383
+//line lib/promscrape/targetstatus.qtpl:385
 	qt422016.ReleaseByteBuffer(qb422016)
-//line lib/promscrape/targetstatus.qtpl:383
+//line lib/promscrape/targetstatus.qtpl:385
 	return qs422016
-//line lib/promscrape/targetstatus.qtpl:383
+//line lib/promscrape/targetstatus.qtpl:385
 }
 
-//line lib/promscrape/targetstatus.qtpl:385
+//line lib/promscrape/targetstatus.qtpl:387
 func streamshowHideScrapeJobButtons(qw422016 *qt422016.Writer, num int) {
-//line lib/promscrape/targetstatus.qtpl:385
+//line lib/promscrape/targetstatus.qtpl:387
 	qw422016.N().S(`<button type="button" class="btn btn-primary btn-sm me-1"onclick="document.getElementById('scrape-job-`)
-//line lib/promscrape/targetstatus.qtpl:387
+//line lib/promscrape/targetstatus.qtpl:389
 	qw422016.N().D(num)
-//line lib/promscrape/targetstatus.qtpl:387
+//line lib/promscrape/targetstatus.qtpl:389
 	qw422016.N().S(`').style.display='none'">collapse</button><button type="button" class="btn btn-secondary btn-sm me-1"onclick="document.getElementById('scrape-job-`)
-//line lib/promscrape/targetstatus.qtpl:391
+//line lib/promscrape/targetstatus.qtpl:393
 	qw422016.N().D(num)
-//line lib/promscrape/targetstatus.qtpl:391
+//line lib/promscrape/targetstatus.qtpl:393
 	qw422016.N().S(`').style.display='block'">expand</button>`)
-//line lib/promscrape/targetstatus.qtpl:394
-}
-
-//line lib/promscrape/targetstatus.qtpl:394
-func writeshowHideScrapeJobButtons(qq422016 qtio422016.Writer, num int) {
-//line lib/promscrape/targetstatus.qtpl:394
-	qw422016 := qt422016.AcquireWriter(qq422016)
-//line lib/promscrape/targetstatus.qtpl:394
-	streamshowHideScrapeJobButtons(qw422016, num)
-//line lib/promscrape/targetstatus.qtpl:394
-	qt422016.ReleaseWriter(qw422016)
-//line lib/promscrape/targetstatus.qtpl:394
-}
-
-//line lib/promscrape/targetstatus.qtpl:394
-func showHideScrapeJobButtons(num int) string {
-//line lib/promscrape/targetstatus.qtpl:394
-	qb422016 := qt422016.AcquireByteBuffer()
-//line lib/promscrape/targetstatus.qtpl:394
-	writeshowHideScrapeJobButtons(qb422016, num)
-//line lib/promscrape/targetstatus.qtpl:394
-	qs422016 := string(qb422016.B)
-//line lib/promscrape/targetstatus.qtpl:394
-	qt422016.ReleaseByteBuffer(qb422016)
-//line lib/promscrape/targetstatus.qtpl:394
-	return qs422016
-//line lib/promscrape/targetstatus.qtpl:394
+//line lib/promscrape/targetstatus.qtpl:396
 }
 
 //line lib/promscrape/targetstatus.qtpl:396
-func streamqueryArgs(qw422016 *qt422016.Writer, filter *requestFilter, override map[string]string) {
+func writeshowHideScrapeJobButtons(qq422016 qtio422016.Writer, num int) {
+//line lib/promscrape/targetstatus.qtpl:396
+	qw422016 := qt422016.AcquireWriter(qq422016)
+//line lib/promscrape/targetstatus.qtpl:396
+	streamshowHideScrapeJobButtons(qw422016, num)
+//line lib/promscrape/targetstatus.qtpl:396
+	qt422016.ReleaseWriter(qw422016)
+//line lib/promscrape/targetstatus.qtpl:396
+}
+
+//line lib/promscrape/targetstatus.qtpl:396
+func showHideScrapeJobButtons(num int) string {
+//line lib/promscrape/targetstatus.qtpl:396
+	qb422016 := qt422016.AcquireByteBuffer()
+//line lib/promscrape/targetstatus.qtpl:396
+	writeshowHideScrapeJobButtons(qb422016, num)
+//line lib/promscrape/targetstatus.qtpl:396
+	qs422016 := string(qb422016.B)
+//line lib/promscrape/targetstatus.qtpl:396
+	qt422016.ReleaseByteBuffer(qb422016)
+//line lib/promscrape/targetstatus.qtpl:396
+	return qs422016
+//line lib/promscrape/targetstatus.qtpl:396
+}
+
 //line lib/promscrape/targetstatus.qtpl:398
+func streamqueryArgs(qw422016 *qt422016.Writer, filter *requestFilter, override map[string]string) {
+//line lib/promscrape/targetstatus.qtpl:400
 	showOnlyUnhealthy := "false"
 	if filter.showOnlyUnhealthy {
 		showOnlyUnhealthy = "true"
@@ -1057,89 +1063,89 @@ func streamqueryArgs(qw422016 *qt422016.Writer, filter *requestFilter, override 
 		qa[k] = []string{v}
 	}
 
-//line lib/promscrape/targetstatus.qtpl:415
+//line lib/promscrape/targetstatus.qtpl:417
 	qw422016.E().S(qa.Encode())
-//line lib/promscrape/targetstatus.qtpl:416
-}
-
-//line lib/promscrape/targetstatus.qtpl:416
-func writequeryArgs(qq422016 qtio422016.Writer, filter *requestFilter, override map[string]string) {
-//line lib/promscrape/targetstatus.qtpl:416
-	qw422016 := qt422016.AcquireWriter(qq422016)
-//line lib/promscrape/targetstatus.qtpl:416
-	streamqueryArgs(qw422016, filter, override)
-//line lib/promscrape/targetstatus.qtpl:416
-	qt422016.ReleaseWriter(qw422016)
-//line lib/promscrape/targetstatus.qtpl:416
-}
-
-//line lib/promscrape/targetstatus.qtpl:416
-func queryArgs(filter *requestFilter, override map[string]string) string {
-//line lib/promscrape/targetstatus.qtpl:416
-	qb422016 := qt422016.AcquireByteBuffer()
-//line lib/promscrape/targetstatus.qtpl:416
-	writequeryArgs(qb422016, filter, override)
-//line lib/promscrape/targetstatus.qtpl:416
-	qs422016 := string(qb422016.B)
-//line lib/promscrape/targetstatus.qtpl:416
-	qt422016.ReleaseByteBuffer(qb422016)
-//line lib/promscrape/targetstatus.qtpl:416
-	return qs422016
-//line lib/promscrape/targetstatus.qtpl:416
+//line lib/promscrape/targetstatus.qtpl:418
 }
 
 //line lib/promscrape/targetstatus.qtpl:418
+func writequeryArgs(qq422016 qtio422016.Writer, filter *requestFilter, override map[string]string) {
+//line lib/promscrape/targetstatus.qtpl:418
+	qw422016 := qt422016.AcquireWriter(qq422016)
+//line lib/promscrape/targetstatus.qtpl:418
+	streamqueryArgs(qw422016, filter, override)
+//line lib/promscrape/targetstatus.qtpl:418
+	qt422016.ReleaseWriter(qw422016)
+//line lib/promscrape/targetstatus.qtpl:418
+}
+
+//line lib/promscrape/targetstatus.qtpl:418
+func queryArgs(filter *requestFilter, override map[string]string) string {
+//line lib/promscrape/targetstatus.qtpl:418
+	qb422016 := qt422016.AcquireByteBuffer()
+//line lib/promscrape/targetstatus.qtpl:418
+	writequeryArgs(qb422016, filter, override)
+//line lib/promscrape/targetstatus.qtpl:418
+	qs422016 := string(qb422016.B)
+//line lib/promscrape/targetstatus.qtpl:418
+	qt422016.ReleaseByteBuffer(qb422016)
+//line lib/promscrape/targetstatus.qtpl:418
+	return qs422016
+//line lib/promscrape/targetstatus.qtpl:418
+}
+
+//line lib/promscrape/targetstatus.qtpl:420
 func streamformatLabels(qw422016 *qt422016.Writer, labels *promutil.Labels) {
-//line lib/promscrape/targetstatus.qtpl:419
+//line lib/promscrape/targetstatus.qtpl:421
 	labelsList := labels.GetLabels()
 
-//line lib/promscrape/targetstatus.qtpl:419
-	qw422016.N().S(`{`)
 //line lib/promscrape/targetstatus.qtpl:421
+	qw422016.N().S(`{`)
+//line lib/promscrape/targetstatus.qtpl:423
 	for i, label := range labelsList {
-//line lib/promscrape/targetstatus.qtpl:422
+//line lib/promscrape/targetstatus.qtpl:424
 		qw422016.E().S(label.Name)
-//line lib/promscrape/targetstatus.qtpl:422
+//line lib/promscrape/targetstatus.qtpl:424
 		qw422016.N().S(`=`)
-//line lib/promscrape/targetstatus.qtpl:422
+//line lib/promscrape/targetstatus.qtpl:424
 		qw422016.E().Q(label.Value)
-//line lib/promscrape/targetstatus.qtpl:423
+//line lib/promscrape/targetstatus.qtpl:425
 		if i+1 < len(labelsList) {
-//line lib/promscrape/targetstatus.qtpl:423
+//line lib/promscrape/targetstatus.qtpl:425
 			qw422016.N().S(`,`)
-//line lib/promscrape/targetstatus.qtpl:423
+//line lib/promscrape/targetstatus.qtpl:425
 			qw422016.N().S(` `)
-//line lib/promscrape/targetstatus.qtpl:423
+//line lib/promscrape/targetstatus.qtpl:425
 		}
-//line lib/promscrape/targetstatus.qtpl:424
+//line lib/promscrape/targetstatus.qtpl:426
 	}
-//line lib/promscrape/targetstatus.qtpl:424
+//line lib/promscrape/targetstatus.qtpl:426
 	qw422016.N().S(`}`)
-//line lib/promscrape/targetstatus.qtpl:426
+//line lib/promscrape/targetstatus.qtpl:428
 }
 
-//line lib/promscrape/targetstatus.qtpl:426
+//line lib/promscrape/targetstatus.qtpl:428
 func writeformatLabels(qq422016 qtio422016.Writer, labels *promutil.Labels) {
-//line lib/promscrape/targetstatus.qtpl:426
+//line lib/promscrape/targetstatus.qtpl:428
 	qw422016 := qt422016.AcquireWriter(qq422016)
-//line lib/promscrape/targetstatus.qtpl:426
+//line lib/promscrape/targetstatus.qtpl:428
 	streamformatLabels(qw422016, labels)
-//line lib/promscrape/targetstatus.qtpl:426
+//line lib/promscrape/targetstatus.qtpl:428
 	qt422016.ReleaseWriter(qw422016)
-//line lib/promscrape/targetstatus.qtpl:426
+//line lib/promscrape/targetstatus.qtpl:428
 }
 
-//line lib/promscrape/targetstatus.qtpl:426
+//line lib/promscrape/targetstatus.qtpl:428
 func formatLabels(labels *promutil.Labels) string {
-//line lib/promscrape/targetstatus.qtpl:426
+//line lib/promscrape/targetstatus.qtpl:428
 	qb422016 := qt422016.AcquireByteBuffer()
-//line lib/promscrape/targetstatus.qtpl:426
+//line lib/promscrape/targetstatus.qtpl:428
 	writeformatLabels(qb422016, labels)
-//line lib/promscrape/targetstatus.qtpl:426
+//line lib/promscrape/targetstatus.qtpl:428
 	qs422016 := string(qb422016.B)
-//line lib/promscrape/targetstatus.qtpl:426
+//line lib/promscrape/targetstatus.qtpl:428
 	qt422016.ReleaseByteBuffer(qb422016)
-//line lib/promscrape/targetstatus.qtpl:426
+//line lib/promscrape/targetstatus.qtpl:428
 	return qs422016
-//line lib/promscrape/targetstatus.qtpl:426
+//line lib/promscrape/targetstatus.qtpl:428
 }


### PR DESCRIPTION
### Describe Your Changes

Related to https://github.com/VictoriaMetrics/VictoriaMetrics/issues/10237, https://github.com/VictoriaMetrics/VictoriaMetrics/issues/9901

When `-promscrape.dropOriginalLabels=true` is enabled, original target labels are unavailable. These labels are required to compute the target ID used by the /target_response endpoint, so the response link cannot be generated. See
https://github.com/VictoriaMetrics/VictoriaMetrics/blob/7a5003212ed77d526daf19c4b415e863ba1aa3ba/lib/promscrape/targetstatus.qtpl#L236

Previously, the link silently disappeared from the UI. Now the UI shows (N/A) Not available, explicitly indicating that required data is missing.

<img width="1512" height="809" alt="Screenshot 2026-01-05 at 21 08 32" src="https://github.com/user-attachments/assets/99d325c6-6fab-4e16-bd40-36a9657532e0" />

### Checklist

The following checks are **mandatory**:

- [ ] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [ ] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
