### PR TITLE
vmalert: adopt additional rule states in the list rules API

### DIFF
--- a/app/vmalert/web.go
+++ b/app/vmalert/web.go
@@ -52,7 +52,13 @@ var (
 		"alert":  rule.TypeAlerting,
 		"record": rule.TypeRecording,
 	}
-	ruleStates = []string{"ok", "nomatch", "inactive", "firing", "pending", "unhealthy"}
+
+	// The "recovering", "noData", "normal", "error" states are used by Grafana.
+	// Ignore "recovering" since it is not currently acknowledged by vmalert,
+	// treat "noData" as an alias for "nomatch",
+	// treat "normal" as an alias for "inactive",
+	// treat "error" as an alias for "unhealthy"
+	ruleStates = []string{"ok", "nomatch", "inactive", "firing", "pending", "unhealthy", "recovering", "noData", "normal", "error"}
 )
 
 type requestHandler struct {
@@ -362,6 +368,15 @@ func newRulesFilter(r *http.Request) (*rulesFilter, *httpserver.ErrorWithStatusC
 			}
 			if !slices.Contains(ruleStates, v) {
 				return nil, errResponse(fmt.Errorf(`invalid parameter "state": contains not supported value %q`, v), http.StatusBadRequest)
+			}
+			// Replace grafana states with supported internal states
+			switch v {
+			case "noData":
+				v = "nomatch"
+			case "normal":
+				v = "inactive"
+			case "error":
+				v = "unhealthy"
 			}
 			rf.states = append(rf.states, v)
 		}


### PR DESCRIPTION
In grafana, the alert list panel can use VictoriaMetrics as datasource and call `/api/v1/rules` api with [specific states](https://grafana.com/docs/grafana/latest/alerting/fundamentals/alert-rule-evaluation/nodata-and-error-states/#alert-instance-states). 
See https://play-grafana.victoriametrics.com/d/febljk0a32qyoa/3e68cf3?orgId=1&from=now-1h&to=now&timezone=browser&var-prometheus_datasource=P4169E866C3094E38&var-jaeger_datasource=P14D5514F5CCC0D1C&var-victorialogs_datasource=PD775F2863313E6C7&var-service_namespace=$__all&var-service_name=checkout&refresh=5m&editPanel=40.
Some states are already defined in vmalert, although with different names. Others, such as "recovering", are currently undefined. 
This pull request adopts all these states, rather than fail the request.

Above panel request also uses the `matcher` param to filter rules. However, [prometheus](https://prometheus.io/docs/prometheus/latest/querying/api/#rules) also does not support this parameter and simply ignore it, so I don't think vmalert needs to support it now.

JFYI, the grafana [Alerting page](https://play-grafana.victoriametrics.com/alerting) does not include any of the mentioned `state` or `matcher` parameters in rule listing requests to the datasource. Filtering is handled by the Grafana frontend, so most users are not affected by partial support for filtering in backend products.