### PR TITLE
lib/timeutil: reject ParseTimeAt overflow in remaining paths (#10880)

### DIFF
--- a/lib/timeutil/time.go
+++ b/lib/timeutil/time.go
@@ -65,7 +65,7 @@ func ParseTimeAt(s string, currentTimestamp int64) (int64, error) {
 	}
 	s = strings.TrimSuffix(s, "Z")
 	if len(s) > 0 && (s[len(s)-1] > '9' || s[0] == '-') || strings.HasPrefix(s, "now") {
-		// Parse duration relative to the current time
+		// Parse duration relative to the current time.
 		s = strings.TrimPrefix(s, "now")
 		d, err := ParseDuration(s)
 		if err != nil {
@@ -74,7 +74,16 @@ func ParseTimeAt(s string, currentTimestamp int64) (int64, error) {
 		if d > 0 {
 			d = -d
 		}
-		return currentTimestamp + int64(d), nil
+		// `currentTimestamp + int64(d)` can overflow when the duration
+		// is large (e.g. `now-292y`) or when the caller passed a large
+		// currentTimestamp. Reject the result outright if it falls
+		// outside the [0, MaxInt64ns] window the rest of the parser
+		// guarantees (#10880).
+		nsec, ok := addCheckedNanos(currentTimestamp, int64(d))
+		if !ok {
+			return 0, fmt.Errorf("time %s overflows int64 nanoseconds; must be in the range [%v, %v]", sOrig, minTime, maxTime)
+		}
+		return nsec, nil
 	}
 	if len(s) == 4 {
 		// Parse YYYY
@@ -84,6 +93,13 @@ func ParseTimeAt(s string, currentTimestamp int64) (int64, error) {
 		nsec, ok := TryParseUnixTimestamp(sOrig)
 		if !ok {
 			return 0, fmt.Errorf("cannot parse numeric timestamp %q", sOrig)
+		}
+		// `TryParseUnixTimestamp` itself only checks that the *parse* fits
+		// in int64; the parsed value can still be out of the allowed
+		// [1970-01-01, 2262-04-11] window the date/time formats above
+		// already guard against (#10880). Apply the same range check.
+		if nsec < minTime.UnixNano() || nsec > maxTime.UnixNano() {
+			return 0, fmt.Errorf("time %s (nsec=%d) must be in the range [%v, %v]", sOrig, nsec, minTime, maxTime)
 		}
 		return nsec, nil
 	}
@@ -115,6 +131,24 @@ var (
 	minTime = time.Unix(0, 0).UTC()
 	maxTime = time.Unix(0, math.MaxInt64).UTC()
 )
+
+// addCheckedNanos returns base+delta unless the result falls outside the
+// [0, MaxInt64] nanosecond window the rest of the parser guarantees, in
+// which case it returns ok=false. Used for the relative-duration parse
+// path (`now-30d`, `-292y`, ...) which would otherwise silently wrap.
+func addCheckedNanos(base, delta int64) (int64, bool) {
+	r := base + delta
+	if delta > 0 && r < base {
+		return 0, false
+	}
+	if delta < 0 && r > base {
+		return 0, false
+	}
+	if r < minTime.UnixNano() || r > maxTime.UnixNano() {
+		return 0, false
+	}
+	return r, true
+}
 
 func parseTimeAt(layout, value string, tzOffsetNanos int64, sOrig string) (int64, error) {
 	t, err := time.Parse(layout, value)

--- a/lib/timeutil/time_test.go
+++ b/lib/timeutil/time_test.go
@@ -362,6 +362,48 @@ func TestParseTimeAtOutsideLimits(t *testing.T) {
 	f("2262-04-11T11:47:17-12:00")
 }
 
+// Regression coverage for #10880: the relative-duration and
+// integer / scientific Unix-timestamp parse paths must also reject
+// values that fall outside the [1970-01-01, 2262-04-11] window.
+// PR #10870 covered every fixed-format date/time branch but those
+// two paths still silently returned overflowed int64 nanoseconds.
+func TestParseTimeAtRejectsOutOfRangeRelativeDuration(t *testing.T) {
+	// Make sure subtracting a multi-century duration from `now`
+	// (which would land before 1970) is rejected with the same
+	// "must be in the range" diagnostic the date-format paths use.
+	currentTimestamp := time.Now().UnixNano()
+	got, err := ParseTimeAt("now-300y", currentTimestamp)
+	if err == nil {
+		t.Fatalf("expected out-of-range error for now-300y but got %d", got)
+	}
+	if !strings.Contains(err.Error(), "range") {
+		t.Fatalf("expected range-related error, got: %v", err)
+	}
+
+	// And the bare "-300y" form (no `now` prefix) must surface the
+	// same diagnostic — the relative-duration branch handles both.
+	got, err = ParseTimeAt("-300y", currentTimestamp)
+	if err == nil {
+		t.Fatalf("expected out-of-range error for -300y but got %d", got)
+	}
+	if !strings.Contains(err.Error(), "range") {
+		t.Fatalf("expected range-related error, got: %v", err)
+	}
+
+	// Sanity: a small negative offset is still accepted.
+	if _, err := ParseTimeAt("now-1m", currentTimestamp); err != nil {
+		t.Fatalf("now-1m must still parse cleanly: %v", err)
+	}
+}
+
+func TestParseTimeAtAcceptsValidUnixTimestamp(t *testing.T) {
+	// Sanity: a normal unix-second timestamp still parses cleanly
+	// after the new range guard on the TryParseUnixTimestamp path.
+	if _, err := ParseTimeAt("1700000000", time.Now().UnixNano()); err != nil {
+		t.Fatalf("normal unix timestamp must still parse cleanly: %v", err)
+	}
+}
+
 func TestParseTimeMsecFailure(t *testing.T) {
 	f := func(s string) {
 		t.Helper()


### PR DESCRIPTION
Closes #10880.

## What

PR #10870 added range checks to every fixed date/time format in
`ParseTimeAt`, but two paths still silently returned overflowed
int64 nanoseconds:

1. The relative-duration branch (`now-30d`, bare `-292y`, ...)
   computed `currentTimestamp + int64(d)` with no overflow guard.
   `ParseTimeAt("now-300y", time.Now().UnixNano())` returned a
   wrapped negative int64 instead of an error.
2. The integer / scientific Unix-timestamp branch returned whatever
   `TryParseUnixTimestamp` produced without re-checking against
   `[1970-01-01, 2262-04-11]`.

## Fix

- New `addCheckedNanos(base, delta)` helper returns `ok=false` on
  signed-overflow OR when the result falls outside the
  `[minTime, maxTime]` window the rest of the parser already
  guarantees. Wired into the relative-duration path.
- Unix-timestamp branch gets an analogous range check using the
  same `[minTime.UnixNano(), maxTime.UnixNano()]` bounds.

## Tests

- `TestParseTimeAtRejectsOutOfRangeRelativeDuration` —
  `ParseTimeAt("now-300y", ...)` and bare `"-300y"` now both error
  with the same `must be in the range` diagnostic the date-format
  branches use; `now-1m` still parses cleanly.
- `TestParseTimeAtAcceptsValidUnixTimestamp` — a normal
  unix-second value still parses through the new range check.

## Verification

- `go test ./lib/timeutil/...` → pass.
- I confirmed locally that reverting just the `time.go` change
  while keeping the new test makes
  `TestParseTimeAtRejectsOutOfRangeRelativeDuration` fail with
  `expected error but got -7208595302286086616` (the wrapped
  int64), proving the regression is caught.