### PR TITLE
docs/playgrounds: add aliases for old links

### DIFF
--- a/docs/playgrounds/_index.md
+++ b/docs/playgrounds/_index.md
@@ -10,5 +10,11 @@ tags:
   - logs
   - traces
   - playground
+aliases:
+  - /playgrounds/victoriametrics/
+  - /playgrounds/victorialogs/
+  - /playgrounds/victoriatraces/
+  - /playgrounds/cloud/
+  - /playgrounds/vmanomaly/
 ---
 {{% content "README.md" %}}


### PR DESCRIPTION
The old links were removed in https://github.com/VictoriaMetrics/VictoriaMetrics/pull/10754 mistakenly thinking that google didn't index it yet. However, it did. And users can get 404 when searching in google for VM plyagrounds.

Restoring the links via aliases. It means hugo will serve the `/playgrounds` page when user requests `/playgrounds/victoriametrics/`.

### Describe Your Changes

Please provide a brief description of the changes you made. Be as specific as possible to help others understand the purpose and impact of your modifications.

### Checklist

The following checks are **mandatory**:

- [ ] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [ ] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
