### PR TITLE
app/vmalert: prevent fallthrough resends for Inactive alerts in alertsToSend

### DIFF
--- a/app/vmalert/rule/alerting.go
+++ b/app/vmalert/rule/alerting.go
@@ -866,8 +866,8 @@ func (ar *AlertingRule) alertsToSend(resolveDuration, resendDelay time.Duration)
 		if a.State == notifier.StateFiring && a.End.Before(a.LastSent) {
 			return true
 		}
-		if a.State == notifier.StateInactive && a.ResolvedAt.After(a.LastSent) {
-			return true
+		if a.State == notifier.StateInactive {
+			return a.ResolvedAt.After(a.LastSent)
 		}
 		return a.LastSent.Add(resendDelay).Before(currentTime)
 	}

--- a/app/vmalert/rule/alerting_test.go
+++ b/app/vmalert/rule/alerting_test.go
@@ -1313,7 +1313,7 @@ func TestAlertsToSend(t *testing.T) {
 		// no need to resend resolved
 		{Name: "b", State: notifier.StateInactive, ResolvedAt: ts, LastSent: ts},
 		// resend resolved
-		{Name: "c", State: notifier.StateInactive, ResolvedAt: ts.Add(-1 * time.Minute), LastSent: ts.Add(-1 * time.Minute)},
+		{Name: "c", State: notifier.StateInactive, ResolvedAt: ts.Add(1 * time.Minute), LastSent: ts.Add(-1 * time.Minute)},
 	},
 		[]*notifier.Alert{{Name: "a"}, {Name: "c"}},
 		5*time.Minute, time.Minute,


### PR DESCRIPTION
Ensure inactive alerts are only resent if ResolvedAt is later than LastSent. Updated tests to verify the fix.

### Describe Your Changes
Previously, `Inactive` alerts could fall through the state check and hit the generic `resendDelay` logic, causing them to be resent repeatedly.
This PR modifies the condition to explicitly return `false` for `Inactive` alerts if they haven't been updated (i.e. `ResolvedAt` is not newer than `LastSent`), ensuring they are not resent.
fix #10246 

### Checklist
The following checks are **mandatory**:
- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
