### PR TITLE
lib/streamaggr: fixed missed data when enable_windows and dedup_interval are set

### DIFF
--- a/docs/victoriametrics/changelog/CHANGELOG.md
+++ b/docs/victoriametrics/changelog/CHANGELOG.md
@@ -27,6 +27,7 @@ See also [LTS releases](https://docs.victoriametrics.com/victoriametrics/lts-rel
 ## tip
 
 * BUGFIX: [vmagent](https://docs.victoriametrics.com/victoriametrics/vmagent/): fix `ec2_sd_configs` returning 401 `AuthFailure` from AWS when credentials are obtained via IRSA, instance role or `AWS_CONTAINER_CREDENTIALS_*` env vars. The regression was introduced in [v1.140.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.140.0). See [#10815](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/10815).
+* BUGFIX: [stream aggregation](https://docs.victoriametrics.com/victoriametrics/stream-aggregation/): properly choose state when deduplication and aggregation windows are enabled. See [#10719](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/10719).
 
 ## [v1.140.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.140.0)
 

--- a/lib/streamaggr/output.go
+++ b/lib/streamaggr/output.go
@@ -106,7 +106,7 @@ func (ao *aggrOutputs) flushState(ctx *flushCtx) {
 			return true
 		}
 		outputKey := k.(string)
-		if ctx.isGreen {
+		if ctx.isGreen && ao.useSharedState {
 			outputs = av.green
 		} else {
 			outputs = av.blue


### PR DESCRIPTION
### Describe Your Changes

fixes https://github.com/VictoriaMetrics/VictoriaMetrics/issues/10719

when `enable_windows` and `dedup_interval` are set aggregation windows are enabled on deduplicator only and it writes data to output's blue state. this PR fixes an issue, when aggregator tries to use green output's state for flush, which is empty

### Checklist

The following checks are **mandatory**:

- [ ] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [ ] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
