### PR TITLE
lib/timerpool: remove misleading panic

### DIFF
--- a/lib/timerpool/timerpool.go
+++ b/lib/timerpool/timerpool.go
@@ -3,8 +3,6 @@ package timerpool
 import (
 	"sync"
 	"time"
-
-	"github.com/VictoriaMetrics/VictoriaMetrics/lib/logger"
 )
 
 // Get returns a timer for the given duration d from the pool.
@@ -13,9 +11,9 @@ import (
 func Get(d time.Duration) *time.Timer {
 	if v := timerPool.Get(); v != nil {
 		t := v.(*time.Timer)
-		if t.Reset(d) {
-			logger.Panicf("BUG: active timer trapped to the pool!")
-		}
+		// any receive from t.C after Reset has returned is guaranteed not
+		// to receive a time value corresponding to the previous timer settings
+		t.Reset(d)
 		return t
 	}
 	return time.NewTimer(d)


### PR DESCRIPTION
After golang 1.23 it's safe to ignore timer.Reset True value.

According to the spec:

 For a chan-based timer created with NewTimer, as of Go 1.23,
 any receive from t.C after Reset has returned is guaranteed not
 to receive a time value corresponding to the previous timer
settings;

 If the program has not received from t.C already and the timer is
 running, Reset is guaranteed to return true.
 Before Go 1.23, the only safe way to use Reset was to call [Timer.Stop]
and explicitly drain the timer first.

 Golang 1.23 changed timer implementation from sync and async. And it
made possible that chan send and timer.Stop could happen in the same time.

Fixes https://github.com/VictoriaMetrics/VictoriaMetrics/issues/9721

### Describe Your Changes

Please provide a brief description of the changes you made. Be as specific as possible to help others understand the purpose and impact of your modifications.

### Checklist

The following checks are **mandatory**:

- [ ] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [ ] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
