### PR TITLE
go.mod: update metrics module

### DIFF
--- a/docs/victoriametrics/changelog/CHANGELOG.md
+++ b/docs/victoriametrics/changelog/CHANGELOG.md
@@ -27,6 +27,7 @@ See also [LTS releases](https://docs.victoriametrics.com/victoriametrics/lts-rel
 ## tip
 
 * FEATURE: [vmauth](https://docs.victoriametrics.com/victoriametrics/vmauth/): add JWT token authentication support with signature verification based on provided `public_keys`. Read more about configuration in [JWT Token auth proxy](https://docs.victoriametrics.com/victoriametrics/vmauth/#jwt-token-auth-proxy) documentation. See [#10445](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/10445).
+* FEATURE: all VictoriaMetrics components: expose `process_cpu_seconds_total`, `process_resident_memory_bytes`, and other process-level metrics when running on macOS. See [metrics#75](https://github.com/VictoriaMetrics/metrics/issues/75).
 
 ## [v1.136.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.136.0)
 

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/VictoriaMetrics/VictoriaLogs v0.0.0-20260125191521-bc89d84cd61d
 	github.com/VictoriaMetrics/easyproto v1.1.3
 	github.com/VictoriaMetrics/fastcache v1.13.2
-	github.com/VictoriaMetrics/metrics v1.40.2
+	github.com/VictoriaMetrics/metrics v1.41.1
 	github.com/VictoriaMetrics/metricsql v0.84.10
 	github.com/aws/aws-sdk-go-v2 v1.41.1
 	github.com/aws/aws-sdk-go-v2/config v1.32.7

--- a/go.sum
+++ b/go.sum
@@ -58,10 +58,8 @@ github.com/VictoriaMetrics/easyproto v1.1.3 h1:gRSA3ZQs7n4+5I+SniDWD59jde1jVq4Jm
 github.com/VictoriaMetrics/easyproto v1.1.3/go.mod h1:QlGlzaJnDfFd8Lk6Ci/fuLxfTo3/GThPs2KH23mv710=
 github.com/VictoriaMetrics/fastcache v1.13.2 h1:2XTB49aLSuCex7e9P5rqrfQcMkzGjh5Vq3GMFa8YpCA=
 github.com/VictoriaMetrics/fastcache v1.13.2/go.mod h1:hHXhl4DA2fTL2HTZDJFXWgW0LNjo6B+4aj2Wmng3TjU=
-github.com/VictoriaMetrics/metrics v1.40.2 h1:OVSjKcQEx6JAwGeu8/KQm9Su5qJ72TMEW4xYn5vw3Ac=
-github.com/VictoriaMetrics/metrics v1.40.2/go.mod h1:XE4uudAAIRaJE614Tl5HMrtoEU6+GDZO4QTnNSsZRuA=
-github.com/VictoriaMetrics/metricsql v0.84.9 h1:EsUwj7IYI7BeBzNSuJEelL+BBHmolRXwqxl3hI+jcmQ=
-github.com/VictoriaMetrics/metricsql v0.84.9/go.mod h1:d4EisFO6ONP/HIGDYTAtwrejJBBeKGQYiRl095bS4QQ=
+github.com/VictoriaMetrics/metrics v1.41.1 h1:xYQilpPmq5BPB+uIbe4Iygdw1cSiI4obYQjfLdQN2Xo=
+github.com/VictoriaMetrics/metrics v1.41.1/go.mod h1:xDM82ULLYCYdFRgQ2JBxi8Uf1+8En1So9YUwlGTOqTc=
 github.com/VictoriaMetrics/metricsql v0.84.10 h1:P5cEnLxZlPn5DaIoQUUGqyb9TfLIWwbJXYtgOuzbHsg=
 github.com/VictoriaMetrics/metricsql v0.84.10/go.mod h1:d4EisFO6ONP/HIGDYTAtwrejJBBeKGQYiRl095bS4QQ=
 github.com/VividCortex/ewma v1.2.0 h1:f58SaIzcDXrSy3kWaHNvuJgJ3Nmz59Zji6XoJR/q1ow=

--- a/vendor/github.com/VictoriaMetrics/metrics/process_metrics_darwin.go
+++ b/vendor/github.com/VictoriaMetrics/metrics/process_metrics_darwin.go
@@ -1,0 +1,153 @@
+//go:build darwin && !ios
+
+package metrics
+
+import (
+	"encoding/binary"
+	"errors"
+	"io"
+	"log"
+	"os"
+	"syscall"
+	"time"
+	"unsafe"
+)
+
+// errNotImplemented is returned by stub functions that replace cgo functions, when cgo
+// isn't available.
+var errNotImplemented = errors.New("not implemented")
+
+func writeProcessMetrics(w io.Writer) {
+	if memInfo, err := getMemory(); err == nil {
+		WriteGaugeUint64(w, "process_resident_memory_bytes", memInfo.rss)
+		WriteGaugeUint64(w, "process_virtual_memory_bytes", memInfo.vsize)
+	} else if !errors.Is(err, errNotImplemented) {
+		log.Printf("ERROR: metrics: %s", err)
+	}
+
+	// The proc structure returned by kern.proc.pid above has an Rusage member,
+	// but it is not filled in, so it needs to be fetched by getrusage(2).  For
+	// that call, the UTime, STime, and Maxrss members are filled out, but not
+	// Ixrss, Idrss, or Isrss for the memory usage.  Memory stats will require
+	// access to the C API to call task_info(TASK_BASIC_INFO).
+	rusage := syscall.Rusage{}
+
+	if err := syscall.Getrusage(syscall.RUSAGE_SELF, &rusage); err == nil {
+		cpuTime := time.Duration(rusage.Stime.Nano() + rusage.Utime.Nano()).Seconds()
+		WriteGaugeFloat64(w, "process_cpu_seconds_total", cpuTime)
+	} else {
+		log.Printf("ERROR: metrics: %s", err)
+	}
+
+	if addressSpace, err := getSoftLimit(syscall.RLIMIT_AS); err == nil {
+		WriteGaugeFloat64(w, "process_virtual_memory_max_bytes", float64(addressSpace))
+	} else {
+		log.Printf("ERROR: metrics: %s", err)
+	}
+}
+
+func writeFDMetrics(w io.Writer) {
+	if fds, err := getOpenFileCount(); err == nil {
+		WriteGaugeFloat64(w, "process_open_fds", fds)
+	} else {
+		log.Printf("ERROR: metrics: %s", err)
+	}
+
+	if openFiles, err := getSoftLimit(syscall.RLIMIT_NOFILE); err == nil {
+		WriteGaugeFloat64(w, "process_max_fds", float64(openFiles))
+	} else {
+		log.Printf("ERROR: metrics: %s", err)
+	}
+}
+
+func getOpenFileCount() (float64, error) {
+	// Alternately, the undocumented proc_pidinfo(PROC_PIDLISTFDS) can be used to
+	// return a list of open fds, but that requires a way to call C APIs.  The
+	// benefits, however, include fewer system calls and not failing when at the
+	// open file soft limit.
+
+	if dir, err := os.Open("/dev/fd"); err != nil {
+		return 0.0, err
+	} else {
+		defer dir.Close()
+
+		// Avoid ReadDir(), as it calls stat(2) on each descriptor.  Not only is
+		// that info not used, but KQUEUE descriptors fail stat(2), which causes
+		// the whole method to fail.
+		if names, err := dir.Readdirnames(0); err != nil {
+			return 0.0, err
+		} else {
+			// Subtract 1 to ignore the open /dev/fd descriptor above.
+			return float64(len(names) - 1), nil
+		}
+	}
+}
+
+func getSoftLimit(which int) (uint64, error) {
+	rlimit := syscall.Rlimit{}
+
+	if err := syscall.Getrlimit(which, &rlimit); err != nil {
+		return 0, err
+	}
+
+	return rlimit.Cur, nil
+}
+
+func getProcessStartTime() (float64, error) {
+	// Call sysctl to get kinfo_proc for current process
+	mib := []int32{1 /* CTL_KERN */, 14 /* KERN_PROC */, 1 /* KERN_PROC_PID */, int32(os.Getpid())}
+
+	// First call to get the size
+	n := uintptr(0)
+	_, _, errno := syscall.Syscall6(
+		syscall.SYS___SYSCTL,
+		uintptr(unsafe.Pointer(&mib[0])),
+		uintptr(len(mib)),
+		0,
+		uintptr(unsafe.Pointer(&n)),
+		0,
+		0,
+	)
+	if errno != 0 {
+		return 0, errno
+	}
+	if n == 0 {
+		return 0, syscall.EINVAL
+	}
+
+	// Second call to get the actual data
+	buf := make([]byte, n)
+	_, _, errno = syscall.Syscall6(
+		syscall.SYS___SYSCTL,
+		uintptr(unsafe.Pointer(&mib[0])),
+		uintptr(len(mib)),
+		uintptr(unsafe.Pointer(&buf[0])),
+		uintptr(unsafe.Pointer(&n)),
+		0,
+		0,
+	)
+	if errno != 0 {
+		return 0, errno
+	}
+
+	// The kinfo_proc struct layout on Darwin has p_starttime (struct timeval) at specific offset
+	// For amd64 and arm64, the offset is at 0x60 (96 bytes)
+	// struct timeval has tv_sec (int64) and tv_usec (int32)
+	const startTimeOffset = 0x60
+
+	if len(buf) < startTimeOffset+16 {
+		return 0, syscall.EINVAL
+	}
+
+	// Read tv_sec (8 bytes) and tv_usec (4 bytes)
+	tvSec := int64(binary.LittleEndian.Uint64(buf[startTimeOffset:]))
+	tvUsec := int32(binary.LittleEndian.Uint32(buf[startTimeOffset+8:]))
+
+	startTime := float64(tvSec) + float64(tvUsec)/1e6
+	return startTime, nil
+}
+
+type memoryInfo struct {
+	vsize uint64 // Virtual memory size in bytes
+	rss   uint64 // Resident memory size in bytes
+}

--- a/vendor/github.com/VictoriaMetrics/metrics/process_metrics_darwin_cgo.c
+++ b/vendor/github.com/VictoriaMetrics/metrics/process_metrics_darwin_cgo.c
@@ -1,0 +1,84 @@
+// Copyright 2024 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build darwin && !ios && cgo
+
+#include <mach/mach_init.h>
+#include <mach/task.h>
+#include <mach/mach_vm.h>
+
+// The compiler warns that mach/shared_memory_server.h is deprecated, and to use
+// mach/shared_region.h instead.  But that doesn't define
+// SHARED_DATA_REGION_SIZE or SHARED_TEXT_REGION_SIZE, so redefine them here and
+// avoid a warning message when running tests.
+#define GLOBAL_SHARED_TEXT_SEGMENT      0x90000000U
+#define SHARED_DATA_REGION_SIZE         0x10000000
+#define SHARED_TEXT_REGION_SIZE         0x10000000
+
+
+int vm_get_memory_info(unsigned long long *rss, unsigned long long *vsize)
+{
+    // This is lightly adapted from how ps(1) obtains its memory info.
+    // https://github.com/apple-oss-distributions/adv_cmds/blob/8744084ea0ff41ca4bb96b0f9c22407d0e48e9b7/ps/tasks.c#L109
+
+    kern_return_t               error;
+    task_t                      task = MACH_PORT_NULL;
+    mach_task_basic_info_data_t info;
+    mach_msg_type_number_t      info_count = MACH_TASK_BASIC_INFO_COUNT;
+
+    error = task_info(
+                mach_task_self(),
+                MACH_TASK_BASIC_INFO,
+                (task_info_t) &info,
+                &info_count );
+
+    if( error != KERN_SUCCESS )
+    {
+        return error;
+    }
+
+    *rss   = info.resident_size;
+    *vsize = info.virtual_size;
+
+    {
+        vm_region_basic_info_data_64_t    b_info;
+        mach_vm_address_t                 address = GLOBAL_SHARED_TEXT_SEGMENT;
+        mach_vm_size_t                    size;
+        mach_port_t                       object_name;
+
+        /*
+         * try to determine if this task has the split libraries
+         * mapped in... if so, adjust its virtual size down by
+         * the 2 segments that are used for split libraries
+         */
+        info_count = VM_REGION_BASIC_INFO_COUNT_64;
+
+        error = mach_vm_region(
+                    mach_task_self(),
+                    &address,
+                    &size,
+                    VM_REGION_BASIC_INFO_64,
+                    (vm_region_info_t) &b_info,
+                    &info_count,
+                    &object_name);
+
+        if (error == KERN_SUCCESS) {
+            if (b_info.reserved && size == (SHARED_TEXT_REGION_SIZE) &&
+                *vsize > (SHARED_TEXT_REGION_SIZE + SHARED_DATA_REGION_SIZE)) {
+                    *vsize -= (SHARED_TEXT_REGION_SIZE + SHARED_DATA_REGION_SIZE);
+            }
+        }
+    }
+
+    return 0;
+}

--- a/vendor/github.com/VictoriaMetrics/metrics/process_metrics_darwin_cgo.go
+++ b/vendor/github.com/VictoriaMetrics/metrics/process_metrics_darwin_cgo.go
@@ -1,0 +1,22 @@
+//go:build darwin && !ios && cgo
+
+package metrics
+
+/*
+int vm_get_memory_info(unsigned long long *rss, unsigned long long *vs);
+*/
+import "C"
+
+import (
+	"fmt"
+)
+
+func getMemory() (*memoryInfo, error) {
+	var rss, vsize C.ulonglong
+
+	if err := C.vm_get_memory_info(&rss, &vsize); err != 0 {
+		return nil, fmt.Errorf("task_info() failed with 0x%x", int(err))
+	}
+
+	return &memoryInfo{vsize: uint64(vsize), rss: uint64(rss)}, nil
+}

--- a/vendor/github.com/VictoriaMetrics/metrics/process_metrics_darwin_nocgo.go
+++ b/vendor/github.com/VictoriaMetrics/metrics/process_metrics_darwin_nocgo.go
@@ -1,0 +1,7 @@
+//go:build darwin && !ios && !cgo
+
+package metrics
+
+func getMemory() (*memoryInfo, error) {
+	return nil, errNotImplemented
+}

--- a/vendor/github.com/VictoriaMetrics/metrics/process_metrics_other.go
+++ b/vendor/github.com/VictoriaMetrics/metrics/process_metrics_other.go
@@ -1,4 +1,4 @@
-//go:build !linux && !windows && !solaris
+//go:build !linux && !windows && !solaris && !darwin
 
 package metrics
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -142,8 +142,8 @@ github.com/VictoriaMetrics/easyproto
 # github.com/VictoriaMetrics/fastcache v1.13.2
 ## explicit; go 1.24.0
 github.com/VictoriaMetrics/fastcache
-# github.com/VictoriaMetrics/metrics v1.40.2
-## explicit; go 1.18
+# github.com/VictoriaMetrics/metrics v1.41.1
+## explicit; go 1.24.0
 github.com/VictoriaMetrics/metrics
 # github.com/VictoriaMetrics/metricsql v0.84.10
 ## explicit; go 1.24.2


### PR DESCRIPTION
### Describe Your Changes

VictoriaMetrics binaries will now expose some process-level metrics when run on macOS.

See:
- https://github.com/VictoriaMetrics/metrics/issues/75
- https://github.com/VictoriaMetrics/metrics/pull/107

### Checklist

The following checks are **mandatory**:

- [ ] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [ ] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
