### PR TITLE
.github: pin go version to 1.25 to fix CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,6 +72,7 @@ jobs:
             Makefile
             app/**/Makefile
           go-version: stable
+      - run: go version
 
       - name: Build victoria-metrics for ${{ matrix.os }}-${{ matrix.arch }}
         run: make victoria-metrics-${{ matrix.os }}-${{ matrix.arch }}

--- a/.github/workflows/check-licenses.yml
+++ b/.github/workflows/check-licenses.yml
@@ -23,6 +23,7 @@ jobs:
         with:
           go-version: stable
           cache: false
+      - run: go version
 
       - name: Cache Go artifacts
         uses: actions/cache@v4

--- a/.github/workflows/codeql-analysis-go.yml
+++ b/.github/workflows/codeql-analysis-go.yml
@@ -37,6 +37,7 @@ jobs:
         with:
           cache: false
           go-version: stable
+      - run: go version
 
       - name: Cache Go artifacts
         uses: actions/cache@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,8 +42,14 @@ jobs:
             go.sum
             Makefile
             app/**/Makefile
-          go-version: stable
-
+          # It was pinned to 1.25 (prev value "stable") because Go 1.26 removed SYNCTEST experiment,
+          # and it is used in VictoriaMetrics codebase.
+          # So CI fails:
+          #   GOEXPERIMENT=synctest go vet ./lib/...
+          #   go: unknown GOEXPERIMENT synctest
+          # https://github.com/VictoriaMetrics/VictoriaMetrics/actions/runs/21903996751/job/63239331425?pr=10435
+          go-version: "1.25.7"
+      - run: go version
 
       - name: Cache golangci-lint
         uses: actions/cache@v4
@@ -81,7 +87,14 @@ jobs:
             go.sum
             Makefile
             app/**/Makefile
-          go-version: stable
+          # It was pinned to 1.25 (prev value "stable") because Go 1.26 removed SYNCTEST experiment,
+          # and it is used in VictoriaMetrics codebase.
+          # So CI fails:
+          #   GOEXPERIMENT=synctest go vet ./lib/...
+          #   go: unknown GOEXPERIMENT synctest
+          # https://github.com/VictoriaMetrics/VictoriaMetrics/actions/runs/21903996751/job/63239331425?pr=10435
+          go-version: "1.25.7"
+      - run: go version
 
       - name: Run tests
         run: GOGC=10 make ${{ matrix.scenario}}
@@ -108,6 +121,7 @@ jobs:
             Makefile
             app/**/Makefile
           go-version: stable
+      - run: go version
 
       - name: Run integration tests
         run: make integration-test


### PR DESCRIPTION
Go1.26 has been recently released and was picked up by CI actions.

The tests and linter actions start to fail with:

GOEXPERIMENT=synctest go vet ./lib/...
go: unknown GOEXPERIMENT synctest

This happens because Go 1.26 remove synctest experiment.

Changelog:
This package was first available in Go 1.24 under GOEXPERIMENT=synctest, with a slightly different API. The experiment has now graduated to general availability. The old API is still present if GOEXPERIMENT=synctest is set, but will be removed in Go 1.26.

https://go.dev/doc/go1.25#library

### Describe Your Changes

Please provide a brief description of the changes you made. Be as specific as possible to help others understand the purpose and impact of your modifications.

### Checklist

The following checks are **mandatory**:

- [ ] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [ ] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
