### PR TITLE
cluster test: fix flaky 386 test of getMaxBufSizePerStorageNode, add notes

### DIFF
--- a/app/vminsert/netstorage/netstorage.go
+++ b/app/vminsert/netstorage/netstorage.go
@@ -640,6 +640,9 @@ func getMaxBufSizePerInsertCtxStorageNode(mem, concurrency, netstorageCount int)
 // 2. count of netstorage.
 // 3. count of storageNodesBucket.
 // 4. in range [1MB, 30MB], usually user won't reach the min border so it should be safe enough.
+//
+// since each storage node has two buffers (data and metadata), the netstorageCount should be halved.
+// see: https://github.com/VictoriaMetrics/VictoriaMetrics/issues/10725#issuecomment-4282256709
 func getMaxBufSizePerStorageNode(mem, netstorageCount int) int {
 	maxBufSize := mem / 4 / netstorageCount / 2
 	maxBufSize = max(consts.MinInsertPacketSizeForVMInsert, min(consts.MaxInsertPacketSizeForVMInsert, maxBufSize))

--- a/app/vminsert/netstorage/netstorage_test.go
+++ b/app/vminsert/netstorage/netstorage_test.go
@@ -163,12 +163,12 @@ func TestGetMaxBufSizePerStorageNode(t *testing.T) {
 		}
 	}
 
-	// 1 GiB / 4 / 5 / 2 = ~25 MiB per node
+	// 1 GiB / 4 / 5 / 2 = ~25 MiB per node, ~5*2*25MiB = 250MiB = 1/4 of 1 GiB.
 	f(1*1024*1024*1024, 5, 26*1024*1024)
 
 	// many storages: 1 GiB / 4 / 50 / 2 = ~2.5 MiB, clamped to min 1 MiB
 	f(1*1024*1024*1024, 50, 2*1024*1024+600*1024)
 
 	// a lot of memory, few storages: clamped to max 30 MiB
-	f(100*1024*1024*1024, 2, 30*1024*1024)
+	f(1*1024*1024*1024, 1, 30*1024*1024)
 }


### PR DESCRIPTION
- follow-up of https://github.com/VictoriaMetrics/VictoriaMetrics/pull/10846 to fix test for `GOARCH=386`.
- added comment for `getMaxBufSizePerStorageNode` about 2x buffer of netstorage.