### PR TITLE
docs: re-visit Troubleshooting docs

### DIFF
--- a/docs/victoriametrics/Troubleshooting.md
+++ b/docs/victoriametrics/Troubleshooting.md
@@ -12,6 +12,7 @@ aliases:
 - /troubleshooting/index.html
 - /troubleshooting/
 ---
+
 This document contains troubleshooting guides for the most common issues when working with VictoriaMetrics.
 
 ## General troubleshooting checklist
@@ -22,18 +23,18 @@ If you encounter an issue or have a question about VictoriaMetrics components, f
    it with [the latest available version](https://docs.victoriametrics.com/victoriametrics/changelog/).
 
    If you are running an older version, the issue may already be fixed. Review the [changelog](https://docs.victoriametrics.com/victoriametrics/changelog/)
-   for all releases between your version and the latest one to see whether the problem has been resolved.
+   for all releases between your version and the latest release to see whether the problem has been resolved.
 
    If the issue is fixed in a newer release, upgrade and verify that the problem no longer occurs:
 
    - [How to upgrade single-node VictoriaMetrics](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#how-to-upgrade-victoriametrics)
    - [How to upgrade VictoriaMetrics cluster](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/#updating--reconfiguring-cluster-nodes)
 
-   Upgrade procedure for other VictoriaMetrics components is as simple as gracefully stopping the component
-   by sending a `SIGINT` signal to it and starting the new version of the component.
+   The upgrade procedure for other VictoriaMetrics components is as simple as gracefully stopping the component
+   by sending it a `SIGINT` signal and starting the new version of the component.
 
    In rare cases, upgrades may include breaking changes. These cases are documented in the [changelog](https://docs.victoriametrics.com/victoriametrics/changelog/),
-   especially check for **Update notes** near the top of the changelog, as they point out any special actions or considerations to take when upgrading.
+   especially check the **Update notes** near the top of the changelog, as they point out any special actions or considerations to take when upgrading.
 
 1. Review command-line flags passed to VictoriaMetrics components and remove any flags whose impact on your workload is unclear.
    VictoriaMetrics components are optimized to work well with default settings (that is, when flags aren't explicitly set).
@@ -45,45 +46,44 @@ If you encounter an issue or have a question about VictoriaMetrics components, f
    already been discussed (in documentation, on Stack Overflow, or in GitHub issues), and a solution may already be available.
 
 1. If VictoriaMetrics logs do not have relevant information, then try searching for the issue on Google
-   via multiple keywords and phrases specific to the issue. In many cases, both the issue and its solution are already documented.
+   using multiple keywords and phrases specific to the issue. In many cases, both the issue and its solution are already documented.
 
-1. Try searching for the issue at [VictoriaMetrics GitHub](https://github.com/VictoriaMetrics/VictoriaMetrics/issues).
-   The signal-to-noise quality of search results here is much lower than on Google, but sometimes it can help
-   find the relevant information about the issue when Google fails to find the needed information.
-   If you located the relevant GitHub issue, but it misses some information on how to diagnose or troubleshoot it,
-   then please provide this information in comments to the issue. This increases the chance that it will be resolved soon.
+1. Try searching for the issue in [VictoriaMetrics GitHub](https://github.com/VictoriaMetrics/VictoriaMetrics/issues).
+   The signal-to-noise ratio of search results here is much lower than on Google, but sometimes it can help
+   find relevant information when Google fails.
+   If you located the relevant GitHub issue, but it lacks details for diagnosis or troubleshooting,
+   then please add them in the issue comments. This increases the chance that it will be resolved soon.
 
-1. Try searching for information about the issue in [VictoriaMetrics source code](https://github.com/search?q=repo%3AVictoriaMetrics%2FVictoriaMetrics&type=code).
-   GitHub code search may not be very good in some cases, so it is recommended [checking out VictoriaMetrics source code](https://github.com/VictoriaMetrics/VictoriaMetrics/)
-   and perform local search in the code.
+1. Try searching for information about the issue in the [VictoriaMetrics source code](https://github.com/search?q=repo%3AVictoriaMetrics%2FVictoriaMetrics&type=code).
+   GitHub code search may not be very effective in some cases, so it is recommended [to check out the VictoriaMetrics source code](https://github.com/VictoriaMetrics/VictoriaMetrics/)
+   and perform a local search in the code.
    Note that the source code for the VictoriaMetrics cluster is located in [the cluster](https://github.com/VictoriaMetrics/VictoriaMetrics/tree/cluster) branch.
 
 1. If the steps above didn't help to find the solution to the issue, then please [file a new issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/new/choose)
-   by providing the maximum details on how to reproduce the issue.
+   with as many details as possible on how to reproduce it.
 
-   After that you can post the link to the issue to [VictoriaMetrics Slack chat](https://victoriametrics.slack.com),
-   so VictoriaMetrics community could help finding the solution to the issue. It is better filing the issue at VictoriaMetrics GitHub
-   before posting your question to VictoriaMetrics Slack chat, since GitHub issues are indexed by Google,
-   while Slack messages aren't indexed by Google. This simplifies finding a solution to the issue for future VictoriaMetrics users.
+   After that you can post the link to the issue in the [VictoriaMetrics Slack chat](https://victoriametrics.slack.com),
+   so the VictoriaMetrics community can help find a solution. It is better to file the issue on VictoriaMetrics GitHub
+   before posting your question to the VictoriaMetrics Slack chat, since GitHub issues are indexed by Google,
+   while Slack messages are not. This simplifies finding a solution to the issue for future VictoriaMetrics users.
 
 1. Pro tip 1: if you see that [VictoriaMetrics docs](https://docs.victoriametrics.com/victoriametrics/) contain incomplete or incorrect information,
    then please create a pull request with the relevant changes or a new issue explaining the problem. This will help the VictoriaMetrics community.
 
 1. Pro tip 2: please provide links to existing docs / GitHub issues / StackOverflow questions
    instead of copying and pasting the information from these sources when asking or answering questions
-   from VictoriaMetrics community. If the linked resources have no enough information,
-   then it is better posting the missing information in the web resource before providing links
-   to this information in Slack chat. This will simplify searching for this information in the future
+   to the VictoriaMetrics community. If the linked resources do not have enough information,
+   then it is better to add the missing information to the original web resource before linking it to Slack chat. This will simplify searching for this information in the future
    for VictoriaMetrics users via Google and [Perplexity](https://www.perplexity.ai/).
 
 1. Pro tip 3: if you are answering somebody's question about VictoriaMetrics components
-   at GitHub issues / Slack chat / StackOverflow, then the best answer is a direct link to the information
-   regarding the question.
+   in GitHub issues / Slack chat / StackOverflow, then the best answer is a direct link to the information
+   with the answer or solution to the question.
    The better answer is a concise message with multiple links to the relevant information.
    The worst answer is a message with misleading or completely wrong information.
 
 1. Pro tip 4: If you can fix the issue on your own, then please do it and provide the corresponding pull request!
-   We are glad to get pull requests from the VictoriaMetrics community.
+   We are happy to get pull requests from the VictoriaMetrics community.
 
 ## Unexpected query results
 
@@ -96,30 +96,30 @@ If you see unexpected or unreliable query results from VictoriaMetrics, then try
    - Remove the outer `sum` and execute `rate(http_requests_total[5m])`.
      Aggregations could hide missing series, data gaps, or anomalies.
      
-   - If the query returns too many series, then try adding more specific label filters to it.
+   - If the query returns too many series, try adding more specific label filters.
      For example, if you see that the original query returns unexpected results for the `job="foo"`,
-     then use `rate(http_requests_total{job="foo"}[5m])` query.
+     then use the `rate(http_requests_total{job="foo"}[5m])` query.
      Continue adding more specific label filters until the resulting query returns a manageable number of time series.
 
-   - Remove the outer `rate` and execute `http_requests_total`. Add label filters to reduce the number of returned series,
+   - Remove the outer `rate` and execute `http_requests_total`. Add label filters to reduce the number of returned series
      if needed.
 
    Sometimes the query may be improperly constructed, leading to unexpected results.
-   It is recommended reading and understanding [MetricsQL docs](https://docs.victoriametrics.com/victoriametrics/metricsql/),
+   It is recommended to read and understand [MetricsQL docs](https://docs.victoriametrics.com/victoriametrics/metricsql/),
    especially [subqueries](https://docs.victoriametrics.com/victoriametrics/metricsql/#subqueries)
    and [rollup functions](https://docs.victoriametrics.com/victoriametrics/metricsql/#rollup-functions) sections.
 
 
 1. If the simplest query continues returning unexpected / unreliable results, then try verifying correctness
-   of raw unprocessed samples in [vmui](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#vmui) via `Raw Query` tab.
+   of raw unprocessed samples in [vmui](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#vmui) via the `Raw Query` tab.
 
    Responses returned from [/api/v1/query](https://docs.victoriametrics.com/victoriametrics/keyconcepts/#instant-query)
    and [/api/v1/query_range](https://docs.victoriametrics.com/victoriametrics/keyconcepts/#range-query) contain **evaluated** data
-   instead of raw samples stored. In some cases, [staleness](https://prometheus.io/docs/prometheus/latest/querying/basics/#staleness), 
-   [deduplication](https://docs.victoriametrics.com/victoriametrics/#deduplication) or irregular scrapes can affect evaluations.
+   instead of stored raw samples. In some cases, [staleness](https://prometheus.io/docs/prometheus/latest/querying/basics/#staleness), 
+   [deduplication](https://docs.victoriametrics.com/victoriametrics/#deduplication), or irregular scrapes can affect evaluations.
    See [this short video](https://www.youtube.com/watch?v=7AyVCC6uKfI) for details.
 
-   Raw data can be downloaded via `Export` button in vmui's  `Raw Query` tab or via [/api/v1/export](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#how-to-export-data-in-json-line-format)
+   Raw data can be downloaded via the `Export` button in vmui's  `Raw Query` tab or via [/api/v1/export](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#how-to-export-data-in-json-line-format)
    query on the given `[start..end]` time range and check whether they are expected:
 
    ```sh
@@ -130,41 +130,41 @@ If you see unexpected or unreliable query results from VictoriaMetrics, then try
    When raising a GitHub ticket about query issues, please also attach the raw data, so maintainers can reproduce your case locally.   
 
 1. Try executing the query with [tracer](https://docs.victoriametrics.com/victoriametrics/#query-tracing) enabled. The trace
-   contains a lot of additional information about query execution, series matching, caches, internal modifications.
+   contains a lot of additional information about query execution, series matching, caches, and internal modifications.
    When raising a GitHub ticket about query issues, please also attach the trace so maintainers can investigate.
 
-1. If you observe gaps when plotting series it is likely caused by irregular intervals for metrics collection (network delays
-   or targets unavailability on scrapes, irregular pushes, irregular timestamps).
+1. If you observe gaps when plotting series, it is likely caused by irregular intervals for metrics collection (network delays
+   or targets unavailability during scrapes, irregular pushes, irregular timestamps).
    VictoriaMetrics automatically [fills the gaps](https://docs.victoriametrics.com/victoriametrics/keyconcepts/#range-query)
    based on the median interval between [data samples](https://docs.victoriametrics.com/victoriametrics/keyconcepts/#raw-samples).
-   This may work incorrectly for irregular data, as the median will be skewed. In this case, it is recommended to either fix the
-   irregularities, or switch to the static interval for gaps filling by setting `-search.minStalenessInterval=5m` command-line flag (`5m` is
+   This may yield incorrect results for irregular data, as the median will be skewed. In this case, it is recommended to either fix the
+   irregularities or switch to the static interval for gaps filling by setting `-search.minStalenessInterval=5m` command-line flag (`5m` is
    used by Prometheus by default).
 
-1. Sometimes response caching may lead to unexpected results when samples with older timestamps
+1. Sometimes, response caching may lead to unexpected results when samples with older timestamps
    are ingested into VictoriaMetrics (aka [backfilling](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#backfilling)).
    Try disabling response cache and see whether this helps:
 
-   - By clicking on toggle `Disable cache` in vmui.
+   - By clicking on the toggle `Disable cache` in vmui.
    
    - By passing `-search.disableCache` command-line flag to a single-node VictoriaMetrics
      or to all the `vmselect` components if the cluster version of VictoriaMetrics is used.
 
    - By passing `nocache=1` query arg to every request to `/api/v1/query` and `/api/v1/query_range`.
-     If you use Grafana, then this query arg can be specified in `Custom Query Parameters` field
-     at Prometheus datasource settings - see [these docs](https://grafana.com/docs/grafana/latest/datasources/prometheus/) for details.
+     If you use Grafana, then this query arg can be specified in the `Custom Query Parameters` field
+     in Prometheus datasource settings. See [these docs](https://grafana.com/docs/grafana/latest/datasources/prometheus/) for details.
 
-    If the problem was in the cache, try resetting it via [resetRollupCache handler](https://docs.victoriametrics.com/victoriametrics/url-examples/#internalresetrollupresultcache).
+    If the problem was in the cache, try resetting it via the [resetRollupCache handler](https://docs.victoriametrics.com/victoriametrics/url-examples/#internalresetrollupresultcache).
 
-1. Cluster version of VictoriaMetrics may return partial responses by default when some of `vmstorage` nodes are temporarily
-   unavailable - see [cluster availability docs](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/#cluster-availability).
+1. Cluster version of VictoriaMetrics may return partial responses by default when some of the `vmstorage` nodes are temporarily
+   unavailable. See [cluster availability docs](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/#cluster-availability).
    If you want to prioritize query consistency over cluster availability, then pass `-search.denyPartialResponse` command-line flag to all the `vmselect` nodes.
-   In this case VictoriaMetrics returns an error during querying if at least a single `vmstorage` node is unavailable.
-   Another option is to pass `deny_partial_response=1` query arg to `/api/v1/query` and `/api/v1/query_range`.
-   If you use Grafana, then this query arg can be specified in `Custom Query Parameters` field
-   in Prometheus/VictoriaMetrics datasource settings - see [these docs](https://grafana.com/docs/grafana/latest/datasources/prometheus/) for details.
+   This causes VictoriaMetrics to return an error during query execution if at least one `vmstorage` node is unavailable.
+   Another option is to pass `deny_partial_response=1` query argument to `/api/v1/query` and `/api/v1/query_range`.
+   If you use Grafana, then this query argument can be specified in the `Custom Query Parameters` field
+   in Prometheus/VictoriaMetrics datasource settings. See [these docs](https://grafana.com/docs/grafana/latest/datasources/prometheus/) for details.
 
-1. If you pass `-replicationFactor` command-line flag to `vmselect`, then it is recommended removing this flag from `vmselect`,
+1. If you pass the `-replicationFactor` command-line flag to `vmselect`, then it is recommended to remove this flag from `vmselect`,
    since it may lead to incomplete responses when `vmstorage` nodes contain less than `-replicationFactor`
    copies of the requested data.
 
@@ -179,41 +179,41 @@ If you see unexpected or unreliable query results from VictoriaMetrics, then try
    VictoriaMetrics components are optimized to work well with default settings (that is, when flags aren't explicitly set).
    Unnecessary or poorly understood flags can lead to unexpected behavior, so it's best to remove them unless you clearly understand why they are needed.
 
-1. If the steps above didn't help identifying the root cause of unexpected query results,
-   then [file a bugreport](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/new) with details on how to reproduce the issue.
-   Instead of sharing screenshots in the issue, consider sharing query, [raw samples](https://docs.victoriametrics.com/victoriametrics/#vmui) and [trace](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#query-tracing)
+1. If the steps above didn't help identify the root cause of unexpected query results,
+   then [file a bug report](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/new) with details on how to reproduce the issue.
+   Instead of sharing screenshots in the issue, consider sharing the query, [raw samples](https://docs.victoriametrics.com/victoriametrics/#vmui) and [trace](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#query-tracing)
    results via [VMUI](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#vmui).
 
 ## Slow data ingestion
 
-These are the most commons reasons for slow data ingestion in VictoriaMetrics:
+These are the most common reasons for slow data ingestion in VictoriaMetrics:
 
 1. Memory shortage for the given amounts of [active time series](https://docs.victoriametrics.com/victoriametrics/faq/#what-is-an-active-time-series).
 
-   VictoriaMetrics (or `vmstorage` in cluster version of VictoriaMetrics) maintains an in-memory cache `storage/tsid`
+   VictoriaMetrics (or `vmstorage` in the cluster version of VictoriaMetrics) maintains an in-memory cache `storage/tsid`
    for a quick search for internal series IDs for each incoming metric. VictoriaMetrics automatically determines the maximum 
    size for this cache depending on the available memory on the host where VictoriaMetrics (or `vmstorage`) runs. 
-   If the cache size isn't enough for holding all the entries for active time series, then VictoriaMetrics locates the needed data on disk,
-   unpacks it, re-constructs the missing entry and puts it into the cache. This takes additional CPU time and disk read IO.
+   If the cache size isn't enough to hold all the entries for active time series, then VictoriaMetrics locates the required data on disk,
+   unpacks it, reconstructs the missing entry, and adds it to the cache. This takes additional CPU time and disk read I/O.
 
    The [official Grafana dashboards for VictoriaMetrics](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#monitoring)
-   contain `Slow inserts` graph, that shows the cache miss percentage for `storage/tsid` cache during data ingestion. 
-   If `slow inserts` graph shows values greater than 5% for more than 10 minutes,
-   then it is likely the current number of [active time series](https://docs.victoriametrics.com/victoriametrics/faq/#what-is-an-active-time-series)
+   contain a `Slow inserts` graph that shows the cache miss percentage for the `storage/tsid` cache during data ingestion. 
+   If the `slow inserts` graph shows values greater than 5% for more than 10 minutes,
+   then it is likely that the current number of [active time series](https://docs.victoriametrics.com/victoriametrics/faq/#what-is-an-active-time-series)
    cannot fit the `storage/tsid` cache.
 
    These are the solutions that exist for this issue:
 
-   - To increase the available memory on the host where VictoriaMetrics runs until `slow inserts` percentage
-     will become lower than 5%. If you run a VictoriaMetrics cluster, then you need to increase the total available
+   - Increase the available memory on the host where VictoriaMetrics runs until the `slow inserts` percentage
+     drops to 5% or less. If you run a VictoriaMetrics cluster, then you need to increase the total available
      memory at all `vmstorage` nodes. This can be done in two ways: either to increase the available memory
-     per each existing `vmstorage` node or to add more `vmstorage` nodes to the cluster to spread the load.
+     for each `vmstorage` node or to add more `vmstorage` nodes to the cluster to spread the load.
 
-   - To reduce the number of active time series. The [official Grafana dashboards for VictoriaMetrics](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#monitoring)
-     contain a graph showing the number of active time series. Use [cardinality explorer](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#cardinality-explorer),
+   - Reduce the number of active time series. The [official Grafana dashboards for VictoriaMetrics](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#monitoring)
+     contain a graph showing the number of active time series. Use the [cardinality explorer](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#cardinality-explorer)
      to determine and fix the source of [high cardinality](https://docs.victoriametrics.com/victoriametrics/faq/#what-is-high-cardinality).
 
-   - Insert performance can degrade when the same time series arrives with labels in different order.
+   - Insert performance can degrade when the same time series arrives with labels in a different order.
      Ensure your ingestion client always sends labels in a consistent order for each series.
      Prometheus and `vmagent` already guarantee this, but custom or third-party clients might not.
      As a fallback, you can enable `-sortLabels=true` on VictoriaMetrics or on `vminsert` in cluster mode.
@@ -223,20 +223,20 @@ These are the most commons reasons for slow data ingestion in VictoriaMetrics:
    When VictoriaMetrics encounters a sample for a new time series, it needs to register the time series
    in the internal index (aka `indexdb`), so it can be quickly located during select queries.
    The process of registering new time series in the internal index is an order of magnitude slower
-   than the process of adding new sample to already registered time series.
+   than the process of adding a new sample to an already registered time series.
    So VictoriaMetrics may work slower than expected under [high churn rate](https://docs.victoriametrics.com/victoriametrics/faq/#what-is-high-churn-rate).
 
    The [official Grafana dashboards for VictoriaMetrics](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#monitoring)
-   provides `Churn rate` graph, that shows the average number of new time series registered
+   provide a `Churn rate` graph, which shows the average number of new time series registered
    during the last 24 hours. If this number exceeds the number of [active time series](https://docs.victoriametrics.com/victoriametrics/faq/#what-is-an-active-time-series),
    then you need to identify and fix the source of [high churn rate](https://docs.victoriametrics.com/victoriametrics/faq/#what-is-high-churn-rate).
    The most common source of high churn rate is a label that frequently changes its value (like timestamp, session_id). **Try avoiding such labels.**
-   The [cardinality explorer](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#cardinality-explorer) can help identifying
+   The [cardinality explorer](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#cardinality-explorer) can help identify
    such labels.
 
 1. Resource shortage. The [official Grafana dashboards for VictoriaMetrics](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#monitoring)
-   contain `Resource usage` graphs, that show memory usage, CPU usage, disk IO usage, etc.
-   Make sure VictoriaMetrics has enough free resources for graceful handling of potential spikes in workload
+   contain `Resource usage` graphs that show memory usage, CPU usage, disk I/O usage, etc.
+   Make sure VictoriaMetrics has enough free resources for gracefully handling potential spikes in workload
    according to the following recommendations:
 
    - 50% of free CPU
@@ -244,52 +244,51 @@ These are the most commons reasons for slow data ingestion in VictoriaMetrics:
    - 20% of free disk space
 
    If VictoriaMetrics components have lower amounts of free resources, then this may lead
-   to **significant** performance degradation after workload increases slightly.
+   to **significant** performance degradation when workload increases slightly.
    For example:
 
    - If the percentage of free CPU is close to 0, then VictoriaMetrics
-     may experience arbitrary long delays during data ingestion when it cannot keep up
-     with slightly increased ingestion rate.
+     may experience arbitrarily long delays during data ingestion, even with slight increases in ingestion rate.
 
-   - If the percentage of free memory reaches 0, then the Operating System where VictoriaMetrics components run,
-     may not have enough memory for [page cache](https://en.wikipedia.org/wiki/Page_cache).
-     VictoriaMetrics relies on page cache for quick queries over recently ingested data.
-     If the operating system does not have enough free memory for page cache, then it needs
-     to re-read the requested data from disk. This may **significantly** increase disk read IO
+   - If the percentage of free memory reaches 0, then the Operating System where VictoriaMetrics components run
+     may not have enough memory for the [page cache](https://en.wikipedia.org/wiki/Page_cache).
+     VictoriaMetrics relies on the page cache for quick queries over recently ingested data.
+     If the operating system does not have enough free memory for the page cache, then it must
+     re-read the requested data from disk. This may **significantly** increase disk read I/O
      and slow down both queries and data ingestion.
 
-   - If free disk space is lower than 20%, then VictoriaMetrics could be unable to perform optimal
-     background merge of the incoming data. This leads to an increased number of data files on disk.
+   - If free disk space is below 20%, then VictoriaMetrics may be unable to perform optimal
+     background merge of the incoming data. This results in more data files on disk.
      That, in turn, slows down both data ingestion and querying. See [these docs](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#storage) for details.
 
-1. If you run cluster version of VictoriaMetrics, then make sure `vminsert` and `vmstorage` components
-   are located in the same network with small network latency between them.
-   `vminsert` packs incoming data into batch packets and sends them to `vmstorage` one-by-one.
-   It waits until `vmstorage` returns back `ack` response before sending the next packet.
+1. If you run the cluster version of VictoriaMetrics, then make sure `vminsert` and `vmstorage` components
+   are located in the same network with a low network latency between them.
+   `vminsert` packs incoming data into batch packets and sends them to `vmstorage` one by one.
+   It waits until `vmstorage` returns back an `ack` response before sending the next packet.
    If the network latency between `vminsert` and `vmstorage` is high (for example, if they run in different datacenters),
    then this may become a limiting factor for data ingestion speed.
 
-   The [official Grafana dashboard for cluster version of VictoriaMetrics](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/#monitoring)
-   contains `connection saturation` panel for `vminsert` components. If this graph reaches 100% (1s),
+   The [official Grafana dashboard for the cluster version of VictoriaMetrics](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/#monitoring)
+   contains a `connection saturation` panel for `vminsert` components. If this graph reaches 100% (1s),
    then it is likely you have issues with network latency between `vminsert` and `vmstorage`.
    Another possible issue for 100% connection saturation between `vminsert` and `vmstorage`
-   is resource shortage at `vmstorage` nodes. In this case, you need to increase the amount
-   of available resources (CPU, RAM, disk IO) at `vmstorage` nodes or to add more `vmstorage` nodes to the cluster.
+   is a resource shortage in the `vmstorage` nodes. In this case, you need to increase the amount
+   of available resources (CPU, RAM, disk I/O) at `vmstorage` nodes or add more `vmstorage` nodes to the cluster.
 
 1. Noisy neighbor. Make sure VictoriaMetrics components run in an environment without other resource-hungry apps.
-   Such apps may steal RAM, CPU, disk IO, and network bandwidth, which is needed for VictoriaMetrics components.
-   Issues like this are hard to catch via [official Grafana dashboard for cluster version of VictoriaMetrics](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/#monitoring)
+   Such apps may steal RAM, CPU, disk I/O, and network bandwidth that are needed for VictoriaMetrics components.
+   Issues like this are hard to catch via the [official Grafana dashboard for the cluster version of VictoriaMetrics](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/#monitoring)
    and proper diagnosis would require checking resource usage on the instances where VictoriaMetrics runs.
 
-1. If you see `TooHighSlowInsertsRate` [alert](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#monitoring) when single-node VictoriaMetrics or `vmstorage` has enough
-   free CPU and RAM, then increase `-cacheExpireDuration` command-line flag at single-node VictoriaMetrics or at `vmstorage` to the value,
+1. If you see a `TooHighSlowInsertsRate` [alert](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#monitoring) when single-node VictoriaMetrics or `vmstorage` has enough
+   free CPU and RAM, then increase the `-cacheExpireDuration` command-line flag at single-node VictoriaMetrics or at `vmstorage` to a value
    that exceeds the interval between ingested samples for the same time series (aka `scrape_interval`).
    See [this comment](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/3976#issuecomment-1476883183) for more details.
 
-1. If you see constant and abnormally high CPU usage of VictoriaMetrics component, check `CPU spent on GC` panel
-   on the corresponding [Grafana dashboard](https://grafana.com/orgs/victoriametrics) in `Resource usage` section. If the percentage of CPU time spent on garbage collection
-   is high, then CPU usage of the component can be reduced at the cost of higher memory usage by changing [GOGC](https://tip.golang.org/doc/gc-guide#GOGC) environment variable
-   to higher values. By default, VictoriaMetrics components use `GOGC=30`. Try running VictoriaMetrics components with `GOGC=100` and see whether this helps reducing CPU usage.
+1. If you see constant and abnormally high CPU usage for the VictoriaMetrics component, check the `CPU spent on GC` panel
+   on the corresponding [Grafana dashboard](https://grafana.com/orgs/victoriametrics) in the `Resource usage` section. If the percentage of CPU time spent on garbage collection
+   is high, then CPU usage of the component can be reduced at the cost of higher memory usage by increasing the [GOGC](https://tip.golang.org/doc/gc-guide#GOGC) environment variable.
+   By default, VictoriaMetrics components use `GOGC=30`. Try running VictoriaMetrics components with `GOGC=100` and see whether this helps reduce CPU usage.
    Note that higher `GOGC` values may increase memory usage.
 
 ## Slow queries
@@ -298,21 +297,21 @@ Some queries may take more time and resources (CPU, RAM, network bandwidth) than
 VictoriaMetrics logs slow queries if their execution time exceeds the duration passed
 to `-search.logSlowQueryDuration` command-line flag (5s by default).
 
-VictoriaMetrics provides [`top queries` page at VMUI](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#top-queries), that shows
-queries that took the most time to execute. And [Query execution stats](https://docs.victoriametrics.com/victoriametrics/query-stats/) for dumping slow queries
+VictoriaMetrics provides a [`top queries` page in VMUI](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#top-queries) that shows
+the longest-running queries. And [Query execution stats](https://docs.victoriametrics.com/victoriametrics/query-stats/) for dumping slow queries
 to logs.
 
 These are the solutions that exist for improving the performance of slow queries:
 
 - Investigating the bottleneck in query execution using [query tracing](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#query-tracing).
-  It will show the percentage of time spent on each execution step and helps understanding the volume of processed data.
+  It will show the percentage of time spent on each execution step and help understand the volume of processed data.
 
 - Adding more CPU and memory to VictoriaMetrics, so it may perform the slow query faster.
-  If you use cluster version of VictoriaMetrics, then migrating `vmselect` nodes to machines
-  with more CPU and RAM should help improving speed for slow queries. Query performance
-  is always limited by resources of **one** `vmselect` that processes the query. For example, if 2vCPU cores on `vmselect`
-  isn't enough to process query fast enough, then migrating `vmselect` to a machine with 4vCPU cores should increase heavy query performance by up to 2x.
-  If the line on `concurrent select` graph form the [official Grafana dashboard for VictoriaMetrics](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/#monitoring)
+  If you use the cluster version of VictoriaMetrics, then migrating `vmselect` nodes to machines
+  with more CPU and RAM should help improve speed for slow queries. Query performance
+  is always limited by the resources of **one** `vmselect` that processes the query. For example, if 2 vCPU cores on `vmselect`
+  can't process queries fast enough, then migrating `vmselect` to a machine with 4 vCPU cores should increase heavy query performance by up to 2x.
+  If the line on the `concurrent select` graph from the [official Grafana dashboard for VictoriaMetrics](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/#monitoring)
   is close to the limit, then prefer adding more `vmselect` nodes to the cluster.
   Sometimes adding more `vmstorage` nodes can also help improve the speed for slow queries.
 
@@ -323,18 +322,18 @@ These are the solutions that exist for improving the performance of slow queries
 
   For example, `avg_over_time(up[30d]) > 0.99` needs to read and process
   all the [raw samples](https://docs.victoriametrics.com/victoriametrics/keyconcepts/#raw-samples)
-  for `up` [time series](https://docs.victoriametrics.com/victoriametrics/keyconcepts/#time-series) over the last 30 days
-  each time it executes. If this query is executed frequently, then it can take significant share of CPU, disk read IO, network bandwidth and RAM.
+  for the `up` [time series](https://docs.victoriametrics.com/victoriametrics/keyconcepts/#time-series) over the last 30 days
+  each time it executes. If this query is executed frequently, it can take a significant share of CPU, disk read I/O, network bandwidth, and RAM.
   Such queries can be optimized in the following ways:
 
-  - To reduce the lookbehind window in square brackets. For example, `avg_over_time(up[10d])` takes up to 3x less compute resources
+  - To reduce the look-behind window in square brackets. For example, `avg_over_time(up[10d])` takes up to 3x less compute resources
     than `avg_over_time(up[30d])` at VictoriaMetrics.
   - To increase the evaluation interval for alerting and recording rules, so they are executed less frequently.
-    For example, increasing `-evaluationInterval` command-line flag value at [vmalert](https://docs.victoriametrics.com/victoriametrics/vmalert/)
-    from `1m` to `2m` should reduce compute resource usage at VictoriaMetrics by 2x.
+    For example, increasing the `-evaluationInterval` command-line flag value at [vmalert](https://docs.victoriametrics.com/victoriametrics/vmalert/)
+    from `1m` to `2m` should reduce compute resource usage by VictoriaMetrics 2x.
 
   Another source of slow queries is improper use of [subqueries](https://docs.victoriametrics.com/victoriametrics/metricsql/#subqueries).
-  It is recommended avoiding subqueries if you don't understand clearly how they work.
+  It is recommended to avoid subqueries if you don't clearly understand how they work.
   It is easy to create a subquery without knowing about it.
   For example, `rate(sum(some_metric))` is implicitly transformed into the following subquery
   according to [implicit conversion rules for MetricsQL queries](https://docs.victoriametrics.com/victoriametrics/metricsql/#implicit-query-conversions):
@@ -351,63 +350,63 @@ These are the solutions that exist for improving the performance of slow queries
   See [this article](https://www.robustperception.io/rate-then-sum-never-sum-then-rate/) for more details.
 
   See also [this article](https://valyala.medium.com/how-to-optimize-promql-and-metricsql-queries-85a1b75bf986),
-  that explains how to determine and optimize slow queries.
+  which explains how to identify and optimize slow queries.
 
 ## Out of memory errors
 
-There are the following most common sources of out of memory (aka OOM) crashes in VictoriaMetrics:
+The following are the most common sources of out-of-memory (aka OOM) crashes in VictoriaMetrics:
 
 1. Improper command-line flag values. Inspect command-line flags passed to VictoriaMetrics components.
-   If you don't understand clearly the purpose or the effect of some flags - remove them
-   from the list of flags passed to VictoriaMetrics components. Improper command-line flags values
+   If you don't clearly understand the purpose or the effect of some flags, remove them
+   from the list of flags passed to VictoriaMetrics components. Improper command-line flag values
    may lead to increased memory and CPU usage. Increased memory usage increases the risk of OOM crashes.
-   VictoriaMetrics is optimized for running with default flag values (e.g. when they aren't set explicitly).
+   VictoriaMetrics is optimized to run with default flag values (e.g., when they aren't explicitly set).
 
-   For example, it isn't recommended changing cache sizes in VictoriaMetrics, since it frequently leads to OOM exceptions.
-   [These docs](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#cache-tuning) refer command-line flags, that aren't
-   recommended to tune. If you see that VictoriaMetrics needs increasing some cache sizes for the current workload,
-   then it is better migrating to a host with more memory instead of trying to tune cache sizes manually.
+   For example, it isn't recommended to change cache sizes in VictoriaMetrics, as this frequently leads to OOM exceptions.
+   [These docs](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#cache-tuning) refer to command-line flags that aren't
+   recommended to tune. If you see that VictoriaMetrics needs to increase some cache sizes for the current workload,
+   then it is better to migrate to a host with more memory instead of trying to tune cache sizes manually.
 
-1. Unexpected heavy queries. The query is considered as heavy if it needs to select and process millions of unique time series.
-   Such a query may lead to an OOM exception, since VictoriaMetrics needs to keep some of the per-series data in memory.
-   VictoriaMetrics provides [various settings](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#resource-usage-limits),
+1. Unexpected heavy queries. The query is considered heavy if it needs to select and process millions of unique time series.
+   Such a query may cause an OOM exception, as VictoriaMetrics needs to keep some per-series data in memory.
+   VictoriaMetrics provides [various settings](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#resource-usage-limits)
    that can help limit resource usage.
    For more context, see [How to optimize PromQL and MetricsQL queries](https://valyala.medium.com/how-to-optimize-promql-and-metricsql-queries-85a1b75bf986).
    VictoriaMetrics also provides [query tracer](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#query-tracing)
    to help identify the source of heavy queries. Slow queries can be logged with additional details via [Query execution stats](https://docs.victoriametrics.com/victoriametrics/query-stats/). 
 
 1. Lack of free memory for processing workload spikes. If VictoriaMetrics components use almost all the available memory
-   under the current workload, then it is recommended migrating to a host with larger amounts of memory.
+   under the current workload, then it is recommended to migrate to a host with larger amounts of memory.
    This would protect from possible OOM crashes on workload spikes. It is recommended to have at least 50%
-   of free memory for graceful handling of possible workload spikes.
+   of free memory to gracefully handle possible workload spikes.
    See [capacity planning for single-node VictoriaMetrics](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#capacity-planning)
-   and [capacity planning for cluster version of VictoriaMetrics](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/#capacity-planning).
+   and [capacity planning for the cluster version of VictoriaMetrics](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/#capacity-planning).
 
 ## Cluster instability
 
-VictoriaMetrics cluster may become unstable if there are not enough free resources (CPU, RAM, disk IO, network bandwidth)
+The VictoriaMetrics cluster may become unstable if there are not enough free resources (CPU, RAM, disk I/O, network bandwidth)
 for processing the current workload.
 
 The most common sources of cluster instability are:
 
 - Workload spikes. For example, if the number of active time series increases by 2x while
-  the cluster has no enough free resources for processing the increased workload, then it may become unstable.
-  VictoriaMetrics provides various configuration settings that can be used for limiting unexpected workload spikes.
+  the cluster does not have enough free resources for processing the increased workload, then it may become unstable.
+  VictoriaMetrics provides several configuration settings to limit unexpected workload spikes.
   See [these docs](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/#resource-usage-limits) for details.
 
-- Various maintenance tasks such as rolling upgrades or rolling restarts during configuration changes.
+- Various maintenance tasks, such as rolling upgrades or rolling restarts, during configuration changes.
   For example, if a cluster contains `N=3` `vmstorage` nodes and they are restarted one-by-one (aka rolling restart),
   then the cluster will have only `N-1=2` healthy `vmstorage` nodes during the rolling restart.
   This means that the load on healthy `vmstorage` nodes increases by at least `100%/(N-1)=50%`
-  comparing to the load before rolling restart. E.g. they need to process 50% more incoming
+  compared to the load before rolling restart. E.g., they need to process 50% more incoming
   data and to return 50% more data during queries. In reality, the load on the remaining `vmstorage`
-  nodes increases even more because they need to register new time series, that were re-routed
-  from temporarily unavailable `vmstorage` node. If `vmstorage` nodes had less than 50%
-  of free resources (CPU, RAM, disk IO) before the rolling restart, then it
+  nodes increases even more because they need to register new time series that were re-routed
+  from a temporarily unavailable `vmstorage` node. If `vmstorage` nodes had less than 50%
+  of free resources (CPU, RAM, disk I/O) before the rolling restart, then it
   can lead to cluster overload and instability for both data ingestion and querying.
 
   The workload increase during rolling restart can be reduced by increasing
-  the number of `vmstorage` nodes in the cluster. For example, if VictoriaMetrics cluster contains
+  the number of `vmstorage` nodes in the cluster. For example, if the VictoriaMetrics cluster contains
   `N=11` `vmstorage` nodes, then the workload increase during rolling restart of `vmstorage` nodes
   would be `100%/(N-1)=10%`. It is recommended to have at least 8 `vmstorage` nodes in the cluster.
   The recommended number of `vmstorage` nodes should be multiplied by `-replicationFactor` if replication is enabled -
@@ -415,11 +414,11 @@ The most common sources of cluster instability are:
   for details.
 
 - Time series sharding. Received time series [are consistently sharded](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/#architecture-overview)
-  by `vminsert` between configured `vmstorage` nodes. As a sharding key `vminsert` is using time series name and labels,
+  by `vminsert` between configured `vmstorage` nodes. As a sharding key, `vminsert` is using time series name and labels,
   respecting their order. If the order of labels in a time series is constantly changing, this could cause wrong sharding
   calculation and result in uneven and suboptimal time series distribution across available vmstorages. It is expected
-  that the client who is pushing metrics is responsible for consistent labels order (like `Prometheus` or `vmagent` during scraping).
-  If this can't be guaranteed, set `-sortLabels=true` command-line flag to `vminsert`. Please note, sorting may increase
+  that the client who is pushing metrics is responsible for consistent label order (like `Prometheus` or `vmagent` during scraping).
+  If this can't be guaranteed, set `-sortLabels=true` command-line flag to `vminsert`. Please note that sorting may increase
   CPU usage for `vminsert`.
 
 - Network instability between cluster components (`vminsert`, `vmselect`, `vmstorage`) may lead to increased error rates, timeouts, or degraded performance.
@@ -429,14 +428,14 @@ The most common sources of cluster instability are:
   but can still cause transient network failures. In such cases, check CPU usage at the OS level with higher-resolution tools.
   Consider increasing `-vmstorageDialTimeout` and `-rpc.handshakeTimeout`{{% available_from "v1.124.0" %}} to mitigate the effects of CPU spikes.
 
-  If resource usage looks normal but networking issues still occur, then the root cause is likely outside VictoriaMetrics.
+  If resource usage appears normal but networking issues persist, the root cause is likely outside VictoriaMetrics.
   This may be caused by unreliable or congested network links, especially across availability zones or regions.
   In multi-AZ setups, consider [a multi-level cluster](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/#multi-level-cluster-setup) with region-local load balancers to reduce cross-zone connections.
   If the network cannot be improved, increasing timeouts such as `-vmstorageDialTimeout`, `-rpc.handshakeTimeout`{{% available_from "v1.124.0" %}}, or `-search.maxQueueDuration` may help, but should be done cautiously, as higher timeouts can impact cluster stability in other ways.
   Keep in mind that VictoriaMetrics assumes reliable networking between components. If the network is unstable, the overall cluster stability may degrade regardless of resource availability.
 
-The obvious solution against VictoriaMetrics cluster instability is to make sure cluster components
-have enough free resources for graceful processing of the increased workload.
+The obvious solution to VictoriaMetrics cluster instability is to make sure cluster components
+have sufficient free resources to handle the increased workload gracefully.
 See [capacity planning docs](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/#capacity-planning)
 and [cluster resizing and scalability docs](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/#cluster-resizing-and-scalability)
 for details.
@@ -449,7 +448,7 @@ at [VictoriaMetrics cluster](https://docs.victoriametrics.com/victoriametrics/cl
 - Make sure that there are no old snapshots, since they can occupy disk space. See [how to work with snapshots](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#how-to-work-with-snapshots),
   [snapshot troubleshooting](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#snapshot-troubleshooting) and [vmbackup troubleshooting](https://docs.victoriametrics.com/victoriametrics/vmbackup/#troubleshooting).
 
-- Under normal conditions the size of `<-storageDataPath>/indexdb` folder must be smaller than the size of `<-storageDataPath>/data` folder, where `-storageDataPath`
+- Under normal conditions, the size of `<-storageDataPath>/indexdb` folder must be smaller than the size of `<-storageDataPath>/data` folder, where `-storageDataPath`
   is the corresponding command-line flag value. This can be checked by the following query if [VictoriaMetrics monitoring](#monitoring) is properly set up:
 
   ```metricsql
@@ -458,22 +457,22 @@ at [VictoriaMetrics cluster](https://docs.victoriametrics.com/victoriametrics/cl
   sum(vm_data_size_bytes{type=~"(storage|indexdb)/.+"}) without(type)
   ```
 
-  If this query returns values bigger than 0.5, then it is likely there is a [high churn rate](https://docs.victoriametrics.com/victoriametrics/faq/#what-is-high-churn-rate) issue,
-  that results in excess disk space usage for both `indexdb` and `data` folders under `-storageDataPath` folder.
-  The solution is to identify and fix the source of high churn rate with [cardinality explorer](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#cardinality-explorer).
+  If this query returns values greater than 0.5, then it is likely there is a [high churn rate](https://docs.victoriametrics.com/victoriametrics/faq/#what-is-high-churn-rate) issue,
+  that results in excess disk space usage for both the `indexdb` and `data` folders under the `-storageDataPath` folder.
+  The solution is to identify and fix the source of the high churn rate with the [cardinality explorer](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#cardinality-explorer).
 
 ## Monitoring
 
 Having proper [monitoring](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#monitoring)
-would help identify and prevent most of the issues listed above.
+can help identify and prevent most of the issues listed above.
 
 [Grafana dashboards](https://grafana.com/orgs/victoriametrics/dashboards) contain panels reflecting the
 health state, resource usage, and other specific metrics for VictoriaMetrics components.
 
-The list of [recommended alerting rules](https://github.com/VictoriaMetrics/VictoriaMetrics/tree/master/deployment/docker#alerts)
-for VictoriaMetrics components will notify about issues and provide recommendations for how to solve them.
+Check the list of [recommended alerting rules](https://github.com/VictoriaMetrics/VictoriaMetrics/tree/master/deployment/docker#alerts)
+for VictoriaMetrics components to receive notifications about issues and receive recommendations for resolving them.
 
-Internally, we heavily rely both on dashboards and alerts, and constantly improve them.
+Internally, we rely heavily on both dashboards and alerts, and we constantly improve them.
 It is important to stay up to date with such changes.
 
 
@@ -487,7 +486,7 @@ Symptoms:
 - Corrupted or inconsistent query results.
 - Crashes or panics in storage/query components when reading from ZFS.
 
-It could be mitigated with `--fs.disableMincore` flag:
+It could be mitigated with the `--fs.disableMincore` flag:
 
 ```text
 ./bin/victoria-metrics --storageDataPath /path/to/zfs/data --fs.disableMincore


### PR DESCRIPTION
* remove ToC in the beginning, as it duplicates right-bar functionality and is easier to make a mistake with. For example, it didn't have the ZFS section in it
* simplify wording where it was possible
* reference new tools VM got in recent releases
* re-prioritize tips order based on personal experience
