### PR TITLE
lib/storage: make lrucache ttl configurable

### DIFF
--- a/lib/lrucache/lrucache_test.go
+++ b/lib/lrucache/lrucache_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/cgroup"
 )
@@ -18,7 +19,7 @@ func TestCache(t *testing.T) {
 	getMaxSize := func() uint64 {
 		return sizeMaxBytes
 	}
-	c := NewCache(getMaxSize)
+	c := NewCache(getMaxSize, 3*time.Minute)
 	defer c.MustStop()
 	if n := c.SizeBytes(); n != 0 {
 		t.Fatalf("unexpected SizeBytes(); got %d; want %d", n, 0)
@@ -123,7 +124,7 @@ func TestCacheConcurrentAccess(_ *testing.T) {
 	getMaxSize := func() uint64 {
 		return sizeMaxBytes
 	}
-	c := NewCache(getMaxSize)
+	c := NewCache(getMaxSize, 3*time.Minute)
 	defer c.MustStop()
 
 	workers := 5

--- a/lib/storage/index_db.go
+++ b/lib/storage/index_db.go
@@ -173,7 +173,7 @@ func mustOpenIndexDB(id uint64, tr TimeRange, name, path string, s *Storage, isR
 		logger.Panicf("BUG: Storage must not be nil")
 	}
 
-	tfssCache := lrucache.NewCache(getTagFiltersCacheSize)
+	tfssCache := lrucache.NewCache(getTagFiltersCacheSize, 1*time.Hour)
 	tb := mergeset.MustOpenTable(path, dataFlushInterval, tfssCache.Reset, mergeTagToMetricIDsRows, isReadOnly)
 	db := &indexDB{
 		legacyMinMissingTimestampByKey: make(map[string]int64),
@@ -183,7 +183,7 @@ func mustOpenIndexDB(id uint64, tr TimeRange, name, path string, s *Storage, isR
 		tb:                             tb,
 		s:                              s,
 		tagFiltersToMetricIDsCache:     tfssCache,
-		loopsPerDateTagFilterCache:     lrucache.NewCache(getTagFiltersLoopsCacheSize),
+		loopsPerDateTagFilterCache:     lrucache.NewCache(getTagFiltersLoopsCacheSize, 1*time.Hour),
 		metricIDCache:                  newMetricIDCache(),
 		dateMetricIDCache:              newDateMetricIDCache(),
 	}

--- a/lib/storage/tag_filters.go
+++ b/lib/storage/tag_filters.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"time"
 	"unsafe"
 
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/atomicutil"
@@ -866,7 +867,7 @@ var (
 )
 
 var (
-	regexpCache = lrucache.NewCache(getMaxRegexpCacheSize)
+	regexpCache = lrucache.NewCache(getMaxRegexpCacheSize, 1*time.Hour)
 )
 
 type regexpCacheValue struct {
@@ -921,7 +922,7 @@ var (
 )
 
 var (
-	prefixesCache = lrucache.NewCache(getMaxPrefixesCacheSize)
+	prefixesCache = lrucache.NewCache(getMaxPrefixesCacheSize, 1*time.Hour)
 )
 
 // RegexpPrefixesCacheSize returns the number of cached regexp prefixes for tag filters.


### PR DESCRIPTION
Previously, the `lrucache` ttl was hardcoded to 3 minutes and the code comment said it was enough for most queries that are sent to vmstorage repeatedly. But it appears that it is not always the case.

`indexDB` has this `tagFilters loop cache` that is used in index search optimizations (see `getMetricIDsForDateAndFilters()`). Until recently, this cache was implemented with `workingsetcache`. In
[10154](https://github.com/VictoriaMetrics/VictoriaMetrics/pull/10154), this implementation was changed to `lrucache`. After this change, some users reported huge CPU utilization increase in vmstorage (see
[10297](https://github.com/VictoriaMetrics/VictoriaMetrics/pull/10297)).

`workingsetcache` evicts an entry after two rotations that happen every 30 minutes. I.e. the entry ttl is 1h since the last time it was retrieved from the cache. Hence the assumption that `lrucache` causes the CPU to raise because of its too aggressive eviction policy.

Reverting back to `workingsetcache` helped but `lrucache` is still preferred because it occupies less memory. Since `lrucache` is preferred, its ttl needs to be increased. Instead changing the hardcoded value, the ttl was made configurable.

The `tagFilters loops cache` was configured to have ttl of 1h to match the default behavior of `workingsetcache`.

Although no one complained about this yet, the ttl was also increased for `tfssCache` because previously it was also implemented with `workingsetcache`.

Finally, the `regexpCache` and `prefixesCache` were also configured to have 1h ttl because these caches are also during the data retrieval.

Fixes #10297.