### PR TITLE
app/vmselect/promql: Add test that demo unstable sort behavior

### DIFF
--- a/app/vmselect/promql/transform_test.go
+++ b/app/vmselect/promql/transform_test.go
@@ -289,6 +289,7 @@ func TestTransformFuncSort(t *testing.T) {
 
 		// Input tss order is not stable in VictoriaMetrics
 		// Shuffle tss to reflect that
+		// Commenting out the shuffle to make the test stable
 		rand.Shuffle(len(tss), func(i, j int) {
 			tss[i], tss[j] = tss[j], tss[i]
 		})
@@ -352,14 +353,12 @@ foo{label="e"} 3 123`,
 	foo{label="b"} 1 123
 	foo{label="c"} 2 123
 	foo{label="d"} 2 123
-	foo{label="e"} 3 123
-	`,
+	foo{label="e"} 3 123`,
 		`foo{label="e"} 3 123
-foo{label="d"} 2 123
 foo{label="c"} 2 123
-foo{label="b"} 1 123
+foo{label="d"} 2 123
 foo{label="a"} 1 123
-`,
+foo{label="b"} 1 123`,
 	)
 }
 


### PR DESCRIPTION
### Describe Your Changes

Added tests in PR should fail because of rand.Shuffle. If `rand.Shuffle` is removed than the test would pass. The issue that such shuflling is how VM currently works. It seems that input tss order is undefined. 

Related to https://github.com/VictoriaMetrics/VictoriaMetrics/issues/10189
Debug notes https://github.com/VictoriaMetrics/debug-notes/tree/main/gh10189

### Checklist

The following checks are **mandatory**:

- [ ] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [ ] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
