### PR TITLE
app/vmauth: userinfo returns `jwt` as name

### DIFF
--- a/app/vmauth/auth_config.go
+++ b/app/vmauth/auth_config.go
@@ -1130,6 +1130,9 @@ func (ui *UserInfo) name() string {
 		h := xxhash.Sum64([]byte(ui.AuthToken))
 		return fmt.Sprintf("auth_token:hash:%016X", h)
 	}
+	if ui.JWT != nil {
+		return `jwt`
+	}
 	return ""
 }
 


### PR DESCRIPTION
### Describe Your Changes

Previously it would return empty string if jwt auth method is configured. The empty string complicates reading logs.

### Checklist

The following checks are **mandatory**:

- [ ] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [ ] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
