### PR TITLE
lib/netutil: add NextProtos to tls.Config for HTTP/2 ALPN negotiation

### DIFF
--- a/lib/netutil/tls.go
+++ b/lib/netutil/tls.go
@@ -32,6 +32,11 @@ func GetServerTLSConfig(tlsCertFile, tlsKeyFile, tlsMinVersion string, tlsCipher
 		// This can only result in lower security level if improperly set.
 
 		CipherSuites: cipherSuites,
+
+		// Enable HTTP/2 and HTTP/1.1 support for TLS listeners via ALPN.
+		// See https://datatracker.ietf.org/doc/html/rfc7540#section-3.3
+		// See https://github.com/VictoriaMetrics/VictoriaTraces/issues/108
+		NextProtos: []string{"h2", "http/1.1"},
 	}
 
 	cfg.GetCertificate = newGetCertificateFunc(tlsCertFile, tlsKeyFile)

--- a/lib/netutil/tls_test.go
+++ b/lib/netutil/tls_test.go
@@ -3,6 +3,7 @@ package netutil
 import (
 	"crypto/tls"
 	"errors"
+	"os"
 	"reflect"
 	"testing"
 
@@ -132,6 +133,104 @@ func TestGetServerTLSConfig(t *testing.T) {
 	f("./test.crt", "/b", true)
 	// cert file and key file all exist
 	f("./test.crt", "./test.key", false)
+}
+
+func TestGetServerTLSConfig_RealSignature(t *testing.T) {
+	// Prepare test certificate files
+	certFile := "test.crt"
+	keyFile := "test.key"
+	mustCreateFile(certFile, testCRT)
+	mustCreateFile(keyFile, testPK)
+	defer func() {
+		os.Remove(certFile)
+		os.Remove(keyFile)
+	}()
+
+	// f is the core test helper: calls GetServerTLSConfig and validates the result.
+	f := func(minVer string, ciphers []string, expectErr bool) {
+		t.Helper()
+		cfg, err := GetServerTLSConfig(certFile, keyFile, minVer, ciphers)
+		if (err != nil) != expectErr {
+			t.Fatalf("minVer=%s ciphers=%v | expectErr=%v got err=%v", minVer, ciphers, expectErr, err)
+		}
+		if err != nil {
+			return
+		}
+
+		// Assertion 1: NextProtos must contain both "h2" and "http/1.1" for ALPN negotiation.
+		// Required by RFC 7540 §3.3 so that gRPC-go 1.67+ can negotiate HTTP/2 over TLS.
+		// This guard prevents accidental removal of the NextProtos field in the future.
+		wantProtos := map[string]bool{"h2": false, "http/1.1": false}
+		for _, proto := range cfg.NextProtos {
+			if _, ok := wantProtos[proto]; ok {
+				wantProtos[proto] = true
+			}
+		}
+		for proto, found := range wantProtos {
+			if !found {
+				t.Errorf("NextProtos missing %q, got: %v", proto, cfg.NextProtos)
+			}
+		}
+
+		// Assertion 2: CipherSuites count must match the requested ciphers.
+		if len(ciphers) > 0 && len(cfg.CipherSuites) != len(ciphers) {
+			t.Errorf("CipherSuites count mismatch: want %d, got %d", len(ciphers), len(cfg.CipherSuites))
+		}
+
+		// Assertion 3: MinVersion must be set to a non-zero value.
+		if cfg.MinVersion == 0 {
+			t.Errorf("MinVersion is 0, expected a valid TLS version constant")
+		}
+	}
+
+	// --- Test cases ---
+
+	// Happy path: TLS 1.2 with a standard cipher suite.
+	t.Run("Valid_TLS12_WithCipher", func(t *testing.T) {
+		f("TLS12", []string{"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"}, false)
+	})
+
+	// Happy path: TLS 1.3 — cipher suites are ignored by Go's TLS stack for 1.3,
+	// so passing nil should succeed and fall back to Go defaults.
+	t.Run("Valid_TLS13_NilCiphers", func(t *testing.T) {
+		f("TLS13", nil, false)
+	})
+
+	// Happy path: empty cipher slice should fall back to Go's default cipher list.
+	t.Run("Valid_TLS12_EmptyCiphers", func(t *testing.T) {
+		f("TLS12", []string{}, false)
+	})
+
+	// Happy path: nil cipher slice should behave the same as empty.
+	t.Run("Valid_TLS12_NilCiphers", func(t *testing.T) {
+		f("TLS12", nil, false)
+	})
+
+	// Error path: unsupported TLS version string should return an error.
+	t.Run("Invalid_TLS_Version", func(t *testing.T) {
+		f("TLS99", nil, true)
+	})
+
+	// Error path: unrecognized cipher suite name should return an error.
+	t.Run("Invalid_CipherSuite_Name", func(t *testing.T) {
+		f("TLS12", []string{"NON_EXISTENT_CIPHER"}, true)
+	})
+
+	// Error path: non-existent certificate file should return an error.
+	t.Run("Invalid_CertFile_Path", func(t *testing.T) {
+		_, err := GetServerTLSConfig("nonexistent.crt", keyFile, "TLS12", nil)
+		if err == nil {
+			t.Fatal("expected error for missing cert file, got nil")
+		}
+	})
+
+	// Error path: non-existent key file should return an error.
+	t.Run("Invalid_KeyFile_Path", func(t *testing.T) {
+		_, err := GetServerTLSConfig(certFile, "nonexistent.key", "TLS12", nil)
+		if err == nil {
+			t.Fatal("expected error for missing key file, got nil")
+		}
+	})
 }
 
 const (


### PR DESCRIPTION
### Describe Your Changes

Add `NextProtos: []string{"h2", "http/1.1"}` to the `tls.Config` struct in `lib/netutil/tls.go`.

Without this field, the TLS layer does not advertise HTTP/2 support during the ALPN (Application-Layer Protocol Negotiation) handshake. This causes gRPC clients (including grpc-go v1.67+, which enforces ALPN-based HTTP/2 negotiation) to fail when connecting over TLS, as the server never signals readiness to speak HTTP/2.

Per [RFC 7540 §3.3](https://datatracker.ietf.org/doc/html/rfc7540#section-3.3), HTTP/2 over TLS **must** be negotiated via ALPN using the `h2` identifier. The `http/1.1` entry is included alongside it to preserve backward compatibility with HTTP/1.1-only clients.

This change is required upstream in VictoriaMetrics so that VictoriaTraces can pick it up by bumping the VictoriaMetrics dependency version in its `go.mod`, fixing [VictoriaTraces#108](https://github.com/VictoriaMetrics/VictoriaTraces/issues/108).

### Checklist

The following checks are **mandatory**:
- [ ] My change adheres to [[VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist)](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [ ] My change adheres to [[VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/)](https://docs.victoriametrics.com/victoriametrics/goals/).