### PR TITLE
vmrestore: add -doNothingOnNoBackup option

### DIFF
--- a/app/vmrestore/main.go
+++ b/app/vmrestore/main.go
@@ -30,6 +30,7 @@ var (
 	concurrency             = flag.Int("concurrency", 10, "The number of concurrent workers. Higher concurrency may reduce restore duration")
 	maxBytesPerSecond       = flagutil.NewBytes("maxBytesPerSecond", 0, "The maximum download speed. There is no limit if it is set to 0")
 	skipBackupCompleteCheck = flag.Bool("skipBackupCompleteCheck", false, "Whether to skip checking for 'backup complete' file in -src. This may be useful for restoring from old backups, which were created without 'backup complete' file")
+	doNothingOnNoBackup     = flag.Bool("doNothingOnNoBackup", false, "Whether to do nothing (rather than fail) when no backup is present in -src")
 )
 
 func main() {
@@ -63,6 +64,7 @@ func main() {
 		Src:                     srcFS,
 		Dst:                     dstFS,
 		SkipBackupCompleteCheck: *skipBackupCompleteCheck,
+		DoNothingOnNoBackup:     *doNothingOnNoBackup,
 	}
 	pushmetrics.Init()
 	if err := a.Run(ctx); err != nil {

--- a/docs/victoriametrics/vmrestore.md
+++ b/docs/victoriametrics/vmrestore.md
@@ -69,6 +69,8 @@ Run `vmrestore -help` in order to see all the available options:
      Custom S3 endpoint for use with S3-compatible storages (e.g. MinIO). S3 is used if not set
   -deleteAllObjectVersions
      Whether to prune previous object versions when deleting an object. By default, when object storage has versioning enabled deleting the file removes only current version. This option forces removal of all previous versions. See: https://docs.victoriametrics.com/victoriametrics/vmbackup/#permanent-deletion-of-objects-in-s3-compatible-storages
+  -doNothingOnNoBackup
+     Whether to do nothing (rather than fail) when no backup is present in -src
   -enableTCP6
      Whether to enable IPv6 for listening and dialing. By default, only IPv4 TCP and UDP are used
   -envflag.enable

--- a/lib/backup/actions/restore.go
+++ b/lib/backup/actions/restore.go
@@ -40,6 +40,10 @@ type Restore struct {
 	//
 	// This may be needed for restoring from old backups with missing `backup complete` file.
 	SkipBackupCompleteCheck bool
+
+	// DoNothingOnNoBackup may be set in order to do nothing (rather than failing) when there
+	// is no `backup complete` file and no parts in Src.
+	DoNothingOnNoBackup bool
 }
 
 // Run runs r with the provided settings.
@@ -58,14 +62,9 @@ func (r *Restore) Run(ctx context.Context) error {
 	src := r.Src
 	dst := r.Dst
 
-	if !r.SkipBackupCompleteCheck {
-		ok, err := src.HasFile(backupnames.BackupCompleteFilename)
-		if err != nil {
+	if !r.SkipBackupCompleteCheck && !r.DoNothingOnNoBackup {
+		if err := checkBackupComplete(src); err != nil {
 			return err
-		}
-		if !ok {
-			return fmt.Errorf("cannot find %s file in %s; this means either incomplete backup or old backup; "+
-				"pass -skipBackupCompleteCheck command-line flag if you still need restoring from this backup", backupnames.BackupCompleteFilename, src)
 		}
 	}
 
@@ -75,6 +74,16 @@ func (r *Restore) Run(ctx context.Context) error {
 	srcParts, err := src.ListParts()
 	if err != nil {
 		return fmt.Errorf("cannot list src parts: %w", err)
+	}
+	if r.DoNothingOnNoBackup {
+		if len(srcParts) == 0 {
+			logger.Infof("no backup present at %s, assuming first start", src)
+			removeRestoreLock(r.Dst.Dir)
+			return nil
+		}
+		if err := checkBackupComplete(src); err != nil {
+			return err
+		}
 	}
 	logger.Infof("obtaining list of parts at %s", dst)
 	dstParts, err := dst.ListParts()
@@ -236,4 +245,16 @@ func createRestoreLock(dstDir string) error {
 func removeRestoreLock(dstDir string) {
 	lockF := path.Join(dstDir, backupnames.RestoreInProgressFilename)
 	fs.MustRemovePath(lockF)
+}
+
+func checkBackupComplete(src common.RemoteFS) error {
+	ok, err := src.HasFile(backupnames.BackupCompleteFilename)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return fmt.Errorf("cannot find %s file in %s; this means either incomplete backup or old backup; "+
+			"pass -skipBackupCompleteCheck command-line flag if you still need restoring from this backup", backupnames.BackupCompleteFilename, src)
+	}
+	return nil
 }


### PR DESCRIPTION
Currently, when attempting to restore from an empty remote source, vmrestore fails because the `backup_complete.ignore` file is missing. Disabling the check for this file is usually undesirable, but sometimes it is useful to be able to run vmrestore on every VM container startup without having to initalize the empty remote source with a `backup_complete.ignore` file. This PR adds an option to do this.

### Checklist

The following checks are **mandatory**:

- [X] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [X] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
