### PR TITLE
lib/stringsutil: optimize AppendLowercase

### DIFF
--- a/lib/stringsutil/stringsutil.go
+++ b/lib/stringsutil/stringsutil.go
@@ -1,8 +1,11 @@
 package stringsutil
 
 import (
+	"slices"
+	"sync"
 	"unicode"
 	"unicode/utf8"
+	"unsafe"
 )
 
 // LimitStringLen limits the length of s with maxLen.
@@ -21,9 +24,24 @@ func LimitStringLen(s string, maxLen int) string {
 }
 
 // AppendLowercase appends lowercase s to dst and returns the result.
-//
-// It is faster alternative to strings.ToLower.
+// It is recommended to use ToLowercaseFunc if possible to avoid copying of s.
 func AppendLowercase(dst []byte, s string) []byte {
+	// Try to find the first uppercase character.
+	n := uppercaseIndex(s)
+	if n < 0 {
+		// Fast path: no uppercase characters found.
+		dst = append(dst, s...)
+		return dst
+	}
+
+	// Slow path: convert s to lowercase.
+	dst = slices.Grow(dst, len(s))
+	dst = append(dst, s[:n]...)
+	s = s[n:]
+	return appendLowercaseInternal(dst, s)
+}
+
+func appendLowercaseInternal(dst []byte, s string) []byte {
 	dstLen := len(dst)
 
 	// Try fast path at first by assuming that s contains only ASCII chars.
@@ -48,4 +66,116 @@ func AppendLowercase(dst []byte, s string) []byte {
 		}
 	}
 	return dst
+}
+
+// ToLowercaseFunc calls f with a lowercase version of s.
+// The resulting value is only valid during the f call.
+func ToLowercaseFunc(s string, f func(s string)) {
+	// Try to find the first uppercase character.
+	n := uppercaseIndex(s)
+	if n < 0 {
+		// Fast path: no uppercase characters found.
+		f(s)
+		return
+	}
+
+	sb := getStringBuilder()
+	defer putStringBuilder(sb)
+
+	sb.buf = slices.Grow(sb.buf, len(s))
+	sb.appendString(s[:n])
+	sb.buf = appendLowercaseInternal(sb.buf, s[n:])
+	f(sb.string())
+}
+
+// IsLowercase returns true if the given string does not contain uppercase characters.
+func IsLowercase(s string) bool {
+	return uppercaseIndex(s) < 0
+}
+
+// uppercaseIndex returns the index of the first uppercase character in s,
+// or -1 if s does not contain uppercase characters.
+func uppercaseIndex(s string) int {
+	idx := 0
+
+	// Fast path for ASCII-only strings - process 8 bytes at a time.
+	for idx <= len(s)-8 {
+		v := uint64FromString(s[idx:])
+		// ASCII characters have the 8th bit clear.
+		// The operation bellow is the same as s[idx] < utf8.RuneSelf, but for multiple bytes.
+		if isASCII := v&0x8080808080808080 == 0; !isASCII {
+			break
+		}
+
+		// Check if any byte lacks the 6th bit, which indicates uppercase symbol or '@', '[', '\', ']', '^', '_'.
+		mightHaveUpper := ^v&0x2020202020202020 != 0
+		if mightHaveUpper {
+			for j := 0; j < 8; j++ {
+				c := s[idx+j]
+				if c >= 'A' && c <= 'Z' {
+					return idx + j
+				}
+			}
+		}
+		idx += 8
+	}
+
+	// Handle the rest of the s.
+	for idx < len(s) {
+		if c := s[idx]; c < utf8.RuneSelf {
+			if c >= 'A' && c <= 'Z' {
+				return idx
+			}
+			idx++
+			continue
+		}
+		r, size := utf8.DecodeRuneInString(s[idx:])
+		if r != unicode.ToLower(r) {
+			return idx
+		}
+		idx += size
+	}
+	return -1
+}
+
+// uint64FromString interprets the first 8 bytes of string b as a little-endian uint64.
+// The same as binary.LittleEndian.Uint64, but operates on strings.
+//
+// This function is a bit slower than (*uint64)(unsafe.Pointer(ptr)) alternative,
+// but does not have the issue with data alignment. See: https://github.com/VictoriaMetrics/VictoriaMetrics/pull/3927
+func uint64FromString(b string) uint64 {
+	_ = b[7] // bounds check hint to compiler; see golang.org/issue/14808
+	return uint64(b[0]) | uint64(b[1])<<8 | uint64(b[2])<<16 | uint64(b[3])<<24 |
+		uint64(b[4])<<32 | uint64(b[5])<<40 | uint64(b[6])<<48 | uint64(b[7])<<56
+}
+
+type stringBuilder struct {
+	buf []byte
+}
+
+func (sb *stringBuilder) appendString(s string) {
+	sb.buf = append(sb.buf, s...)
+}
+
+func (sb *stringBuilder) reset() {
+	sb.buf = sb.buf[:0]
+}
+
+func (sb *stringBuilder) string() string {
+	return unsafe.String(unsafe.SliceData(sb.buf), len(sb.buf))
+}
+
+var stringBuilderPool = sync.Pool{
+	New: func() any {
+		return &stringBuilder{}
+	},
+}
+
+func getStringBuilder() *stringBuilder {
+	return stringBuilderPool.Get().(*stringBuilder)
+}
+
+func putStringBuilder(sb *stringBuilder) {
+	sb.reset()
+	stringBuilderPool.Put(sb)
 }

--- a/lib/stringsutil/stringsutil_test.go
+++ b/lib/stringsutil/stringsutil_test.go
@@ -23,18 +23,255 @@ func TestLimitStringLen(t *testing.T) {
 	f("abcde", 5, "abcde")
 }
 
-func TestAppendLowercase(t *testing.T) {
-	f := func(s, resultExpected string) {
+func TestAppendLowercaseToLowercaseFunc(t *testing.T) {
+	f := func(s, expected string) {
 		t.Helper()
 
-		result := AppendLowercase(nil, s)
-		if string(result) != resultExpected {
-			t.Fatalf("unexpected result; got %q; want %q", result, resultExpected)
+		got := AppendLowercase(nil, s)
+		if string(got) != expected {
+			t.Fatalf("unexpected result; got %q; want %q", got, expected)
+		}
+
+		ToLowercaseFunc(s, func(s string) {
+			if s != expected {
+				t.Fatalf("unexpected result; got %q; want %q", got, expected)
+			}
+		})
+	}
+
+	// Empty string
+	f("", "")
+
+	// ASCII lowercase
+	f("hello", "hello")
+	f("world", "world")
+	f("abcdefghijklmnopqrstuvwxyz", "abcdefghijklmnopqrstuvwxyz")
+
+	// ASCII uppercase
+	f("HELLO", "hello")
+	f("WORLD", "world")
+	f("ABCDEFGHIJKLMNOPQRSTUVWXYZ", "abcdefghijklmnopqrstuvwxyz")
+
+	// ASCII mixed case
+	f("Hello", "hello")
+	f("heLLo", "hello")
+	f("WOrld", "world")
+	f("HeLLo WoRLd", "hello world")
+
+	// Unicode Cyrillic
+	f("привіт", "привіт")
+	f("світ", "світ")
+	f("ПРИВІТ", "привіт")
+	f("СВІТ", "світ")
+	f("Привіт", "привіт")
+	f("приВіт", "привіт")
+
+	// Unicode Greek
+	f("αβγδε", "αβγδε")
+	f("ΑΒΓΔΕ", "αβγδε")
+	f("Αβγδε", "αβγδε")
+
+	// Latin Extended
+	f("café", "café")
+	f("naïve", "naïve")
+	f("niño", "niño")
+	f("ærøå", "ærøå")
+	f("ñüöäß", "ñüöäß")
+	f("CAFÉ", "café")
+	f("NAÏVE", "naïve")
+	f("NIÑO", "niño")
+	f("ÆRØÅ", "ærøå")
+	f("ÑÜÖÄ", "ñüöä")
+	f("Café", "café")
+	f("naÏve", "naïve")
+	f("Niño", "niño")
+
+	// Thai
+	f("สวัสดี", "สวัสดี")
+	f("โลก", "โลก")
+
+	// Japanese Hiragana
+	f("こんにちは", "こんにちは")
+	f("せかい", "せかい")
+
+	// Japanese Katakana
+	f("コンニチハ", "コンニチハ")
+	f("セカイ", "セカイ")
+
+	// Chinese
+	f("你好", "你好")
+	f("世界", "世界")
+
+	// Devanagari
+	f("नमस्ते", "नमस्ते")
+	f("दुनिया", "दुनिया")
+
+	// Georgian
+	f("გამარჯობა", "გამარჯობა")
+	f("ᲒᲐᲛᲐᲠᲯᲝᲑᲐ", "გამარჯობა")
+
+	// Armenian
+	f("բարեւ", "բարեւ")
+	f("ԲԱՐԵՒ", "բարեւ")
+
+	// Turkish
+	f("İSTANBUL", "istanbul")
+
+	// Mixed languages
+	f("hello世界", "hello世界")
+	f("привет123", "привет123")
+	f("test你好", "test你好")
+	f("Hello世界", "hello世界")
+	f("Привет123", "привет123")
+	f("Test你好", "test你好")
+
+	// Emoji and symbols
+	f("hello😀world", "hello😀world")
+	f("test✨case", "test✨case")
+	f("foo🎉bar", "foo🎉bar")
+	f("HELLO😀WORLD", "hello😀world")
+
+	// Digits
+	f("hello123", "hello123")
+	f("test456world", "test456world")
+	f("abc123def456", "abc123def456")
+	f("123", "123")
+	f("456789", "456789")
+	f("0", "0")
+	f("HELLO123", "hello123")
+	f("TEST456WORLD", "test456world")
+	f("ABC123DEF456", "abc123def456")
+
+	// Special characters
+	f("hello-world", "hello-world")
+	f("test_case", "test_case")
+	f("foo.bar", "foo.bar")
+	f("a@b#c$d", "a@b#c$d")
+	f("!@#$%", "!@#$%")
+	f(".,;:-_", ".,;:-_")
+	f("()[]{}", "()[]{}")
+	f("HELLO-WORLD", "hello-world")
+	f("TEST_CASE", "test_case")
+	f("FOO.BAR", "foo.bar")
+	f("A@B#C$D", "a@b#c$d")
+}
+
+func TestIsLower(t *testing.T) {
+	f := func(s string, want bool) {
+		t.Helper()
+		if IsLowercase(s) != want {
+			t.Fatalf("unexpected result; got %v; want %v for %q", IsLowercase(s), want, s)
 		}
 	}
 
-	f("", "")
-	f("foo", "foo")
-	f("FOO", "foo")
-	f("foo БаР baz 123", "foo бар baz 123")
+	// Empty string
+	f("", true)
+
+	// ASCII lowercase
+	f("hello", true)
+	f("world", true)
+	f("abcdefghijklmnopqrstuvwxyz", true)
+
+	// ASCII uppercase
+	f("HELLO", false)
+	f("WORLD", false)
+	f("ABCDEFGHIJKLMNOPQRSTUVWXYZ", false)
+
+	// ASCII mixed case
+	f("Hello", false)
+	f("heLLo", false)
+	f("WOrld", false)
+
+	// Unicode Cyrillic
+	f("привіт", true)
+	f("світ", true)
+	f("ПРИВІТ", false)
+	f("СВІТ", false)
+	f("Привіт", false)
+	f("приВіт", false)
+
+	// Unicode Greek
+	f("αβγδε", true)
+	f("ΑΒΓΔΕ", false)
+	f("Αβγδε", false)
+
+	// Latin Extended with diacritics
+	f("café", true)
+	f("naïve", true)
+	f("niño", true)
+	f("ærøå", true)
+	f("ñüöäß", true)
+	f("CAFÉ", false)
+	f("NAÏVE", false)
+	f("NIÑO", false)
+	f("ÆRØÅ", false)
+	f("ÑÜÖÄ", false)
+	f("Café", false)
+	f("naÏve", false)
+	f("Niño", false)
+
+	// Thai
+	f("สวัสดี", true)
+	f("โลก", true)
+
+	// Japanese Hiragana
+	f("こんにちは", true)
+	f("せかい", true)
+
+	// Japanese Katakana
+	f("コンニチハ", true)
+	f("セカイ", true)
+
+	// Chinese characters
+	f("你好", true)
+	f("世界", true)
+
+	// Devanagari
+	f("नमस्ते", true)
+	f("दुनिया", true)
+
+	// Georgian
+	f("გამარჯობა", true)
+	f("ᲒᲐᲛᲐᲠᲯᲝᲑᲐ", false)
+
+	// Armenian
+	f("բարեւ", true)
+	f("ԲԱՐԵՒ", false)
+
+	// Mixed languages
+	f("hello世界", true)
+	f("привет123", true)
+	f("test你好", true)
+	f("Hello世界", false)
+	f("Привет123", false)
+	f("Test你好", false)
+
+	// Emoji and symbols
+	f("hello😀world", true)
+	f("test✨case", true)
+	f("foo🎉bar", true)
+
+	// Digits
+	f("hello123", true)
+	f("test456world", true)
+	f("abc123def456", true)
+	f("123", true)
+	f("456789", true)
+	f("0", true)
+	f("HELLO123", false)
+	f("TEST456WORLD", false)
+	f("ABC123DEF456", false)
+
+	// Special characters
+	f("hello-world", true)
+	f("test_case", true)
+	f("foo.bar", true)
+	f("a@b#c$d", true)
+	f("!@#$%", true)
+	f(".,;:-_", true)
+	f("()[]{}", true)
+	f("HELLO-WORLD", false)
+	f("TEST_CASE", false)
+	f("FOO.BAR", false)
+	f("A@B#C$D", false)
 }

--- a/lib/stringsutil/stringsutil_timing_test.go
+++ b/lib/stringsutil/stringsutil_timing_test.go
@@ -1,96 +1,132 @@
 package stringsutil
 
 import (
-	"strings"
 	"sync/atomic"
 	"testing"
 )
 
 func BenchmarkAppendLowercase(b *testing.B) {
-	b.Run("ascii-all-lowercase", func(b *testing.B) {
-		benchmarkAppendLowercase(b, []string{"foo bar baz abc def", "23k umlkds", "lq, poweri2349)"})
+	b.Run("ascii-full-lowercase", func(b *testing.B) {
+		data := `started kubernetes log collector for node "gke-sandbox-e2-standard-8-20250715071-5b0a2ce9-vyko"`
+		benchmarkToLower(b, data)
 	})
-	b.Run("ascii-some-uppercase", func(b *testing.B) {
-		benchmarkAppendLowercase(b, []string{"Foo Bar baz ABC def", "23k umlKDs", "lq, Poweri2349)"})
+	b.Run("ascii-partial-lowercase", func(b *testing.B) {
+		data := `started Kubernetes log collector for Node "gke-sandbox-e2-standard-8-20250715071-5b0a2ce9-vyko"`
+		benchmarkToLower(b, data)
 	})
-	b.Run("ascii-all-uppercase", func(b *testing.B) {
-		benchmarkAppendLowercase(b, []string{"FOO BAR BAZ ABC DEF", "23K UMLKDS", "LQ, POWERI2349)"})
+	b.Run("ascii-full-uppercase", func(b *testing.B) {
+		data := `STARTED KUBERNETES LOG COLLECTOR FOR NODE "GKE-SANDBOX-E2-STANDARD-8-20250715071-5B0A2CE9-VYKO"`
+		benchmarkToLower(b, data)
 	})
-	b.Run("unicode-all-lowercase", func(b *testing.B) {
-		benchmarkAppendLowercase(b, []string{"хщцукодл длобючф дл", "23и юбывлц", "лф, длощшу2349)"})
+	b.Run("ascii-partial-uppercase", func(b *testing.B) {
+		data := `started KUBERNETES log collector FOR NODE "gke-sandbox-e2-standard-8-20250715071-5b0a2ce9-vyko"`
+		benchmarkToLower(b, data)
 	})
-	b.Run("unicode-some-uppercase", func(b *testing.B) {
-		benchmarkAppendLowercase(b, []string{"Хщцукодл Длобючф ДЛ", "23и юбыВЛц", "лф, Длощшу2349)"})
+	b.Run("ascii-full-title", func(b *testing.B) {
+		data := `Started Kubernetes Log Collector For Node "Gke-Sandbox-E2-Standard-8-20250715071-5b0a2ce9-Vyko"`
+		benchmarkToLower(b, data)
 	})
-	b.Run("unicode-all-uppercase", func(b *testing.B) {
-		benchmarkAppendLowercase(b, []string{"ХЩЦУКОДЛ ДЛОБЮЧФ ДЛ", "23И ЮБЫВЛЦ", "ЛФ, ДЛОЩШУ2349)"})
+	b.Run("ascii-partial-title", func(b *testing.B) {
+		data := `started Kubernetes log Collector for Node "gke-sandbox-e2-standard-8-20250715071-5b0a2ce9-vyko"`
+		benchmarkToLower(b, data)
+	})
+	b.Run("ascii-mixcase", func(b *testing.B) {
+		data := `Started Kubernetes log COLLECTOR for nodE "GKE-Sandbox-E2-Standard-8-20250715071-5b0a2ce9-VYKO"`
+		benchmarkToLower(b, data)
+	})
+
+	b.Run("unicode-full-lowercase", func(b *testing.B) {
+		data := `запущен кубернетес лог коллектор на ноде гке-сендбокс-е2-стандарт-8-20250715071-5в0а2се9-вико`
+		benchmarkToLower(b, data)
+	})
+	b.Run("unicode-partial-lowercase", func(b *testing.B) {
+		data := `запущен КубернеТЕС лОг кОллектор нА НодЕ гке-сендбокс-е2-стандарт-8-20250715071-5в0а2се9-вико`
+		benchmarkToLower(b, data)
+	})
+	b.Run("unicode-full-uppercase", func(b *testing.B) {
+		data := `ЗАПУЩЕН КУБЕРНЕТЕС ЛОГ КОЛЛЕКТОР НА НОДЕ ГКЕ-СЕНДБОКС-Е2-СТАНДАРТ-8-20250715071-5В0А2СЕ9-ВИКО`
+		benchmarkToLower(b, data)
+	})
+	b.Run("unicode-partial-uppercase", func(b *testing.B) {
+		data := `запущен КУБЕРНЕТЕС лог коллектор НА НОДЕ гке-сендбокс-е2-стандарт-8-20250715071-5в0а2се9-вико`
+		benchmarkToLower(b, data)
+	})
+	b.Run("unicode-full-title", func(b *testing.B) {
+		data := `Запущен Кубернетес Лог Коллектор На Ноде Гке-Сендбокс-Е2-Стандарт-8-20250715071-5В0а2се9-Вико`
+		benchmarkToLower(b, data)
+	})
+	b.Run("unicode-partial-title", func(b *testing.B) {
+		data := `запущен Кубернетес лог Коллектор на Ноде гке-сендбокс-е2-стандарт-8-20250715071-5в0а2се9-вико`
+		benchmarkToLower(b, data)
+	})
+	b.Run("unicode-mixcase", func(b *testing.B) {
+		data := `Запущен Кубернетес лог КОЛЛЕКТОР на нодЕ гке-Сендбокс-Е2-Стандарт-8-20250715071-5В0а2се9-ВИКО`
+		benchmarkToLower(b, data)
 	})
 }
 
-func benchmarkAppendLowercase(b *testing.B, a []string) {
-	n := 0
-	for _, s := range a {
-		n += len(s)
-	}
+func benchmarkToLower(b *testing.B, s string) {
+	b.Helper()
 
 	b.ReportAllocs()
-	b.SetBytes(int64(n))
+	b.SetBytes(int64(len(s)))
 	b.RunParallel(func(pb *testing.PB) {
 		var buf []byte
-		var n uint64
 		for pb.Next() {
-			buf = buf[:0]
-			for _, s := range a {
-				buf = AppendLowercase(buf, s)
-			}
-			n += uint64(len(buf))
+			buf = AppendLowercase(buf[:0], s)
 		}
-		GlobalSink.Add(n)
-	})
-}
-
-func BenchmarkStringsToLower(b *testing.B) {
-	b.Run("ascii-all-lowercase", func(b *testing.B) {
-		benchmarkStringsToLower(b, []string{"foo bar baz abc def", "23k umlkds", "lq, poweri2349)"})
-	})
-	b.Run("ascii-some-uppercase", func(b *testing.B) {
-		benchmarkStringsToLower(b, []string{"Foo Bar baz ABC def", "23k umlKDs", "lq, Poweri2349)"})
-	})
-	b.Run("ascii-all-uppercase", func(b *testing.B) {
-		benchmarkStringsToLower(b, []string{"FOO BAR BAZ ABC DEF", "23K UMLKDS", "LQ, POWERI2349)"})
-	})
-	b.Run("unicode-all-lowercase", func(b *testing.B) {
-		benchmarkStringsToLower(b, []string{"хщцукодл длобючф дл", "23и юбывлц", "лф, длощшу2349)"})
-	})
-	b.Run("unicode-some-uppercase", func(b *testing.B) {
-		benchmarkStringsToLower(b, []string{"Хщцукодл Длобючф ДЛ", "23и юбыВЛц", "лф, Длощшу2349)"})
-	})
-	b.Run("unicode-all-uppercase", func(b *testing.B) {
-		benchmarkStringsToLower(b, []string{"ХЩЦУКОДЛ ДЛОБЮЧФ ДЛ", "23И ЮБЫВЛЦ", "ЛФ, ДЛОЩШУ2349)"})
-	})
-}
-
-func benchmarkStringsToLower(b *testing.B, a []string) {
-	n := 0
-	for _, s := range a {
-		n += len(s)
-	}
-
-	b.ReportAllocs()
-	b.SetBytes(int64(n))
-	b.RunParallel(func(pb *testing.PB) {
-		var buf []byte
-		var n uint64
-		for pb.Next() {
-			buf = buf[:0]
-			for _, s := range a {
-				sLower := strings.ToLower(s)
-				buf = append(buf, sLower...)
-			}
-			n += uint64(len(buf))
-		}
-		GlobalSink.Add(n)
+		GlobalSink.Add(uint64(len(buf)))
 	})
 }
 
 var GlobalSink atomic.Uint64
+
+func BenchmarkIsLowercase(b *testing.B) {
+	b.Run("ascii-mismatch", func(b *testing.B) {
+		data := `started kubernetes log collector for node "gke-sandbox-e2-standard-8-20250715071-5b0a2ce9-vyko"`
+		benchmarkIsLowercase(b, data, true)
+	})
+	b.Run("ascii-match-start", func(b *testing.B) {
+		data := `started Kubernetes log collector for Node "gke-sandbox-e2-standard-8-20250715071-5b0a2ce9-vyko"`
+		benchmarkIsLowercase(b, data, false)
+	})
+	b.Run("ascii-match-middle", func(b *testing.B) {
+		data := `started kubernetes log collector for Node "gke-sandbox-e2-standard-8-20250715071-5b0a2ce9-vyko"`
+		benchmarkIsLowercase(b, data, false)
+	})
+	b.Run("ascii-match-end", func(b *testing.B) {
+		data := `started kubernetes log collector for node "gke-sandbox-e2-standard-8-20250715071-5b0a2ce9-vyKo"`
+		benchmarkIsLowercase(b, data, false)
+	})
+
+	b.Run("unicode-mismatch", func(b *testing.B) {
+		data := `запущен кубернетес лог коллектор на ноде гке-сендбокс-е2-стандарт-8-20250715071-5в0а2се9-вико`
+		benchmarkIsLowercase(b, data, true)
+	})
+	b.Run("unicode-match-start", func(b *testing.B) {
+		data := `запущен Кубернетес лог коллектор на ноде гке-сендбокс-е2-стандарт-8-20250715071-5в0а2се9-вико`
+		benchmarkIsLowercase(b, data, false)
+	})
+	b.Run("unicode-match-middle", func(b *testing.B) {
+		data := `запущен кубернетес лог коллектор на Ноде гке-сендбокс-е2-стандарт-8-20250715071-5в0а2се9-вико`
+		benchmarkIsLowercase(b, data, false)
+	})
+	b.Run("unicode-match-end", func(b *testing.B) {
+		data := `запущен кубернетес лог коллектор на ноде гке-сендбокс-е2-стандарт-8-20250715071-5в0а2се9-виКо`
+		benchmarkIsLowercase(b, data, false)
+	})
+}
+
+func benchmarkIsLowercase(b *testing.B, s string, expected bool) {
+	b.Helper()
+
+	b.ReportAllocs()
+	b.SetBytes(int64(len(s)))
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			if IsLowercase(s) != expected {
+				b.Fatalf("expected IsLower(%q) to return %v", s, expected)
+			}
+		}
+	})
+}


### PR DESCRIPTION
The optimization includes the following improvements:
- Implementation of a function that processes 8 bytes per loop iteration to locate ASCII uppercase characters.
- Implementation of the `ToLowercaseFunc` function that prevents string copying if the string is already in lowercase.

Updates https://github.com/VictoriaMetrics/VictoriaLogs/issues/67

Benchmark results bellow

<details>
<summary> AppendLowercase amd64 </summary>

```
goos: linux
goarch: amd64
pkg: github.com/VictoriaMetrics/VictoriaMetrics/lib/stringsutil
cpu: AMD Ryzen 9 5950X 16-Core Processor
                                             │   old.txt    │               new.txt                │
                                             │    sec/op    │    sec/op     vs base                │
AppendLowercase/ascii-full-lowercase-32        5.1140n ± 1%   0.9960n ± 0%  -80.52% (p=0.000 n=20)
AppendLowercase/ascii-partial-lowercase-32      5.344n ± 0%    4.421n ± 0%  -17.25% (p=0.000 n=20)
AppendLowercase/ascii-full-uppercase-32         5.298n ± 0%    4.362n ± 0%  -17.66% (p=0.000 n=20)
AppendLowercase/ascii-partial-uppercase-32      5.527n ± 0%    4.445n ± 0%  -19.58% (p=0.000 n=20)
AppendLowercase/ascii-full-title-32             5.405n ± 0%    4.656n ± 0%  -13.85% (p=0.000 n=20)
AppendLowercase/ascii-partial-title-32          5.418n ± 0%    4.443n ± 0%  -17.99% (p=0.000 n=20)
AppendLowercase/ascii-mixcase-32                5.432n ± 0%    4.694n ± 0%  -13.58% (p=0.000 n=20)
AppendLowercase/unicode-full-lowercase-32       58.67n ± 0%    49.24n ± 0%  -16.07% (p=0.000 n=20)
AppendLowercase/unicode-partial-lowercase-32    56.97n ± 0%    56.27n ± 0%   -1.23% (p=0.000 n=20)
AppendLowercase/unicode-full-uppercase-32       47.60n ± 0%    47.22n ± 0%   -0.80% (p=0.000 n=20)
AppendLowercase/unicode-partial-uppercase-32    56.28n ± 1%    54.95n ± 0%   -2.36% (p=0.000 n=20)
AppendLowercase/unicode-full-title-32           56.79n ± 0%    56.53n ± 0%   -0.46% (p=0.000 n=20)
AppendLowercase/unicode-partial-title-32        58.58n ± 0%    57.50n ± 0%   -1.84% (p=0.000 n=20)
AppendLowercase/unicode-mixcase-32              55.40n ± 0%    55.10n ± 0%   -0.54% (p=0.000 n=20)
geomean                                         17.27n         13.96n       -19.17%

                                             │   old.txt    │                new.txt                │
                                             │     B/s      │     B/s       vs base                 │
AppendLowercase/ascii-full-lowercase-32        17.30Gi ± 1%   88.83Gi ± 0%  +413.44% (p=0.000 n=20)
AppendLowercase/ascii-partial-lowercase-32     16.56Gi ± 0%   20.01Gi ± 0%   +20.84% (p=0.000 n=20)
AppendLowercase/ascii-full-uppercase-32        16.70Gi ± 0%   20.28Gi ± 0%   +21.44% (p=0.000 n=20)
AppendLowercase/ascii-partial-uppercase-32     16.01Gi ± 0%   19.90Gi ± 0%   +24.32% (p=0.000 n=20)
AppendLowercase/ascii-full-title-32            16.37Gi ± 0%   19.00Gi ± 0%   +16.08% (p=0.000 n=20)
AppendLowercase/ascii-partial-title-32         16.33Gi ± 0%   19.91Gi ± 0%   +21.94% (p=0.000 n=20)
AppendLowercase/ascii-mixcase-32               16.29Gi ± 0%   18.85Gi ± 0%   +15.71% (p=0.000 n=20)
AppendLowercase/unicode-full-lowercase-32      2.476Gi ± 0%   2.950Gi ± 0%   +19.15% (p=0.000 n=20)
AppendLowercase/unicode-partial-lowercase-32   2.550Gi ± 0%   2.582Gi ± 0%    +1.25% (p=0.000 n=20)
AppendLowercase/unicode-full-uppercase-32      3.052Gi ± 0%   3.077Gi ± 0%    +0.79% (p=0.000 n=20)
AppendLowercase/unicode-partial-uppercase-32   2.582Gi ± 1%   2.644Gi ± 0%    +2.43% (p=0.000 n=20)
AppendLowercase/unicode-full-title-32          2.558Gi ± 0%   2.570Gi ± 0%    +0.46% (p=0.000 n=20)
AppendLowercase/unicode-partial-title-32       2.480Gi ± 0%   2.527Gi ± 0%    +1.88% (p=0.000 n=20)
AppendLowercase/unicode-mixcase-32             2.622Gi ± 0%   2.637Gi ± 0%    +0.55% (p=0.000 n=20)
geomean                                        6.565Gi        8.121Gi        +23.71%
```

</details>

<details>
<summary> AppendLowercase arm64 </summary>

```
goos: darwin
goarch: arm64
pkg: github.com/VictoriaMetrics/VictoriaMetrics/lib/stringsutil
cpu: Apple M4 Pro
                                             │   old.txt    │               new.txt                │
                                             │    sec/op    │    sec/op     vs base                │
AppendLowercase/ascii-full-lowercase-14        4.5720n ± 0%   0.7892n ± 0%  -82.74% (p=0.000 n=20)
AppendLowercase/ascii-partial-lowercase-14      4.705n ± 0%    4.609n ± 0%   -2.03% (p=0.000 n=20)
AppendLowercase/ascii-full-uppercase-14         4.620n ± 0%    4.887n ± 1%   +5.79% (p=0.000 n=20)
AppendLowercase/ascii-partial-uppercase-14      4.577n ± 0%    4.512n ± 0%   -1.41% (p=0.000 n=20)
AppendLowercase/ascii-full-title-14             4.580n ± 0%    4.859n ± 0%   +6.09% (p=0.000 n=20)
AppendLowercase/ascii-partial-title-14          4.587n ± 0%    4.527n ± 0%   -1.29% (p=0.000 n=20)
AppendLowercase/ascii-mixcase-14                4.594n ± 0%    4.870n ± 0%   +6.00% (p=0.000 n=20)
AppendLowercase/unicode-full-lowercase-14       61.85n ± 0%    56.03n ± 0%   -9.40% (p=0.000 n=20)
AppendLowercase/unicode-partial-lowercase-14    61.45n ± 0%    60.25n ± 0%   -1.95% (p=0.000 n=20)
AppendLowercase/unicode-full-uppercase-14       48.44n ± 1%    47.98n ± 1%   -0.94% (p=0.003 n=20)
AppendLowercase/unicode-partial-uppercase-14    59.37n ± 0%    58.95n ± 0%   -0.72% (p=0.000 n=20)
AppendLowercase/unicode-full-title-14           61.11n ± 0%    61.25n ± 0%   +0.23% (p=0.003 n=20)
AppendLowercase/unicode-partial-title-14        63.12n ± 0%    62.20n ± 0%   -1.47% (p=0.000 n=20)
AppendLowercase/unicode-mixcase-14              59.85n ± 0%    59.53n ± 0%   -0.53% (p=0.000 n=20)
geomean                                         16.50n         14.53n       -11.96%

                                             │   old.txt    │                new.txt                 │
                                             │     B/s      │      B/s       vs base                 │
AppendLowercase/ascii-full-lowercase-14        19.35Gi ± 0%   112.11Gi ± 0%  +479.33% (p=0.000 n=20)
AppendLowercase/ascii-partial-lowercase-14     18.81Gi ± 0%    19.19Gi ± 0%    +2.06% (p=0.000 n=20)
AppendLowercase/ascii-full-uppercase-14        19.15Gi ± 0%    18.10Gi ± 1%    -5.48% (p=0.000 n=20)
AppendLowercase/ascii-partial-uppercase-14     19.33Gi ± 0%    19.61Gi ± 0%    +1.44% (p=0.000 n=20)
AppendLowercase/ascii-full-title-14            19.32Gi ± 0%    18.21Gi ± 0%    -5.74% (p=0.000 n=20)
AppendLowercase/ascii-partial-title-14         19.29Gi ± 0%    19.54Gi ± 0%    +1.29% (p=0.000 n=20)
AppendLowercase/ascii-mixcase-14               19.26Gi ± 0%    18.17Gi ± 0%    -5.66% (p=0.000 n=20)
AppendLowercase/unicode-full-lowercase-14      2.349Gi ± 0%    2.593Gi ± 0%   +10.38% (p=0.000 n=20)
AppendLowercase/unicode-partial-lowercase-14   2.364Gi ± 0%    2.411Gi ± 0%    +1.99% (p=0.000 n=20)
AppendLowercase/unicode-full-uppercase-14      2.999Gi ± 1%    3.028Gi ± 1%    +0.96% (p=0.003 n=20)
AppendLowercase/unicode-partial-uppercase-14   2.447Gi ± 0%    2.465Gi ± 0%    +0.72% (p=0.000 n=20)
AppendLowercase/unicode-full-title-14          2.378Gi ± 0%    2.372Gi ± 0%    -0.24% (p=0.003 n=20)
AppendLowercase/unicode-partial-title-14       2.302Gi ± 0%    2.336Gi ± 0%    +1.49% (p=0.000 n=20)
AppendLowercase/unicode-mixcase-14             2.428Gi ± 0%    2.441Gi ± 0%    +0.53% (p=0.000 n=20)
geomean                                        6.872Gi         7.805Gi        +13.58%
```

</details>

See also benchmark results from VictoriaLogs repository for the any case prefix and phrase:



<details>
<summary> any case prefix/phrase amd64 </summary>

`git patch`:

```
diff --git a/lib/logstorage/filter_any_case_phrase.go b/lib/logstorage/filter_any_case_phrase.go
index 7d75aac05..fa444ece9 100644
--- a/lib/logstorage/filter_any_case_phrase.go
+++ b/lib/logstorage/filter_any_case_phrase.go
@@ -170,7 +170,7 @@ func matchAnyCasePhrase(s, phraseLowercase string) bool {
 		return false
 	}
 
-	if isASCIILowercase(s) {
+	if stringsutil.IsLowercase(s) {
 		// Fast path - s is in lowercase
 		return matchPhrase(s, phraseLowercase)
 	}
diff --git a/lib/logstorage/filter_any_case_prefix.go b/lib/logstorage/filter_any_case_prefix.go
index 6c0ee27f2..8da4d65c4 100644
--- a/lib/logstorage/filter_any_case_prefix.go
+++ b/lib/logstorage/filter_any_case_prefix.go
@@ -171,7 +171,7 @@ func matchAnyCasePrefix(s, prefixLowercase string) bool {
 		return false
 	}
 
-	if isASCIILowercase(s) {
+	if stringsutil.IsLowercase(s) {
 		// Fast path - s is in lowercase
 		return matchPrefix(s, prefixLowercase)
 	}

```

**Note**: the performance is even better for mixcase/uppercase scenarios if we'll use the new `ToLowercaseFunc` function.

```
goos: linux
goarch: amd64
pkg: github.com/VictoriaMetrics/VictoriaLogs/lib/logstorage
cpu: AMD Ryzen 9 5950X 16-Core Processor
                                                         │    old.txt    │                new.txt                │
                                                         │    sec/op     │    sec/op      vs base                │
MatchAnyCasePrefix/match-ascii-lowercase-32                 3.698n ±  1%    2.960n ±  1%  -19.95% (p=0.000 n=10)
MatchAnyCasePrefix/match-ascii-mixcase-32                  11.034n ± 38%    9.030n ± 55%        ~ (p=0.579 n=10)
MatchAnyCasePrefix/match-unicode-lowercase-32               27.15n ± 21%    15.05n ±  1%  -44.55% (p=0.000 n=10)
MatchAnyCasePrefix/match-unicode-mixcase-32                 25.77n ± 20%    27.88n ± 12%        ~ (p=0.085 n=10)
MatchAnyCasePrefix/mismatch-partial-ascii-lowercase-32      5.037n ±  3%    4.200n ±  1%  -16.64% (p=0.000 n=10)
MatchAnyCasePrefix/mismatch-partial-ascii-mixcase-32        13.33n ± 31%    14.15n ± 22%        ~ (p=0.796 n=10)
MatchAnyCasePrefix/mismatch-partial-unicode-lowercase-32    31.06n ±  9%    16.14n ±  0%  -48.04% (p=0.000 n=10)
MatchAnyCasePrefix/mismatch-partial-unicode-mixcase-32      31.31n ± 16%    32.41n ± 19%        ~ (p=0.971 n=10)
MatchAnyCasePrefix/mismatch-full-lowercase-32               3.632n ±  5%    2.846n ±  1%  -21.64% (p=0.000 n=10)
MatchAnyCasePrefix/mismatch-full-mixcase-32                 7.877n ± 47%    9.031n ± 26%        ~ (p=0.063 n=10)
MatchAnyCasePrefix/mismatch-full-unicode-lowercase-32       30.46n ± 16%    14.75n ±  1%  -51.57% (p=0.000 n=10)
MatchAnyCasePrefix/mismatch-full-unicode-mixcase-32         25.89n ± 24%    25.62n ±  5%        ~ (p=0.579 n=10)
MatchAnyCasePhrase/match-ascii-lowercase-32                 4.497n ±  1%    3.708n ±  0%  -17.57% (p=0.000 n=10)
MatchAnyCasePhrase/match-ascii-mixcase-32                   9.141n ± 76%   10.470n ± 33%        ~ (p=0.280 n=10)
MatchAnyCasePhrase/match-unicode-lowercase-32               28.67n ± 27%    15.69n ±  0%  -45.30% (p=0.000 n=10)
MatchAnyCasePhrase/match-unicode-mixcase-32                 26.91n ± 13%    27.20n ± 15%        ~ (p=0.684 n=10)
MatchAnyCasePhrase/mismatch-partial-ascii-lowercase-32      5.333n ±  2%    4.530n ±  1%  -15.06% (p=0.000 n=10)
MatchAnyCasePhrase/mismatch-partial-ascii-mixcase-32        12.75n ± 30%    11.01n ± 12%        ~ (p=0.927 n=10)
MatchAnyCasePhrase/mismatch-partial-unicode-lowercase-32    29.16n ± 11%    16.81n ±  1%  -42.37% (p=0.000 n=10)
MatchAnyCasePhrase/mismatch-partial-unicode-mixcase-32      29.18n ± 14%    29.12n ± 16%        ~ (p=0.796 n=10)
MatchAnyCasePhrase/mismatch-full-lowercase-32               3.924n ±  8%    3.178n ±  1%  -19.00% (p=0.000 n=10)
MatchAnyCasePhrase/mismatch-full-mixcase-32                 9.042n ± 31%   12.135n ± 19%  +34.21% (p=0.011 n=10)
MatchAnyCasePhrase/mismatch-full-unicode-lowercase-32       27.79n ± 16%    15.04n ±  2%  -45.86% (p=0.000 n=10)
MatchAnyCasePhrase/mismatch-full-unicode-mixcase-32         25.28n ± 11%    29.00n ± 12%  +14.72% (p=0.002 n=10)
geomean                                                     13.70n          11.40n        -16.84%

                                                         │    old.txt    │                 new.txt                 │
                                                         │      B/s      │      B/s        vs base                 │
MatchAnyCasePrefix/match-ascii-lowercase-32                11.33Gi ±  1%    14.16Gi ±  1%   +24.92% (p=0.000 n=10)
MatchAnyCasePrefix/match-ascii-mixcase-32                  3.862Gi ± 47%    4.645Gi ± 36%         ~ (p=0.579 n=10)
MatchAnyCasePrefix/match-unicode-lowercase-32              2.128Gi ± 17%    3.835Gi ±  1%   +80.24% (p=0.000 n=10)
MatchAnyCasePrefix/match-unicode-mixcase-32                2.205Gi ± 17%    2.039Gi ± 11%         ~ (p=0.089 n=10)
MatchAnyCasePrefix/mismatch-partial-ascii-lowercase-32     8.319Gi ±  3%    9.979Gi ±  1%   +19.95% (p=0.000 n=10)
MatchAnyCasePrefix/mismatch-partial-ascii-mixcase-32       3.161Gi ± 44%    2.963Gi ± 27%         ~ (p=0.796 n=10)
MatchAnyCasePrefix/mismatch-partial-unicode-lowercase-32   1.859Gi ± 10%    3.577Gi ±  0%   +92.38% (p=0.000 n=10)
MatchAnyCasePrefix/mismatch-partial-unicode-mixcase-32     1.815Gi ± 19%    1.757Gi ± 24%         ~ (p=0.971 n=10)
MatchAnyCasePrefix/mismatch-full-lowercase-32              11.54Gi ±  5%    14.72Gi ±  1%   +27.62% (p=0.000 n=10)
MatchAnyCasePrefix/mismatch-full-mixcase-32                5.321Gi ± 32%    4.642Gi ± 21%         ~ (p=0.063 n=10)
MatchAnyCasePrefix/mismatch-full-unicode-lowercase-32      1.897Gi ± 18%    3.915Gi ±  1%  +106.36% (p=0.000 n=10)
MatchAnyCasePrefix/mismatch-full-unicode-mixcase-32        2.195Gi ± 19%    2.217Gi ±  4%         ~ (p=0.579 n=10)
MatchAnyCasePhrase/match-ascii-lowercase-32                9.318Gi ±  1%   11.304Gi ±  0%   +21.32% (p=0.000 n=10)
MatchAnyCasePhrase/match-ascii-mixcase-32                  4.587Gi ± 43%    4.004Gi ± 25%         ~ (p=0.280 n=10)
MatchAnyCasePhrase/match-unicode-lowercase-32              2.014Gi ± 21%    3.682Gi ±  0%   +82.83% (p=0.000 n=10)
MatchAnyCasePhrase/match-unicode-mixcase-32                2.111Gi ± 12%    2.089Gi ± 13%         ~ (p=0.684 n=10)
MatchAnyCasePhrase/mismatch-partial-ascii-lowercase-32     7.859Gi ±  2%    9.251Gi ±  0%   +17.72% (p=0.000 n=10)
MatchAnyCasePhrase/mismatch-partial-ascii-mixcase-32       3.348Gi ± 41%    3.806Gi ± 10%         ~ (p=0.971 n=10)
MatchAnyCasePhrase/mismatch-partial-unicode-lowercase-32   1.980Gi ± 10%    3.436Gi ±  1%   +73.51% (p=0.000 n=10)
MatchAnyCasePhrase/mismatch-partial-unicode-mixcase-32     1.947Gi ± 12%    1.951Gi ± 13%         ~ (p=0.796 n=10)
MatchAnyCasePhrase/mismatch-full-lowercase-32              10.68Gi ±  7%    13.19Gi ±  1%   +23.47% (p=0.000 n=10)
MatchAnyCasePhrase/mismatch-full-mixcase-32                4.639Gi ± 23%    3.454Gi ± 16%   -25.55% (p=0.011 n=10)
MatchAnyCasePhrase/mismatch-full-unicode-lowercase-32      2.078Gi ± 13%    3.838Gi ±  2%   +84.69% (p=0.000 n=10)
MatchAnyCasePhrase/mismatch-full-unicode-mixcase-32        2.248Gi ± 10%    1.959Gi ± 10%   -12.84% (p=0.002 n=10)
geomean                                                    3.582Gi          4.300Gi         +20.05%
```
</details>