### PR TITLE
app/vmui: fix tenant ID handling via URL path

### DIFF
--- a/app/vmui/packages/vmui/src/components/Configurators/GlobalSettings/ServerConfigurator/ServerConfigurator.tsx
+++ b/app/vmui/packages/vmui/src/components/Configurators/GlobalSettings/ServerConfigurator/ServerConfigurator.tsx
@@ -9,7 +9,6 @@ import { getFromStorage, removeFromStorage, saveToStorage } from "../../../../ut
 import useBoolean from "../../../../hooks/useBoolean";
 import { ChildComponentHandle } from "../GlobalSettings";
 import { useAppDispatch, useAppState } from "../../../../state/common/StateContext";
-import { getTenantIdFromUrl } from "../../../../utils/tenants";
 
 interface ServerConfiguratorProps {
   onClose: () => void;
@@ -39,10 +38,6 @@ const ServerConfigurator = forwardRef<ChildComponentHandle, ServerConfiguratorPr
   };
 
   const handleApply = useCallback(() => {
-    const tenantIdFromUrl = getTenantIdFromUrl(serverUrl);
-    if (tenantIdFromUrl !== "") {
-      dispatch({ type: "SET_TENANT_ID", payload: tenantIdFromUrl });
-    }
     dispatch({ type: "SET_SERVER", payload: serverUrl });
     onClose();
   }, [serverUrl]);
@@ -59,12 +54,6 @@ const ServerConfigurator = forwardRef<ChildComponentHandle, ServerConfiguratorPr
       removeFromStorage(["SERVER_URL"]);
     }
   }, [enabledStorage]);
-
-  useEffect(() => {
-    if (enabledStorage) {
-      saveToStorage("SERVER_URL", serverUrl);
-    }
-  }, [serverUrl]);
 
   useEffect(() => {
     // the tenant selector can change the serverUrl

--- a/app/vmui/packages/vmui/src/components/Configurators/GlobalSettings/TenantsConfiguration/TenantsConfiguration.tsx
+++ b/app/vmui/packages/vmui/src/components/Configurators/GlobalSettings/TenantsConfiguration/TenantsConfiguration.tsx
@@ -1,4 +1,4 @@
-import { FC, useState, useRef, useEffect, useMemo } from "preact/compat";
+import { FC, useState, useRef, useMemo } from "preact/compat";
 import { useAppDispatch, useAppState } from "../../../../state/common/StateContext";
 import { useTimeDispatch } from "../../../../state/time/TimeStateContext";
 import { ArrowDownIcon, StorageIcon } from "../../../Main/Icons";
@@ -10,14 +10,14 @@ import { getAppModeEnable } from "../../../../utils/app-mode";
 import Tooltip from "../../../Main/Tooltip/Tooltip";
 import useDeviceDetect from "../../../../hooks/useDeviceDetect";
 import TextField from "../../../Main/TextField/TextField";
-import { getTenantIdFromUrl, replaceTenantId } from "../../../../utils/tenants";
+import { replaceTenantId } from "../../../../utils/tenants";
 import useBoolean from "../../../../hooks/useBoolean";
 
 const TenantsConfiguration: FC<{accountIds: string[]}> = ({ accountIds }) => {
   const appModeEnable = getAppModeEnable();
   const { isMobile } = useDeviceDetect();
 
-  const { tenantId: tenantIdState, serverUrl } = useAppState();
+  const { tenantId, serverUrl } = useAppState();
   const dispatch = useAppDispatch();
   const timeDispatch = useTimeDispatch();
 
@@ -48,26 +48,14 @@ const TenantsConfiguration: FC<{accountIds: string[]}> = ({ accountIds }) => {
   }, [accountIds]);
 
   const createHandlerChange = (value: string) => () => {
-    const tenant = value;
-    dispatch({ type: "SET_TENANT_ID", payload: tenant });
     if (serverUrl) {
-      const updateServerUrl = replaceTenantId(serverUrl, tenant);
+      const updateServerUrl = replaceTenantId(serverUrl, value);
       if (updateServerUrl === serverUrl) return;
       dispatch({ type: "SET_SERVER", payload: updateServerUrl });
       timeDispatch({ type: "RUN_QUERY" });
     }
     handleCloseOptions();
   };
-
-  useEffect(() => {
-    const id = getTenantIdFromUrl(serverUrl);
-
-    if (tenantIdState && tenantIdState !== id) {
-      createHandlerChange(tenantIdState)();
-    } else {
-      createHandlerChange(id)();
-    }
-  }, [serverUrl]);
 
   if (!showTenantSelector) return null;
 
@@ -83,7 +71,7 @@ const TenantsConfiguration: FC<{accountIds: string[]}> = ({ accountIds }) => {
               <span className="vm-mobile-option__icon"><StorageIcon/></span>
               <div className="vm-mobile-option-text">
                 <span className="vm-mobile-option-text__label">Tenant ID</span>
-                <span className="vm-mobile-option-text__value">{tenantIdState}</span>
+                <span className="vm-mobile-option-text__value">{tenantId}</span>
               </div>
               <span className="vm-mobile-option__arrow"><ArrowDownIcon/></span>
             </div>
@@ -106,7 +94,7 @@ const TenantsConfiguration: FC<{accountIds: string[]}> = ({ accountIds }) => {
               )}
               onClick={toggleOpenOptions}
             >
-              {tenantIdState}
+              {tenantId}
             </Button>
           )}
         </div>
@@ -138,7 +126,7 @@ const TenantsConfiguration: FC<{accountIds: string[]}> = ({ accountIds }) => {
               className={classNames({
                 "vm-list-item": true,
                 "vm-list-item_mobile": isMobile,
-                "vm-list-item_active": id === tenantIdState
+                "vm-list-item_active": id === tenantId
               })}
               key={id}
               onClick={createHandlerChange(id)}

--- a/app/vmui/packages/vmui/src/components/Configurators/GlobalSettings/TenantsConfiguration/hooks/useFetchAccountIds.ts
+++ b/app/vmui/packages/vmui/src/components/Configurators/GlobalSettings/TenantsConfiguration/hooks/useFetchAccountIds.ts
@@ -3,19 +3,18 @@ import { useEffect, useMemo, useState } from "preact/compat";
 import { ErrorTypes } from "../../../../../types";
 import { getAccountIds } from "../../../../../api/accountId";
 import { getAppModeEnable, getAppModeParams } from "../../../../../utils/app-mode";
-import { getTenantIdFromUrl } from "../../../../../utils/tenants";
 
 export const useFetchAccountIds = () => {
   const { useTenantID } = getAppModeParams();
   const appModeEnable = getAppModeEnable();
-  const { serverUrl } = useAppState();
+  const { tenantId, serverUrl } = useAppState();
 
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<ErrorTypes | string>();
   const [accountIds, setAccountIds] = useState<string[]>([]);
 
   const fetchUrl = useMemo(() => getAccountIds(serverUrl), [serverUrl]);
-  const isServerUrlWithTenant = useMemo(() => !!getTenantIdFromUrl(serverUrl), [serverUrl]);
+  const isServerUrlWithTenant = useMemo(() => !!tenantId, [tenantId]);
   const preventFetch = appModeEnable ? !useTenantID : !isServerUrlWithTenant;
 
   useEffect(() => {

--- a/app/vmui/packages/vmui/src/pages/CardinalityPanel/hooks/useCardinalityFetch.ts
+++ b/app/vmui/packages/vmui/src/pages/CardinalityPanel/hooks/useCardinalityFetch.ts
@@ -7,7 +7,6 @@ import AppConfigurator from "../appConfigurator";
 import { useSearchParams } from "react-router-dom";
 import dayjs from "dayjs";
 import { DATE_FORMAT } from "../../../constants/date";
-import { getTenantIdFromUrl } from "../../../utils/tenants";
 import usePrevious from "../../../hooks/usePrevious";
 
 export const useFetchQuery = (): {
@@ -27,7 +26,7 @@ export const useFetchQuery = (): {
   const prevDate = usePrevious(date);
   const prevTotal = useRef<{ data: TSDBStatus }>();
 
-  const { serverUrl } = useAppState();
+  const { tenantId, serverUrl } = useAppState();
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<ErrorTypes | string>();
   const [tsdbStatus, setTSDBStatus] = useState<TSDBStatus>(appConfigurator.defaultTSDBStatus);
@@ -158,9 +157,8 @@ export const useFetchQuery = (): {
   }, [error]);
 
   useEffect(() => {
-    const id = getTenantIdFromUrl(serverUrl);
-    setIsCluster(!!id);
-  }, [serverUrl]);
+    setIsCluster(!!tenantId);
+  }, [tenantId]);
 
 
   appConfigurator.tsdbStatusData = tsdbStatus;

--- a/app/vmui/packages/vmui/src/pages/CustomPanel/hooks/useSetQueryParams.ts
+++ b/app/vmui/packages/vmui/src/pages/CustomPanel/hooks/useSetQueryParams.ts
@@ -1,7 +1,6 @@
 import { useEffect, useState } from "react";
 import { useTimeDispatch, useTimeState } from "../../../state/time/TimeStateContext";
 import { useCustomPanelDispatch, useCustomPanelState } from "../../../state/customPanel/CustomPanelStateContext";
-import { useAppDispatch, useAppState } from "../../../state/common/StateContext";
 import { useQueryDispatch, useQueryState } from "../../../state/query/QueryStateContext";
 import { displayTypeTabs } from "../DisplayTypeSwitch";
 import { useGraphDispatch, useGraphState } from "../../../state/graph/GraphStateContext";
@@ -15,14 +14,12 @@ import { arrayEquals } from "../../../utils/array";
 import { isEqualURLSearchParams } from "../../../utils/url";
 
 export const useSetQueryParams = () => {
-  const { tenantId } = useAppState();
   const { displayType } = useCustomPanelState();
   const { query } = useQueryState();
   const { duration, relativeTime, period: { date, step } } = useTimeState();
   const { customStep } = useGraphState();
   const [searchParams, setSearchParams] = useSearchParams();
 
-  const dispatch = useAppDispatch();
   const timeDispatch = useTimeDispatch();
   const graphDispatch = useGraphDispatch();
   const queryDispatch = useQueryDispatch();
@@ -72,10 +69,6 @@ export const useSetQueryParams = () => {
       if (searchParams.get(`${group}.tab`) !== displayTypeCode) {
         newSearchParams.set(`${group}.tab`, `${displayTypeCode}`);
       }
-
-      if (searchParams.get(`${group}.tenantID`) !== tenantId && tenantId) {
-        newSearchParams.set(`${group}.tenantID`, tenantId);
-      }
     });
 
     // Remove extra parameters that exceed the request size
@@ -89,7 +82,7 @@ export const useSetQueryParams = () => {
 
     if (isEqualURLSearchParams(newSearchParams, searchParams) || !newSearchParams.size) return;
     setSearchParams(newSearchParams);
-  }, [tenantId, displayType, query, duration, relativeTime, date, step, customStep]);
+  }, [displayType, query, duration, relativeTime, date, step, customStep]);
 
   useEffect(() => {
     const timer = setTimeout(setterSearchParams, 200);
@@ -112,11 +105,6 @@ export const useSetQueryParams = () => {
     const displayTypeFromUrl = getInitialDisplayType();
     if (displayTypeFromUrl !== displayType) {
       customPanelDispatch({ type: "SET_DISPLAY_TYPE", payload: displayTypeFromUrl });
-    }
-
-    const tenantIdFromUrl = searchParams.get("g0.tenantID") || "";
-    if (tenantIdFromUrl !== tenantId) {
-      dispatch({ type: "SET_TENANT_ID", payload: tenantIdFromUrl });
     }
 
     const queryFromUrl = getQueryArray();

--- a/app/vmui/packages/vmui/src/state/common/StateContext.tsx
+++ b/app/vmui/packages/vmui/src/state/common/StateContext.tsx
@@ -1,7 +1,8 @@
-import { createContext, FC, useContext, useMemo, useReducer } from "preact/compat";
+import { createContext, FC, useContext, useEffect, useMemo, useReducer } from "preact/compat";
 import { Action, AppState, initialState, reducer } from "./reducer";
 import { getQueryStringValue } from "../../utils/query-string";
 import { Dispatch } from "react";
+import { getFromStorage, removeFromStorage, saveToStorage } from "../../utils/storage";
 
 type StateContextType = { state: AppState, dispatch: Dispatch<Action> };
 
@@ -22,6 +23,17 @@ export const AppStateProvider: FC = ({ children }) => {
   const contextValue = useMemo(() => {
     return { state, dispatch };
   }, [state, dispatch]);
+
+  useEffect(() => {
+    if (!state.serverUrl) return;
+    const enabledStorage = !!getFromStorage("SERVER_URL");
+
+    if (enabledStorage) {
+      saveToStorage("SERVER_URL", state.serverUrl);
+    } else {
+      removeFromStorage(["SERVER_URL"]);
+    }
+  }, [state.serverUrl]);
 
   return <StateContext.Provider value={contextValue}>
     {children}

--- a/app/vmui/packages/vmui/src/state/common/reducer.ts
+++ b/app/vmui/packages/vmui/src/state/common/reducer.ts
@@ -1,9 +1,9 @@
 import { getDefaultServer } from "../../utils/default-server-url";
-import { getQueryStringValue } from "../../utils/query-string";
 import { getFromStorage, saveToStorage } from "../../utils/storage";
 import { AppConfig, Theme } from "../../types";
 import { isDarkTheme } from "../../utils/theme";
 import { removeTrailingSlash } from "../../utils/url";
+import { getTenantIdFromUrl } from "../../utils/tenants";
 
 export interface AppState {
   serverUrl: string;
@@ -16,15 +16,14 @@ export interface AppState {
 export type Action =
   | { type: "SET_SERVER", payload: string }
   | { type: "SET_THEME", payload: Theme }
-  | { type: "SET_TENANT_ID", payload: string }
   | { type: "SET_APP_CONFIG", payload: AppConfig }
   | { type: "SET_DARK_THEME" }
 
-const tenantId = getQueryStringValue("g0.tenantID", "") as string;
+const serverUrl = removeTrailingSlash(getDefaultServer());
 
 export const initialState: AppState = {
-  serverUrl: removeTrailingSlash(getDefaultServer(tenantId)),
-  tenantId,
+  serverUrl,
+  tenantId: getTenantIdFromUrl(serverUrl),
   theme: (getFromStorage("THEME") || Theme.system) as Theme,
   isDarkTheme: null,
   appConfig: {}
@@ -35,12 +34,8 @@ export function reducer(state: AppState, action: Action): AppState {
     case "SET_SERVER":
       return {
         ...state,
+        tenantId: getTenantIdFromUrl(action.payload),
         serverUrl: removeTrailingSlash(action.payload)
-      };
-    case "SET_TENANT_ID":
-      return {
-        ...state,
-        tenantId: action.payload
       };
     case "SET_THEME":
       saveToStorage("THEME", action.payload);

--- a/app/vmui/packages/vmui/src/utils/default-server-url.ts
+++ b/app/vmui/packages/vmui/src/utils/default-server-url.ts
@@ -1,5 +1,4 @@
 import { getAppModeParams } from "./app-mode";
-import { replaceTenantId } from "./tenants";
 import { APP_TYPE, AppType } from "../constants/appType";
 import { getFromStorage } from "./storage";
 
@@ -7,7 +6,7 @@ export const getDefaultURL = (u: string) => {
   return u.replace(/(\/(?:prometheus\/)?(?:graph|vmui)\/.*|\/#\/.*)/, "/prometheus");
 };
 
-export const getDefaultServer = (tenantId?: string): string => {
+export const getDefaultServer = (): string => {
   const { serverURL } = getAppModeParams();
   const storageURL = getFromStorage("SERVER_URL") as string;
   const anomalyURL = `${window.location.origin}${window.location.pathname.replace(/^\/vmui/, "")}`;
@@ -18,6 +17,6 @@ export const getDefaultServer = (tenantId?: string): string => {
     case AppType.vmanomaly:
       return storageURL || anomalyURL;
     default:
-      return tenantId ? replaceTenantId(url, tenantId) : url;
+      return url;
   }
 };

--- a/app/vmui/packages/vmui/src/utils/tenants.test.ts
+++ b/app/vmui/packages/vmui/src/utils/tenants.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  replaceTenantId,
+  getTenantIdFromUrl,
+  getUrlWithoutTenant,
+} from "./tenants";
+
+describe("tenant url helpers", () => {
+  describe("getTenantIdFromUrl", () => {
+    it("returns accountID", () => {
+      expect(getTenantIdFromUrl("http://vmselect:8481/select/0/vmui/")).toBe("0");
+    });
+
+    it("returns accountID:projectID", () => {
+      expect(getTenantIdFromUrl("http://vmselect:8481/select/12:7/vmui/")).toBe("12:7");
+    });
+
+    it("returns empty string if tenant is missing", () => {
+      expect(getTenantIdFromUrl("http://vmselect:8481/select/vmui/")).toBe("");
+    });
+
+    it("returns empty string for unrelated paths", () => {
+      expect(getTenantIdFromUrl("http://vmselect:8481/foo/bar")).toBe("");
+    });
+
+    it("returns accountID when url ends right after tenant", () => {
+      expect(getTenantIdFromUrl("http://vmselect:8481/select/0")).toBe("0");
+    });
+  });
+
+  describe("replaceTenantId", () => {
+    it("replaces accountID with another accountID", () => {
+      expect(
+        replaceTenantId("http://vmselect:8481/select/0/vmui/", "2")
+      ).toBe("http://vmselect:8481/select/2/vmui/");
+    });
+
+    it("replaces accountID with accountID:projectID", () => {
+      expect(
+        replaceTenantId("http://vmselect:8481/select/0/prometheus/", "1:9")
+      ).toBe("http://vmselect:8481/select/1:9/prometheus/");
+    });
+
+    it("keeps the rest of the path intact", () => {
+      expect(
+        replaceTenantId("http://vmselect:8481/select/3:4/prometheus/api/v1/query", "7")
+      ).toBe("http://vmselect:8481/select/7/prometheus/api/v1/query");
+    });
+
+    it("does not change url if it doesn't match expected pattern", () => {
+      expect(
+        replaceTenantId("http://vmselect:8481/foo/bar", "2")
+      ).toBe("http://vmselect:8481/foo/bar");
+    });
+  });
+
+  describe("getUrlWithoutTenant", () => {
+    it("removes /select/<tenant>/... and returns base url", () => {
+      expect(
+        getUrlWithoutTenant("http://vmselect:8481/select/0/vmui/")
+      ).toBe("http://vmselect:8481");
+    });
+
+    it("removes /select/<tenant>/... for accountID:projectID and returns base url", () => {
+      expect(
+        getUrlWithoutTenant("http://vmselect:8481/select/5:6/prometheus/")
+      ).toBe("http://vmselect:8481");
+    });
+
+    it("works with deep paths and returns base url", () => {
+      expect(
+        getUrlWithoutTenant("http://vmselect:8481/select/1:2/prometheus/api/v1/query")
+      ).toBe("http://vmselect:8481");
+    });
+
+    it("does not change url if it doesn't match expected pattern", () => {
+      expect(
+        getUrlWithoutTenant("http://vmselect:8481/foo/bar")
+      ).toBe("http://vmselect:8481/foo/bar");
+    });
+
+    it("removes url ending right after tenant", () => {
+      expect(
+        getUrlWithoutTenant("http://vmselect:8481/select/0")
+      ).toBe("http://vmselect:8481");
+    });
+  });
+});

--- a/app/vmui/packages/vmui/src/utils/tenants.ts
+++ b/app/vmui/packages/vmui/src/utils/tenants.ts
@@ -1,13 +1,21 @@
-const regexp = /(\/select\/)([^/])(\/)(.+)/;
+const TENANT_REGEXP = /(\/select\/)(\d+(?::\d+)?)(\/.*)?$/;
 
 export const replaceTenantId = (serverUrl: string, tenantId: string) => {
-  return serverUrl.replace(regexp, `$1${tenantId}/$4`);
+  return serverUrl.replace(TENANT_REGEXP, `$1${tenantId}$3`);
 };
 
 export const getTenantIdFromUrl = (url: string): string => {
-  return url.match(regexp)?.[2] || "";
+  return url.match(TENANT_REGEXP)?.[2] ?? "";
 };
 
 export const getUrlWithoutTenant = (url: string): string => {
-  return url.replace(regexp, "");
+  return url.replace(TENANT_REGEXP, "");
+};
+
+export const updateBrowserUrlTenant = (tenantId: string) => {
+  const base = `${window.location.origin}${window.location.pathname}${window.location.search}`;
+  const nextBase = replaceTenantId(base, tenantId);
+
+  const nextUrl = `${nextBase}${window.location.hash}`;
+  window.history.replaceState(null, "", nextUrl);
 };

--- a/docs/victoriametrics/changelog/CHANGELOG.md
+++ b/docs/victoriametrics/changelog/CHANGELOG.md
@@ -35,7 +35,8 @@ See also [LTS releases](https://docs.victoriametrics.com/victoriametrics/lts-rel
 * FEATURE: [dashboards/vmagent](https://grafana.com/grafana/dashboards/12683): add `Persistent queue Full ETA` panel to the `Drilldown` section. This panel helps estimate how much time remains until `vmagent` starts dropping incoming metrics. See [#10193](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/10193).
 
 * BUGFIX: [vmagent](https://docs.victoriametrics.com/victoriametrics/vmagent/): fix configuration reloading for `-remoteWrite.relabelConfig` and `-remoteWrite.urlRelabelConfig` when vmagent is launched with empty files. Previously, if vmagent started with an empty config, subsequent config reloads were ignored. See [#10211](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/10211).
-* BUGFIX: [vmsingle](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/): Fixed a missing path error for `http://<victoriametrics-addr>:8428/zabbixconnector/api/v1/history`. See PR [10214](https://github.com/VictoriaMetrics/VictoriaMetrics/pull/10214)
+* BUGFIX: [vmsingle](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/): Fixed a missing path error for `http://<victoriametrics-addr>:8428/zabbixconnector/api/v1/history`. See PR [10214](https://github.com/VictoriaMetrics/VictoriaMetrics/pull/10214).
+* BUGFIX: [vmui](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#vmui): remove legacy `tenantID` query param and use the URL path as the single source of truth for multitenancy. See [#10232](https://github.com/VictoriaMetrics/VictoriaMetrics/pull/10232).
 
 ## [v1.133.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.133.0)
 


### PR DESCRIPTION
### Describe Your Changes

**Problem**

* VMUI had two tenant ID sources:

  * URL path: `/select/<accountID>/vmui/`
  * Query param: `tenantID`
* These could differ, causing confusion and inconsistent behavior.

**Solution**

* Removed the legacy `tenantID` query parameter.
* Use the URL path as the single source of truth for tenant ID.
* Changing the tenant in the UI now updates the URL path.

Related issue: #10232

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
