### PR TITLE
lib/promscrape: apply metric_relabel_configs to auto-generated metrics

### DIFF
--- a/docs/victoriametrics/changelog/CHANGELOG.md
+++ b/docs/victoriametrics/changelog/CHANGELOG.md
@@ -26,6 +26,8 @@ See also [LTS releases](https://docs.victoriametrics.com/victoriametrics/lts-rel
 
 ## tip
 
+* BUGFIX: [vmagent](https://docs.victoriametrics.com/victoriametrics/vmagent/): apply `metric_relabel_configs` (including global configs) to [auto-generated metrics](https://docs.victoriametrics.com/victoriametrics/vmagent/#automatically-generated-metrics) such as `scrape_duration_seconds`, `up`, etc. Previously, these metrics bypassed relabeling, causing issues when users needed to drop labels from all metrics including auto-generated ones. See [#10322](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/10322).
+
 ## [v1.134.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.134.0)
 
 Released at 2026-01-16


### PR DESCRIPTION
### Describe Your Changes

This PR fixes issue #10322 where `metric_relabel_configs` (including global configs like globalScrapeMetricRelabelConfigs) were not being applied to VMAgent's auto-generated metrics such as `scrape_duration_seconds`, `up`, `scrape_samples_scraped`,etc.

### Problem
Users configuring labeldrop rules to remove node labels (e.g.,feature_node_kubernetes.*) found that these rules worked for scraped metrics but not for auto-generated metrics, causing those metrics to exceed label limits and getdropped.

### Solution
  - Added `isInternalAutoMetric` parameter to `addRow()` and `addRows()` functions
  - Auto-metrics now pass through MetricRelabelConfigs with `needRelabel=true`
  - The `exported_` prefix logic correctly skips internal auto-metrics to avoid renaming
  them

### Changes
  - lib/promscrape/scrapework.go: Core fix
  - lib/promscrape/scrapework_test.go: Updated tests + new test case for the exact
  issue scenario

### Checklist

The following checks are **mandatory**:

- [✅] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [✅] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
