### PR TITLE
app/vmauth: mention that vmauth can be used with other components

### DIFF
--- a/app/vmauth/main.go
+++ b/app/vmauth/main.go
@@ -763,7 +763,7 @@ var concurrentRequestsLimitReached = metrics.NewCounter("vmauth_concurrent_reque
 
 func usage() {
 	const s = `
-vmauth authenticates and authorizes incoming requests and proxies them to VictoriaMetrics.
+vmauth authenticates and authorizes incoming requests and proxies them to VictoriaMetrics components or any other HTTP backends.
 
 See the docs at https://docs.victoriametrics.com/victoriametrics/vmauth/ .
 `

--- a/docs/victoriametrics/vmauth_common_flags.md
+++ b/docs/victoriametrics/vmauth_common_flags.md
@@ -9,7 +9,7 @@ sitemap:
 <!-- The file should not be updated manually. Run make docs-update-flags while preparing a new release to sync flags in docs from actual binaries. -->
 ```shellhelp
 
-vmauth authenticates and authorizes incoming requests and proxies them to VictoriaMetrics.
+vmauth authenticates and authorizes incoming requests and proxies them to VictoriaMetrics components or any other HTTP backends.
 
 See the docs at https://docs.victoriametrics.com/victoriametrics/vmauth/ .
 


### PR DESCRIPTION
A cosmetic change to highlight that vmauth can be used with other compnents besides VM only.