### PR TITLE
lib/httpserver: suppress TCP health check for tls connections

### DIFF
--- a/docs/victoriametrics/changelog/CHANGELOG.md
+++ b/docs/victoriametrics/changelog/CHANGELOG.md
@@ -26,6 +26,8 @@ See also [LTS releases](https://docs.victoriametrics.com/victoriametrics/lts-rel
 
 ## tip
 
+* FEATURE: all VictoriaMetrics components: suppress TCP health check errors when `-tls` flag is set. See [#10538](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/10538).
+
 ## [v1.142.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.142.0)
 
 Released at 2026-04-28

--- a/lib/httpserver/httpserver.go
+++ b/lib/httpserver/httpserver.go
@@ -1,6 +1,7 @@
 package httpserver
 
 import (
+	"bytes"
 	"context"
 	"crypto/tls"
 	_ "embed"
@@ -165,7 +166,7 @@ func serveWithListener(addr string, ln net.Listener, rh RequestHandler, disableB
 		// Do not set ReadTimeout and WriteTimeout here,
 		// since these timeouts must be controlled by request handlers.
 
-		ErrorLog: logger.StdErrorLogger(),
+		ErrorLog: log.New(&tlsErrorSkipLogger{}, "", 0),
 	}
 	s.s.SetKeepAlivesEnabled(!*disableKeepAlive)
 	if *connTimeout > 0 {
@@ -805,4 +806,15 @@ func LogError(req *http.Request, errStr string) {
 	uri := GetRequestURI(req)
 	remoteAddr := GetQuotedRemoteAddr(req)
 	logger.Errorf("uri: %s, remote address: %q: %s", uri, remoteAddr, errStr)
+}
+
+type tlsErrorSkipLogger struct{}
+
+func (*tlsErrorSkipLogger) Write(p []byte) (int, error) {
+	// skip common health check errors produced by Kubernetes and other tools
+	if bytes.Contains(p, []byte("TLS handshake error")) &&
+		(bytes.Contains(p, []byte("EOF")) || bytes.Contains(p, []byte("connection reset by peer"))) {
+		return len(p), nil
+	}
+	return logger.StdErrorLogger().Writer().Write(p)
 }


### PR DESCRIPTION
 Previously, if `-tls` flag was provided, victoria metrics components
produced the following log error entry at health checks:

 http: TLS handshake error from 10.244.0.1:46556: EOF

 Such health checks are common for many orchestration systems, such as consul
or kubernetes. And default http server already suppresses such EOF health checks.

 This commit adds suppression to the tls server as well.

Fixes https://github.com/VictoriaMetrics/VictoriaMetrics/issues/10538