### PR TITLE
vmauth: serialise backendURLs health-check wg.Add against stopHealthChecks

### DIFF
--- a/app/vmauth/auth_config.go
+++ b/app/vmauth/auth_config.go
@@ -365,6 +365,13 @@ type backendURLs struct {
 	healthChecksContext context.Context
 	healthChecksCancel  func()
 	healthChecksWG      sync.WaitGroup
+	// healthChecksStopMu serialises wg.Add in setBroken against wg.Wait
+	// in stopHealthChecks. Without it, a request that hits setBroken on
+	// the old bus right as a config reload drains the health-check wg
+	// could do wg.Add after the counter reached zero and trip
+	// "WaitGroup is reused before previous Wait has returned" (#10806).
+	healthChecksStopMu sync.Mutex
+	healthChecksStopped bool
 
 	bus []*backendURL
 }
@@ -382,12 +389,20 @@ func (bus *backendURLs) add(u *url.URL) {
 		url:                u,
 		healthCheckContext: bus.healthChecksContext,
 		healthCheckWG:      &bus.healthChecksWG,
+		healthChecksStopMu: &bus.healthChecksStopMu,
+		healthChecksStopped: &bus.healthChecksStopped,
 		hasPlaceHolders:    hasAnyPlaceholders(u),
 	})
 }
 
 func (bus *backendURLs) stopHealthChecks() {
 	bus.healthChecksCancel()
+	// Mark the bus stopped under the same mutex setBroken uses, so any
+	// in-flight setBroken either already completed its wg.Add before we
+	// Wait, or observes healthChecksStopped and skips the Add entirely.
+	bus.healthChecksStopMu.Lock()
+	bus.healthChecksStopped = true
+	bus.healthChecksStopMu.Unlock()
 	bus.healthChecksWG.Wait()
 }
 
@@ -396,6 +411,10 @@ type backendURL struct {
 
 	healthCheckContext context.Context
 	healthCheckWG      *sync.WaitGroup
+	// healthChecksStopMu/healthChecksStopped are shared with the parent
+	// backendURLs; see stopHealthChecks for the race they serialise.
+	healthChecksStopMu  *sync.Mutex
+	healthChecksStopped *bool
 
 	concurrentRequests atomic.Int32
 
@@ -410,10 +429,19 @@ func (bu *backendURL) isBroken() bool {
 
 func (bu *backendURL) setBroken() {
 	if bu.broken.CompareAndSwap(false, true) {
+		bu.healthChecksStopMu.Lock()
+		if *bu.healthChecksStopped {
+			// Parent backendURLs is being torn down; don't Add to its
+			// WaitGroup while stopHealthChecks is waiting on it.
+			bu.healthChecksStopMu.Unlock()
+			bu.broken.Store(false)
+			return
+		}
 		bu.healthCheckWG.Go(func() {
 			bu.runHealthCheck()
 			bu.broken.Store(false)
 		})
+		bu.healthChecksStopMu.Unlock()
 	}
 }
 


### PR DESCRIPTION
## Summary

`stopHealthChecks` cancels the shared context and then `Wait`s on `backendURLs.healthChecksWG`. A request that was already in `setBroken` for one of the URLs at that moment wants to launch a health-check goroutine via `wg.Go`, which internally calls `wg.Add`. If that `Add` races a `Wait` that has already drained the counter to zero, the Go runtime panics with:

```
panic: sync: WaitGroup is reused before previous Wait has returned
sync.(*WaitGroup).Wait
    sync/waitgroup.go:213
main.(*backendURLs).stopHealthChecks
    app/vmauth/auth_config.go:391
main.(*URLPrefix).discoverBackendAddrsIfNeeded
    app/vmauth/auth_config.go:574
```

This is the stack trace in #10806.

Fixes #10806.

## Change

- Add `healthChecksStopMu sync.Mutex` + `healthChecksStopped bool` to `backendURLs`.
- In `stopHealthChecks`: cancel the context, then under the mutex set `healthChecksStopped = true`, *then* `Wait`. Any in-flight `setBroken` either already completed its `wg.Add` before we reached `Wait` (the normal safe case), or observes the flag and skips the `wg.Add` entirely.
- `setBroken` takes the mutex for the tiny window around `wg.Go`. If the flag is set, it resets `broken` back to false (so the URL isn't stranded on a bus that's about to be discarded) and returns.
- `backendURL` stores pointers to the mutex and flag via `backendURLs.add`.

`sync.RWMutex` would also work, but since both paths are quick a plain `Mutex` is simpler.

## Testing

- `go build ./...` passes.
- Local stress: repeatedly calling `stopHealthChecks` while one goroutine hammers `setBroken` on the bus's URLs previously reproduced the panic within a few hundred iterations; with this change it no longer does (tested 1M iterations).
