### PR TITLE
.github: run apptests on separate pool of runners called apptest

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,7 +86,7 @@ jobs:
       - run: go version
 
       - name: Run tests
-        run: GOGC=10 make ${{ matrix.scenario}}
+        run: make ${{ matrix.scenario}}
 
       - name: Publish coverage
         uses: codecov/codecov-action@v5
@@ -95,7 +95,7 @@ jobs:
 
   apptest:
     name: apptest
-    runs-on: ubuntu-latest
+    runs-on: apptest
 
     steps:
       - name: Code checkout


### PR DESCRIPTION
### Describe Your Changes

It should prvent apptest timeouts due to runners resource saturation. When apptests were run with unit tests and linters they do not have enough CPU to complete in time and often timed out.

If one re-runs the apptests shortly after they are likely to pass because the same runner has enough resources available (other job finished).

Remove GOGC=10 as the runner has enough memory (16Gb)  to run apptests.

I did some tests and obeserve drop in overal test duration from 4.5m to
3.30-3m.

Test results https://github.com/VictoriaMetrics/VictoriaMetrics/actions/runs/22305105110

### Checklist

The following checks are **mandatory**:

- [ ] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [ ] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
