### PR TITLE
app/vmrestore: Add concurrencyPerFile functionality 

### DIFF
--- a/app/vmrestore/main.go
+++ b/app/vmrestore/main.go
@@ -28,6 +28,7 @@ var (
 		"VictoriaMetrics must be stopped when restoring from backup. -storageDataPath dir can be non-empty. In this case the contents of -storageDataPath dir "+
 		"is synchronized with -src contents, i.e. it works like 'rsync --delete'")
 	concurrency             = flag.Int("concurrency", 10, "The number of concurrent workers. Higher concurrency may reduce restore duration")
+	concurrencyPerFile      = flag.Int("concurrencyPerFile", 4, "The maximum number of concurrent workers per restored file. Higher values may reduce restore duration for big files")
 	maxBytesPerSecond       = flagutil.NewBytes("maxBytesPerSecond", 0, "The maximum download speed. There is no limit if it is set to 0")
 	skipBackupCompleteCheck = flag.Bool("skipBackupCompleteCheck", false, "Whether to skip checking for 'backup complete' file in -src. This may be useful for restoring from old backups, which were created without 'backup complete' file")
 	SkipPreallocation       = flag.Bool("skipFilePreallocation", false, "Whether to skip pre-allocated files. This will likely be slower in most cases, but allows restores to resume mid file on failure")
@@ -61,6 +62,7 @@ func main() {
 	}
 	a := &actions.Restore{
 		Concurrency:             *concurrency,
+		ConcurrencyPerFile:      *concurrencyPerFile,
 		Src:                     srcFS,
 		Dst:                     dstFS,
 		SkipBackupCompleteCheck: *skipBackupCompleteCheck,

--- a/docs/victoriametrics/vmrestore.md
+++ b/docs/victoriametrics/vmrestore.md
@@ -49,6 +49,8 @@ i.e. the end result would be similar to [rsync --delete](https://askubuntu.com/q
 
 * See [how to setup credentials via environment variables](https://docs.victoriametrics.com/victoriametrics/vmbackup/#providing-credentials-via-env-variables).
 * If `vmrestore` consumes all the network bandwidth, then set `-maxBytesPerSecond` to the desired value.
+* If restore speed drops near the end when only a few big files remain, then increase `-concurrencyPerFile`.
+  The total number of concurrent downloads is still limited by `-concurrency`.
 * If `vmrestore` has been interrupted due to temporary error, then just restart it with the same args. It will resume the restore process.
 
 ## Advanced usage
@@ -61,6 +63,8 @@ Run `vmrestore -help` in order to see all the available options:
 ```sh
   -concurrency int
      The number of concurrent workers. Higher concurrency may reduce restore duration (default 10)
+  -concurrencyPerFile int
+     The maximum number of concurrent workers per restored file. Higher values may reduce restore duration for big files (default 4)
   -configFilePath string
      Path to file with S3 configs. Configs are loaded from default location if not set.
      See https://docs.aws.amazon.com/general/latest/gr/aws-security-credentials.html

--- a/lib/backup/actions/restore.go
+++ b/lib/backup/actions/restore.go
@@ -29,6 +29,9 @@ type Restore struct {
 	// Concurrency is the number of concurrent workers to run during restore.
 	Concurrency int
 
+	// ConcurrencyPerFile is the maximum number of concurrent workers to run for a single restored file.
+	ConcurrencyPerFile int
+
 	// Src is the source containing backed up data.
 	Src common.RemoteFS
 
@@ -177,25 +180,7 @@ func (r *Restore) Run(ctx context.Context) error {
 		}
 		logger.Infof("downloading %d parts from %s to %s", len(partsToCopy), src, dst)
 		var bytesDownloaded atomic.Uint64
-		err = runParallelPerPath(ctx, concurrency, perPath, func(parts []common.Part) error {
-			// Sort partsToCopy in order to properly grow file size during downloading
-			common.SortParts(parts)
-			if !r.SkipPreallocation {
-				if err := dst.PreallocateFile(parts[0]); err != nil {
-					return fmt.Errorf("cannot preallocate %s: %w", parts[0].Path, err)
-				}
-			}
-			for _, p := range parts {
-				logger.Infof("downloading %s from %s to %s", &p, src, dst)
-				if err := pipelinedDownload(src, dst, p, &bytesDownloaded); err != nil {
-					return err
-				}
-			}
-			if err := dst.FinalizeFile(parts[0]); err != nil {
-				return fmt.Errorf("cannot finalize %s: %w", parts[0].Path, err)
-			}
-			return nil
-		}, func(elapsed time.Duration) {
+		err = r.runParallelPerPath(ctx, concurrency, perPath, &bytesDownloaded, func(elapsed time.Duration) {
 			if elapsed.Seconds() <= 0 {
 				// The only way for this to happen is when the operation is immediately canceled.
 				// There is no need to log progress in this case, and this prevents division by zero below.
@@ -219,6 +204,148 @@ func (r *Restore) Run(ctx context.Context) error {
 
 	removeRestoreLock(r.Dst.Dir)
 	return nil
+}
+
+func (r *Restore) runParallelPerPath(ctx context.Context, concurrency int, perPath map[string][]common.Part, bytesDownloaded *atomic.Uint64, progress func(elapsed time.Duration)) error {
+	var err error
+	runWithProgress(progress, func() {
+		err = r.runParallelPerPathInternal(ctx, concurrency, perPath, bytesDownloaded)
+	})
+	return err
+}
+
+func (r *Restore) runParallelPerPathInternal(ctx context.Context, concurrency int, perPath map[string][]common.Part, bytesDownloaded *atomic.Uint64) error {
+	if concurrency <= 0 {
+		concurrency = 1
+	}
+	if len(perPath) == 0 {
+		return nil
+	}
+
+	concurrencyPerFile := r.ConcurrencyPerFile
+	if concurrencyPerFile <= 0 {
+		concurrencyPerFile = 1
+	}
+	concurrencyPerFile = min(concurrencyPerFile, concurrency)
+
+	ctxLocal, cancelLocal := context.WithCancel(ctx)
+	defer cancelLocal()
+
+	globalConcurrencyCh := make(chan struct{}, concurrency)
+	pathConcurrencyCh := make(chan struct{}, concurrency)
+
+	var errMu sync.Mutex
+	var firstErr error
+	setErr := func(err error) {
+		if err == nil {
+			return
+		}
+		errMu.Lock()
+		if firstErr == nil {
+			firstErr = err
+			cancelLocal()
+		}
+		errMu.Unlock()
+	}
+
+	var wg sync.WaitGroup
+	for _, parts := range perPath {
+		parts := parts
+		if err := acquireRestoreSlot(ctxLocal, pathConcurrencyCh); err != nil {
+			setErr(err)
+			break
+		}
+		wg.Go(func() {
+			defer releaseRestoreSlot(pathConcurrencyCh)
+			if err := r.downloadPath(ctxLocal, parts, concurrencyPerFile, globalConcurrencyCh, bytesDownloaded); err != nil {
+				setErr(err)
+			}
+		})
+	}
+	wg.Wait()
+
+	errMu.Lock()
+	err := firstErr
+	errMu.Unlock()
+	return err
+}
+
+func (r *Restore) downloadPath(ctx context.Context, parts []common.Part, concurrencyPerFile int, globalConcurrencyCh chan struct{}, bytesDownloaded *atomic.Uint64) error {
+	// Sort parts in order to keep file preallocation and finalization tied to the file metadata.
+	common.SortParts(parts)
+	if !r.SkipPreallocation {
+		if err := r.Dst.PreallocateFile(parts[0]); err != nil {
+			return fmt.Errorf("cannot preallocate %s: %w", parts[0].Path, err)
+		}
+	}
+
+	if err := r.downloadPathParts(ctx, parts, concurrencyPerFile, globalConcurrencyCh, bytesDownloaded); err != nil {
+		return err
+	}
+	if err := r.Dst.FinalizeFile(parts[0]); err != nil {
+		return fmt.Errorf("cannot finalize %s: %w", parts[0].Path, err)
+	}
+	return nil
+}
+
+func (r *Restore) downloadPathParts(ctx context.Context, parts []common.Part, concurrencyPerFile int, globalConcurrencyCh chan struct{}, bytesDownloaded *atomic.Uint64) error {
+	ctxLocal, cancelLocal := context.WithCancel(ctx)
+	defer cancelLocal()
+
+	pathConcurrencyCh := make(chan struct{}, concurrencyPerFile)
+	var errMu sync.Mutex
+	var firstErr error
+	setErr := func(err error) {
+		if err == nil {
+			return
+		}
+		errMu.Lock()
+		if firstErr == nil {
+			firstErr = err
+			cancelLocal()
+		}
+		errMu.Unlock()
+	}
+
+	var wg sync.WaitGroup
+	for _, p := range parts {
+		if err := acquireRestoreSlot(ctxLocal, pathConcurrencyCh); err != nil {
+			setErr(err)
+			break
+		}
+		if err := acquireRestoreSlot(ctxLocal, globalConcurrencyCh); err != nil {
+			releaseRestoreSlot(pathConcurrencyCh)
+			setErr(err)
+			break
+		}
+		wg.Go(func() {
+			defer releaseRestoreSlot(pathConcurrencyCh)
+			defer releaseRestoreSlot(globalConcurrencyCh)
+			logger.Infof("downloading %s from %s to %s", &p, r.Src, r.Dst)
+			if err := pipelinedDownload(r.Src, r.Dst, p, bytesDownloaded); err != nil {
+				setErr(err)
+			}
+		})
+	}
+	wg.Wait()
+
+	errMu.Lock()
+	err := firstErr
+	errMu.Unlock()
+	return err
+}
+
+func acquireRestoreSlot(ctx context.Context, ch chan struct{}) error {
+	select {
+	case ch <- struct{}{}:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func releaseRestoreSlot(ch chan struct{}) {
+	<-ch
 }
 
 const writeBufSize = 2 * 1024 * 1024

--- a/lib/backup/actions/restore_test.go
+++ b/lib/backup/actions/restore_test.go
@@ -1,0 +1,161 @@
+package actions
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/backup/common"
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/backup/fslocal"
+)
+
+func TestRestoreDownloadPathPartsConcurrencyPerFile(t *testing.T) {
+	const (
+		path     = "big/file"
+		partSize = 4
+	)
+	parts := []common.Part{
+		{
+			Path:       path,
+			FileSize:   3 * partSize,
+			Offset:     0,
+			Size:       partSize,
+			ActualSize: partSize,
+		},
+		{
+			Path:       path,
+			FileSize:   3 * partSize,
+			Offset:     partSize,
+			Size:       partSize,
+			ActualSize: partSize,
+		},
+		{
+			Path:       path,
+			FileSize:   3 * partSize,
+			Offset:     2 * partSize,
+			Size:       partSize,
+			ActualSize: partSize,
+		},
+	}
+	src := &concurrencyTrackingRemoteFS{
+		parts: parts,
+		data: map[uint64][]byte{
+			0:            []byte("aaaa"),
+			partSize:     []byte("bbbb"),
+			2 * partSize: []byte("cccc"),
+		},
+	}
+	dst := &fslocal.FS{
+		Dir: t.TempDir(),
+	}
+	if err := dst.Init(); err != nil {
+		t.Fatalf("unexpected error in dst.Init: %s", err)
+	}
+	defer dst.MustStop()
+
+	r := &Restore{
+		Src: src,
+		Dst: dst,
+	}
+	var bytesDownloaded atomic.Uint64
+	globalConcurrencyCh := make(chan struct{}, 3)
+	if err := r.downloadPathParts(t.Context(), parts, 2, globalConcurrencyCh, &bytesDownloaded); err != nil {
+		t.Fatalf("unexpected error in downloadPathParts: %s", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dst.Dir, filepath.FromSlash(path)))
+	if err != nil {
+		t.Fatalf("cannot read restored file: %s", err)
+	}
+	if !bytes.Equal(data, []byte("aaaabbbbcccc")) {
+		t.Fatalf("unexpected restored data; got %q; want %q", data, "aaaabbbbcccc")
+	}
+	if src.maxActivePerPath != 2 {
+		t.Fatalf("unexpected max concurrency per file; got %d; want %d", src.maxActivePerPath, 2)
+	}
+	if src.maxActiveTotal > 3 {
+		t.Fatalf("unexpected total concurrency; got %d; want <= 3", src.maxActiveTotal)
+	}
+}
+
+type concurrencyTrackingRemoteFS struct {
+	parts []common.Part
+	data  map[uint64][]byte
+
+	mu               sync.Mutex
+	activeTotal      int
+	activePerPath    map[string]int
+	maxActiveTotal   int
+	maxActivePerPath int
+}
+
+func (fs *concurrencyTrackingRemoteFS) MustStop() {}
+
+func (fs *concurrencyTrackingRemoteFS) String() string {
+	return "concurrencyTrackingRemoteFS"
+}
+
+func (fs *concurrencyTrackingRemoteFS) ListParts() ([]common.Part, error) {
+	parts := append([]common.Part(nil), fs.parts...)
+	return parts, nil
+}
+
+func (fs *concurrencyTrackingRemoteFS) DeletePart(_ common.Part) error {
+	return nil
+}
+
+func (fs *concurrencyTrackingRemoteFS) RemoveEmptyDirs() error {
+	return nil
+}
+
+func (fs *concurrencyTrackingRemoteFS) CopyPart(_ common.OriginFS, _ common.Part) error {
+	return nil
+}
+
+func (fs *concurrencyTrackingRemoteFS) DownloadPart(p common.Part, w io.Writer) error {
+	fs.mu.Lock()
+	if fs.activePerPath == nil {
+		fs.activePerPath = make(map[string]int)
+	}
+	fs.activeTotal++
+	fs.activePerPath[p.Path]++
+	fs.maxActiveTotal = max(fs.maxActiveTotal, fs.activeTotal)
+	fs.maxActivePerPath = max(fs.maxActivePerPath, fs.activePerPath[p.Path])
+	fs.mu.Unlock()
+
+	time.Sleep(50 * time.Millisecond)
+	_, err := w.Write(fs.data[p.Offset])
+
+	fs.mu.Lock()
+	fs.activeTotal--
+	fs.activePerPath[p.Path]--
+	fs.mu.Unlock()
+
+	return err
+}
+
+func (fs *concurrencyTrackingRemoteFS) UploadPart(_ common.Part, _ io.Reader) error {
+	return nil
+}
+
+func (fs *concurrencyTrackingRemoteFS) DeleteFile(_ string) error {
+	return nil
+}
+
+func (fs *concurrencyTrackingRemoteFS) CreateFile(_ string, _ []byte) error {
+	return nil
+}
+
+func (fs *concurrencyTrackingRemoteFS) HasFile(filePath string) (bool, error) {
+	return false, nil
+}
+
+func (fs *concurrencyTrackingRemoteFS) ReadFile(filePath string) ([]byte, error) {
+	return nil, fmt.Errorf("unexpected ReadFile call for %q", filePath)
+}

--- a/lib/backup/actions/util.go
+++ b/lib/backup/actions/util.go
@@ -50,69 +50,6 @@ func runParallel(concurrency int, parts []common.Part, f func(p common.Part) err
 	return err
 }
 
-func runParallelPerPath(ctx context.Context, concurrency int, perPath map[string][]common.Part, f func(parts []common.Part) error, progress func(elapsed time.Duration)) error {
-	var err error
-	runWithProgress(progress, func() {
-		err = runParallelPerPathInternal(ctx, concurrency, perPath, f)
-	})
-	return err
-}
-
-func runParallelPerPathInternal(ctx context.Context, concurrency int, perPath map[string][]common.Part, f func(parts []common.Part) error) error {
-	if concurrency <= 0 {
-		concurrency = 1
-	}
-	if len(perPath) == 0 {
-		return nil
-	}
-
-	// len(perPath) capacity guarantees non-blocking behavior below.
-	resultCh := make(chan error, len(perPath))
-	workCh := make(chan []common.Part, len(perPath))
-	ctxLocal, cancelLocal := context.WithCancel(ctx)
-	defer cancelLocal()
-
-	// Start workers
-	var wg sync.WaitGroup
-	for range concurrency {
-		wg.Go(func() {
-			for parts := range workCh {
-				select {
-				case <-ctxLocal.Done():
-					return
-				default:
-				}
-				resultCh <- f(parts)
-			}
-		})
-	}
-
-	// Feed workers with work.
-	for _, parts := range perPath {
-		workCh <- parts
-	}
-	close(workCh)
-
-	// Read results.
-	var err error
-	for range len(perPath) {
-		select {
-		case <-ctx.Done():
-			err = ctx.Err()
-		case err = <-resultCh:
-		}
-		if err != nil {
-			cancelLocal()
-			break
-		}
-	}
-
-	// Wait for all the workers to stop.
-	wg.Wait()
-
-	return err
-}
-
 func runParallelInternal(concurrency int, parts []common.Part, f func(p common.Part) error) error {
 	if concurrency <= 0 {
 		concurrency = 1


### PR DESCRIPTION
`vmrestore` now supports per-file parallel part downloads via `-concurrencyPerFile` with default `4`. The existing `-concurrency` still caps total concurrent downloads globally, so big/slow files can use spare workers during the tail without unbounded S3 fan-out.

Changed:
- Added `-concurrencyPerFile` in `app/vmrestore/main.go`.
- Reworked restore scheduling in `lib/backup/actions/restore.go` to download multiple non-overlapping parts of the same file concurrently.
- Updated `docs/victoriametrics/vmrestore.md`.
- Added a focused concurrency test in `lib/backup/actions/restore_test.go`.
- Removed the old unused per-path helper from `lib/backup/actions/util.go`.

Verified with:
`go test ./lib/backup/actions ./app/vmrestore`