### PR TITLE
fix offset bug in instant queries

### DIFF
--- a/app/vmselect/prometheus/prometheus.go
+++ b/app/vmselect/prometheus/prometheus.go
@@ -415,7 +415,7 @@ func exportHandler(qt *querytracer.Tracer, w http.ResponseWriter, cp *commonPara
 				}
 				xb := exportBlockPool.Get().(*exportBlock)
 				xb.mn = &rs.MetricName
-				xb.timestamps = rs.Timestamps
+				xb.timestamps = shiftTimestamps(rs.Timestamps, cp.timestampOffset)
 				xb.values = rs.Values
 				if err := writeLineFunc(xb, workerID); err != nil {
 					return err
@@ -440,6 +440,7 @@ func exportHandler(qt *querytracer.Tracer, w http.ResponseWriter, cp *commonPara
 				xb := exportBlockPool.Get().(*exportBlock)
 				xb.mn = mn
 				xb.timestamps, xb.values = b.AppendRowsWithTimeRangeFilter(xb.timestamps[:0], xb.values[:0], tr)
+				xb.timestamps = shiftTimestamps(xb.timestamps, cp.timestampOffset)
 				if len(xb.timestamps) > 0 {
 					if err := writeLineFunc(xb, workerID); err != nil {
 						return err
@@ -806,6 +807,7 @@ func QueryHandler(qt *querytracer.Tracer, startTime time.Time, w http.ResponseWr
 			deadline: deadline,
 			start:    start,
 			end:      end,
+			timestampOffset: offset,
 			filterss: filterss,
 		}
 		if err := exportHandler(qt, w, cp, "promapi", 0, false); err != nil {
@@ -1164,11 +1166,23 @@ type commonParams struct {
 	start            int64
 	end              int64
 	currentTimestamp int64
+	timestampOffset  int64
 	filterss         [][]storage.TagFilter
 }
 
 func (cp *commonParams) IsDefaultTimeRange() bool {
 	return cp.start == 0 && cp.currentTimestamp-cp.end < 1000
+}
+
+func shiftTimestamps(timestamps []int64, offset int64) []int64 {
+	if offset == 0 || len(timestamps) == 0 {
+		return timestamps
+	}
+	dstTimestamps := append([]int64{}, timestamps...)
+	for i := range dstTimestamps {
+		dstTimestamps[i] += offset
+	}
+	return dstTimestamps
 }
 
 // getExportParams obtains common params from r, which are used in /api/v1/export* handlers

--- a/app/vmselect/prometheus/prometheus_test.go
+++ b/app/vmselect/prometheus/prometheus_test.go
@@ -231,6 +231,31 @@ func TestGetLatencyOffsetMillisecondsFailure(t *testing.T) {
 	f("http://localhost?latency_offset=foobar")
 }
 
+func TestShiftTimestamps(t *testing.T) {
+	f := func(timestamps []int64, offset int64, expected []int64) {
+		t.Helper()
+		result := shiftTimestamps(timestamps, offset)
+		if !reflect.DeepEqual(result, expected) {
+			t.Fatalf("unexpected result; got %v; want %v", result, expected)
+		}
+	}
+
+	f(nil, 123, nil)
+	f([]int64{100, 200, 300}, 0, []int64{100, 200, 300})
+	f([]int64{100, 200, 300}, 50, []int64{150, 250, 350})
+}
+
+func TestShiftTimestampsDoesNotMutateInput(t *testing.T) {
+	src := []int64{100, 200, 300}
+	result := shiftTimestamps(src, 50)
+	if !reflect.DeepEqual(src, []int64{100, 200, 300}) {
+		t.Fatalf("unexpected source timestamps mutation; got %v", src)
+	}
+	if len(result) > 0 && len(src) > 0 && &result[0] == &src[0] {
+		t.Fatalf("shiftTimestamps must return a copy for non-zero offset")
+	}
+}
+
 func TestCalculateMaxMetricsLimitByResource(t *testing.T) {
 	f := func(maxConcurrentRequest, remainingMemory, expect int) {
 		t.Helper()


### PR DESCRIPTION
### Describe Your Changes

Fixes #9651
Added offset timestamp shifting for instant queries
### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
