### PR TITLE
vmalert: add vmalert_alerts_resolved_total counter metric

### DIFF
--- a/app/vmalert/rule/alerting.go
+++ b/app/vmalert/rule/alerting.go
@@ -567,6 +567,7 @@ func (ar *AlertingRule) exec(ctx context.Context, ts time.Time, limit int) ([]pr
 				if ts.Sub(a.KeepFiringSince) >= ar.KeepFiringFor {
 					a.State = notifier.StateInactive
 					a.ResolvedAt = ts
+					alertsResolved.Inc()
 					// add stale time series
 					tss = append(tss, firingAlertStaleTimeSeries(a.Labels, ts.Unix())...)
 

--- a/app/vmalert/rule/group.go
+++ b/app/vmalert/rule/group.go
@@ -733,7 +733,8 @@ func (e *executor) execConcurrently(ctx context.Context, rules []Rule, ts time.T
 }
 
 var (
-	alertsFired = metrics.NewCounter(`vmalert_alerts_fired_total`)
+	alertsFired    = metrics.NewCounter(`vmalert_alerts_fired_total`)
+	alertsResolved = metrics.NewCounter(`vmalert_alerts_resolved_total`)
 
 	execTotal  = metrics.NewCounter(`vmalert_execution_total`)
 	execErrors = metrics.NewCounter(`vmalert_execution_errors_total`)


### PR DESCRIPTION
Fixes: #10408
### Describe Your Changes

As described in the issue, `vmalert_alerts_resolved_total` metrics allows to see if alert was marked as resolved by vmalert(which means it will send it to notifier) which makes debugging between notifier and vmalert easier.

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
