### PR TITLE
vmselect: optimize the performance of the or operation by reducing the marshaling call from O(m*n) to O(m+n)

### DIFF
--- a/app/vmselect/promql/binary_op_timing_test.go
+++ b/app/vmselect/promql/binary_op_timing_test.go
@@ -92,6 +92,22 @@ func BenchmarkBinaryOpOr(b *testing.B) {
 		}
 		benchmarkBinaryOpOr(b, bfa)
 	})
+
+	b.Run("tss:1000 or tss:40000: new", func(b *testing.B) {
+		left, right := make([]*timeseries, 1000), make([]*timeseries, 40000)
+		for i := range left {
+			left[i] = ts(fmt.Sprintf(`a{foo="%d"}`, i))
+		}
+		for i := range right {
+			right[i] = ts(fmt.Sprintf(`b{foo="%d"}`, i))
+		}
+		bfa := &binaryOpFuncArg{
+			be:    mustParseMetricsQL("a or b"),
+			left:  left,
+			right: right,
+		}
+		benchmarkBinaryOpOr(b, bfa)
+	})
 }
 
 func benchmarkBinaryOpOr(b *testing.B, bfa *binaryOpFuncArg) {

--- a/docs/victoriametrics/changelog/CHANGELOG.md
+++ b/docs/victoriametrics/changelog/CHANGELOG.md
@@ -26,6 +26,8 @@ See also [LTS releases](https://docs.victoriametrics.com/victoriametrics/lts-rel
 
 ## tip
 
+* FEATURE: [vmsingle](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/) and `vmselect` in [VictoriaMetrics cluster](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/): optimize the performance of the `or` operation by reducing the marshaling call from `O(m*n)` to `O(m+n)` when large volumes of series are involved. See [#10374](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/10374).
+
 ## [v1.135.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.135.0)
 
 Released at 2026-01-30


### PR DESCRIPTION
### Describe Your Changes

Fix #10374

optimize the performance of the `or` operation by reducing the marshaling call from `O(m*n)` to `O(m+n)` when large volumes of series are involved.

```
goos: darwin
goarch: arm64
pkg: github.com/VictoriaMetrics/VictoriaMetrics/app/vmselect/promql
cpu: Apple M1 Pro
BenchmarkBinaryOpOr
BenchmarkBinaryOpOr/tss:1000_or_tss:40000:_new
BenchmarkBinaryOpOr/tss:1000_or_tss:40000:_new-8         	      15	  68202592 ns/op	 7450664 B/op	  137552 allocs/op
BenchmarkBinaryOpOr/tss:1000_or_tss:40000:_old
BenchmarkBinaryOpOr/tss:1000_or_tss:40000:_old-8         	       8	 152796240 ns/op	 5946259 B/op	   71886 allocs/op
```

Note: memory allocation increased.

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
