### PR TITLE
lib/timeutil: introduce backoff timer struct

### DIFF
--- a/app/vmagent/remotewrite/client.go
+++ b/app/vmagent/remotewrite/client.go
@@ -13,6 +13,9 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/VictoriaMetrics/metrics"
+	"github.com/golang/snappy"
+
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/awsapi"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/encoding"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/flagutil"
@@ -21,10 +24,7 @@ import (
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/persistentqueue"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/promauth"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/ratelimiter"
-	"github.com/VictoriaMetrics/VictoriaMetrics/lib/timerpool"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/timeutil"
-	"github.com/VictoriaMetrics/metrics"
-	"github.com/golang/snappy"
 )
 
 var (
@@ -405,8 +405,7 @@ func (c *client) newRequest(url string, body []byte) (*http.Request, error) {
 // Otherwise, it tries sending the block to remote storage indefinitely.
 func (c *client) sendBlockHTTP(block []byte) bool {
 	c.rl.Register(len(block))
-	maxRetryDuration := timeutil.AddJitterToDuration(c.retryMaxInterval)
-	retryDuration := timeutil.AddJitterToDuration(c.retryMinInterval)
+	bt := timeutil.NewBackoffTimer(c.retryMinInterval, c.retryMaxInterval)
 	retriesCount := 0
 
 again:
@@ -415,19 +414,10 @@ again:
 	c.requestDuration.UpdateDuration(startTime)
 	if err != nil {
 		c.errorsCount.Inc()
-		retryDuration *= 2
-		if retryDuration > maxRetryDuration {
-			retryDuration = maxRetryDuration
-		}
-		remoteWriteRetryLogger.Warnf("couldn't send a block with size %d bytes to %q: %s; re-sending the block in %.3f seconds",
-			len(block), c.sanitizedURL, err, retryDuration.Seconds())
-		t := timerpool.Get(retryDuration)
-		select {
-		case <-c.stopCh:
-			timerpool.Put(t)
+		remoteWriteRetryLogger.Warnf("couldn't send a block with size %d bytes to %q: %s; re-sending the block in %s",
+			len(block), c.sanitizedURL, err, bt.CurrentDelay())
+		if !bt.Wait(c.stopCh) {
 			return false
-		case <-t.C:
-			timerpool.Put(t)
 		}
 		c.retriesCount.Inc()
 		goto again
@@ -493,7 +483,10 @@ again:
 	// Unexpected status code returned
 	retriesCount++
 	retryAfterHeader := parseRetryAfterHeader(resp.Header.Get("Retry-After"))
-	retryDuration = getRetryDuration(retryAfterHeader, retryDuration, maxRetryDuration)
+	// retryAfterDuration has the highest priority duration
+	if retryAfterHeader > 0 {
+		bt.SetDelay(retryAfterHeader)
+	}
 
 	// Handle response
 	body, err := io.ReadAll(resp.Body)
@@ -502,15 +495,10 @@ again:
 		logger.Errorf("cannot read response body from %q during retry #%d: %s", c.sanitizedURL, retriesCount, err)
 	} else {
 		logger.Errorf("unexpected status code received after sending a block with size %d bytes to %q during retry #%d: %d; response body=%q; "+
-			"re-sending the block in %.3f seconds", len(block), c.sanitizedURL, retriesCount, statusCode, body, retryDuration.Seconds())
+			"re-sending the block in %s", len(block), c.sanitizedURL, retriesCount, statusCode, body, bt.CurrentDelay())
 	}
-	t := timerpool.Get(retryDuration)
-	select {
-	case <-c.stopCh:
-		timerpool.Put(t)
+	if !bt.Wait(c.stopCh) {
 		return false
-	case <-t.C:
-		timerpool.Put(t)
 	}
 	c.retriesCount.Inc()
 	goto again
@@ -518,27 +506,6 @@ again:
 
 var remoteWriteRejectedLogger = logger.WithThrottler("remoteWriteRejected", 5*time.Second)
 var remoteWriteRetryLogger = logger.WithThrottler("remoteWriteRetry", 5*time.Second)
-
-// getRetryDuration returns retry duration.
-// retryAfterDuration has the highest priority.
-// If retryAfterDuration is not specified, retryDuration gets doubled.
-// retryDuration can't exceed maxRetryDuration.
-//
-// Also see: https://github.com/VictoriaMetrics/VictoriaMetrics/issues/6097
-func getRetryDuration(retryAfterDuration, retryDuration, maxRetryDuration time.Duration) time.Duration {
-	// retryAfterDuration has the highest priority duration
-	if retryAfterDuration > 0 {
-		return timeutil.AddJitterToDuration(retryAfterDuration)
-	}
-
-	// default backoff retry policy
-	retryDuration *= 2
-	if retryDuration > maxRetryDuration {
-		retryDuration = maxRetryDuration
-	}
-
-	return retryDuration
-}
 
 // repackBlockFromZstdToSnappy repacks the given zstd-compressed block to snappy-compressed block.
 //
@@ -576,11 +543,6 @@ func parseRetryAfterHeader(retryAfterString string) (retryAfterDuration time.Dur
 	if retryAfterString == "" {
 		return retryAfterDuration
 	}
-
-	defer func() {
-		v := retryAfterDuration.Seconds()
-		logger.Infof("'Retry-After: %s' parsed into %.2f second(s)", retryAfterString, v)
-	}()
 
 	// Retry-After could be in "Mon, 02 Jan 2006 15:04:05 GMT" format.
 	if parsedTime, err := time.Parse(http.TimeFormat, retryAfterString); err == nil {

--- a/app/vmagent/remotewrite/client_test.go
+++ b/app/vmagent/remotewrite/client_test.go
@@ -6,65 +6,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/VictoriaMetrics/VictoriaMetrics/lib/encoding"
 	"github.com/golang/snappy"
+
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/encoding"
 )
-
-func TestCalculateRetryDuration(t *testing.T) {
-	// `testFunc` call `calculateRetryDuration` for `n` times
-	// and evaluate if the result of `calculateRetryDuration` is
-	// 1. >= expectMinDuration
-	// 2. <= expectMinDuration + 10% (see timeutil.AddJitterToDuration)
-	f := func(retryAfterDuration, retryDuration time.Duration, n int, expectMinDuration time.Duration) {
-		t.Helper()
-
-		for range n {
-			retryDuration = getRetryDuration(retryAfterDuration, retryDuration, time.Minute)
-		}
-
-		expectMaxDuration := helper(expectMinDuration)
-		expectMinDuration = expectMinDuration - (1000 * time.Millisecond) // Avoid edge case when calculating time.Until(now)
-
-		if retryDuration < expectMinDuration || retryDuration > expectMaxDuration {
-			t.Fatalf(
-				"incorrect retry duration, want (ms): [%d, %d], got (ms): %d",
-				expectMinDuration.Milliseconds(), expectMaxDuration.Milliseconds(),
-				retryDuration.Milliseconds(),
-			)
-		}
-	}
-
-	// Call calculateRetryDuration for 1 time.
-	{
-		// default backoff policy
-		f(0, time.Second, 1, 2*time.Second)
-		// default backoff policy exceed max limit"
-		f(0, 10*time.Minute, 1, time.Minute)
-
-		// retry after > default backoff policy
-		f(10*time.Second, 1*time.Second, 1, 10*time.Second)
-		// retry after < default backoff policy
-		f(1*time.Second, 10*time.Second, 1, 1*time.Second)
-		// retry after invalid and < default backoff policy
-		f(0, time.Second, 1, 2*time.Second)
-
-	}
-
-	// Call calculateRetryDuration for multiple times.
-	{
-		// default backoff policy 2 times
-		f(0, time.Second, 2, 4*time.Second)
-		// default backoff policy 3 times
-		f(0, time.Second, 3, 8*time.Second)
-		// default backoff policy N times exceed max limit
-		f(0, time.Second, 10, time.Minute)
-
-		// retry after 120s 1 times
-		f(120*time.Second, time.Second, 1, 120*time.Second)
-		// retry after 120s 2 times
-		f(120*time.Second, time.Second, 2, 120*time.Second)
-	}
-}
 
 func TestParseRetryAfterHeader(t *testing.T) {
 	f := func(retryAfterString string, expectResult time.Duration) {
@@ -89,13 +34,6 @@ func TestParseRetryAfterHeader(t *testing.T) {
 	f("invalid-retry-after", 0)
 	// retry after header not in GMT
 	f(time.Now().Add(10*time.Second).Format("Mon, 02 Jan 2006 15:04:05 FAKETZ"), 0)
-}
-
-// helper calculate the max possible time duration calculated by timeutil.AddJitterToDuration.
-func helper(d time.Duration) time.Duration {
-	dv := min(d/10, 10*time.Second)
-
-	return d + dv
 }
 
 func TestRepackBlockFromZstdToSnappy(t *testing.T) {

--- a/app/vmalert/remotewrite/client.go
+++ b/app/vmalert/remotewrite/client.go
@@ -21,6 +21,8 @@ import (
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/netutil"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/promauth"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/prompb"
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/timeutil"
+
 	"github.com/VictoriaMetrics/metrics"
 )
 
@@ -235,10 +237,8 @@ func (c *Client) flush(ctx context.Context, wr *prompb.WriteRequest) {
 	data := wr.MarshalProtobuf(nil)
 	b := snappy.Encode(nil, data)
 
-	retryInterval, maxRetryInterval := *retryMinInterval, *retryMaxTime
-	if retryInterval > maxRetryInterval {
-		retryInterval = maxRetryInterval
-	}
+	maxRetryInterval := *retryMaxTime
+	bt := timeutil.NewBackoffTimer(*retryMinInterval, maxRetryInterval)
 	timeStart := time.Now()
 	defer func() {
 		sendDuration.Add(time.Since(timeStart).Seconds())
@@ -281,12 +281,11 @@ L:
 			break
 		}
 
-		if retryInterval > timeLeftForRetries {
-			retryInterval = timeLeftForRetries
+		if bt.CurrentDelay() > timeLeftForRetries {
+			bt.SetDelay(timeLeftForRetries)
 		}
 		// sleeping to prevent remote db hammering
-		time.Sleep(retryInterval)
-		retryInterval *= 2
+		bt.Wait(ctx.Done())
 
 		attempts++
 	}

--- a/lib/promscrape/discovery/kubernetes/api_watcher.go
+++ b/lib/promscrape/discovery/kubernetes/api_watcher.go
@@ -786,23 +786,7 @@ func (uw *urlWatcher) reloadObjects() string {
 func (uw *urlWatcher) watchForUpdates() {
 	gw := uw.gw
 	stopCh := gw.ctx.Done()
-	minBackoffDelay := timeutil.AddJitterToDuration(time.Second)
-	maxBackoffDelay := timeutil.AddJitterToDuration(time.Second * 30)
-	backoffDelay := minBackoffDelay
-	backoffSleep := func() {
-		t := timerpool.Get(backoffDelay)
-		select {
-		case <-stopCh:
-			timerpool.Put(t)
-			return
-		case <-t.C:
-			timerpool.Put(t)
-		}
-		backoffDelay *= 2
-		if backoffDelay > maxBackoffDelay {
-			backoffDelay = maxBackoffDelay
-		}
-	}
+	bt := timeutil.NewBackoffTimer(time.Second, time.Second*30)
 	apiURL := uw.apiURL
 	delimiter := getQueryArgsDelimiter(apiURL)
 	timeoutSeconds := time.Duration(0.9 * float64(gw.client.Timeout)).Seconds()
@@ -818,7 +802,7 @@ func (uw *urlWatcher) watchForUpdates() {
 
 		resourceVersion := uw.reloadObjects()
 		if resourceVersion == "" {
-			backoffSleep()
+			bt.Wait(stopCh)
 			continue
 		}
 		requestURL := apiURL + "&resourceVersion=" + url.QueryEscape(resourceVersion)
@@ -826,25 +810,25 @@ func (uw *urlWatcher) watchForUpdates() {
 		if err != nil {
 			if !errors.Is(err, context.Canceled) {
 				logger.Errorf("cannot perform request to %q: %s", requestURL, err)
-				backoffSleep()
+				bt.Wait(stopCh)
 			}
 			continue
 		}
 		if resp.StatusCode != http.StatusOK {
 			if resp.StatusCode == 410 {
 				// There is no need for sleep on 410 error. See https://kubernetes.io/docs/reference/using-api/api-concepts/#410-gone-responses
-				backoffDelay = minBackoffDelay
+				bt.Reset()
 				uw.staleResourceVersions.Inc()
 				uw.resourceVersion = ""
 			} else {
 				body, _ := io.ReadAll(resp.Body)
 				_ = resp.Body.Close()
 				logger.Errorf("unexpected status code for request to %q: %d; want %d; response: %q", requestURL, resp.StatusCode, http.StatusOK, body)
-				backoffSleep()
+				bt.Wait(stopCh)
 			}
 			continue
 		}
-		backoffDelay = minBackoffDelay
+		bt.Reset()
 		err = uw.readObjectUpdateStream(resp.Body)
 		_ = resp.Body.Close()
 		if err != nil {
@@ -852,7 +836,7 @@ func (uw *urlWatcher) watchForUpdates() {
 				logger.Errorf("error when reading WatchEvent stream from %q: %s", requestURL, err)
 				uw.resourceVersion = ""
 			}
-			backoffSleep()
+			bt.Wait(stopCh)
 			continue
 		}
 	}

--- a/lib/timeutil/backoff_timer.go
+++ b/lib/timeutil/backoff_timer.go
@@ -1,0 +1,68 @@
+package timeutil
+
+import (
+	"time"
+
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/timerpool"
+)
+
+// BackoffTimer implements an exponential backoff timer with jitter.
+type BackoffTimer struct {
+	min     time.Duration
+	max     time.Duration
+	current time.Duration
+}
+
+// NewBackoffTimer returns a new BackoffTimer initialized with the given minDelay and maxDelay.
+func NewBackoffTimer(minDelay, maxDelay time.Duration) *BackoffTimer {
+	if maxDelay < minDelay {
+		minDelay = maxDelay
+	}
+	return &BackoffTimer{
+		min:     minDelay,
+		max:     maxDelay,
+		current: minDelay,
+	}
+}
+
+// Wait sleeps for the current delay with jitter, doubling the delay for the next Wait.
+// Use CurrentDelay to get the current backoff duration.
+//
+// Wait returns false if stopCh is closed.
+func (bt *BackoffTimer) Wait(stopCh <-chan struct{}) bool {
+	v := AddJitterToDuration(bt.current)
+	bt.current *= 2
+	if bt.current > bt.max {
+		bt.current = bt.max
+	}
+
+	timer := timerpool.Get(v)
+	defer timerpool.Put(timer)
+	select {
+	case <-stopCh:
+		return false
+	case <-timer.C:
+		return true
+	}
+}
+
+// CurrentDelay returns the current backoff duration.
+func (bt *BackoffTimer) CurrentDelay() time.Duration {
+	return bt.current
+}
+
+// SetDelay overrides the current delay. Useful for respecting Retry-After headers.
+func (bt *BackoffTimer) SetDelay(d time.Duration) {
+	if d < bt.min {
+		d = bt.min
+	}
+	if d > bt.max {
+		d = bt.max
+	}
+	bt.current = d
+}
+
+// Reset sets the backoff delay to its minimum.
+func (bt *BackoffTimer) Reset() {
+	bt.current = bt.min
+}


### PR DESCRIPTION
### Describe Your Changes

I noticed that the backoff timer logic is repeated across multiple packages. I've implemented a universal wrapper to avoid duplicating this logic. This structure is already [actively used](https://github.com/VictoriaMetrics/VictoriaLogs/blob/2aa0ea10bb59937aeb6618b6fa3710a156cc3af3/app/vlagent/kubernetescollector/backoff_timer.go#L11) for the Kubernetes Collector in vlagent and can be reused in vlagent's remotewrite. I've also included a usage example in this PR so you can evaluate its utility.

### Checklist

The following checks are **mandatory**:

- [X] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [X] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
