### PR TITLE
docs: add unique identifier to FAQ page

### DIFF
--- a/docs/victoriametrics/FAQ.md
+++ b/docs/victoriametrics/FAQ.md
@@ -5,6 +5,7 @@ menu:
   docs:
     parent: 'victoriametrics'
     weight: 24
+    identifier: vm-faq
 tags:
   - metrics
 aliases:


### PR DESCRIPTION
Due to a conflict with VL FAQ page identifier,
VM FAQ page stopped rendering.

This change adds unique identifier to VM FAQ page and fixes the issue.
