### PR TITLE
docs: Add docs-update-flags step to release.

### DIFF
--- a/docs/victoriametrics/Release-Guide.md
+++ b/docs/victoriametrics/Release-Guide.md
@@ -114,6 +114,7 @@ and the candidate is deployed to the sandbox environment.
 1. Make sure that the release branches have no security issues.
 1. Update release versions if needed in [SECURITY.md](https://github.com/VictoriaMetrics/VictoriaMetrics/blob/master/SECURITY.md).
 1. Run `PKG_TAG=v1.xx.y make docs-update-version` command to update version help tooltips.
+1. Run `make docs-update-flags` command to update command-line flags in the documentation. [Commit example](https://github.com/VictoriaMetrics/VictoriaMetrics/commit/4d42b291e55ac9211130efbd5a56aa819998516d). 
 1. Cut new version in [CHANGELOG.md](https://github.com/VictoriaMetrics/VictoriaMetrics/blob/master/docs/victoriametrics/changelog/CHANGELOG.md) and commit it. See example in this [commit](https://github.com/VictoriaMetrics/VictoriaMetrics/commit/b771152039d23b5ccd637a23ea748bc44a9511a7).
 1. Create the following release tags:
    * `git tag -s v1.xx.y` in `master` branch


### PR DESCRIPTION
### Describe Your Changes

Previously, we had to manually update flags in documentation whenever we made flag-related changes in source code. Someone did it by hand, others compiled enterprise binaries, executed them with `-help` flag, and copied and pasted output to the documentation.

In https://github.com/VictoriaMetrics/VictoriaMetrics/pull/9632 a command `make docs-update-flags` was introduced (impr in https://github.com/VictoriaMetrics/VictoriaMetrics/pull/10241). It automates the whole process. It compiles binaries, runs `-help,` and syncs output to changes automatically. 

Now, we can **omit updating doc flags in the PR** and do it once before releasing a new version.

### Checklist

The following checks are **mandatory**:

- [ ] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [ ] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
