### PR TITLE
lib/storage: use only dateMetricIDCache for registering per-day index entries

### DIFF
--- a/lib/storage/date_metric_id_cache.go
+++ b/lib/storage/date_metric_id_cache.go
@@ -41,7 +41,7 @@ type dateMetricIDCache struct {
 
 func newDateMetricIDCache() *dateMetricIDCache {
 	c := dateMetricIDCache{
-		rotationPeriod:    timeutil.AddJitterToDuration(1 * time.Hour),
+		rotationPeriod:    timeutil.AddJitterToDuration(1 * time.Minute),
 		stopCh:            make(chan struct{}),
 		rotationStoppedCh: make(chan struct{}),
 	}

--- a/lib/storage/storage_synctest_test.go
+++ b/lib/storage/storage_synctest_test.go
@@ -533,7 +533,7 @@ func TestStorageAddRows_nextDayIndexPrefill(t *testing.T) {
 		s.DebugFlush()
 		got59min := countMetricIDs(t, s, "metric5", nextDay)
 		if got59min < got45min {
-			t.Fatalf("unexpected metric id count for next day: got %d, want > %d", got59min, got59min)
+			t.Fatalf("unexpected metric id count for next day: got %d, want > %d", got59min, got45min)
 		}
 
 		// Sleep until the next day


### PR DESCRIPTION
This is an experiment to see if the new sharded version of `dateMetricIDCache` (#10486) could replace `prevHourMetricIDs`, `currHourMetricIDs`, and `nextDayMetricIDs` caches.

If successful it could be a proper fix for #10064.

TODO: save the cache to disk.