### PR TITLE
lib/timeutil: ensure parsed time is in allowed range

### DIFF
--- a/lib/timeutil/time.go
+++ b/lib/timeutil/time.go
@@ -23,12 +23,6 @@ func ParseTimeMsec(s string) (int64, error) {
 	return msecs, nil
 }
 
-const (
-	// time.UnixNano can only store maxInt64, which is 2262
-	maxValidYear = 2262
-	minValidYear = 1970
-)
-
 // ParseTimeAt parses time s in different formats, assuming the given currentTimestamp.
 //
 // See https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#timestamp-formats
@@ -83,15 +77,7 @@ func ParseTimeAt(s string, currentTimestamp int64) (int64, error) {
 	}
 	if len(s) == 4 {
 		// Parse YYYY
-		t, err := time.Parse("2006", s)
-		if err != nil {
-			return 0, err
-		}
-		y := t.Year()
-		if y > maxValidYear || y < minValidYear {
-			return 0, fmt.Errorf("cannot parse year from %q: year must in range [%d, %d]", s, minValidYear, maxValidYear)
-		}
-		return tzOffset + t.UnixNano(), nil
+		return parseTimeAt("2006", s, tzOffset, sOrig)
 	}
 	if !strings.Contains(sOrig, "-") {
 		nsec, ok := TryParseUnixTimestamp(sOrig)
@@ -102,48 +88,42 @@ func ParseTimeAt(s string, currentTimestamp int64) (int64, error) {
 	}
 	if len(s) == 7 {
 		// Parse YYYY-MM
-		t, err := time.Parse("2006-01", s)
-		if err != nil {
-			return 0, err
-		}
-		return tzOffset + t.UnixNano(), nil
+		return parseTimeAt("2006-01", s, tzOffset, sOrig)
 	}
 	if len(s) == 10 {
 		// Parse YYYY-MM-DD
-		t, err := time.Parse("2006-01-02", s)
-		if err != nil {
-			return 0, err
-		}
-		return tzOffset + t.UnixNano(), nil
+		return parseTimeAt("2006-01-02", s, tzOffset, sOrig)
 	}
 	if len(s) == 13 {
 		// Parse YYYY-MM-DDTHH
-		t, err := time.Parse("2006-01-02T15", s)
-		if err != nil {
-			return 0, err
-		}
-		return tzOffset + t.UnixNano(), nil
+		return parseTimeAt("2006-01-02T15", s, tzOffset, sOrig)
 	}
 	if len(s) == 16 {
 		// Parse YYYY-MM-DDTHH:MM
-		t, err := time.Parse("2006-01-02T15:04", s)
-		if err != nil {
-			return 0, err
-		}
-		return tzOffset + t.UnixNano(), nil
+		return parseTimeAt("2006-01-02T15:04", s, tzOffset, sOrig)
 	}
 	if len(s) == 19 {
 		// Parse YYYY-MM-DDTHH:MM:SS
-		t, err := time.Parse("2006-01-02T15:04:05", s)
-		if err != nil {
-			return 0, err
-		}
-		return tzOffset + t.UnixNano(), nil
+		return parseTimeAt("2006-01-02T15:04:05", s, tzOffset, sOrig)
 	}
 	// Parse RFC3339
-	t, err := time.Parse(time.RFC3339, sOrig)
+	return parseTimeAt(time.RFC3339, sOrig, 0, sOrig)
+}
+
+var (
+	minTime = time.UnixMicro(0).UTC()
+	maxTime = time.UnixMicro(math.MaxInt64 / 1000).UTC()
+)
+
+func parseTimeAt(layout, value string, tzOffsetNanos int64, sOrig string) (int64, error) {
+	t, err := time.Parse(layout, value)
 	if err != nil {
 		return 0, err
+	}
+	tzOffset := time.Duration(tzOffsetNanos)
+	t = t.UTC().Add(tzOffset)
+	if t.Before(minTime) || t.After(maxTime) {
+		return 0, fmt.Errorf("time %s (%v) must be in the range [%v, %v]", sOrig, t, minTime, maxTime)
 	}
 	return t.UnixNano(), nil
 }

--- a/lib/timeutil/time.go
+++ b/lib/timeutil/time.go
@@ -112,8 +112,8 @@ func ParseTimeAt(s string, currentTimestamp int64) (int64, error) {
 }
 
 var (
-	minTime = time.UnixMicro(0).UTC()
-	maxTime = time.UnixMicro(math.MaxInt64 / 1000).UTC()
+	minTime = time.Unix(0, 0).UTC()
+	maxTime = time.Unix(0, math.MaxInt64).UTC()
 )
 
 func parseTimeAt(layout, value string, tzOffsetNanos int64, sOrig string) (int64, error) {

--- a/lib/timeutil/time.go
+++ b/lib/timeutil/time.go
@@ -28,6 +28,7 @@ func ParseTimeMsec(s string) (int64, error) {
 // See https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#timestamp-formats
 //
 // If s doesn't contain timezone information, then the local timezone is used.
+// The time must be in the range [1970-01-01T00:00:00Z, 2262-04-11T23:47:16Z].
 //
 // It returns unix timestamp in nanoseconds.
 func ParseTimeAt(s string, currentTimestamp int64) (int64, error) {

--- a/lib/timeutil/time_test.go
+++ b/lib/timeutil/time_test.go
@@ -202,6 +202,162 @@ func TestParseTimeAtSuccess(t *testing.T) {
 	f("2023-05-20T04:57:43.123456789-02:30", now, 1684567663123456789)
 }
 
+func TestParseTimeAtLimits(t *testing.T) {
+	f := func(s string, wantTime time.Time) {
+		t.Helper()
+		currentTimestamp := time.Now().UnixNano()
+		got, err := ParseTimeAt(s, currentTimestamp)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if want := wantTime.UnixNano(); got != want {
+			t.Fatalf("unexpected result; got %d; want %d", got, want)
+		}
+	}
+
+	location := func(t *testing.T, location string) *time.Location {
+		t.Helper()
+		l, err := time.LoadLocation(location)
+		if err != nil {
+			t.Fatalf("could not load location %q: %v", location, err)
+		}
+		return l
+	}
+	east := location(t, "Etc/GMT-14") // UTC+14:00
+	west := location(t, "Etc/GMT+12") // UTC-12:00
+
+	// min year
+	f("1970Z", time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC))
+	f("1971+14:00", time.Date(1971, 1, 1, 0, 0, 0, 0, east))
+	f("1970-12:00", time.Date(1970, 1, 1, 0, 0, 0, 0, west))
+
+	// min month
+	f("1970-01Z", time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC))
+	f("1970-02+14:00", time.Date(1970, 2, 1, 0, 0, 0, 0, east))
+	f("1970-01-12:00", time.Date(1970, 1, 1, 0, 0, 0, 0, west))
+
+	// min day
+	f("1970-01-01Z", time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC))
+	f("1970-01-02+14:00", time.Date(1970, 1, 2, 0, 0, 0, 0, east))
+	f("1970-01-01-12:00", time.Date(1970, 1, 1, 0, 0, 0, 0, west))
+
+	// min hour
+	f("1970-01-01T00Z", time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC))
+	f("1970-01-01T14+14:00", time.Date(1970, 1, 1, 14, 0, 0, 0, east))
+	f("1969-12-31T12-12:00", time.Date(1969, 12, 31, 12, 0, 0, 0, west))
+
+	// min minute
+	f("1970-01-01T00:00Z", time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC))
+	f("1970-01-01T14:00+14:00", time.Date(1970, 1, 1, 14, 0, 0, 0, east))
+	f("1969-12-31T12:00-12:00", time.Date(1969, 12, 31, 12, 0, 0, 0, west))
+
+	// min second
+	f("1970-01-01T00:00:00Z", time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC))
+	f("1970-01-01T14:00:00+14:00", time.Date(1970, 1, 1, 14, 0, 0, 0, east))
+	f("1969-12-31T12:00:00-12:00", time.Date(1969, 12, 31, 12, 0, 0, 0, west))
+
+	// max year
+	f("2262Z", time.Date(2262, 1, 1, 0, 0, 0, 0, time.UTC))
+	f("2262+14:00", time.Date(2262, 1, 1, 0, 0, 0, 0, east))
+	f("2262-12:00", time.Date(2262, 1, 1, 0, 0, 0, 0, west))
+
+	// max month
+	f("2262-04Z", time.Date(2262, 4, 1, 0, 0, 0, 0, time.UTC))
+	f("2262-04+14:00", time.Date(2262, 4, 1, 0, 0, 0, 0, east))
+	f("2262-04-12:00", time.Date(2262, 4, 1, 0, 0, 0, 0, west))
+
+	// max day
+	f("2262-04-11Z", time.Date(2262, 4, 11, 0, 0, 0, 0, time.UTC))
+	f("2262-04-12+14:00", time.Date(2262, 4, 12, 0, 0, 0, 0, east))
+	f("2262-04-11-12:00", time.Date(2262, 4, 11, 0, 0, 0, 0, west))
+
+	// max hour
+	f("2262-04-11T23Z", time.Date(2262, 4, 11, 23, 0, 0, 0, time.UTC))
+	f("2262-04-12T13+14:00", time.Date(2262, 4, 12, 13, 0, 0, 0, east))
+	f("2262-04-11T11-12:00", time.Date(2262, 4, 11, 11, 0, 0, 0, west))
+
+	// max minute
+	f("2262-04-11T23:47Z", time.Date(2262, 4, 11, 23, 47, 0, 0, time.UTC))
+	f("2262-04-12T13:47+14:00", time.Date(2262, 4, 12, 13, 47, 0, 0, east))
+	f("2262-04-11T11:47-12:00", time.Date(2262, 4, 11, 11, 47, 0, 0, west))
+
+	// max second
+	f("2262-04-11T23:47:16Z", time.Date(2262, 4, 11, 23, 47, 16, 0, time.UTC))
+	f("2262-04-12T13:47:16+14:00", time.Date(2262, 4, 12, 13, 47, 16, 0, east))
+	f("2262-04-11T11:47:16-12:00", time.Date(2262, 4, 11, 11, 47, 16, 0, west))
+}
+
+func TestParseTimeAtOutsideLimits(t *testing.T) {
+	f := func(s string) {
+		t.Helper()
+		currentTimestamp := time.Now().UnixNano()
+		got, err := ParseTimeAt(s, currentTimestamp)
+		if err == nil {
+			t.Fatalf("expected error but got %d", got)
+		}
+	}
+
+	// min year
+	f("1969Z")
+	f("1970+14:00")
+	f("1969-12:00")
+
+	// min month
+	f("1969-12Z")
+	f("1970-01+14:00")
+	f("1969-12-12:00")
+
+	// min day
+	f("1969-12-31Z")
+	f("1970-01-01+14:00")
+	f("1969-12-31-12:00")
+
+	// min hour
+	f("1969-12-31T23Z")
+	f("1970-01-01T13+14:00")
+	f("1969-12-31T11-12:00")
+
+	// min minute
+	f("1969-12-311T23:59Z")
+	f("1970-01-01T13:59+14:00")
+	f("1969-12-31T11:59-12:00")
+
+	// min second
+	f("1969-12-311T23:59:59Z")
+	f("1970-01-01T13:59:59+14:00")
+	f("1969-12-31T11:59:59-12:00")
+
+	// max year
+	f("2263Z")
+	f("2263+14:00")
+	f("2263-12:00")
+
+	// max month
+	f("2262-05Z")
+	f("2262-05+14:00")
+	f("2262-05-12:00")
+
+	// max day
+	f("2262-04-12Z")
+	f("2262-04-13+14:00")
+	f("2262-04-12-12:00")
+
+	// max hour
+	f("2262-04-12T00Z")
+	f("2262-04-12T14+14:00")
+	f("2262-04-11T12-12:00")
+
+	// max minute
+	f("2262-04-11T23:48Z")
+	f("2262-04-12T13:48+14:00")
+	f("2262-04-11T11:48-12:00")
+
+	// max second
+	f("2262-04-11T23:47:17Z")
+	f("2262-04-12T13:47:17+14:00")
+	f("2262-04-11T11:47:17-12:00")
+}
+
 func TestParseTimeMsecFailure(t *testing.T) {
 	f := func(s string) {
 		t.Helper()

--- a/lib/timeutil/time_test.go
+++ b/lib/timeutil/time_test.go
@@ -1,6 +1,7 @@
 package timeutil
 
 import (
+	"strings"
 	"testing"
 	"time"
 )
@@ -295,6 +296,9 @@ func TestParseTimeAtOutsideLimits(t *testing.T) {
 		if err == nil {
 			t.Fatalf("expected error but got %d", got)
 		}
+		if !strings.Contains(err.Error(), "must be in the range") {
+			t.Fatalf("expected error: %v", err)
+		}
 	}
 
 	// min year
@@ -318,12 +322,12 @@ func TestParseTimeAtOutsideLimits(t *testing.T) {
 	f("1969-12-31T11-12:00")
 
 	// min minute
-	f("1969-12-311T23:59Z")
+	f("1969-12-31T23:59Z")
 	f("1970-01-01T13:59+14:00")
 	f("1969-12-31T11:59-12:00")
 
 	// min second
-	f("1969-12-311T23:59:59Z")
+	f("1969-12-31T23:59:59Z")
 	f("1970-01-01T13:59:59+14:00")
 	f("1969-12-31T11:59:59-12:00")
 


### PR DESCRIPTION
Update `timeutil.ParseTimeAt` to check the time limits for all date/time formats, not just year. Related to #10718.