### PR TITLE
github: update PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,3 @@
 **PLEASE REMOVE LINE BELOW BEFORE SUBMITTING**
 
-Before creating the PR, verify that you read and followed [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
+Before creating the PR, make sure you have read and followed the [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,1 +1,3 @@
-Before creating the PR, please read [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist) and remove this line after confirming you understand and follow them.
+**PLEASE REMOVE LINE BELOW BEFORE SUBMITTING**
+
+Before creating the PR, verify that you read and followed [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).


### PR DESCRIPTION
Visually outline that guideline message should be removed from description before submitting the PR. This should prevent cases when PR template was blending into the PRs description remaining unnoticed.
