### PR TITLE
app/vmui: fix label escaping for cardinality and autocomplete

### DIFF
--- a/app/vmui/packages/vmui/src/components/Configurators/QueryEditor/QueryEditorAutocomplete.tsx
+++ b/app/vmui/packages/vmui/src/components/Configurators/QueryEditor/QueryEditorAutocomplete.tsx
@@ -7,6 +7,7 @@ import { AUTOCOMPLETE_LIMITS } from "../../../constants/queryAutocomplete";
 import { QueryEditorAutocompleteProps } from "./QueryEditor";
 import { getExprLastPart, getValueByContext, getContext } from "./autocompleteUtils";
 import { extractCurrentLabel, extractLabelMatchers, extractMetric, splitByCursor } from "./utils/parser";
+import { escapeLabelName } from "../../../utils/metric";
 
 const QueryEditorAutocomplete: FC<QueryEditorAutocompleteProps> = ({
   value,
@@ -90,6 +91,7 @@ const QueryEditorAutocomplete: FC<QueryEditorAutocompleteProps> = ({
     }
 
     if (context === QueryContextType.label) {
+      insert = escapeLabelName(insert);
       valueAfterCursor = valueAfterCursor.replace(/^[^\s=!,{}()"|+\-/*^]*/, "");
     }
 

--- a/app/vmui/packages/vmui/src/pages/CardinalityPanel/helpers.ts
+++ b/app/vmui/packages/vmui/src/pages/CardinalityPanel/helpers.ts
@@ -1,4 +1,5 @@
 import { QueryUpdater } from "./types";
+import { escapeLabelName } from "../../utils/metric";
 
 export const queryUpdater: QueryUpdater = {
   seriesCountByMetricName: ({ query }): string => {
@@ -28,5 +29,5 @@ const getSeriesSelector = (label: string | null, value: string): string => {
   if (!label) {
     return "";
   }
-  return "{" + label + "=" + JSON.stringify(value) + "}";
+  return "{" + escapeLabelName(label) + "=" + JSON.stringify(value) + "}";
 };

--- a/app/vmui/packages/vmui/src/pages/CardinalityPanel/index.tsx
+++ b/app/vmui/packages/vmui/src/pages/CardinalityPanel/index.tsx
@@ -18,6 +18,7 @@ import {
   TipHighNumberOfValues
 } from "./CardinalityTips";
 import useSearchParamsFromObject from "../../hooks/useSearchParamsFromObject";
+import { escapeLabelName } from "../../utils/metric";
 
 const spinnerMessage = `Please wait while cardinality stats is calculated. 
                         This may take some time if the db contains big number of time series.`;
@@ -36,12 +37,17 @@ const CardinalityPanel: FC = () => {
   const defaultState = getDefaultState(match, focusLabel);
 
   const handleFilterClick = (key: string) => (query: string) => {
+    const rawQuery = query;
+
+    const isLabelKey = ["labelValueCountByLabelName", "seriesCountByLabelName"].includes(key);
+    if (isLabelKey) query = escapeLabelName(query);
+
     const value = queryUpdater[key]({ query, focusLabel, match });
     const params: Record<string, string> = { match: value };
-    if (key === "labelValueCountByLabelName" || key == "seriesCountByLabelName") {
-      params.focusLabel = query;
+    if (isLabelKey) {
+      params.focusLabel = rawQuery;
     }
-    if (key == "seriesCountByFocusLabelValue") {
+    if (key === "seriesCountByFocusLabelValue") {
       params.focusLabel = "";
     }
     setSearchParamsFromKeys(params);

--- a/app/vmui/packages/vmui/src/utils/metric.ts
+++ b/app/vmui/packages/vmui/src/utils/metric.ts
@@ -52,3 +52,7 @@ export const isHistogramData = (result: MetricBase[]) => {
 
   return isHistogram && result.every(r => histogramLabels.some(l => l in r.metric));
 };
+
+export const escapeLabelName = (s: string) => {
+  return s.replace(/([\\./-])/g, "\\$1");
+};

--- a/docs/victoriametrics/changelog/CHANGELOG.md
+++ b/docs/victoriametrics/changelog/CHANGELOG.md
@@ -31,6 +31,8 @@ See also [LTS releases](https://docs.victoriametrics.com/victoriametrics/lts-rel
 * FEATURE: all VictoriaMetrics components: expose `process_cpu_seconds_total`, `process_resident_memory_bytes`, and other process-level metrics when running on macOS. See [metrics#75](https://github.com/VictoriaMetrics/metrics/issues/75).
 * FEATURE: [dashboards/vmauth](https://grafana.com/grafana/dashboards/21394): add `Request body buffering duration` panel to the `Troubleshooting` section. This panel shows the time spent buffering incoming client request bodies, helping identify slow client uploads and potential concurrency issues. The panel is only available when `-requestBufferSize` is non-zero. See [#10309](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/10309).
 
+* BUGFIX: [vmui](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#vmui): fix escaping for label names with special characters. See [#10485](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/10485).
+
 ## [v1.136.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.136.0)
 
 Released at 2026-02-13


### PR DESCRIPTION
### Describe Your Changes

This PR fixes handling of label names containing special characters (e.g. `.`, `/`, `-`).

Changes:
- Fixed escaping logic for cardinality requests.
- Fixed autocomplete insertion to escape label names in query selectors.

![ezgif-5480b4578cdbada7](https://github.com/user-attachments/assets/41312802-e559-4f8b-9b38-f765374f275d)

Related issue: #10485

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
