### PR TITLE
vmalert: add `-rule.stripFilePath` to support strip rule file paths

### DIFF
--- a/app/vmalert/rule/group.go
+++ b/app/vmalert/rule/group.go
@@ -8,6 +8,7 @@ import (
 	"hash/fnv"
 	"maps"
 	"net/url"
+	"path"
 	"sync"
 	"time"
 
@@ -42,6 +43,9 @@ var (
 		"For example, if lookback=1h then range from now() to now()-1h will be scanned.")
 	maxStartDelay = flag.Duration("group.maxStartDelay", 5*time.Minute, "Defines the max delay before starting the group evaluation. Group's start is artificially delayed for random duration on interval"+
 		" [0..min(--group.maxStartDelay, group.interval)]. This helps smoothing out the load on the configured datasource, so evaluations aren't executed too close to each other.")
+	ruleStripFilePath = flag.Bool("rule.stripFilePath", false, "Whether to strip rule file paths in logs and all API responses, including /metrics. "+
+		"For example, file path '/path/to/tenant_id/rules.yml' will be stripped to 'groupHashID/rules.yml'. "+
+		"This flag may be useful for hiding sensitive information in file paths, such as S3 bucket details.")
 )
 
 // Group is an entity for grouping rules
@@ -147,6 +151,12 @@ func NewGroup(cfg config.Group, qb datasource.QuerierBuilder, defaultInterval ti
 		g.EvalDelay = &cfg.EvalDelay.D
 	}
 	g.id = g.CreateID()
+	// strip file path from group.File after generated group ID when ruleStripFilePath is set,
+	// so it won't be exposed in logs and api responses
+	if *ruleStripFilePath {
+		_, filename := path.Split(g.File)
+		g.File = fmt.Sprintf("%d/%s", g.id, filename)
+	}
 	for _, h := range cfg.Headers {
 		g.Headers[h.Key] = h.Value
 	}

--- a/app/vmalert/rule/group_test.go
+++ b/app/vmalert/rule/group_test.go
@@ -742,3 +742,64 @@ func parseTime(t *testing.T, s string) time.Time {
 	}
 	return tt
 }
+
+func TestRuleStripFilePath(t *testing.T) {
+	configG := config.Group{
+		Name:        "group",
+		File:        "/var/local/test/rules.yaml",
+		Type:        config.NewRawType("prometheus"),
+		Concurrency: 1,
+		Rules: []config.Rule{
+			{
+				ID:    0,
+				Alert: "alert",
+			},
+			{
+				ID:     1,
+				Record: "record",
+			},
+		}}
+	qb := &datasource.FakeQuerier{}
+	g := NewGroup(configG, qb, 1*time.Minute, nil)
+
+	gID := g.id
+	if g.File != "/var/local/test/rules.yaml" {
+		t.Fatalf("expected file path to be unchanged; got %q instead", g.File)
+	}
+
+	for _, r := range g.Rules {
+		if ar, ok := r.(*AlertingRule); ok {
+			if ar.File != "/var/local/test/rules.yaml" {
+				t.Fatalf("expected rule file path to be unchanged; got %q instead", ar.File)
+			}
+		}
+		if rr, ok := r.(*RecordingRule); ok {
+			if rr.File != "/var/local/test/rules.yaml" {
+				t.Fatalf("expected rule file path to be unchanged; got %q instead", rr.File)
+			}
+		}
+	}
+
+	oldRuleStripFilePath := *ruleStripFilePath
+	*ruleStripFilePath = true
+	defer func() {
+		*ruleStripFilePath = oldRuleStripFilePath
+	}()
+	g = NewGroup(configG, qb, 1*time.Minute, nil)
+
+	if g.File != fmt.Sprintf("%d/rules.yaml", gID) {
+		t.Fatalf("expected file path to be stripped to %q; got %q instead", fmt.Sprintf("%d/rules.yaml", gID), g.File)
+	}
+	for _, r := range g.Rules {
+		if ar, ok := r.(*AlertingRule); ok {
+			if ar.File != fmt.Sprintf("%d/rules.yaml", gID) {
+				t.Fatalf("expected rule file path to be unchanged; got %q instead", ar.File)
+			}
+		}
+		if rr, ok := r.(*RecordingRule); ok {
+			if rr.File != fmt.Sprintf("%d/rules.yaml", gID) {
+				t.Fatalf("expected rule file path to be unchanged; got %q instead", rr.File)
+			}
+		}
+	}
+}

--- a/app/vmalert/rule/web.go
+++ b/app/vmalert/rule/web.go
@@ -252,6 +252,9 @@ func (r *ApiRule) ExtendState() {
 
 // ToAPI returns ApiGroup representation of g
 func (g *Group) ToAPI() *ApiGroup {
+	if g == nil {
+		return &ApiGroup{}
+	}
 	g.mu.RLock()
 	defer g.mu.RUnlock()
 	ag := ApiGroup{

--- a/docs/victoriametrics/changelog/CHANGELOG.md
+++ b/docs/victoriametrics/changelog/CHANGELOG.md
@@ -26,6 +26,8 @@ See also [LTS releases](https://docs.victoriametrics.com/victoriametrics/lts-rel
 
 ## tip
 
+* FEATURE: [vmalert](https://docs.victoriametrics.com/victoriametrics/vmalert/): add `-rule.stripFilePath` to support stripping rule file paths in logs and all API responses, including /metrics. See [#5625](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/5625).
+
 ## [v1.142.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.142.0)
 
 Released at 2026-04-28

--- a/docs/victoriametrics/vmalert_common_flags.md
+++ b/docs/victoriametrics/vmalert_common_flags.md
@@ -434,6 +434,8 @@ See the docs at https://docs.victoriametrics.com/victoriametrics/vmalert/ .
      Minimum amount of time to wait before resending an alert to notifier.
   -rule.resultsLimit int
      Limits the number of alerts or recording results a single rule can produce. Can be overridden by the limit option under group if specified. If exceeded, the rule will be marked with an error and all its results will be discarded. 0 means no limit.
+  -rule.stripFilePath
+     Whether to strip rule file paths in logs and all API responses, including /metrics. For example, file path '/path/to/tenant_id/rules.yml' will be stripped to 'groupHashID/rules.yml'. This flag may be useful for hiding sensitive information in file paths, such as S3 bucket details.
   -rule.templates array
      Path or glob pattern to location with go template definitions for rules annotations templating. Flag can be specified multiple times.
      Examples:

--- a/docs/victoriametrics/vmalert_enterprise_flags.md
+++ b/docs/victoriametrics/vmalert_enterprise_flags.md
@@ -32,8 +32,6 @@ sitemap:
      Optional path to TLS Root CA for verifying client certificates at the corresponding -httpListenAddr when -mtls is enabled. By default the host system TLS Root CA is used for client certificate verification. This flag is available only in Enterprise binaries. See https://docs.victoriametrics.com/victoriametrics/enterprise/
      Supports an array of values separated by comma or specified via multiple flags.
      Each array item can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
-  -rule.stripFilePath
-     Whether to strip file path in responses from the api/v1/rules API for files configured via -rule cmd-line flag. For example, the file path '/path/to/tenant_id/rules.yml' will be stripped to just 'rules.yml'. This flag might be useful to hide sensitive information in file path such as tenant ID. This flag is available only in Enterprise binaries. See https://docs.victoriametrics.com/victoriametrics/enterprise/
   -s3.configFilePath string
      Path to file with S3 configs. Configs are loaded from default location if not set.
      See https://docs.aws.amazon.com/general/latest/gr/aws-security-credentials.html . This flag is available only in Enterprise binaries. See https://docs.victoriametrics.com/victoriametrics/enterprise/


### PR DESCRIPTION
fix https://github.com/VictoriaMetrics/VictoriaMetrics/issues/5625

The flag already exists in the ENT version. We decided to expose it in OSS and strip the path from all public places, including all APIs(includes `/metrics`) and debug logs(it's minor info there).

