### PR TITLE
vmauth: drop form-body params clashing with url_prefix query args

### DIFF
--- a/app/vmauth/main.go
+++ b/app/vmauth/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"flag"
@@ -391,6 +392,44 @@ func bufferRequestBody(ctx context.Context, r io.ReadCloser, userName string) (i
 	return bb, nil
 }
 
+// filterRequestFormBody drops form-body params that would otherwise override query args pinned by url_prefix.
+func filterRequestFormBody(r *http.Request, targetParams url.Values, mergeQueryArgs []string) {
+	ct := r.Header.Get("Content-Type")
+	if !strings.HasPrefix(ct, "application/x-www-form-urlencoded") {
+		return
+	}
+	bb, ok := r.Body.(*bufferedBody)
+	if !ok || !bb.canRetry() {
+		return
+	}
+	// skip the rewriting round-trip unless the body actually mentions a clashing key.
+	for k := range targetParams {
+		if !slices.Contains(mergeQueryArgs, k) && bytes.Contains(bb.buf, []byte(url.QueryEscape(k)+"=")) {
+			rewriteFormBody(r, bb, targetParams, mergeQueryArgs)
+			return
+		}
+	}
+}
+
+func rewriteFormBody(r *http.Request, bb *bufferedBody, targetParams url.Values, mergeQueryArgs []string) {
+	bodyParams, _ := url.ParseQuery(bytesutil.ToUnsafeString(bb.buf))
+	changed := false
+	for k := range targetParams {
+		if slices.Contains(mergeQueryArgs, k) {
+			continue
+		}
+		if _, ok := bodyParams[k]; ok {
+			delete(bodyParams, k)
+			changed = true
+		}
+	}
+	if !changed {
+		return
+	}
+	bb.buf = []byte(bodyParams.Encode())
+	r.ContentLength = int64(len(bb.buf))
+}
+
 func processRequest(w http.ResponseWriter, r *http.Request, ui *UserInfo, tkn *jwt.Token) {
 	u := normalizeURL(r.URL)
 	up, hc := ui.getURLPrefixAndHeaders(u, r.Host, r.Header)
@@ -435,6 +474,7 @@ func processRequest(w http.ResponseWriter, r *http.Request, ui *UserInfo, tkn *j
 			targetURLCopy.RawQuery = query.Encode()
 			targetURL = &targetURLCopy
 		} else {
+			filterRequestFormBody(r, targetURL.Query(), up.mergeQueryArgs)
 			// Update path for regular routes.
 			targetURL = mergeURLs(targetURL, u, up.dropSrcPathPrefixParts, up.mergeQueryArgs)
 		}

--- a/app/vmauth/main_test.go
+++ b/app/vmauth/main_test.go
@@ -546,6 +546,88 @@ requested_url={BACKEND}/path2/foo/?de=fg`
 	}
 }
 
+func TestRequestHandler_FormBodyClash(t *testing.T) {
+	f := func(cfgStr, body, responseExpected string) {
+		t.Helper()
+
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			b, err := io.ReadAll(r.Body)
+			if err != nil {
+				panic(fmt.Errorf("cannot read body: %w", err))
+			}
+			fmt.Fprintf(w, "url=%s\nbody=%s", r.URL, b)
+		}))
+		defer ts.Close()
+
+		cfgStr = strings.ReplaceAll(cfgStr, "{BACKEND}", ts.URL)
+
+		cfgOrigP := authConfigData.Load()
+		if _, err := reloadAuthConfigData([]byte(cfgStr)); err != nil {
+			t.Fatalf("cannot load config data: %s", err)
+		}
+		defer func() {
+			cfgOrig := []byte("unauthorized_user:\n  url_prefix: http://foo/bar")
+			if cfgOrigP != nil {
+				cfgOrig = *cfgOrigP
+			}
+			if _, err := reloadAuthConfigData(cfgOrig); err != nil {
+				t.Fatalf("cannot load the original config: %s", err)
+			}
+		}()
+
+		r, err := http.NewRequest(http.MethodPost, "http://some-host.com/api/v1/query", strings.NewReader(body))
+		if err != nil {
+			t.Fatalf("cannot initialize http request: %s", err)
+		}
+		r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+		w := &fakeResponseWriter{}
+		if !requestHandlerWithInternalRoutes(w, r) {
+			t.Fatalf("unexpected false is returned from requestHandler")
+		}
+
+		response := strings.TrimSpace(strings.ReplaceAll(w.getResponse(), "\r\n", "\n"))
+		responseExpected = strings.TrimSpace(responseExpected)
+		if response != responseExpected {
+			t.Fatalf("unexpected response\ngot\n%s\nwant\n%s", response, responseExpected)
+		}
+	}
+
+	// clashing body param is dropped
+	cfgStr := `
+unauthorized_user:
+  url_prefix: '{BACKEND}/select/multitenant/prometheus?extra_filters={vm_account_id="2"}'`
+	body := `query=up&extra_filters={vm_account_id="3"}`
+	responseExpected := `
+statusCode=200
+url=/select/multitenant/prometheus/api/v1/query?extra_filters={vm_account_id="2"}
+body=query=up`
+	f(cfgStr, body, responseExpected)
+
+	// merge_query_args keeps the body param
+	cfgStr = `
+unauthorized_user:
+  merge_query_args: [extra_filters]
+  url_prefix: '{BACKEND}/select/multitenant/prometheus?extra_filters={vm_account_id="2"}'`
+	body = `query=up&extra_filters={vm_account_id="3"}`
+	responseExpected = `
+statusCode=200
+url=/select/multitenant/prometheus/api/v1/query?extra_filters={vm_account_id="2"}
+body=query=up&extra_filters={vm_account_id="3"}`
+	f(cfgStr, body, responseExpected)
+
+	// non-clashing body params pass thru
+	cfgStr = `
+unauthorized_user:
+  url_prefix: '{BACKEND}/select/multitenant/prometheus?extra_filters={vm_account_id="2"}'`
+	body = `query=up&time=420`
+	responseExpected = `
+statusCode=200
+url=/select/multitenant/prometheus/api/v1/query?extra_filters={vm_account_id="2"}
+body=query=up&time=420`
+	f(cfgStr, body, responseExpected)
+}
+
 func TestJWTRequestHandler(t *testing.T) {
 	// Generate RSA key pair for testing
 	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)

--- a/docs/victoriametrics/changelog/CHANGELOG.md
+++ b/docs/victoriametrics/changelog/CHANGELOG.md
@@ -27,12 +27,11 @@ See also [LTS releases](https://docs.victoriametrics.com/victoriametrics/lts-rel
 ## tip
 
 * BUGFIX: `vminsert` in [VictoriaMetrics cluster](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/): properly discover addresses of storage nodes with [enterprise automatic-vmstorage-discovery](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/#automatic-vmstorage-discovery). Bug was introduced at [v1.141.0](https://github.com/VictoriaMetrics/VictoriaMetrics/blob/master/docs/victoriametrics/changelog/CHANGELOG.md#v11410).
+* BUGFIX: [vmauth](https://docs.victoriametrics.com/victoriametrics/vmauth/): apply query arg clash protection to `application/x-www-form-urlencoded` request bodies. Previously, clients could override backend-configured query args (e.g. `extra_filters`) by sending them via POST body, since the backend merges URL and form-body args. See [#10908](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/10908).
 
 * FEATURE: all VictoriaMetrics components: suppress TCP health check errors when `-tls` flag is set. See [#10538](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/10538).
 * FEATURE: [vmalert](https://docs.victoriametrics.com/victoriametrics/vmalert/): add `-rule.stripFilePath` to support stripping rule file paths in logs and all API responses, including /metrics. See [#5625](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/5625).
 * FEATURE: [vmalert](https://docs.victoriametrics.com/victoriametrics/vmalert/): add `formatTime` template function for formatting a Unix timestamp using the provided layout. For example, `{{ now | formatTime "2006-01-02T15:04:05Z07:00" }}` returns the current time in RFC3339 format. See issue [#10624](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/10624). Thanks to @andriibeee for the contribution.
-
-* BUGFIX: [vmauth](https://docs.victoriametrics.com/victoriametrics/vmauth/): apply query arg clash protection to `application/x-www-form-urlencoded` request bodies. Previously, clients could override backend-configured query args (e.g. `extra_filters`) by sending them via POST body, since the backend merges URL and form-body args. See [#10908](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/10908).
 
 ## [v1.142.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.142.0)
 

--- a/docs/victoriametrics/changelog/CHANGELOG.md
+++ b/docs/victoriametrics/changelog/CHANGELOG.md
@@ -30,6 +30,8 @@ See also [LTS releases](https://docs.victoriametrics.com/victoriametrics/lts-rel
 * FEATURE: [vmalert](https://docs.victoriametrics.com/victoriametrics/vmalert/): add `-rule.stripFilePath` to support stripping rule file paths in logs and all API responses, including /metrics. See [#5625](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/5625).
 * FEATURE: [vmalert](https://docs.victoriametrics.com/victoriametrics/vmalert/): add `formatTime` template function for formatting a Unix timestamp using the provided layout. For example, `{{ now | formatTime "2006-01-02T15:04:05Z07:00" }}` returns the current time in RFC3339 format. See issue [#10624](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/10624). Thanks to @andriibeee for the contribution.
 
+* BUGFIX: [vmauth](https://docs.victoriametrics.com/victoriametrics/vmauth/): apply query arg clash protection to `application/x-www-form-urlencoded` request bodies. Previously, clients could override backend-configured query args (e.g. `extra_filters`) by sending them via POST body, since the backend merges URL and form-body args. See [#10908](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/10908).
+
 ## [v1.142.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.142.0)
 
 Released at 2026-04-28


### PR DESCRIPTION
Closes #10908 

The function `(*http.Request).ParseForm`, used by backends like vmselect, merges form-body params with URL query args. Without these changes a client can bypass url_prefix?extra_filters=... by sending its own extra_filters in the body.

The fix drops form-body params clashing with url_prefix query args before forwarding. Params listed in merge_query_args are exempt bc the user opted into merging them.
