### PR TITLE
vmagent: fix calculation of vm_persistentqueue_free_disk_space_bytes

### DIFF
--- a/lib/persistentqueue/fastqueue.go
+++ b/lib/persistentqueue/fastqueue.go
@@ -70,7 +70,10 @@ func MustOpenFastQueue(path, name string, maxInmemoryBlocks int, maxPendingBytes
 		if maxPendingBytes == 0 {
 			return float64(freeSpaceBytes)
 		}
-		return min(float64(maxPendingBytes), float64(freeSpaceBytes))
+		fq.mu.Lock()
+		curPendingBytes := fq.pq.GetPendingBytes()
+		fq.mu.Unlock()
+		return min(float64(maxPendingBytes)-float64(curPendingBytes), float64(freeSpaceBytes))
 	})
 
 	pendingBytes := fq.GetPendingBytes()


### PR DESCRIPTION
### Describe Your Changes

follow  up https://github.com/VictoriaMetrics/VictoriaMetrics/pull/10242, see discussion in https://github.com/VictoriaMetrics/VictoriaMetrics/pull/10267#issuecomment-3729577415 for more context

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
