### PR TITLE
lib/regexutil: prevent panic `error parsing regexp: expression nests too deeply`

### DIFF
--- a/docs/victoriametrics/changelog/CHANGELOG.md
+++ b/docs/victoriametrics/changelog/CHANGELOG.md
@@ -32,6 +32,8 @@ See also [LTS releases](https://docs.victoriametrics.com/victoriametrics/lts-rel
 * FEATURE: [dashboards/vmauth](https://grafana.com/grafana/dashboards/21394): add `Request body buffering duration` panel to the `Troubleshooting` section. This panel shows the time spent buffering incoming client request bodies, helping identify slow client uploads and potential concurrency issues. The panel is only available when `-requestBufferSize` is non-zero. See [#10309](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/10309).
 * FEATURE: [vmagent](https://docs.victoriametrics.com/victoriametrics/vmagent/), [vmsingle](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/), `vminsert` and `vmstorage` in [VictoriaMetrics cluster](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/): enable [ingestion](https://docs.victoriametrics.com/victoriametrics/vmagent/#metric-metadata) and in-memory [storage](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#metrics-metadata) of metrics metadata by default. Metadata ingestion can be disabled with `-enableMetadata=false`. See [#2974](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/2974).
 
+* BUGFIX: [vmsingle](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/) and `vmstorage` in [VictoriaMetrics cluster](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/): prevent panic `error parsing regexp: expression nests too deeply` triggered by large repetition ranges in regex. See [VictoriaLogs#1112](https://github.com/VictoriaMetrics/VictoriaLogs/issues/1112).
+
 ## [v1.136.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.136.0)
 
 Released at 2026-02-13

--- a/lib/regexutil/regex_test.go
+++ b/lib/regexutil/regex_test.go
@@ -17,6 +17,8 @@ func TestNewRegexFailure(t *testing.T) {
 
 	f("[foo")
 	f("(foo")
+	// Trigger syntax.ErrInvalidRepeatOp
+	f("a{0,10000}")
 }
 
 func TestRegexMatchString(t *testing.T) {
@@ -144,6 +146,10 @@ func TestRegexMatchString(t *testing.T) {
 	f("foo(bar|baz)", "a fooxfoobaz a", true)
 	f("foo(bar|baz)", "a fooxfooban a", false)
 	f("foo(bar|baz)", "a fooxfooban foobar a", true)
+
+	// Trigger syntax.ErrNestingDepth
+	// See https://github.com/VictoriaMetrics/VictoriaLogs/issues/1112
+	f("a{0,1000}", "a", true)
 }
 
 func TestGetLiterals(t *testing.T) {


### PR DESCRIPTION
### Describe Your Changes

Fixes victoriaMetrics/victoriaLogs/issues/1112

### Checklist

The following checks are **mandatory**:

- [X] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [X] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
