### PR TITLE
vmauth: make -maxRequestBodySizeToRetry=0 actually disable retries

### DIFF
--- a/app/vmauth/main.go
+++ b/app/vmauth/main.go
@@ -387,7 +387,7 @@ func bufferRequestBody(ctx context.Context, r io.ReadCloser, userName string) (i
 		}
 	}
 
-	bb := newBufferedBody(r, buf, maxBufSize)
+	bb := newBufferedBody(r, buf, maxBufSize, maxRequestBodySizeToRetry.IntN())
 	return bb, nil
 }
 
@@ -816,9 +816,15 @@ type bufferedBody struct {
 
 	// cannotRetry is set to true after Close() call on non-nil r.
 	cannotRetry bool
+
+	// maxRetrySize mirrors -maxRequestBodySizeToRetry at the time the body
+	// was buffered. A request is eligible for retry only when the whole
+	// body fits inside this limit; bodies buffered solely to satisfy
+	// -requestBufferSize must not be replayed.
+	maxRetrySize int
 }
 
-func newBufferedBody(r io.ReadCloser, buf []byte, maxBufSize int) *bufferedBody {
+func newBufferedBody(r io.ReadCloser, buf []byte, maxBufSize, maxRetrySize int) *bufferedBody {
 	// Do not use sync.Pool here, since http.RoundTrip may still use request body after return.
 	// See https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8051
 
@@ -828,8 +834,9 @@ func newBufferedBody(r io.ReadCloser, buf []byte, maxBufSize int) *bufferedBody 
 	}
 
 	return &bufferedBody{
-		r:   r,
-		buf: buf,
+		r:            r,
+		buf:          buf,
+		maxRetrySize: maxRetrySize,
 	}
 }
 
@@ -850,7 +857,11 @@ func (bb *bufferedBody) Read(p []byte) (int, error) {
 }
 
 func (bb *bufferedBody) canRetry() bool {
-	return bb.r == nil
+	// Disable retries when the user set -maxRequestBodySizeToRetry=0, even
+	// if the body fit in the -requestBufferSize buffer. Also refuse to
+	// retry bodies that were buffered only because -requestBufferSize was
+	// larger than -maxRequestBodySizeToRetry.
+	return bb.r == nil && bb.maxRetrySize > 0 && len(bb.buf) <= bb.maxRetrySize
 }
 
 // Close implements io.Closer interface.

--- a/app/vmauth/main_test.go
+++ b/app/vmauth/main_test.go
@@ -1729,7 +1729,7 @@ func TestBufferRequestBody_Failure(t *testing.T) {
 	f := func(body *mockBody, expectedResponse string) {
 		t.Helper()
 
-		if err := maxRequestBodySizeToRetry.Set("0"); err != nil {
+		if err := maxRequestBodySizeToRetry.Set("2048"); err != nil {
 			t.Fatalf("cannot set maxRequestBodySizeToRetry: %s", err)
 		}
 		if err := requestBufferSize.Set("2048"); err != nil {
@@ -1850,7 +1850,7 @@ func TestBufferedBody_RetrySuccess(t *testing.T) {
 				t.Fatalf("cannot reset maxRequestBodySizeToRetry: %s", err)
 			}
 		}()
-		if err := maxRequestBodySizeToRetry.Set("0"); err != nil {
+		if err := maxRequestBodySizeToRetry.Set(fmt.Sprintf("%d", maxBodySize)); err != nil {
 			t.Fatalf("cannot set maxRequestBodySizeToRetry: %s", err)
 		}
 
@@ -1908,7 +1908,7 @@ func TestBufferedBody_RetrySuccessPartialRead(t *testing.T) {
 				t.Fatalf("cannot reset maxRequestBodySizeToRetry: %s", err)
 			}
 		}()
-		if err := maxRequestBodySizeToRetry.Set("0"); err != nil {
+		if err := maxRequestBodySizeToRetry.Set(fmt.Sprintf("%d", maxBodySize)); err != nil {
 			t.Fatalf("cannot set maxRequestBodySizeToRetry: %s", err)
 		}
 


### PR DESCRIPTION
## Summary

Fixes #10857.

After #10309 the per-request buffer used by vmauth for request buffering is the same buffer used for retry replay, so once `requestBufferSize` was non-zero the body still fit in `bb.buf`, `bb.r` became nil, and `bufferedBody.canRetry` returned true. Setting `-maxRequestBodySizeToRetry=0` had no effect unless `-requestBufferSize=0` was also set.

## Fix

Thread the effective `-maxRequestBodySizeToRetry` value into `bufferedBody` and require `canRetry` to honour it: retries are allowed only when the retry limit is positive **and** the buffered body fits inside it. Bodies buffered solely to satisfy `-requestBufferSize` are no longer replayed.

## Tests

- `TestBufferedBody_RetrySuccess` and `TestBufferedBody_RetrySuccessPartialRead` were setting `maxRequestBodySizeToRetry=0` while expecting `canRetry()` to return true. Under the new contract that is the exact case being disabled, so they now set the retry size alongside `requestBufferSize` to exercise the real happy path. The rest of the assertions are unchanged.
- `TestBufferedBody_RetryFailureTooBigBody`, `TestBufferedBody_RetryFailureZeroOrNegativeMaxBodySize`, and the full `go test ./app/vmauth/...` suite stay green.

## Test plan

- [ ] `-maxRequestBodySizeToRetry=0` + `-requestBufferSize=32k`: small bodies are buffered but failing backends are no longer retried.
- [ ] `-maxRequestBodySizeToRetry=16k` + `-requestBufferSize=32k`: a 20k body is buffered (fits in requestBufferSize) but is not retried because it exceeds the retry cap.
- [ ] Default `-maxRequestBodySizeToRetry=16k`: small bodies still retry as before (behaviour unchanged).
