### PR TITLE
[Docs] Increase default label limit in VictoriaMetrics from 30 to 40

### DIFF
--- a/docs/victoriametrics/keyConcepts/keyConcepts.md
+++ b/docs/victoriametrics/keyConcepts/keyConcepts.md
@@ -338,7 +338,7 @@ Following convention is a good practice.
 
 Every measurement can contain an arbitrary number of `key="value"` labels. The good practice is to keep this number limited.
 Otherwise, it would be difficult to deal with measurements containing a big number of labels.
-By default, VictoriaMetrics limits the number of labels per measurement to `30` and drops other labels.
+By default, VictoriaMetrics limits the number of labels per measurement to `40` and drops other labels.
 This limit can be changed via `-maxLabelsPerTimeseries` command-line flag if necessary (but this isn't recommended).
 
 Every label value can contain an arbitrary string value. The good practice is to use short and meaningful label values to


### PR DESCRIPTION
Updated the default label limit of vminsert from 30 to 40.

### Describe Your Changes

The docs currently wrongly states that vminsert applies a label limit per timeseries of `30`. Currently, the limit is `40`, which is also correctly stated in in vmcluster docs. This PR corrects this in the key concepts docs.

```
  -maxLabelsPerTimeseries int
     The maximum number of labels per time series to be accepted. Series with superfluous labels are ignored. In this case the vm_rows_ignored_total{reason="too_many_labels"} metric at /metrics page is incremented (default 40)
```

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
