### PR TITLE
app/vmauth: log sub\iss claims as username when needed

### DIFF
--- a/app/vmauth/auth_config.go
+++ b/app/vmauth/auth_config.go
@@ -1116,24 +1116,6 @@ func (ui *UserInfo) initURLs() error {
 	return nil
 }
 
-func (ui *UserInfo) name() string {
-	if ui.Name != "" {
-		return ui.Name
-	}
-	if ui.Username != "" {
-		return ui.Username
-	}
-	if ui.BearerToken != "" {
-		h := xxhash.Sum64([]byte(ui.BearerToken))
-		return fmt.Sprintf("bearer_token:hash:%016X", h)
-	}
-	if ui.AuthToken != "" {
-		h := xxhash.Sum64([]byte(ui.AuthToken))
-		return fmt.Sprintf("auth_token:hash:%016X", h)
-	}
-	return ""
-}
-
 func getAuthTokens(authToken, bearerToken, username, password string) ([]string, error) {
 	if authToken != "" {
 		if bearerToken != "" {

--- a/app/vmauth/main.go
+++ b/app/vmauth/main.go
@@ -188,7 +188,7 @@ func requestHandler(w http.ResponseWriter, r *http.Request) bool {
 	}
 	if ui, tkn := getUserInfoByJWTToken(ats); ui != nil {
 		if tkn == nil {
-			logger.Panicf("BUG: unexpected nil jwt token for user %q", ui.name())
+			logger.Panicf("BUG: unexpected nil jwt token for user %q", userName(ui, nil))
 		}
 
 		processUserRequest(w, r, ui, tkn)
@@ -253,7 +253,7 @@ func processUserRequest(w http.ResponseWriter, r *http.Request, ui *UserInfo, tk
 	}
 
 	// Read the initial chunk for the request body.
-	userName := ui.name()
+	userName := userName(ui, tkn)
 	if userName == "" {
 		userName = "unauthorized"
 	}
@@ -412,7 +412,7 @@ func processRequest(w http.ResponseWriter, r *http.Request, ui *UserInfo, tkn *j
 		ui.backendErrors.Inc()
 	}
 	err := &httpserver.ErrorWithStatusCode{
-		Err:        fmt.Errorf("all the %d backends for the user %q are unavailable for proxying the request - check previous WARN logs to see the exact error for each failed backend", up.getBackendsCount(), ui.name()),
+		Err:        fmt.Errorf("all the %d backends for the user %q are unavailable for proxying the request - check previous WARN logs to see the exact error for each failed backend", up.getBackendsCount(), userName(ui, tkn)),
 		StatusCode: http.StatusBadGateway,
 	}
 	httpserver.Errorf(w, r, "%s", err)

--- a/lib/jwt/jwt.go
+++ b/lib/jwt/jwt.go
@@ -236,6 +236,8 @@ func parseJWTBody(data string) (*body, error) {
 		// issued at time unix_ts
 		Iat   int64           `json:"iat"`
 		Jti   string          `json:"jti,omitempty"`
+		Sub   string          `json:"sub,omitempty"`
+		Iss   string          `json:"iss,omitempty"`
 		Scope json.RawMessage `json:"scope,omitempty"`
 		// store as raw message to support different types
 		VMAccess *json.RawMessage `json:"vm_access"`
@@ -284,6 +286,8 @@ func parseJWTBody(data string) (*body, error) {
 		Exp:      tb.Exp,
 		Iat:      tb.Iat,
 		Jti:      tb.Jti,
+		Sub:      tb.Sub,
+		Iss:      tb.Iss,
 		Scope:    scope,
 		VMAccess: &a,
 	}

--- a/lib/jwt/jwt.go
+++ b/lib/jwt/jwt.go
@@ -50,6 +50,8 @@ type body struct {
 	Iat      int64          `json:"iat"`
 	Jti      string         `json:"jti,omitempty"`
 	Scope    string         `json:"scope,omitempty"`
+	Sub      string         `json:"sub,omitempty"`
+	Iss      string         `json:"iss,omitempty"`
 	VMAccess *VMAccessClaim `json:"vm_access"`
 }
 
@@ -205,6 +207,14 @@ func (t *Token) ExtraFilters() []string {
 
 func (t *Token) VMAccess() *VMAccessClaim {
 	return t.body.VMAccess
+}
+
+func (t *Token) Subject() string {
+	return t.body.Sub
+}
+
+func (t *Token) Issuer() string {
+	return t.body.Iss
 }
 
 func parseJWTHeader(data string) (*header, error) {


### PR DESCRIPTION
### Describe Your Changes

Currently, when vmauth logs messages and calls `ui.name()` to include
user context, it returns an empty string for the JWT authentication
method. As a result, logs lack any user-identifying information, which
makes debugging and incident analysis harder.

This PR improves the logging behavior for JWT-based auth:
- Use the `sub` claim as the primary user identifier.
- Fall back to the `iss` claim if sub is not present.
- If neither claim is available, explicitly indicate that the
authentication method is JWT.

This ensures logs always contain meaningful context about the
authenticated entity and avoids silent empty user fields.

Related to https://github.com/VictoriaMetrics/VictoriaMetrics/issues/9439, https://github.com/VictoriaMetrics/VictoriaMetrics/issues/10445

<img width="1512" height="303" alt="Screenshot 2026-02-25 at 16 03 12" src="https://github.com/user-attachments/assets/e17beeb2-b2ad-4503-bdc3-3234fec5efa9" />

### Checklist

The following checks are **mandatory**:

- [ ] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [ ] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
