### PR TITLE
Make stats panel use the range specified in grafana

### DIFF
--- a/dashboards/backupmanager.json
+++ b/dashboards/backupmanager.json
@@ -452,7 +452,7 @@
             "uid": "$ds"
           },
           "editorMode": "code",
-          "expr": "sum(increase(vm_backup_errors_total{job=~\"$job\", instance=~\"$instance\"}[1h]))",
+          "expr": "sum(increase(vm_backup_errors_total{job=~\"$job\", instance=~\"$instance\"}[$__range]))",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"


### PR DESCRIPTION
### Describe Your Changes

The Backups errors panel uses a hard coded rate, when looking over a large period of time this number would likely stay low do to the hard coded rate when in reality the amount of errors is much larger.

This change addresses this by using the __rate variable in Grafana so the rate will align with the date/time range in Grafana.

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
