### PR TITLE
app/vmui: fix the 'Percentage from total' stat

### DIFF
--- a/app/vmui/packages/vmui/src/pages/CardinalityPanel/CardinalityTotals/CardinalityTotals.tsx
+++ b/app/vmui/packages/vmui/src/pages/CardinalityPanel/CardinalityTotals/CardinalityTotals.tsx
@@ -13,7 +13,6 @@ export interface CardinalityTotalsProps {
   totalSeriesAll: number;
   totalSeriesPrev: number;
   totalLabelValuePairs: number;
-  seriesCountByMetricName: TopHeapEntry[];
   metricNameStats: MetricNameStats;
   isPrometheus?: boolean;
   isCluster: boolean;
@@ -23,7 +22,6 @@ const CardinalityTotals: FC<CardinalityTotalsProps> = ({
   totalSeries = 0,
   totalSeriesPrev = 0,
   totalSeriesAll = 0,
-  seriesCountByMetricName = [],
   metricNameStats,
   isPrometheus,
 }) => {
@@ -34,7 +32,7 @@ const CardinalityTotals: FC<CardinalityTotalsProps> = ({
   const focusLabel = searchParams.get("focusLabel");
   const isMetric = /__name__/.test(match || "");
 
-  const progress = seriesCountByMetricName[0]?.value / totalSeriesAll * 100;
+  const progress = totalSeries / totalSeriesAll * 100;
   const diff = totalSeries - totalSeriesPrev;
   const dynamic = Math.abs(diff) / totalSeriesPrev * 100;
 

--- a/docs/victoriametrics/changelog/CHANGELOG.md
+++ b/docs/victoriametrics/changelog/CHANGELOG.md
@@ -50,6 +50,7 @@ Released at 2026-01-16
 * BUGFIX: [vmui](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#vmui): fix heatmap rendering issues where charts could break or appear empty when bucket values were uniform or sparse. See [#10240](https://github.com/VictoriaMetrics/VictoriaMetrics/pull/10240).
 * BUGFIX: all VictoriaMetrics components: prefer numerical values over [stale markers](https://docs.victoriametrics.com/victoriametrics/vmagent/#prometheus-staleness-markers) when samples share the same timestamp during deduplication. See [#10196](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/10196#issuecomment-3738433938).
 * BUGFIX: `vmstorage` in [VictoriaMetrics cluster](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/): correctly return results for `/api/v1/labels` and `/api/v1/label/{}/values` when `match[]`, `extra_filters` or `extra_labels` are specified. See [#10294](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/10294)
+* BUGFIX: [vmui](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#vmui): fix Cardinality Explorer "Percentage from total" display. See PR [10288](https://github.com/VictoriaMetrics/VictoriaMetrics/pull/10288).
 
 ## [v1.133.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.133.0)
 


### PR DESCRIPTION
In the Cardinality Explorer, when filtering, a "Percentage from total" stat appears. This stat is documented as "the share of these series in the total number of time series".

This works for pages for individual metrics. However, if using a filter that returns *multiple* metrics, the value of "Percentage from total" will only account for the size of the *first* metric. One can have a filter that returns, say, 10k time series (out of, say, 100k in the VM cluster), and if the first metric returned has 1k time series, then "Percentage from total" will show 1%, not 10%.

This PR fixes that calculation.

- [X] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [X] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).

(Please let me know if I need to change my commit in some way. I'm also happy for a maintainer to take it over and sign it - I just want the fix made. :)