### PR TITLE
docs: make docs-update-flags should rely on git tag

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -68,17 +68,22 @@ docs-images-to-webp: docs-image
 				-exec sh -c 'cwebp -preset drawing -m 6 -o $$(echo {} | cut -f-1 -d.).webp {} && rm -rf {}' {} \;
 
 docs-update-vmsingle-flags:
-	(cd /tmp/vm-enterprise-single-node && make victoria-metrics)
-	(cd /tmp/vm-opensource-single-node && make victoria-metrics)
-	(cd /tmp/vm-enterprise-single-node && ./bin/victoria-metrics -help 2>&1) > /tmp/vm-enterprise-single-node/victoria_metrics_enterprise_flags_tmp.md
-	(cd /tmp/vm-opensource-single-node && ./bin/victoria-metrics -help 2>&1) > /tmp/vm-opensource-single-node/victoria_metrics_common_flags_tmp.md
-	echo "$$FLAGS_HEADER" > docs/victoriametrics/victoria_metrics_common_flags.md
-	cat /tmp/vm-opensource-single-node/victoria_metrics_common_flags_tmp.md >> docs/victoriametrics/victoria_metrics_common_flags.md
-	printf -- '```\n' >> docs/victoriametrics/victoria_metrics_common_flags.md
+ifndef TAG
+	$(error TAG must be provided to update flags in docs)
+endif
+	git checkout $(TAG) && $(MAKE) victoria-metrics && \
+	./bin/victoria-metrics -help > /tmp/victoria_metrics_common_flags_tmp.md
 
-	echo "$$FLAGS_HEADER" > docs/victoriametrics/victoria_metrics_enterprise_flags.md
-	diff /tmp/vm-enterprise-single-node/victoria_metrics_enterprise_flags_tmp.md /tmp/vm-opensource-single-node/victoria_metrics_common_flags_tmp.md |grep '^<' | sed 's/^< //' >> docs/victoriametrics/victoria_metrics_enterprise_flags.md
-	printf -- '```\n' >> docs/victoriametrics/victoria_metrics_enterprise_flags.md
+	git checkout $(TAG)-enterprise && $(MAKE) victoria-metrics && \
+	./bin/victoria-metrics -help > /tmp/victoria_metrics_enterprise_flags_tmp.md
+
+	echo "$$FLAGS_HEADER" > docs/victoriametrics/victoria_metrics_common_flags.md && \
+	cat /tmp/victoria_metrics_common_flags_tmp.md >> docs/victoriametrics/victoria_metrics_common_flags.md && \
+	printf '```\n' >> docs/victoriametrics/victoria_metrics_common_flags.md
+
+	echo "$$FLAGS_HEADER" > docs/victoriametrics/victoria_metrics_enterprise_flags.md && \
+	diff /tmp/victoria_metrics_enterprise_flags_tmp.md /tmp/victoria_metrics_common_flags_tmp.md |grep '^<' | sed 's/^< //' >> docs/victoriametrics/victoria_metrics_enterprise_flags.md && \
+	printf '```\n' >> docs/victoriametrics/victoria_metrics_enterprise_flags.md
 
 	# replace tabs in output with one space
 	sed -i 's/\t/ /g' docs/victoriametrics/victoria_metrics_common_flags.md
@@ -92,19 +97,21 @@ docs-update-vmsingle-flags:
 	sed -i '/The maximum number of concurrent goroutines to work with files;/ s/(default [0-9]\+)/(default fsutil.getDefaultConcurrency())/' docs/victoriametrics/victoria_metrics_common_flags.md
 
 docs-update-vmauth-flags:
-	# ---- vmauth
-	(cd /tmp/vm-enterprise-single-node && make vmauth)
-	(cd /tmp/vm-opensource-single-node && make vmauth)
-	(cd /tmp/vm-enterprise-single-node && ./bin/vmauth -help 2>&1) > /tmp/vm-enterprise-single-node/vmauth_enterprise_flags_tmp.md
-	(cd /tmp/vm-opensource-single-node && ./bin/vmauth -help 2>&1) > /tmp/vm-opensource-single-node/vmauth_common_flags_tmp.md
+ifndef TAG
+	$(error TAG must be provided to update flags in docs)
+endif
+	git checkout $(TAG) && $(MAKE) vmauth && \
+	./bin/vmauth -help > /tmp/vmauth_common_flags_tmp.md
+	git checkout $(TAG)-enterprise && $(MAKE) vmauth && \
+	./bin/vmauth -help > /tmp/vmauth_enterprise_flags_tmp.md
 
 	echo "$$FLAGS_HEADER" > docs/victoriametrics/vmauth_common_flags.md
-	cat /tmp/vm-opensource-single-node/vmauth_common_flags_tmp.md >> docs/victoriametrics/vmauth_common_flags.md
-	printf -- '```\n' >> docs/victoriametrics/vmauth_common_flags.md
+	cat /tmp/vmauth_common_flags_tmp.md >> docs/victoriametrics/vmauth_common_flags.md
+	printf '```\n' >> docs/victoriametrics/vmauth_common_flags.md
 
 	echo "$$FLAGS_HEADER" > docs/victoriametrics/vmauth_enterprise_flags.md
-	diff /tmp/vm-enterprise-single-node/vmauth_enterprise_flags_tmp.md /tmp/vm-opensource-single-node/vmauth_common_flags_tmp.md |grep '^<' | sed 's/^< //' >> docs/victoriametrics/vmauth_enterprise_flags.md
-	printf -- '```' >> docs/victoriametrics/vmauth_enterprise_flags.md
+	diff /tmp/vmauth_enterprise_flags_tmp.md /tmp/vmauth_common_flags_tmp.md |grep '^<' | sed 's/^< //' >> docs/victoriametrics/vmauth_enterprise_flags.md
+	printf '```' >> docs/victoriametrics/vmauth_enterprise_flags.md
 
 	# replace tabs in output with one space
 	sed -i 's/\t/ /g' docs/victoriametrics/vmauth_common_flags.md
@@ -115,17 +122,22 @@ docs-update-vmauth-flags:
 	sed -i '/The maximum number of concurrent goroutines to work with files;/ s/(default [0-9]\+)/(default fsutil.getDefaultConcurrency())/' docs/victoriametrics/vmauth_common_flags.md
 
 docs-update-vmagent-flags:
-	(cd /tmp/vm-enterprise-single-node && make vmagent)
-	(cd /tmp/vm-opensource-single-node && make vmagent)
-	(cd /tmp/vm-enterprise-single-node && ./bin/vmagent -help 2>&1) > /tmp/vm-enterprise-single-node/vmagent_enterprise_flags_tmp.md
-	(cd /tmp/vm-opensource-single-node && ./bin/vmagent -help 2>&1) > /tmp/vm-opensource-single-node/vmagent_common_flags_tmp.md
-	echo "$$FLAGS_HEADER" > docs/victoriametrics/vmagent_common_flags.md
-	cat /tmp/vm-opensource-single-node/vmagent_common_flags_tmp.md >> docs/victoriametrics/vmagent_common_flags.md
-	printf -- '```\n' >> docs/victoriametrics/vmagent_common_flags.md
+ifndef TAG
+	$(error TAG must be provided to update flags in docs)
+endif
+	git checkout $(TAG) && $(MAKE) vmagent && \
+	./bin/vmagent -help > /tmp/vmagent_common_flags_tmp.md
 
-	echo "$$FLAGS_HEADER" > docs/victoriametrics/vmagent_enterprise_flags.md
-	diff /tmp/vm-enterprise-single-node/vmagent_enterprise_flags_tmp.md /tmp/vm-opensource-single-node/vmagent_common_flags_tmp.md |grep '^<' | sed 's/^< //' >> docs/victoriametrics/vmagent_enterprise_flags.md
-	printf -- '```\n' >> docs/victoriametrics/vmagent_enterprise_flags.md
+	git checkout $(TAG)-enterprise && $(MAKE) vmagent && \
+	./bin/vmagent -help > /tmp/vmagent_enterprise_flags_tmp.md
+
+	echo "$$FLAGS_HEADER" > docs/victoriametrics/vmagent_common_flags.md && \
+	cat /tmp/vmagent_common_flags_tmp.md >> docs/victoriametrics/vmagent_common_flags.md && \
+	printf '```\n' >> docs/victoriametrics/vmagent_common_flags.md
+
+	echo "$$FLAGS_HEADER" > docs/victoriametrics/vmagent_enterprise_flags.md && \
+	diff /tmp/vmagent_enterprise_flags_tmp.md /tmp/vmagent_common_flags_tmp.md |grep '^<' | sed 's/^< //' >> docs/victoriametrics/vmagent_enterprise_flags.md && \
+	printf '```\n' >> docs/victoriametrics/vmagent_enterprise_flags.md
 
 	# replace tabs in output with one space
 	sed -i 's/\t/ /g' docs/victoriametrics/vmagent_common_flags.md
@@ -138,18 +150,22 @@ docs-update-vmagent-flags:
 	sed -i '/The maximum number of concurrent goroutines to work with files;/ s/(default [0-9]\+)/(default fsutil.getDefaultConcurrency())/' docs/victoriametrics/vmagent_common_flags.md
 
 docs-update-vmalert-flags:
-	(cd /tmp/vm-enterprise-single-node && make vmalert)
-	(cd /tmp/vm-opensource-single-node && make vmalert)
-	(cd /tmp/vm-enterprise-single-node && ./bin/vmalert -help 2>&1) > /tmp/vm-enterprise-single-node/vmalert_enterprise_flags_tmp.md
-	(cd /tmp/vm-opensource-single-node && ./bin/vmalert -help 2>&1) > /tmp/vm-opensource-single-node/vmalert_common_flags_tmp.md
+ifndef TAG
+	$(error TAG must be provided to update flags in docs)
+endif
+	git checkout $(TAG) && $(MAKE) vmalert && \
+	./bin/vmalert -help > /tmp/vmalert_common_flags_tmp.md
 
-	echo "$$FLAGS_HEADER" > docs/victoriametrics/vmalert_common_flags.md
-	cat /tmp/vm-opensource-single-node/vmalert_common_flags_tmp.md >> docs/victoriametrics/vmalert_common_flags.md
-	printf -- '```\n' >> docs/victoriametrics/vmalert_common_flags.md
+	git checkout $(TAG)-enterprise && $(MAKE) vmalert && \
+	./bin/vmalert -help > /tmp/vmalert_enterprise_flags_tmp.md
 
-	echo "$$FLAGS_HEADER" > docs/victoriametrics/vmalert_enterprise_flags.md
-	diff /tmp/vm-enterprise-single-node/vmalert_enterprise_flags_tmp.md /tmp/vm-opensource-single-node/vmalert_common_flags_tmp.md |grep '^<' | sed 's/^< //' >> docs/victoriametrics/vmalert_enterprise_flags.md
-	printf -- '```' >> docs/victoriametrics/vmalert_enterprise_flags.md
+	echo "$$FLAGS_HEADER" > docs/victoriametrics/vmalert_common_flags.md && \
+	cat /tmp/vmalert_common_flags_tmp.md >> docs/victoriametrics/vmalert_common_flags.md && \
+	printf '```\n' >> docs/victoriametrics/vmalert_common_flags.md
+
+	echo "$$FLAGS_HEADER" > docs/victoriametrics/vmalert_enterprise_flags.md && \
+	diff /tmp/vmalert_enterprise_flags_tmp.md /tmp/vmalert_common_flags_tmp.md |grep '^<' | sed 's/^< //' >> docs/victoriametrics/vmalert_enterprise_flags.md && \
+	printf '```' >> docs/victoriametrics/vmalert_enterprise_flags.md
 
 	# replace tabs in output with one space
 	sed -i 's/\t/ /g' docs/victoriametrics/vmalert_common_flags.md
@@ -161,18 +177,22 @@ docs-update-vmalert-flags:
 	sed -i '/The maximum number of concurrent goroutines to work with files;/ s/(default [0-9]\+)/(default fsutil.getDefaultConcurrency())/' docs/victoriametrics/vmalert_common_flags.md
 
 docs-update-vmselect-flags:
-	(cd /tmp/vm-enterprise-cluster && make vmselect)
-	(cd /tmp/vm-opensource-cluster && make vmselect)
-	(cd /tmp/vm-enterprise-cluster && ./bin/vmselect -help 2>&1) > /tmp/vm-enterprise-cluster/vmselect_enterprise_flags_tmp.md
-	(cd /tmp/vm-opensource-cluster && ./bin/vmselect -help 2>&1) > /tmp/vm-opensource-cluster/vmselect_common_flags_tmp.md
+ifndef TAG
+	$(error TAG must be provided to update flags in docs)
+endif
+	git checkout $(TAG)-cluster && $(MAKE) vmselect && \
+	./bin/vmselect -help > /tmp/vmselect_common_flags_tmp.md
 
-	echo "$$FLAGS_HEADER" > docs/victoriametrics/vmselect_common_flags.md
-	cat /tmp/vm-opensource-cluster/vmselect_common_flags_tmp.md >> docs/victoriametrics/vmselect_common_flags.md
-	printf -- '```\n' >> docs/victoriametrics/vmselect_common_flags.md
+	git checkout $(TAG)-enterprise-cluster && $(MAKE) vmselect && \
+	./bin/vmselect -help > /tmp/vmselect_enterprise_flags_tmp.md
 
-	echo "$$FLAGS_HEADER" > docs/victoriametrics/vmselect_enterprise_flags.md
-	diff /tmp/vm-enterprise-cluster/vmselect_enterprise_flags_tmp.md /tmp/vm-opensource-cluster/vmselect_common_flags_tmp.md |grep '^<' | sed 's/^< //' >> docs/victoriametrics/vmselect_enterprise_flags.md
-	printf -- '```' >> docs/victoriametrics/vmselect_enterprise_flags.md
+	echo "$$FLAGS_HEADER" > docs/victoriametrics/vmselect_common_flags.md && \
+	cat /tmp/vmselect_common_flags_tmp.md >> docs/victoriametrics/vmselect_common_flags.md && \
+	printf '```\n' >> docs/victoriametrics/vmselect_common_flags.md
+
+	echo "$$FLAGS_HEADER" > docs/victoriametrics/vmselect_enterprise_flags.md && \
+	diff /tmp/vmselect_enterprise_flags_tmp.md /tmp/vmselect_common_flags_tmp.md |grep '^<' | sed 's/^< //' >> docs/victoriametrics/vmselect_enterprise_flags.md && \
+	printf '```' >> docs/victoriametrics/vmselect_enterprise_flags.md
 
 	# replace tabs in output with one space
 	sed -i 's/\t/ /g' docs/victoriametrics/vmselect_common_flags.md
@@ -186,18 +206,22 @@ docs-update-vmselect-flags:
 	sed -i '/The maximum number of concurrent goroutines to work with files;/ s/(default [0-9]\+)/(default fsutil.getDefaultConcurrency())/' docs/victoriametrics/vmselect_common_flags.md
 
 docs-update-vminsert-flags:
-	(cd /tmp/vm-enterprise-cluster && make vminsert)
-	(cd /tmp/vm-opensource-cluster && make vminsert)
-	(cd /tmp/vm-enterprise-cluster && ./bin/vminsert -help 2>&1) > /tmp/vm-enterprise-cluster/vminsert_enterprise_flags_tmp.md
-	(cd /tmp/vm-opensource-cluster && ./bin/vminsert -help 2>&1) > /tmp/vm-opensource-cluster/vminsert_common_flags_tmp.md
+ifndef TAG
+	$(error TAG must be provided to update flags in docs)
+endif
+	git checkout $(TAG)-cluster && $(MAKE) vminsert && \
+	./bin/vminsert -help > /tmp/vminsert_common_flags_tmp.md
 
-	echo "$$FLAGS_HEADER" > docs/victoriametrics/vminsert_common_flags.md
-	cat /tmp/vm-opensource-cluster/vminsert_common_flags_tmp.md >> docs/victoriametrics/vminsert_common_flags.md
-	printf -- '```\n' >> docs/victoriametrics/vminsert_common_flags.md
+	git checkout $(TAG)-enterprise-cluster && $(MAKE) vminsert && \
+	./bin/vminsert -help > /tmp/vminsert_enterprise_flags_tmp.md
 
-	echo "$$FLAGS_HEADER" > docs/victoriametrics/vminsert_enterprise_flags.md
-	diff /tmp/vm-enterprise-cluster/vminsert_enterprise_flags_tmp.md /tmp/vm-opensource-cluster/vminsert_common_flags_tmp.md |grep '^<' | sed 's/^< //' >> docs/victoriametrics/vminsert_enterprise_flags.md
-	printf -- '```' >> docs/victoriametrics/vminsert_enterprise_flags.md
+	echo "$$FLAGS_HEADER" > docs/victoriametrics/vminsert_common_flags.md && \
+	cat /tmp/vminsert_common_flags_tmp.md >> docs/victoriametrics/vminsert_common_flags.md && \
+	printf '```\n' >> docs/victoriametrics/vminsert_common_flags.md
+
+	echo "$$FLAGS_HEADER" > docs/victoriametrics/vminsert_enterprise_flags.md && \
+	diff /tmp/vminsert_enterprise_flags_tmp.md /tmp/vminsert_common_flags_tmp.md |grep '^<' | sed 's/^< //' >> docs/victoriametrics/vminsert_enterprise_flags.md && \
+	printf '```' >> docs/victoriametrics/vminsert_enterprise_flags.md
 
 	# replace tabs in output with one space
 	sed -i 's/\t/ /g' docs/victoriametrics/vminsert_common_flags.md
@@ -218,18 +242,22 @@ docs-update-vminsert-flags:
 	sed -i '/The maximum number of concurrent goroutines to work with files;/ s/(default [0-9]\+)/(default fsutil.getDefaultConcurrency())/' docs/victoriametrics/vminsert_common_flags.md
 
 docs-update-vmstorage-flags:
-	(cd /tmp/vm-enterprise-cluster && make vmstorage)
-	(cd /tmp/vm-opensource-cluster && make vmstorage)
-	(cd /tmp/vm-enterprise-cluster && ./bin/vmstorage -help 2>&1) > /tmp/vm-enterprise-cluster/vmstorage_enterprise_flags_tmp.md
-	(cd /tmp/vm-opensource-cluster && ./bin/vmstorage -help 2>&1) > /tmp/vm-opensource-cluster/vmstorage_common_flags_tmp.md
+ifndef TAG
+	$(error TAG must be provided to update flags in docs)
+endif
+	git checkout $(TAG)-cluster && $(MAKE) vmstorage && \
+	./bin/vmstorage -help > /tmp/vmstorage_common_flags_tmp.md
 
-	echo "$$FLAGS_HEADER" > docs/victoriametrics/vmstorage_common_flags.md
-	cat /tmp/vm-opensource-cluster/vmstorage_common_flags_tmp.md >> docs/victoriametrics/vmstorage_common_flags.md
-	printf -- '```\n' >> docs/victoriametrics/vmstorage_common_flags.md
+	git checkout $(TAG)-enterprise-cluster && $(MAKE) vmstorage && \
+	./bin/vmstorage -help > /tmp/vmstorage_enterprise_flags_tmp.md
 
-	echo "$$FLAGS_HEADER" > docs/victoriametrics/vmstorage_enterprise_flags.md
-	diff /tmp/vm-enterprise-cluster/vmstorage_enterprise_flags_tmp.md /tmp/vm-opensource-cluster/vmstorage_common_flags_tmp.md |grep '^<' | sed 's/^< //' >> docs/victoriametrics/vmstorage_enterprise_flags.md
-	printf -- '```' >> docs/victoriametrics/vmstorage_enterprise_flags.md
+	echo "$$FLAGS_HEADER" > docs/victoriametrics/vmstorage_common_flags.md && \
+	cat /tmp/vmstorage_common_flags_tmp.md >> docs/victoriametrics/vmstorage_common_flags.md && \
+	printf '```\n' >> docs/victoriametrics/vmstorage_common_flags.md
+
+	echo "$$FLAGS_HEADER" > docs/victoriametrics/vmstorage_enterprise_flags.md && \
+	diff /tmp/vmstorage_enterprise_flags_tmp.md /tmp/vmstorage_common_flags_tmp.md |grep '^<' | sed 's/^< //' >> docs/victoriametrics/vmstorage_enterprise_flags.md && \
+	printf '```' >> docs/victoriametrics/vmstorage_enterprise_flags.md
 
 	# replace tabs in output with one space
 	sed -i 's/\t/ /g' docs/victoriametrics/vmstorage_common_flags.md
@@ -242,37 +270,40 @@ docs-update-vmstorage-flags:
 	sed -i '/The maximum number of concurrent goroutines to work with files;/ s/(default [0-9]\+)/(default fsutil.getDefaultConcurrency())/' docs/victoriametrics/vmstorage_common_flags.md
 
 docs-update-vmctl-flags:
-	(cd /tmp/vm-opensource-single-node && make vmctl)
-	(cd /tmp/vm-opensource-single-node && ./bin/vmctl -help 2>&1) > /tmp/vm-opensource-single-node/vmctl_flags_tmp.md
-	(cd /tmp/vm-opensource-single-node && ./bin/vmctl opentsdb -help 2>&1) > /tmp/vm-opensource-single-node/vmctl_opentsdb_flags_tmp.md
-	(cd /tmp/vm-opensource-single-node && ./bin/vmctl influx -help 2>&1) > /tmp/vm-opensource-single-node/vmctl_influx_flags_tmp.md
-	(cd /tmp/vm-opensource-single-node && ./bin/vmctl remote-read -help 2>&1) > /tmp/vm-opensource-single-node/vmctl_remote-read_flags_tmp.md
-	(cd /tmp/vm-opensource-single-node && ./bin/vmctl prometheus -help 2>&1) > /tmp/vm-opensource-single-node/vmctl_prometheus_flags_tmp.md
-	(cd /tmp/vm-opensource-single-node && ./bin/vmctl vm-native -help 2>&1) > /tmp/vm-opensource-single-node/vmctl_vm-native_flags_tmp.md
+ifndef TAG
+	$(error TAG must be provided to update flags in docs)
+endif
+	git checkout $(TAG) && $(MAKE) vmctl && \
+	./bin/vmctl -help > /tmp/vmctl_flags_tmp.md && \
+	./bin/vmctl opentsdb -help > /tmp/vmctl_opentsdb_flags_tmp.md && \
+	./bin/vmctl influx -help > /tmp/vmctl_influx_flags_tmp.md && \
+	./bin/vmctl remote-read -help > /tmp/vmctl_remote-read_flags_tmp.md && \
+	./bin/vmctl prometheus -help > /tmp/vmctl_prometheus_flags_tmp.md && \
+	./bin/vmctl vm-native -help > /tmp/vmctl_vm-native_flags_tmp.md
 
-	echo "$$FLAGS_HEADER" > docs/victoriametrics/vmctl/vmctl_flags.md
-	cat /tmp/vm-opensource-single-node/vmctl_flags_tmp.md >> docs/victoriametrics/vmctl/vmctl_flags.md
-	printf -- '```\n' >> docs/victoriametrics/vmctl/vmctl_flags.md
+	echo "$$FLAGS_HEADER" > docs/victoriametrics/vmctl/vmctl_flags.md && \
+	cat /tmp/vmctl_flags_tmp.md >> docs/victoriametrics/vmctl/vmctl_flags.md && \
+	printf '```\n' >> docs/victoriametrics/vmctl/vmctl_flags.md
 
-	echo "$$FLAGS_HEADER" > docs/victoriametrics/vmctl/vmctl_opentsdb_flags.md
-	cat /tmp/vm-opensource-single-node/vmctl_opentsdb_flags_tmp.md >> docs/victoriametrics/vmctl/vmctl_opentsdb_flags.md
-	printf -- '```\n' >> docs/victoriametrics/vmctl/vmctl_opentsdb_flags.md
+	echo "$$FLAGS_HEADER" > docs/victoriametrics/vmctl/vmctl_opentsdb_flags.md && \
+	cat /tmp/vmctl_opentsdb_flags_tmp.md >> docs/victoriametrics/vmctl/vmctl_opentsdb_flags.md && \
+	printf '```\n' >> docs/victoriametrics/vmctl/vmctl_opentsdb_flags.md
 
-	echo "$$FLAGS_HEADER" > docs/victoriametrics/vmctl/vmctl_influx_flags.md
-	cat /tmp/vm-opensource-single-node/vmctl_influx_flags_tmp.md >> docs/victoriametrics/vmctl/vmctl_influx_flags.md
-	printf -- '```\n' >> docs/victoriametrics/vmctl/vmctl_influx_flags.md
+	echo "$$FLAGS_HEADER" > docs/victoriametrics/vmctl/vmctl_influx_flags.md && \
+	cat /tmp/vmctl_influx_flags_tmp.md >> docs/victoriametrics/vmctl/vmctl_influx_flags.md && \
+	printf '```\n' >> docs/victoriametrics/vmctl/vmctl_influx_flags.md
 
-	echo "$$FLAGS_HEADER" > docs/victoriametrics/vmctl/vmctl_remote-read_flags.md
-	cat /tmp/vm-opensource-single-node/vmctl_remote-read_flags_tmp.md >> docs/victoriametrics/vmctl/vmctl_remote-read_flags.md
-	printf -- '```\n' >> docs/victoriametrics/vmctl/vmctl_remote-read_flags.md
+	echo "$$FLAGS_HEADER" > docs/victoriametrics/vmctl/vmctl_remote-read_flags.md && \
+	cat /tmp/vmctl_remote-read_flags_tmp.md >> docs/victoriametrics/vmctl/vmctl_remote-read_flags.md && \
+	printf '```\n' >> docs/victoriametrics/vmctl/vmctl_remote-read_flags.md
 
-	echo "$$FLAGS_HEADER" > docs/victoriametrics/vmctl/vmctl_prometheus_flags.md
-	cat /tmp/vm-opensource-single-node/vmctl_prometheus_flags_tmp.md >> docs/victoriametrics/vmctl/vmctl_prometheus_flags.md
-	printf -- '```\n' >> docs/victoriametrics/vmctl/vmctl_prometheus_flags.md
+	echo "$$FLAGS_HEADER" > docs/victoriametrics/vmctl/vmctl_prometheus_flags.md && \
+	cat /tmp/vmctl_prometheus_flags_tmp.md >> docs/victoriametrics/vmctl/vmctl_prometheus_flags.md && \
+	printf '```\n' >> docs/victoriametrics/vmctl/vmctl_prometheus_flags.md
 
-	echo "$$FLAGS_HEADER" > docs/victoriametrics/vmctl/vmctl_vm-native_flags.md
-	cat /tmp/vm-opensource-single-node/vmctl_vm-native_flags_tmp.md >> docs/victoriametrics/vmctl/vmctl_vm-native_flags.md
-	printf -- '```\n' >> docs/victoriametrics/vmctl/vmctl_vm-native_flags.md
+	echo "$$FLAGS_HEADER" > docs/victoriametrics/vmctl/vmctl_vm-native_flags.md && \
+	cat /tmp/vmctl_vm-native_flags_tmp.md >> docs/victoriametrics/vmctl/vmctl_vm-native_flags.md && \
+	printf '```\n' >> docs/victoriametrics/vmctl/vmctl_vm-native_flags.md
 
 	# remove Total time line from all vmctl flag files to reduce diffs noise
 	sed -i '/Total time:/d' docs/victoriametrics/vmctl/vmctl_flags.md
@@ -285,49 +316,30 @@ docs-update-vmctl-flags:
 	# remove Version line and the actual version line from vmctl_flags.md to reduce diffs noise
 	sed -i '/^VERSION:/,+1d' docs/victoriametrics/vmctl/vmctl_flags.md
 
-# docs-update-flags updates flags in the documentation using the actual binaries compiled
-# from the latest enterprise-single-node and enterprise-cluster branches (hardcoded for now).
+# docs-update-flags updates flags in the documentation
+# using the actual binaries compiled from the provided $TAG.
 # The command also normalizes the output a bit.
 #
-# The command does not replace the need to manually update flags in the documentation when
-# new flags are added or existing flags are updated. It just helps to keep the documentation
-# in sync with the actual binaries.
+# There is no need to update flags manually while working on change in the code.
+# The flags will be synced when a new release tag is cut.
 #
-# It can be run from any branch.
-# All work happens inside temporary directories under /tmp.
-# The script checks out the required branch, builds the binaries, and updates the documentation.
-# The current Git repository is not touched.
+# The command can be run from any branch.
+# The script checks out the required $TAG, builds the binaries, and updates the documentation.
 docs-update-flags:
+ifndef TAG
+	$(error TAG must be provided to update flags in docs)
+endif
 	# Note for MacOS users:
-	# You need to install gnu versions of sed and awk inorder fo inplace editing to work
+	# You need to install gnu versions of sed and awk to enable in-place editing
 	# Install using: brew install gnu-sed gawk
 	# Add tools to PATH see how in `brew info gnu-sed` and `brew info gawk
 
-	git fetch enterprise
-	git fetch opensource
-
-	rm -rf /tmp/vm-enterprise-cluster
-	git worktree remove /tmp/vm-enterprise-cluster || true
-	git worktree add /tmp/vm-enterprise-cluster enterprise/enterprise-cluster
-
-	rm -rf /tmp/vm-enterprise-single-node
-	git worktree remove /tmp/vm-enterprise-single-node || true
-	git worktree add /tmp/vm-enterprise-single-node enterprise/enterprise-single-node
-
-
-	rm -rf /tmp/vm-opensource-cluster
-	git worktree remove /tmp/vm-opensource-cluster || true
-	git worktree add /tmp/vm-opensource-cluster opensource/cluster
-
-	rm -rf /tmp/vm-opensource-single-node
-	git worktree remove /tmp/vm-opensource-single-node || true
-	git worktree add /tmp/vm-opensource-single-node opensource/master
-
-	make docs-update-vmctl-flags
-	make docs-update-vmsingle-flags
-	make docs-update-vmalert-flags
-	make docs-update-vmauth-flags
-	make docs-update-vmagent-flags
-	make docs-update-vmselect-flags
-	make docs-update-vminsert-flags
-	make docs-update-vmstorage-flags
+	orig_branch=$$(git rev-parse --abbrev-ref HEAD); \
+	$(MAKE) docs-update-vmctl-flags && git checkout "$$orig_branch" && \
+	$(MAKE) docs-update-vmsingle-flags && git checkout "$$orig_branch" && \
+	$(MAKE) docs-update-vmalert-flags && git checkout "$$orig_branch" && \
+	$(MAKE) docs-update-vmauth-flags && git checkout "$$orig_branch" && \
+	$(MAKE) docs-update-vmagent-flags && git checkout "$$orig_branch" && \
+	$(MAKE) docs-update-vmselect-flags && git checkout "$$orig_branch" && \
+	$(MAKE) docs-update-vminsert-flags && git checkout "$$orig_branch" && \
+	$(MAKE) docs-update-vmstorage-flags && git checkout "$$orig_branch"

--- a/docs/victoriametrics/Release-Guide.md
+++ b/docs/victoriametrics/Release-Guide.md
@@ -113,8 +113,7 @@ and the candidate is deployed to the sandbox environment.
 
 1. Make sure that the release branches have no security issues.
 1. Update release versions if needed in [SECURITY.md](https://github.com/VictoriaMetrics/VictoriaMetrics/blob/master/SECURITY.md).
-1. Run `PKG_TAG=v1.xx.y make docs-update-version` command to update version help tooltips.
-1. Run `make docs-update-flags` command to update command-line flags in the documentation. [Commit example](https://github.com/VictoriaMetrics/VictoriaMetrics/commit/4d42b291e55ac9211130efbd5a56aa819998516d). 
+1. Run `PKG_TAG=v1.xx.y make docs-update-version` command to update version help tooltips. 
 1. Cut new version in [CHANGELOG.md](https://github.com/VictoriaMetrics/VictoriaMetrics/blob/master/docs/victoriametrics/changelog/CHANGELOG.md) and commit it. See example in this [commit](https://github.com/VictoriaMetrics/VictoriaMetrics/commit/b771152039d23b5ccd637a23ea748bc44a9511a7).
 1. Create the following release tags:
    * `git tag -s v1.xx.y` in `master` branch
@@ -199,6 +198,7 @@ Issues included in the release are closed, with the comment.
    ```
 
 1. Bump VictoriaMetrics version mentioned in [docs](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/7388).
+1. Run `TAG=v1.xx.y make docs-update-flags` command to update command-line flags in the documentation. [Commit example](https://github.com/VictoriaMetrics/VictoriaMetrics/commit/4d42b291e55ac9211130efbd5a56aa819998516d).
 1. Follow the instructions in [release follow-up](https://github.com/VictoriaMetrics/VictoriaMetrics-enterprise/blob/enterprise-single-node/Release-Guide.md).
 
 #### Operator


### PR DESCRIPTION
### Describe Your Changes

As requested by @valyala changing the behvior of `make docs-update-flags` from relying on git worktree, specific git remotes to the git tags. Same way as `make publish-release` works. 

### Checklist

The following checks are **mandatory**:

- [ ] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [ ] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
