### PR TITLE
lib/storage: remove 1 cpu special case from storage tests

### DIFF
--- a/lib/storage/storage_test.go
+++ b/lib/storage/storage_test.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
-	"runtime"
 	"slices"
 	"sort"
 	"strings"
@@ -3536,15 +3535,8 @@ func testStorageVariousDataPatterns(t *testing.T, disablePerDayIndex, registerOn
 			sameBatchDates:       sameBatchDates,
 			sameRowDates:         sameRowDates,
 		})
-		// The TestStorageAddRowsForVariousDataPatternsConcurrently/perDayIndexes/serial/sameBatchMetrics/sameRowMetrics/sameBatchDates/diffRowDates
-		// test fails once the indexDB is rotated. This happens reliably when the number
-		// of CPUs is 1. See: https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8654.
-		//
-		// With the higher number of CPUs this failure is very rare.
-		// Temporarily relax the strict equality requirement for got and want
-		// data until this fixed. It is known why the test is failing but the
-		// fix may be non-trivial, See: https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8948
-		strict := concurrency == 1 && runtime.NumCPU() > 1
+
+		strict := concurrency == 1
 		rowsAddedTotal := wantCounts.metrics.RowsAddedTotal
 
 		s := MustOpenStorage(t.Name(), OpenOptions{
@@ -3555,9 +3547,6 @@ func testStorageVariousDataPatterns(t *testing.T, disablePerDayIndex, registerOn
 		s.DebugFlush()
 		assertCounts(t, s, wantCounts, strict)
 
-		// TODO(rtm0): Add a case when a metricID is present in TSID cache but
-		// not in partition idb.
-
 		// Empty the tsidCache to test the case when tsid is retrieved from the
 		// index.
 		s.resetAndSaveTSIDCache()
@@ -3565,9 +3554,6 @@ func testStorageVariousDataPatterns(t *testing.T, disablePerDayIndex, registerOn
 		s.DebugFlush()
 		wantCounts.metrics.RowsAddedTotal += rowsAddedTotal
 		assertCounts(t, s, wantCounts, strict)
-
-		// TODO(rtm0): Add a case when a metricID is present in legacy IDB but
-		// not in partition idb.
 
 		s.MustClose()
 	}


### PR DESCRIPTION
The test should not fail now on systems with 1 cpu because partition indexDBs are not rotated. See #8948.

Also removed two TODOs from the test to keep it simple.