### PR TITLE
lib/httpserver: don't log TLS-handshake-on-tcp-probe noise at ERROR

### DIFF
--- a/lib/httpserver/httpserver.go
+++ b/lib/httpserver/httpserver.go
@@ -165,7 +165,7 @@ func serveWithListener(addr string, ln net.Listener, rh RequestHandler, disableB
 		// Do not set ReadTimeout and WriteTimeout here,
 		// since these timeouts must be controlled by request handlers.
 
-		ErrorLog: logger.StdErrorLogger(),
+		ErrorLog: log.New(&filteredErrLogWriter{}, "", 0),
 	}
 	s.s.SetKeepAlivesEnabled(!*disableKeepAlive)
 	if *connTimeout > 0 {
@@ -805,4 +805,26 @@ func LogError(req *http.Request, errStr string) {
 	uri := GetRequestURI(req)
 	remoteAddr := GetQuotedRemoteAddr(req)
 	logger.Errorf("uri: %s, remote address: %q: %s", uri, remoteAddr, errStr)
+}
+
+// filteredErrLogWriter wraps net/http.Server.ErrorLog so that noisy
+// TLS-handshake-on-TCP-healthcheck lines don't spam the log at ERROR.
+// Kubernetes tcpSocket probes are the common case: they open a TCP
+// connection and close it before the TLS handshake completes, which
+// net/http then reports as `http: TLS handshake error from ...: EOF`.
+// Those events are structurally normal; everything else still flows
+// through the standard error logger unchanged.
+type filteredErrLogWriter struct{}
+
+func (filteredErrLogWriter) Write(p []byte) (int, error) {
+	s := string(p)
+	// The EOF / reset / unexpected-EOF variants are all the shapes net/http
+	// produces for a bare-TCP probe against an HTTPS listener.
+	if strings.Contains(s, "http: TLS handshake error") &&
+		(strings.Contains(s, ": EOF") ||
+			strings.Contains(s, ": connection reset by peer") ||
+			strings.Contains(s, "unexpected EOF")) {
+		return len(p), nil
+	}
+	return logger.StdErrorLogger().Writer().Write(p)
 }


### PR DESCRIPTION
## Summary

Kubernetes `tcpSocket` probes open a TCP connection to the TLS listener and close it before finishing the handshake. `net/http` reports each of those as `http: TLS handshake error from <pod-ip>: EOF` via `http.Server.ErrorLog`, which `lib/httpserver` wires straight to the VictoriaMetrics `StdErrorLogger`. With mTLS enabled on `vlstorage`/`vmstorage`/etc., that's an ERROR line every few seconds, every replica - enough volume to drown out genuine handshake failures. Reported downstream as [VictoriaLogs#1314](https://github.com/VictoriaMetrics/VictoriaLogs/issues/1314).

## Fix

Wrap `ErrorLog` with a small `io.Writer` (`filteredErrLogWriter`) that filters the exact shapes `net/http` produces for bare-TCP probes:

- `http: TLS handshake error ... : EOF`
- `http: TLS handshake error ... : connection reset by peer`
- `http: TLS handshake error ... unexpected EOF`

Everything else still forwards to the standard error logger unchanged, so real handshake failures continue to be visible at ERROR level. This mirrors the earlier #10788 fix that suppressed the equivalent noise on vmselect's `clusternative` handshake path.

## Test plan

- [x] `go build ./lib/httpserver/...`
- [x] `go test ./lib/httpserver/ -count=1` (no regressions)
