### PR TITLE
lib/encoding: fix integer overflow in UnmarshalBytes

### DIFF
--- a/lib/encoding/int.go
+++ b/lib/encoding/int.go
@@ -517,7 +517,7 @@ func UnmarshalBytes(src []byte) ([]byte, int) {
 	if nSize <= 0 {
 		return nil, 0
 	}
-	if uint64(nSize)+n > uint64(len(src)) {
+	if n > uint64(len(src)-nSize) {
 		return nil, 0
 	}
 	start := nSize

--- a/lib/encoding/int_test.go
+++ b/lib/encoding/int_test.go
@@ -295,6 +295,14 @@ func testMarshalUnmarshalVarUint64(t *testing.T, u uint64) {
 	}
 }
 
+func TestUnmarshalBytesOverflow(t *testing.T) {
+	poisonVarint := []byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x01}
+	result, nSize := UnmarshalBytes(poisonVarint)
+	if nSize > 0 || result != nil {
+		t.Fatalf("expected error from overflow input, got nSize=%d result=%x", nSize, result)
+	}
+}
+
 func TestMarshalUnmarshalBytes(t *testing.T) {
 	testMarshalUnmarshalBytes(t, "")
 	testMarshalUnmarshalBytes(t, "x")


### PR DESCRIPTION
### Describe Your Changes

Poison varint: MaxUint64 encoded as varint (0xFFFFFFFFFFFFFFFF). 
The bounds check uint64(nSize)+n overflows to 9, bypassing the guard. 
Then int(MaxUint64)=-1 makes src[10:9] which panics.

### Checklist

The following checks are **mandatory**:

- [ ] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [ ] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
