### PR TITLE
datasource: add SQL datasource support

### DIFF
--- a/app/vmalert/config/config_test.go
+++ b/app/vmalert/config/config_test.go
@@ -714,3 +714,24 @@ rules:
 `, url.Values{"nocache": {"1"}, "denyPartialResponse": {"true"}})
 	})
 }
+func TestGroupValidate_SQLSuccess(t *testing.T) {
+	g := &Group{
+		Name: "sql-group",
+		Type: NewSQLType(),
+		Rules: []Rule{{
+			Alert: "HighCount",
+			Expr:  "SELECT 'all' AS host, count() AS value FROM demo.events HAVING count() > 5 FORMAT JSONCompact",
+			For:   promutil.NewDuration(time.Minute),
+			Labels: map[string]string{
+				"severity": "warning",
+			},
+			Annotations: map[string]string{
+				"summary": "demo.events row count is {{ $value }}",
+			},
+		}},
+	}
+
+	if err := g.Validate(nil, true); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+}

--- a/app/vmalert/config/types.go
+++ b/app/vmalert/config/types.go
@@ -36,6 +36,11 @@ func NewVLogsType() Type {
 		Name: "vlogs",
 	}
 }
+func NewSQLType() Type {
+	return Type{
+		Name: "sql",
+	}
+}
 
 // NewRawType returns datasource type from raw string
 // without validation.
@@ -84,6 +89,9 @@ func (t *Type) ValidateExpr(expr string) error {
 		if slices.Contains(labels, "_time") {
 			return fmt.Errorf("bad LogsQL expr: %q, err: cannot contain time buckets stats pipe `stats by (_time:step)`", expr)
 		}
+	case "sql":
+		// SQL expressions are validated server-side
+		return nil
 	default:
 		return fmt.Errorf("unknown datasource type=%q", t.Name)
 	}
@@ -92,7 +100,7 @@ func (t *Type) ValidateExpr(expr string) error {
 
 // SupportedType is true if given datasource type is supported
 func SupportedType(dsType string) bool {
-	return dsType == "graphite" || dsType == "prometheus" || dsType == "vlogs"
+	return dsType == "graphite" || dsType == "prometheus" || dsType == "vlogs" || dsType == "sql"
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.
@@ -102,7 +110,7 @@ func (t *Type) UnmarshalYAML(unmarshal func(any) error) error {
 		return err
 	}
 	if !SupportedType(s) {
-		return fmt.Errorf("unknown datasource type=%q, want prometheus, graphite or vlogs", s)
+		return fmt.Errorf("unknown datasource type=%q, want prometheus, graphite, vlogs or sql", s)
 	}
 	t.Name = s
 	return nil

--- a/app/vmalert/datasource/client.go
+++ b/app/vmalert/datasource/client.go
@@ -22,6 +22,7 @@ const (
 	datasourcePrometheus datasourceType = "prometheus"
 	datasourceGraphite   datasourceType = "graphite"
 	datasourceVLogs      datasourceType = "vlogs"
+	datasourceSQL        datasourceType = "sql"
 )
 
 func toDatasourceType(s string) datasourceType {
@@ -32,6 +33,8 @@ func toDatasourceType(s string) datasourceType {
 		return datasourceGraphite
 	case string(datasourceVLogs):
 		return datasourceVLogs
+	case string(datasourceSQL):
+		return datasourceSQL
 	default:
 		logger.Panicf("BUG: unknown datasource type %q", s)
 	}
@@ -183,6 +186,9 @@ func (c *Client) Query(ctx context.Context, query string, ts time.Time) (Result,
 		parseFn = parseGraphiteResponse
 	case datasourceVLogs:
 		parseFn = parseVLogsInstantResponse
+	case datasourceSQL:
+		parseFn = parseSQLResponse
+
 	default:
 		logger.Panicf("BUG: unsupported datasource type %q to parse query response", c.dataSourceType)
 	}
@@ -199,6 +205,9 @@ func (c *Client) Query(ctx context.Context, query string, ts time.Time) (Result,
 // Graphite type isn't supported.
 func (c *Client) QueryRange(ctx context.Context, query string, start, end time.Time) (res Result, err error) {
 	if c.dataSourceType == datasourceGraphite {
+		return res, fmt.Errorf("%q is not supported for QueryRange", c.dataSourceType)
+	}
+	if c.dataSourceType == datasourceSQL {
 		return res, fmt.Errorf("%q is not supported for QueryRange", c.dataSourceType)
 	}
 	// TODO: disable range query LogsQL with time filter now
@@ -300,6 +309,8 @@ func (c *Client) newQueryRequest(ctx context.Context, query string, ts time.Time
 		c.setGraphiteReqParams(req, query)
 	case datasourceVLogs:
 		c.setVLogsInstantReqParams(req, query, ts)
+	case datasourceSQL:
+		c.setSQLInstantReqParams(req, query, ts)
 	default:
 		logger.Panicf("BUG: unsupported datasource type %q to create query request", c.dataSourceType)
 	}

--- a/app/vmalert/datasource/client_sql.go
+++ b/app/vmalert/datasource/client_sql.go
@@ -1,0 +1,157 @@
+package datasource
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const sqPath = "/sql"
+
+type sqlColumMeta struct {
+	Name string `json:"name"`
+	Type string `json:"type"`
+}
+type sqlResponse struct {
+	Meta []sqlColumMeta      `json:"meta"`
+	Data [][]json.RawMessage `json:"data"`
+	Row  int                 `json:"row"`
+}
+
+func parseSQLNumericValue(raw json.RawMessage) (float64, error) {
+	var f float64
+	if err := json.Unmarshal(raw, &f); err == nil {
+		return f, nil
+	}
+	var s string
+	if err := json.Unmarshal(raw, &s); err != nil {
+		return 0, fmt.Errorf("cannot parse %q as numeric value", string(raw))
+	}
+	return strconv.ParseFloat(s, 64)
+}
+
+func normalizeSQLType(t string) string {
+	t = strings.ToLower(strings.TrimSpace(t))
+	for {
+		switch {
+		case strings.HasPrefix(t, "nullable(") && strings.HasSuffix(t, ")"):
+			t = strings.TrimSuffix(strings.TrimPrefix(t, "nullable("), ")")
+		case strings.HasPrefix(t, "lowcardinality(") && strings.HasSuffix(t, ")"):
+			t = strings.TrimSuffix(strings.TrimPrefix(t, "lowcardinality("), ")")
+		default:
+			return t
+		}
+	}
+}
+
+func isNumericSQLType(t string) bool {
+	t = normalizeSQLType(t)
+	switch {
+	case strings.HasPrefix(t, "int"),
+		strings.HasPrefix(t, "uint"),
+		strings.HasPrefix(t, "float"),
+		strings.HasPrefix(t, "decimal"),
+		strings.HasPrefix(t, "numeric"),
+		strings.HasPrefix(t, "double"),
+		strings.HasPrefix(t, "real"),
+		strings.HasPrefix(t, "number"):
+		return true
+	default:
+		return false
+	}
+}
+
+func sqlEvalTimestamp(resp *http.Response) (int64, error) {
+	if resp.Request == nil {
+		return 0, fmt.Errorf("missing request in SQL response")
+	}
+	raw := resp.Request.URL.Query().Get("time")
+	if raw == "" {
+		return 0, fmt.Errorf("missing time query param in SQL request")
+	}
+	t, err := time.Parse(time.RFC3339, raw)
+	if err != nil {
+		return 0, fmt.Errorf("cannot parse SQL evaluation time %q: %w", raw, err)
+	}
+	return t.Unix(), nil
+}
+func valueColumnIndex(meta []sqlColumMeta) (int, error) {
+	idx := -1
+	for i, col := range meta {
+		if strings.EqualFold(col.Name, "value") {
+			if !isNumericSQLType(col.Type) {
+				return -1, fmt.Errorf(`column "value" must be numeric, got %q`, col.Type)
+			}
+			if idx != -1 {
+				return -1, fmt.Errorf(`multiple columns named "value"`)
+			}
+			idx = i
+		}
+	}
+	if idx == -1 {
+		return -1, fmt.Errorf(`SQL response must contain exactly one numeric column named "value"`)
+	}
+	return idx, nil
+}
+
+func parseSQLResponse(resp *http.Response) (Result, error) {
+	var r sqlResponse
+	if err := json.NewDecoder(resp.Body).Decode(&r); err != nil {
+		return Result{}, fmt.Errorf("error parsing SQL response: %w", err)
+	}
+	if len(r.Meta) == 0 {
+		return Result{}, fmt.Errorf("SQL response has no columns")
+	}
+	valueIdx, err := valueColumnIndex(r.Meta)
+	if err != nil {
+		return Result{}, err
+	}
+	if valueIdx < 0 {
+		return Result{}, fmt.Errorf("SQL response has no numeric column to use as metric value")
+	}
+	ts, err := sqlEvalTimestamp(resp)
+	if err != nil {
+		return Result{}, err
+	}
+	var metrics []Metric
+	for _, row := range r.Data {
+		if len(row) != len(r.Meta) {
+			return Result{}, fmt.Errorf("SQL row has %d values, expected %d columns", len(row), len(r.Meta))
+		}
+		var m Metric
+		val, err := parseSQLNumericValue(row[valueIdx])
+		if err != nil {
+			return Result{}, fmt.Errorf("error parsing value column %q: %w", r.Meta[valueIdx], err)
+		}
+		m.Values = []float64{val}
+		m.Timestamps = []int64{ts}
+		for i, col := range r.Meta {
+			if i == valueIdx {
+				continue
+			}
+			var labelVal string
+			if err := json.Unmarshal(row[i], &labelVal); err != nil {
+				var numVal float64
+				if err := json.Unmarshal(row[i], &numVal); err != nil {
+					return Result{}, fmt.Errorf("error parsing label column %q: %w", col.Name, err)
+				}
+				labelVal = strconv.FormatFloat(numVal, 'f', -1, 64)
+			}
+			m.AddLabel(col.Name, labelVal)
+		}
+		metrics = append(metrics, m)
+	}
+	return Result{Data: metrics}, nil
+}
+func (c *Client) setSQLInstantReqParams(r *http.Request, query string, timestamp time.Time) {
+	if !*disablePathAppend {
+		r.URL.Path += sqPath
+	}
+	q := r.URL.Query()
+	q.Set("time", timestamp.Format(time.RFC3339))
+	r.URL.RawQuery = q.Encode()
+	c.setReqParams(r, query)
+}

--- a/app/vmalert/datasource/client_test.go
+++ b/app/vmalert/datasource/client_test.go
@@ -851,3 +851,72 @@ func expectError(t *testing.T, err error, exp string) {
 		t.Fatalf("expected error %q to contain %q", err, exp)
 	}
 }
+
+func TestSQLInstantQuery(t *testing.T) {
+	query := "SELECT 'all' AS host, count() AS value FROM demo.events HAVING count() > 5 FORMAT JSONCompact"
+	ts := time.Date(2026, 3, 24, 10, 0, 0, 0, time.UTC)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/sql", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("expected POST method; got %s", r.Method)
+		}
+		if got := r.URL.Query().Get("query"); got != query {
+			t.Fatalf("unexpected query: got %q want %q", got, query)
+		}
+		if got := r.URL.Query().Get("time"); got != ts.Format(time.RFC3339) {
+			t.Fatalf("unexpected time: got %q want %q", got, ts.Format(time.RFC3339))
+		}
+		_, _ = w.Write([]byte(`{"meta":[{"name":"host","type":"String"},{"name":"value","type":"UInt64"}],"data":[["all",6]],"row":1}`))
+	})
+
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	q := (&Client{
+		c:              srv.Client(),
+		datasourceURL:  srv.URL,
+		dataSourceType: datasourceSQL,
+		extraParams:    url.Values{},
+	}).BuildWithParams(QuerierParams{DataSourceType: string(datasourceSQL)})
+
+	res, _, err := q.Query(ctx, query, ts)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	expected := []Metric{{
+		Labels:     []prompb.Label{{Name: "host", Value: "all"}},
+		Timestamps: []int64{ts.Unix()},
+		Values:     []float64{6},
+	}}
+	metricsEqual(t, res.Data, expected)
+}
+
+func TestSQLInstantQuery_MissingValueColumn(t *testing.T) {
+	query := "SELECT host, count() FROM demo.events"
+	ts := time.Date(2026, 3, 24, 10, 0, 0, 0, time.UTC)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/sql", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"meta":[{"name":"host","type":"String"},{"name":"count","type":"UInt64"}],"data":[["all",6]],"row":1}`))
+	})
+
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	q := (&Client{
+		c:              srv.Client(),
+		datasourceURL:  srv.URL,
+		dataSourceType: datasourceSQL,
+		extraParams:    url.Values{},
+	}).BuildWithParams(QuerierParams{DataSourceType: string(datasourceSQL)})
+
+	_, _, err := q.Query(ctx, query, ts)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if !strings.Contains(err.Error(), `named "value"`) {
+		t.Fatalf("unexpected error: %s", err)
+	}
+}

--- a/app/vmalert/datasource/init.go
+++ b/app/vmalert/datasource/init.go
@@ -56,12 +56,26 @@ var (
 		`If true, disables HTTP keep-alive and will only use the connection to the server for a single HTTP request.`)
 	roundDigits = flag.Int("datasource.roundDigits", 0, `Adds "round_digits" GET param to datasource requests which limits the number of digits after the decimal point in response values. `+
 		`Only valid for VictoriaMetrics as the datasource.`)
+	sqlAddr                  = flag.String("datasource.sql.url", "", "Optional URL for SQL datasource queries. If set, groups with type=\"sql\" will send queries to this URL instead of -datasource.url. Supports address in the form of IP address with a port (e.g., http://127.0.0.1:8428)")
+	sqlBasicAuthUsername     = flag.String("datasource.sql.basicAuth.username", "", "Optional basic auth username for -datasource.sql.url")
+	sqlBasicAuthPassword     = flag.String("datasource.sql.basicAuth.password", "", "Optional basic auth password for -datasource.sql.url")
+	sqlBasicAuthPasswordFile = flag.String("datasource.sql.basicAuth.passwordFile", "", "Optional path to basic auth password to use for -datasource.sql.url")
+
+	sqlBearerToken           = flag.String("datasource.sql.bearerToken", "", "Optional bearer auth token to use for -datasource.sql.url.")
+	sqlBearerTokenFile       = flag.String("datasource.sql.bearerTokenFile", "", "Optional path to bearer token file to use for -datasource.sql.url.")
+	sqlHeaders               = flag.String("datasource.sql.headers", "", "Optional HTTP extraHeaders to send with each request to the corresponding -datasource.sql.url. For example, -datasource.sql.headers='My-Auth:foobar' would send 'My-Auth: foobar' HTTP header with every request to the corresponding -datasource.sql.url. Multiple headers must be delimited by '^^': -datasource.sql.headers='header1:value1^^header2:value2'")
+	sqlTLSInsecureSkipVerify = flag.Bool("datasource.sql.tlsInsecureSkipVerify", false, "Whether to skip tls verification when connecting to -datasource.sql.url")
+	sqlTLSCertFile           = flag.String("datasource.sql.tlsCertFile", "", "Optional path to client-side TLS certificate file to use when connecting to -datasource.sql.url")
+	sqlTLSKeyFile            = flag.String("datasource.sql.tlsKeyFile", "", "Optional path to client-side TLS certificate key to use when connecting to -datasource.sql.url")
+	sqlTLSCAFile             = flag.String("datasource.sql.tlsCAFile", "", "Optional path to TLS CA file to use for verifying connections to -datasource.sql.url. By default, system CA is used")
+	sqlTLSServerName         = flag.String("datasource.sql.tlsServerName", "", "Optional TLS server name to use for connections to -datasource.sql.url. By default, the server name from -datasource.sql.url is used")
 )
 
 // InitSecretFlags must be called after flag.Parse and before any logging
 func InitSecretFlags() {
 	if !*showDatasourceURL {
 		flagutil.RegisterSecretFlag("datasource.url")
+		flagutil.RegisterSecretFlag("datasource.sql.url")
 	}
 }
 
@@ -117,12 +131,53 @@ func Init(extraParams url.Values) (QuerierBuilder, error) {
 		return nil, fmt.Errorf("failed to set request auth header to datasource %q: %w", *addr, err)
 	}
 
-	return &Client{
+	defaultClient := &Client{
 		c:                &http.Client{Transport: tr},
 		authCfg:          authCfg,
 		datasourceURL:    strings.TrimSuffix(*addr, "/"),
 		appendTypePrefix: *appendTypePrefix,
 		queryStep:        *queryStep,
 		extraParams:      extraParams,
+	}
+	if *sqlAddr == "" {
+		return defaultClient, nil
+	}
+	if err := httputil.CheckURL(*sqlAddr); err != nil {
+		return nil, fmt.Errorf("invalid -datasource.sql.url:%w", err)
+	}
+	sqlTR, err := promauth.NewTLSTransport(*sqlTLSCertFile, *sqlTLSKeyFile, *sqlTLSCAFile, *sqlTLSServerName, *sqlTLSInsecureSkipVerify, "vmalert_sql_datasource")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create transport for -datasource.sql.url=%q: %w", *sqlAddr, err)
+	}
+	sqlTR.DisableKeepAlives = *disableKeepAlive
+	sqlTR.MaxIdleConnsPerHost = *maxIdleConnections
+	if sqlTR.MaxIdleConns != 0 && sqlTR.MaxIdleConns < sqlTR.MaxIdleConnsPerHost {
+		sqlTR.MaxIdleConns = sqlTR.MaxIdleConnsPerHost
+	}
+	sqlTR.IdleConnTimeout = *idleConnectionTimeout
+
+	sqlAuthCfg, err := vmalertutil.AuthConfig(
+		vmalertutil.WithBasicAuth(*sqlBasicAuthUsername, *sqlBasicAuthPassword, *sqlBasicAuthPasswordFile),
+		vmalertutil.WithBearer(*sqlBearerToken, *sqlBearerTokenFile),
+		vmalertutil.WithHeaders(*sqlHeaders))
+	if err != nil {
+		return nil, fmt.Errorf("failed to configure auth for -datasource.sql.url: %w", err)
+	}
+	_, err = sqlAuthCfg.GetAuthHeader()
+	if err != nil {
+		return nil, fmt.Errorf("failed to set request auth header to sql datasource %q: %w", *sqlAddr, err)
+	}
+
+	sqlClient := &Client{
+		c:              &http.Client{Transport: sqlTR},
+		authCfg:        sqlAuthCfg,
+		datasourceURL:  strings.TrimSuffix(*sqlAddr, "/"),
+		dataSourceType: datasourceSQL,
+		extraParams:    url.Values{},
+	}
+
+	return &Router{
+		defaultClient: defaultClient,
+		sqlClient:     sqlClient,
 	}, nil
 }

--- a/app/vmalert/datasource/router.go
+++ b/app/vmalert/datasource/router.go
@@ -1,0 +1,17 @@
+package datasource
+
+// Router dispatches query building to the appropriate client
+// based on the DataSourceType parameter.
+type Router struct {
+	defaultClient *Client
+	sqlClient     *Client
+}
+
+// BuildWithParams dispatches to the SQL client for "sql" type,
+// otherwise to the default client.
+func (r *Router) BuildWithParams(params QuerierParams) Querier {
+	if params.DataSourceType == string(datasourceSQL) {
+		return r.sqlClient.BuildWithParams(params)
+	}
+	return r.defaultClient.BuildWithParams(params)
+}


### PR DESCRIPTION
### Describe Your Changes

Add initial SQL datasource support to `vmalert` via `type: sql`

### Checklist

The following checks are **mandatory**:

- [ ] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [ ] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
