### PR TITLE
lib/storage: shard dateMetricIDCache

### DIFF
--- a/lib/storage/date_metric_id_cache.go
+++ b/lib/storage/date_metric_id_cache.go
@@ -5,9 +5,22 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+	"unsafe"
 
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/atomicutil"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/timeutil"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/uint64set"
+)
+
+const (
+	dateMetricIDCacheShardCount = 16
+
+	// The number of consecutive metricIDs that will be stored in one shard.
+	// This is 2^16 and corresponds to the size of a 16-bit bucket of the
+	// uint64set. That way the metricIDs end up in one uint64set bucket instead
+	// of being spread across multiple buckets. This reduces the memory size of
+	// the cache and allows for faster access.
+	dateMetricIDCacheShardBucketSize = 65536
 )
 
 // dateMetricIDCache stores (date, metricIDs) entries that have been added to
@@ -16,6 +29,85 @@ import (
 //
 // It should be faster than map[date]*uint64set.Set on multicore systems.
 type dateMetricIDCache struct {
+	shards [dateMetricIDCacheShardCount]dateMetricIDCacheShard
+
+	// The shards are rotated, one shard at a time. rotationPeriod defines the
+	// time interval between two successive rotations.
+	rotationPeriod time.Duration
+
+	stopCh            chan struct{}
+	rotationStoppedCh chan struct{}
+}
+
+func newDateMetricIDCache() *dateMetricIDCache {
+	c := dateMetricIDCache{
+		rotationPeriod:    timeutil.AddJitterToDuration(1 * time.Hour),
+		stopCh:            make(chan struct{}),
+		rotationStoppedCh: make(chan struct{}),
+	}
+	for i := range dateMetricIDCacheShardCount {
+		c.shards[i].prev = newByDateMetricIDMap()
+		c.shards[i].next = newByDateMetricIDMap()
+		c.shards[i].curr.Store(newByDateMetricIDMap())
+	}
+	go c.startRotation()
+	return &c
+}
+
+func (dmc *dateMetricIDCache) MustStop() {
+	close(dmc.stopCh)
+	<-dmc.rotationStoppedCh
+}
+
+func (c *dateMetricIDCache) Stats() dateMetricIDCacheStats {
+	var stats dateMetricIDCacheStats
+	for i := range dateMetricIDCacheShardCount {
+		s := c.shards[i].Stats()
+		stats.Size += s.Size
+		stats.SizeBytes += s.SizeBytes
+		stats.SyncsCount += s.SyncsCount
+		stats.RotationsCount += s.RotationsCount
+	}
+	return stats
+}
+
+func (c *dateMetricIDCache) Has(date, metricID uint64) bool {
+	shardIdx := (metricID / dateMetricIDCacheShardBucketSize) % dateMetricIDCacheShardCount
+	return c.shards[shardIdx].Has(date, metricID)
+}
+
+func (c *dateMetricIDCache) Set(date, metricID uint64) {
+	shardIdx := (metricID / dateMetricIDCacheShardBucketSize) % dateMetricIDCacheShardCount
+	c.shards[shardIdx].Set(date, metricID)
+}
+
+func (c *dateMetricIDCache) startRotation() {
+	ticker := time.NewTicker(c.rotationPeriod)
+	defer ticker.Stop()
+	var shardIdx int
+	for {
+		select {
+		case <-c.stopCh:
+			close(c.rotationStoppedCh)
+			return
+		case <-ticker.C:
+			// Each tick rotate only one shard at a time to avoid slow access
+			// for all shards at once.
+			shardIdx %= dateMetricIDCacheShardCount
+			c.shards[shardIdx].rotate()
+			shardIdx++
+		}
+	}
+}
+
+type dateMetricIDCacheStats struct {
+	Size           uint64
+	SizeBytes      uint64
+	SyncsCount     uint64
+	RotationsCount uint64
+}
+
+type dateMetricIDCacheShardNopad struct {
 	// Contains immutable (date, metricIDs) entries.
 	curr atomic.Pointer[byDateMetricIDMap]
 
@@ -39,36 +131,16 @@ type dateMetricIDCache struct {
 	rotationsCount uint64
 
 	mu sync.Mutex
-
-	stopCh            chan struct{}
-	rotationStoppedCh chan struct{}
 }
 
-func newDateMetricIDCache() *dateMetricIDCache {
-	dmc := dateMetricIDCache{
-		prev:              newByDateMetricIDMap(),
-		next:              newByDateMetricIDMap(),
-		stopCh:            make(chan struct{}),
-		rotationStoppedCh: make(chan struct{}),
-	}
-	dmc.curr.Store(newByDateMetricIDMap())
-	go dmc.startRotation()
-	return &dmc
+type dateMetricIDCacheShard struct {
+	dateMetricIDCacheShardNopad
+
+	// The padding prevents false sharing
+	_ [atomicutil.CacheLineSize - unsafe.Sizeof(dateMetricIDCacheShardNopad{})%atomicutil.CacheLineSize]byte
 }
 
-func (dmc *dateMetricIDCache) MustStop() {
-	close(dmc.stopCh)
-	<-dmc.rotationStoppedCh
-}
-
-type dateMetricIDCacheStats struct {
-	Size           uint64
-	SizeBytes      uint64
-	SyncsCount     uint64
-	RotationsCount uint64
-}
-
-func (dmc *dateMetricIDCache) Stats() dateMetricIDCacheStats {
+func (dmc *dateMetricIDCacheShard) Stats() dateMetricIDCacheStats {
 	dmc.mu.Lock()
 	defer dmc.mu.Unlock()
 
@@ -98,7 +170,7 @@ func (dmc *dateMetricIDCache) Stats() dateMetricIDCacheStats {
 	return s
 }
 
-func (dmc *dateMetricIDCache) Has(date, metricID uint64) bool {
+func (dmc *dateMetricIDCacheShard) Has(date, metricID uint64) bool {
 	curr := dmc.curr.Load()
 	vCurr := curr.get(date)
 	if vCurr.Has(metricID) {
@@ -110,7 +182,7 @@ func (dmc *dateMetricIDCache) Has(date, metricID uint64) bool {
 	return dmc.hasSlow(date, metricID)
 }
 
-func (dmc *dateMetricIDCache) hasSlow(date, metricID uint64) bool {
+func (dmc *dateMetricIDCacheShard) hasSlow(date, metricID uint64) bool {
 	dmc.mu.Lock()
 	defer dmc.mu.Unlock()
 
@@ -146,14 +218,14 @@ func (dmc *dateMetricIDCache) hasSlow(date, metricID uint64) bool {
 	return ok
 }
 
-func (dmc *dateMetricIDCache) Set(date, metricID uint64) {
+func (dmc *dateMetricIDCacheShard) Set(date, metricID uint64) {
 	dmc.mu.Lock()
 	v := dmc.next.getOrCreate(date)
 	v.Add(metricID)
 	dmc.mu.Unlock()
 }
 
-func (dmc *dateMetricIDCache) syncLocked() {
+func (dmc *dateMetricIDCacheShard) syncLocked() {
 	if len(dmc.next.m) == 0 {
 		// Nothing to sync.
 		return
@@ -217,24 +289,8 @@ func (dmc *dateMetricIDCache) syncLocked() {
 	dmc.syncsCount++
 }
 
-func (dmc *dateMetricIDCache) startRotation() {
-	// 1 hour was chosen based on https://github.com/VictoriaMetrics/VictoriaMetrics/issues/10064#issuecomment-3749046726
-	d := timeutil.AddJitterToDuration(time.Hour)
-	ticker := time.NewTicker(d)
-	defer ticker.Stop()
-	for {
-		select {
-		case <-dmc.stopCh:
-			close(dmc.rotationStoppedCh)
-			return
-		case <-ticker.C:
-			dmc.rotate()
-		}
-	}
-}
-
 // rotate atomically rotates next, curr, and prev cache parts.
-func (dmc *dateMetricIDCache) rotate() {
+func (dmc *dateMetricIDCacheShard) rotate() {
 	dmc.mu.Lock()
 	defer dmc.mu.Unlock()
 	curr := dmc.curr.Load()

--- a/lib/storage/date_metric_id_cache_synctest_test.go
+++ b/lib/storage/date_metric_id_cache_synctest_test.go
@@ -1,0 +1,127 @@
+//go:build synctest
+
+package storage
+
+import (
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+)
+
+func (c *dateMetricIDCache) numShards() uint64 {
+	return uint64(len(c.shards))
+}
+
+func (c *dateMetricIDCache) fullRotationPeriod() time.Duration {
+	return dateMetricIDCacheShardCount * c.rotationPeriod
+}
+
+func TestDateMetricIDCache_ClearedWhenUnused(t *testing.T) {
+	// Entries that are added to the cache but then never retrieved will be
+	// eventually removed from it.
+	synctest.Test(t, func(t *testing.T) {
+		c := newDateMetricIDCache()
+		defer c.MustStop()
+		c.Set(123, 456)
+		// It takes 3 full rotation cycles for an entry to be evicted from the
+		// cache:
+		// [in next] -rotation1-> [in curr] -rotation2-> [in prev] -rotation3-> evicted.
+		time.Sleep(3 * c.fullRotationPeriod())
+		if c.Has(123, 456) {
+			t.Fatalf("entry is still in cache")
+		}
+	})
+
+	// Entries that are added to the cache and retrieved but then never
+	// retrieved again will be eventually removed from it.
+	synctest.Test(t, func(t *testing.T) {
+		c := newDateMetricIDCache()
+		defer c.MustStop()
+		c.Set(123, 456)
+		time.Sleep(c.fullRotationPeriod())
+		if !c.Has(123, 456) {
+			t.Fatalf("entry not in cache")
+		}
+		time.Sleep(3 * c.fullRotationPeriod())
+		if c.Has(123, 456) {
+			t.Fatalf("entry is still in cache")
+		}
+	})
+
+	// Entries that are added to the cache and then periodically retrieved,
+	// will remain in cache indefinitely.
+	synctest.Test(t, func(t *testing.T) {
+		c := newDateMetricIDCache()
+		defer c.MustStop()
+		c.Set(123, 456)
+		for range 10_000 {
+			time.Sleep(c.fullRotationPeriod())
+			if !c.Has(123, 456) {
+				t.Fatalf("entry not in cache")
+			}
+		}
+	})
+}
+
+func TestDateMetricIDCache_Stats(t *testing.T) {
+	assertStats := func(t *testing.T, c *dateMetricIDCache, want dateMetricIDCacheStats) {
+		t.Helper()
+		if diff := cmp.Diff(want, c.Stats(), cmpopts.IgnoreFields(dateMetricIDCacheStats{}, "SizeBytes")); diff != "" {
+			t.Fatalf("unexpected stats (-want, +got):\n%s", diff)
+		}
+	}
+
+	const (
+		date         = 12345
+		numMetricIDs = 16 * 65536
+	)
+
+	synctest.Test(t, func(t *testing.T) {
+		c := newDateMetricIDCache()
+		defer c.MustStop()
+
+		// Check stats right after the creation.
+		assertStats(t, c, dateMetricIDCacheStats{})
+
+		// Add metricIDs and check stats.
+		// At this point, all metricIDs are in next.
+		for metricID := range uint64(numMetricIDs) {
+			c.Set(date, metricID)
+		}
+		assertStats(t, c, dateMetricIDCacheStats{
+			Size: numMetricIDs,
+		})
+
+		// Get all metricIDs and check stats.
+		// All metricIDs will be sync'ed from next to curr.
+		for metricID := range uint64(numMetricIDs) {
+			if !c.Has(date, metricID) {
+				t.Fatalf("metricID not in cache: %d", metricID)
+			}
+		}
+		assertStats(t, c, dateMetricIDCacheStats{
+			Size:       numMetricIDs,
+			SyncsCount: c.numShards(),
+		})
+
+		// Wait until all groups are rotated.
+		// curr metricIDs will be moved to prev.
+		time.Sleep(c.fullRotationPeriod() + time.Second)
+		assertStats(t, c, dateMetricIDCacheStats{
+			Size:           numMetricIDs,
+			SyncsCount:     c.numShards(),
+			RotationsCount: c.numShards(),
+		})
+
+		// Wait until all groups are rotated.
+		// The cache now should be empty.
+		time.Sleep(c.fullRotationPeriod())
+		assertStats(t, c, dateMetricIDCacheStats{
+			SyncsCount:     c.numShards(),
+			RotationsCount: 2 * c.numShards(),
+		})
+	})
+}

--- a/lib/storage/date_metric_id_cache_test.go
+++ b/lib/storage/date_metric_id_cache_test.go
@@ -5,25 +5,29 @@ import (
 	"sync"
 	"testing"
 	"time"
-
-	"github.com/VictoriaMetrics/VictoriaMetrics/lib/uint64set"
 )
 
-func TestDateMetricIDCacheSerial(t *testing.T) {
-	c := newDateMetricIDCache()
-	defer c.MustStop()
-	if err := testDateMetricIDCache(c, false); err != nil {
+func newDateMetricIDCacheShard() *dateMetricIDCacheShard {
+	var c dateMetricIDCacheShard
+	c.prev = newByDateMetricIDMap()
+	c.next = newByDateMetricIDMap()
+	c.curr.Store(newByDateMetricIDMap())
+	return &c
+}
+
+func TestDateMetricIDCacheShardSerial(t *testing.T) {
+	c := newDateMetricIDCacheShard()
+	if err := testDateMetricIDCacheShard(c, false); err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
 }
 
-func TestDateMetricIDCacheConcurrent(t *testing.T) {
-	c := newDateMetricIDCache()
-	defer c.MustStop()
+func TestDateMetricIDCacheShardConcurrent(t *testing.T) {
+	c := newDateMetricIDCacheShard()
 	ch := make(chan error, 5)
 	for range 5 {
 		go func() {
-			ch <- testDateMetricIDCache(c, true)
+			ch <- testDateMetricIDCacheShard(c, true)
 		}()
 	}
 	for range 5 {
@@ -38,7 +42,7 @@ func TestDateMetricIDCacheConcurrent(t *testing.T) {
 	}
 }
 
-func testDateMetricIDCache(c *dateMetricIDCache, concurrent bool) error {
+func testDateMetricIDCacheShard(c *dateMetricIDCacheShard, concurrent bool) error {
 	type dmk struct {
 		date     uint64
 		metricID uint64
@@ -149,32 +153,5 @@ func TestDateMetricIDCache_Size(t *testing.T) {
 	}
 	if got, want := dmc.Stats().Size, uint64(100_000); got != want {
 		t.Fatalf("unexpected size: got %d, want %d", got, want)
-	}
-}
-
-func TestDateMetricIDCache_SizeBytes(t *testing.T) {
-	dmc := newDateMetricIDCache()
-	defer dmc.MustStop()
-	metricIDs := &uint64set.Set{}
-	for i := range 100_000 {
-		date := uint64(123)
-		metricID := uint64(i)
-		metricIDs.Add(metricID)
-		dmc.Set(date, metricID)
-	}
-	if got, want := dmc.Stats().SizeBytes, metricIDs.SizeBytes(); got != want {
-		t.Fatalf("unexpected sizeBytes: got %d, want %d", got, want)
-	}
-
-	// Retrieve all entries and check the cache sizeBytes again.
-	for i := range 100_000 {
-		date := uint64(123)
-		metricID := uint64(i)
-		if !dmc.Has(date, metricID) {
-			t.Fatalf("entry not in cache: (date=%d, metricID=%d)", date, metricID)
-		}
-	}
-	if got, want := dmc.Stats().SizeBytes, metricIDs.SizeBytes(); got != want {
-		t.Fatalf("unexpected sizeBytes: got %d, want %d", got, want)
 	}
 }

--- a/lib/storage/date_metric_id_cache_timing_test.go
+++ b/lib/storage/date_metric_id_cache_timing_test.go
@@ -45,7 +45,7 @@ func BenchmarkDateMetricIDCache_Has(b *testing.B) {
 			}
 		}
 		if rotate {
-			c.rotate()
+			c.shards[rand.Intn(dateMetricIDCacheShardCount)].rotate()
 		}
 		b.ResetTimer()
 


### PR DESCRIPTION
Use the same sharded implementation as in metricIDCache. The change is basically a copy-paste. The only difference is that the rotation period remains `1h` instead `1m` in order not to break the fix for #10064.