### PR TITLE
app/vmselect: fix incorrect downsampling when start query arg is miss…

### DIFF
--- a/app/vmselect/prometheus/prometheus.go
+++ b/app/vmselect/prometheus/prometheus.go
@@ -1183,8 +1183,8 @@ func getExportParams(r *http.Request, startTime time.Time) (*commonParams, error
 	cp.deadline = searchutil.GetDeadlineForExport(r, startTime)
 	if cp.IsDefaultTimeRange() {
 		// Adjust start time when it is missing, so it doesn't lead to
-		// fetching all the data from 1970 year.
-		// See https://github.com/VictoriaMetrics/VictoriaMetrics/issues/1806
+		// incorrect downsampling due to MinTimestamp defaulting to 0 (epoch).
+		// See https://github.com/VictoriaMetrics/VictoriaMetrics/issues/10326
 		lookbackDelta, err := getMaxLookback(r)
 		if err != nil {
 			return nil, err

--- a/docs/victoriametrics/changelog/CHANGELOG_2025.md
+++ b/docs/victoriametrics/changelog/CHANGELOG_2025.md
@@ -44,6 +44,7 @@ See also [LTS releases](https://docs.victoriametrics.com/victoriametrics/lts-rel
 
 * BUGFIX: [vmagent](https://docs.victoriametrics.com/victoriametrics/vmagent/): fix configuration reloading for `-remoteWrite.relabelConfig` and `-remoteWrite.urlRelabelConfig` when vmagent is launched with empty files. Previously, if vmagent started with an empty config, subsequent config reloads were ignored. See [#10211](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/10211).
 * BUGFIX: [vmsingle](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/): Fixed a missing path error for `http://<victoriametrics-addr>:8428/zabbixconnector/api/v1/history`. See PR [10214](https://github.com/VictoriaMetrics/VictoriaMetrics/pull/10214)
+* BUGFIX: [vmsingle](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/) and `vmselect` in [VictoriaMetrics cluster](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/): properly handle missing `start` query arg in `/api/v1/export` endpoints to avoid incorrect downsampling. Previously, when `start` was not provided, `MinTimestamp` defaulted to 0 (epoch), causing the downsampling logic to apply the most aggressive period. See [#10326](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/10326).
 
 ## [v1.133.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.133.0)
 


### PR DESCRIPTION
…ing in /api/v1/export

### Describe Your changes
Fix incorrect downsampling when start query parameter is missing in /api/v1/export endpoints in ticket #10326 

### Solution
Added handling in getExportParams() to adjust the start time when not provided, following the same pattern used in FederateHandler. When start is missing, it now defaults to end - lookbackDelta (or defaultStep if lookbackDelta <= 0).

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
