### PR TITLE
docs: remove incorrect description on -search.logSlowQueryStats

### DIFF
--- a/docs/victoriametrics/query-stats.md
+++ b/docs/victoriametrics/query-stats.md
@@ -26,7 +26,7 @@ Here's how `<duration>` works:
 
 * `-search.logSlowQueryStats=5s` logs statistics for queries that take longer than `5s`;
 * `-search.logSlowQueryStats=1us` logs statistics for **all queries**;
-* `-search.logSlowQueryStats=0` turns off query stats logging (this is the default).
+* `-search.logSlowQueryStats=0` turns off query stats logging.
 
 **Example of a query statistics log:**
 


### PR DESCRIPTION
>Query statistics logging is enabled by default {{% available_from "v1.129.0" %}} with a threshold of 5s.