### PR TITLE
fsutil: fix a typo related to default concurrent goroutines working with files

### DIFF
--- a/lib/fs/fsutil/concurrency.go
+++ b/lib/fs/fsutil/concurrency.go
@@ -11,10 +11,7 @@ var maxConcurrency = flag.Int("fs.maxConcurrency", getDefaultConcurrency(), "The
 	"on systems with small number of CPU cores; higher values may help reducing data ingestion latency on systems with high-latency storage such as NFS or Ceph")
 
 func getDefaultConcurrency() int {
-	n := 16 * cgroup.AvailableCPUs()
-	if n > 256 {
-		n = 256
-	}
+	n := min(16*cgroup.AvailableCPUs(), 256)
 	return n
 }
 


### PR DESCRIPTION
s/265/256

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
