### PR TITLE
fix unstable unit test TestAggregatorsSuccess

### DIFF
--- a/lib/streamaggr/streamaggr_synctest_test.go
+++ b/lib/streamaggr/streamaggr_synctest_test.go
@@ -40,6 +40,7 @@ func TestAggregatorsSuccess(t *testing.T) {
 				time.Sleep(interval)
 			}
 
+			time.Sleep(time.Millisecond * 500)
 			a.MustStop()
 
 			// Verify matchIdxs equals to matchIdxsExpected


### PR DESCRIPTION
### Describe Your Changes

fix https://github.com/VictoriaMetrics/VictoriaMetrics/issues/10656

Since the aggregator's interval unit is 1s, a 500ms sleep before stopping it can ensure the aggregator follows the corresponding configured interval, preventing it from being stopped prematurely. See https://github.com/VictoriaMetrics/VictoriaMetrics/issues/10656#issuecomment-4068753312

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
