### PR TITLE
lib/storage: reduce number of shards in metricIDCache

### DIFF
--- a/lib/storage/metric_id_cache.go
+++ b/lib/storage/metric_id_cache.go
@@ -36,7 +36,7 @@ type metricIDCache struct {
 func newMetricIDCache() *metricIDCache {
 	// Shards based on the number of CPUs are taken from
 	// lib/blockcache/blockcache.go.
-	rotationGroupSize := cgroup.AvailableCPUs()
+	rotationGroupSize := 1
 	rotationGroupCount := cgroup.AvailableCPUs()
 	if rotationGroupCount > 16 {
 		rotationGroupCount = 16


### PR DESCRIPTION
This should reduce cpu utilization while still removing the storage connection saturation.

Follow-up for 6bc809813b (#10346)