### PR TITLE
docs: update examples and documentation after nodes/proxy permission removed

### DIFF
--- a/docs/guides/examples/guide-vmcluster-vmagent-values.yaml
+++ b/docs/guides/examples/guide-vmcluster-vmagent-values.yaml
@@ -49,6 +49,8 @@ config:
       relabel_configs:
         - action: labelmap
           regex: __meta_kubernetes_node_label_(.+)
+        - source_labels: [__metrics_path__]
+          target_label: metrics_path
       metric_relabel_configs:
         - action: replace
           source_labels: [pod]

--- a/docs/guides/examples/guide-vmsingle-values.yaml
+++ b/docs/guides/examples/guide-vmsingle-values.yaml
@@ -49,6 +49,8 @@ server:
           relabel_configs:
             - action: labelmap
               regex: __meta_kubernetes_node_label_(.+)
+            - source_labels: [__metrics_path__]
+              target_label: metrics_path
           metric_relabel_configs:
             - action: replace
               source_labels: [pod]

--- a/docs/guides/k8s-ha-monitoring-via-vm-cluster/README.md
+++ b/docs/guides/k8s-ha-monitoring-via-vm-cluster/README.md
@@ -199,6 +199,8 @@ scrape_configs:
       relabel_configs:
         - action: labelmap
           regex: __meta_kubernetes_node_label_(.+)
+        - source_labels: [__metrics_path__]
+          target_label: metrics_path
       metric_relabel_configs:
         - action: replace
           source_labels: [pod]

--- a/docs/guides/k8s-monitoring-via-vm-cluster/README.md
+++ b/docs/guides/k8s-monitoring-via-vm-cluster/README.md
@@ -225,6 +225,8 @@ config:
       relabel_configs:
         - action: labelmap
           regex: __meta_kubernetes_node_label_(.+)
+        - source_labels: [__metrics_path__]
+          target_label: metrics_path
       metric_relabel_configs:
         - action: replace
           source_labels: [pod]

--- a/docs/guides/k8s-monitoring-via-vm-single/README.md
+++ b/docs/guides/k8s-monitoring-via-vm-single/README.md
@@ -126,6 +126,8 @@ server:
           relabel_configs:
             - action: labelmap
               regex: __meta_kubernetes_node_label_(.+)
+            - source_labels: [__metrics_path__]
+              target_label: metrics_path
           metric_relabel_configs:
             - action: replace
               source_labels: [pod]

--- a/docs/victoriametrics/scrape_config_examples.md
+++ b/docs/victoriametrics/scrape_config_examples.md
@@ -324,7 +324,6 @@ scrape_configs:
     ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
   metrics_path: /metrics/cadvisor
   relabel_configs:
-    # Cadvisor metrics are best scraped via Kubernetes API server proxy.
     # There is no need to add container, pod and node labels to the scraped metrics,
     # since cadvisor adds these labels on itself.
     #


### PR DESCRIPTION
### Describe Your Changes

Updated helm-charts and operators no longer come with nodes/proxy permissions for vmagent/vmsingle roles. In the examples using kubelet's proxy endpoint we should explicitly create ClusterRoles / ClusterRoleBinding to grant access.

See https://github.com/VictoriaMetrics/operator/pull/1754 and https://github.com/VictoriaMetrics/helm-charts/pull/2676

Ref: https://github.com/VictoriaMetrics/operator/issues/1753

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
