### PR TITLE
promscrape: add opt-in histograms for label name/value lengths

### DIFF
--- a/lib/promscrape/scrape_label_len_stats.go
+++ b/lib/promscrape/scrape_label_len_stats.go
@@ -1,0 +1,76 @@
+package promscrape
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/prompb"
+	parser "github.com/VictoriaMetrics/VictoriaMetrics/lib/protoparser/prometheus"
+	"github.com/VictoriaMetrics/metrics"
+)
+
+type labelLenHistograms struct {
+	nameLenHist  *metrics.Histogram
+	valueLenHist *metrics.Histogram
+}
+
+var (
+	labelLenHistogramsLock sync.Mutex
+	labelLenHistogramsMap  = make(map[string]*labelLenHistograms)
+)
+
+func getLabelLenHistograms(jobName, relabelStage string) *labelLenHistograms {
+	key := jobName + "/" + relabelStage
+	labelLenHistogramsLock.Lock()
+	defer labelLenHistogramsLock.Unlock()
+
+	h, ok := labelLenHistogramsMap[key]
+	if !ok {
+		h = &labelLenHistograms{
+			nameLenHist: metrics.GetOrCreateHistogram(
+				fmt.Sprintf(`vmagent_scrape_label_name_length_bytes{job=%q,relabel=%q}`, jobName, relabelStage)),
+			valueLenHist: metrics.GetOrCreateHistogram(
+				fmt.Sprintf(`vmagent_scrape_label_value_length_bytes{job=%q,relabel=%q}`, jobName, relabelStage)),
+		}
+		labelLenHistogramsMap[key] = h
+	}
+	return h
+}
+
+// trackLabelLengthsBefore tracks label lengths from parsed rows before relabeling
+func trackLabelLengthsBefore(jobName string, rows []parser.Row) {
+	if len(rows) == 0 {
+		return
+	}
+	h := getLabelLenHistograms(jobName, "before")
+
+	for i := range rows {
+		row := &rows[i]
+		// Track metric name length as __name__ label
+		h.nameLenHist.Update(float64(len("__name__")))
+		h.valueLenHist.Update(float64(len(row.Metric)))
+
+		for j := range row.Tags {
+			tag := &row.Tags[j]
+			h.nameLenHist.Update(float64(len(tag.Key)))
+			h.valueLenHist.Update(float64(len(tag.Value)))
+		}
+	}
+}
+
+// trackLabelLengthsAfter tracks label lengths from TimeSeries after relabeling
+func trackLabelLengthsAfter(jobName string, tss []prompb.TimeSeries) {
+	if len(tss) == 0 {
+		return
+	}
+	h := getLabelLenHistograms(jobName, "after")
+
+	for i := range tss {
+		ts := &tss[i]
+		for j := range ts.Labels {
+			label := &ts.Labels[j]
+			h.nameLenHist.Update(float64(len(label.Name)))
+			h.valueLenHist.Update(float64(len(label.Value)))
+		}
+	}
+}

--- a/lib/promscrape/scrape_label_len_stats.go
+++ b/lib/promscrape/scrape_label_len_stats.go
@@ -1,6 +1,7 @@
 package promscrape
 
 import (
+	"flag"
 	"fmt"
 	"sync"
 
@@ -8,6 +9,10 @@ import (
 	parser "github.com/VictoriaMetrics/VictoriaMetrics/lib/protoparser/prometheus"
 	"github.com/VictoriaMetrics/metrics"
 )
+
+var trackLabelLengths = flag.Bool("promscrape.trackLabelLengths", false,
+	"Whether to track label name and value lengths via vmagent_scrape_label_{name,value}_length_bytes histograms. "+
+		"This adds 4 histogram metrics per scrape job. 2 before relabeling and 2 after.")
 
 type labelLenHistograms struct {
 	nameLenHist  *metrics.Histogram
@@ -39,7 +44,7 @@ func getLabelLenHistograms(jobName, relabelStage string) *labelLenHistograms {
 
 // trackLabelLengthsBefore tracks label lengths from parsed rows before relabeling
 func trackLabelLengthsBefore(jobName string, rows []parser.Row) {
-	if len(rows) == 0 {
+	if !*trackLabelLengths || len(rows) == 0 {
 		return
 	}
 	h := getLabelLenHistograms(jobName, "before")
@@ -60,7 +65,7 @@ func trackLabelLengthsBefore(jobName string, rows []parser.Row) {
 
 // trackLabelLengthsAfter tracks label lengths from TimeSeries after relabeling
 func trackLabelLengthsAfter(jobName string, tss []prompb.TimeSeries) {
-	if len(tss) == 0 {
+	if !*trackLabelLengths || len(tss) == 0 {
 		return
 	}
 	h := getLabelLenHistograms(jobName, "after")

--- a/lib/promscrape/scrapework.go
+++ b/lib/promscrape/scrapework.go
@@ -545,6 +545,9 @@ func (sw *scrapeWork) processDataOneShot(scrapeTimestamp, realTimestamp int64, b
 			wc.rows.UnmarshalWithErrLogger(bodyString, sw.logError)
 		}
 	}
+	jobName := cfg.Job()
+	trackLabelLengthsBefore(jobName, wc.rows.Rows)
+
 	samplesPostRelabeling := 0
 	samplesScraped := len(wc.rows.Rows)
 	scrapedSamples.Update(float64(samplesScraped))
@@ -604,6 +607,7 @@ func (sw *scrapeWork) processDataOneShot(scrapeTimestamp, realTimestamp int64, b
 	}
 	wc.addAutoMetrics(sw, am, scrapeTimestamp)
 
+	trackLabelLengthsAfter(jobName, wc.writeRequest.Timeseries)
 	sw.pushData(&wc.writeRequest)
 	sw.prevLabelsLen = len(wc.labels)
 	writeRequestCtxPool.Put(wc)
@@ -643,6 +647,8 @@ func (sw *scrapeWork) processDataInStreamMode(scrapeTimestamp, realTimestamp int
 	cfg := sw.Config
 	areIdenticalSeries := areIdenticalSeries(cfg, lastScrapeStr, bodyString)
 
+	jobName := cfg.Job()
+
 	r := body.NewReader()
 	err := stream.Parse(r, scrapeTimestamp, "", false, prommetadata.IsEnabled(), func(rows []parser.Row, mms []parser.Metadata) error {
 		labelsLen := maxLabelsLen.Load()
@@ -662,6 +668,7 @@ func (sw *scrapeWork) processDataInStreamMode(scrapeTimestamp, realTimestamp int
 		}()
 
 		samplesScraped.Add(int64(len(rows)))
+		trackLabelLengthsBefore(jobName, rows)
 		if err := wc.addRows(cfg, rows, scrapeTimestamp, true); err != nil {
 			if errors.Is(err, errLabelsLimitExceeded) {
 				scrapesSkippedByLabelLimit.Inc()
@@ -683,6 +690,7 @@ func (sw *scrapeWork) processDataInStreamMode(scrapeTimestamp, realTimestamp int
 			samplesDroppedTotal.Add(int64(samplesDropped))
 		}
 
+		trackLabelLengthsAfter(jobName, wc.writeRequest.Timeseries)
 		sw.pushData(&wc.writeRequest)
 		return nil
 	}, sw.logError)


### PR DESCRIPTION
### promscrape: add opt-in histograms for label name/value lengths

This change provides visibility into label length distributions across scrape jobs. To helps identify jobs with unexpectedly large label values (which increase memory and storage costs) and measure the effect of relabeling rules on label sizes.

Two new histogram metrics added (vmagent_scrape_label_name_length_bytes and vmagent_scrape_label_value_length_bytes) that track the distribution of label name and value lengths per scrape job, before and after relabeling.
Gated behind -promscrape.trackLabelLengths flag (disabled by default) to avoid metric cardinality overhead.

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
