### PR TITLE
lib/streamaggr: fix stale quantiles output

### DIFF
--- a/docs/victoriametrics/changelog/CHANGELOG.md
+++ b/docs/victoriametrics/changelog/CHANGELOG.md
@@ -26,6 +26,8 @@ See also [LTS releases](https://docs.victoriametrics.com/victoriametrics/lts-rel
 
 ## tip
 
+* BUGFIX: [stream aggregation](https://docs.victoriametrics.com/victoriametrics/stream-aggregation/): stop emitting stale values for `quantiles(...)` outputs when a time series has no samples during the current aggregation interval.
+
 ## [v1.143.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.143.0)
 
 Released at 2026-05-08

--- a/docs/victoriametrics/changelog/CHANGELOG.md
+++ b/docs/victoriametrics/changelog/CHANGELOG.md
@@ -26,7 +26,7 @@ See also [LTS releases](https://docs.victoriametrics.com/victoriametrics/lts-rel
 
 ## tip
 
-* BUGFIX: [stream aggregation](https://docs.victoriametrics.com/victoriametrics/stream-aggregation/): stop emitting stale values for `quantiles(...)` outputs when a time series has no samples during the current aggregation interval.
+* BUGFIX: [stream aggregation](https://docs.victoriametrics.com/victoriametrics/stream-aggregation/): stop emitting stale values for `quantiles(...)` outputs when a time series has no samples during the current aggregation interval. Thanks to @alexei38 for the [pull request](https://github.com/VictoriaMetrics/VictoriaMetrics/pull/10918).
 
 ## [v1.143.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.143.0)
 

--- a/lib/streamaggr/quantiles.go
+++ b/lib/streamaggr/quantiles.go
@@ -19,12 +19,13 @@ func (av *quantilesAggrValue) pushSample(_ aggrConfig, sample *pushSample, _ str
 }
 
 func (av *quantilesAggrValue) flush(c aggrConfig, ctx *flushCtx, key string, _ bool) {
-	ac := c.(*quantilesAggrConfig)
-	if av.h != nil {
-		ac.quantiles = av.h.Quantiles(ac.quantiles[:0], ac.phis)
-		histogram.PutFast(av.h)
-		av.h = nil
+	if av.h == nil {
+		return
 	}
+	ac := c.(*quantilesAggrConfig)
+	ac.quantiles = av.h.Quantiles(ac.quantiles[:0], ac.phis)
+	histogram.PutFast(av.h)
+	av.h = nil
 	if len(ac.quantiles) > 0 {
 		for i, quantile := range ac.quantiles {
 			ac.b = strconv.AppendFloat(ac.b[:0], ac.phis[i], 'g', -1, 64)

--- a/lib/streamaggr/quantiles.go
+++ b/lib/streamaggr/quantiles.go
@@ -28,12 +28,11 @@ func (av *quantilesAggrValue) flush(c aggrConfig, ctx *flushCtx, key string, _ b
 	histogram.PutFast(av.h)
 	// reset h to avoid producing stale results on the next flush if av didn't get new pushSample() calls
 	av.h = nil
-	if len(ac.quantiles) > 0 {
-		for i, quantile := range ac.quantiles {
-			ac.b = strconv.AppendFloat(ac.b[:0], ac.phis[i], 'g', -1, 64)
-			phiStr := bytesutil.InternBytes(ac.b)
-			ctx.appendSeriesWithExtraLabel(key, "quantiles", quantile, "quantile", phiStr)
-		}
+
+	for i, quantile := range ac.quantiles {
+		ac.b = strconv.AppendFloat(ac.b[:0], ac.phis[i], 'g', -1, 64)
+		phiStr := bytesutil.InternBytes(ac.b)
+		ctx.appendSeriesWithExtraLabel(key, "quantiles", quantile, "quantile", phiStr)
 	}
 }
 

--- a/lib/streamaggr/quantiles.go
+++ b/lib/streamaggr/quantiles.go
@@ -1,9 +1,10 @@
 package streamaggr
 
 import (
+	"strconv"
+
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/bytesutil"
 	"github.com/valyala/histogram"
-	"strconv"
 )
 
 // quantilesAggrValue calculates output=quantiles, e.g. the given quantiles over the input samples.
@@ -25,6 +26,7 @@ func (av *quantilesAggrValue) flush(c aggrConfig, ctx *flushCtx, key string, _ b
 	ac := c.(*quantilesAggrConfig)
 	ac.quantiles = av.h.Quantiles(ac.quantiles[:0], ac.phis)
 	histogram.PutFast(av.h)
+	// reset h to avoid producing stale results on the next flush if av didn't get new pushSample() calls
 	av.h = nil
 	if len(ac.quantiles) > 0 {
 		for i, quantile := range ac.quantiles {

--- a/lib/streamaggr/streamaggr_synctest_test.go
+++ b/lib/streamaggr/streamaggr_synctest_test.go
@@ -634,6 +634,19 @@ cpu_usage:1m_without_cpu_quantiles{quantile="1"} 90
   outputs: ["quantiles(0, 0.5, 1)"]
 `, "1111111")
 
+	// no stale quantiles should be produced
+	f([]string{`
+cpu_usage{cpu="1"} 3
+cpu_usage{cpu="2"} 3`,
+		`cpu_usage{cpu="2"} 4`,
+	}, time.Minute, `cpu_usage:1m_quantiles{cpu="1",quantile="1"} 3
+cpu_usage:1m_quantiles{cpu="2",quantile="1"} 3
+cpu_usage:1m_quantiles{cpu="2",quantile="1"} 4
+`, `
+- interval: 1m
+  outputs: ["quantiles(1)"]
+`, "111")
+
 	// append additional label
 	f([]string{`
 foo{abc="123"} 4

--- a/lib/streamaggr/streamaggr_test.go
+++ b/lib/streamaggr/streamaggr_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/bytesutil"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/prompb"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/promrelabel"
 )
@@ -249,6 +250,45 @@ func TestAggregatorsEqual(t *testing.T) {
 - outputs: [total]
   interval: 5m
   ignore_first_intervals: 4`, false)
+}
+
+func TestQuantilesAggrValueDoesNotReuseQuantilesForSeriesWithoutSamples(t *testing.T) {
+	ac := newQuantilesAggrConfig([]float64{0.95})
+	ctx := &flushCtx{
+		a: &aggregator{
+			suffix: ":1m_",
+		},
+		flushTimestamp: 1234567890000,
+	}
+
+	activeKey := labelsToAggrOutputKey([]prompb.Label{
+		{Name: "__name__", Value: "request_duration_seconds"},
+		{Name: "group", Value: "active"},
+	})
+	inactiveKey := labelsToAggrOutputKey([]prompb.Label{
+		{Name: "__name__", Value: "request_duration_seconds"},
+		{Name: "group", Value: "inactive"},
+	})
+
+	active := ac.getValue(nil)
+	active.pushSample(ac, &pushSample{
+		value: 123,
+	}, "", 0)
+	active.flush(ac, ctx, activeKey, false)
+
+	inactive := ac.getValue(nil)
+	inactive.flush(ac, ctx, inactiveKey, false)
+
+	result := timeSeriessToString(ctx.tss)
+	resultExpected := `request_duration_seconds:1m_quantiles{group="active",quantile="0.95"} 123
+`
+	if result != resultExpected {
+		t.Fatalf("unexpected output metrics;\ngot\n%s\nwant\n%s", result, resultExpected)
+	}
+}
+
+func labelsToAggrOutputKey(labels []prompb.Label) string {
+	return bytesutil.ToUnsafeString(lc.Compress(nil, labels))
 }
 
 func timeSeriessToString(tss []prompb.TimeSeries) string {

--- a/lib/streamaggr/streamaggr_test.go
+++ b/lib/streamaggr/streamaggr_test.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/VictoriaMetrics/VictoriaMetrics/lib/bytesutil"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/prompb"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/promrelabel"
 )
@@ -250,45 +249,6 @@ func TestAggregatorsEqual(t *testing.T) {
 - outputs: [total]
   interval: 5m
   ignore_first_intervals: 4`, false)
-}
-
-func TestQuantilesAggrValueDoesNotReuseQuantilesForSeriesWithoutSamples(t *testing.T) {
-	ac := newQuantilesAggrConfig([]float64{0.95})
-	ctx := &flushCtx{
-		a: &aggregator{
-			suffix: ":1m_",
-		},
-		flushTimestamp: 1234567890000,
-	}
-
-	activeKey := labelsToAggrOutputKey([]prompb.Label{
-		{Name: "__name__", Value: "request_duration_seconds"},
-		{Name: "group", Value: "active"},
-	})
-	inactiveKey := labelsToAggrOutputKey([]prompb.Label{
-		{Name: "__name__", Value: "request_duration_seconds"},
-		{Name: "group", Value: "inactive"},
-	})
-
-	active := ac.getValue(nil)
-	active.pushSample(ac, &pushSample{
-		value: 123,
-	}, "", 0)
-	active.flush(ac, ctx, activeKey, false)
-
-	inactive := ac.getValue(nil)
-	inactive.flush(ac, ctx, inactiveKey, false)
-
-	result := timeSeriessToString(ctx.tss)
-	resultExpected := `request_duration_seconds:1m_quantiles{group="active",quantile="0.95"} 123
-`
-	if result != resultExpected {
-		t.Fatalf("unexpected output metrics;\ngot\n%s\nwant\n%s", result, resultExpected)
-	}
-}
-
-func labelsToAggrOutputKey(labels []prompb.Label) string {
-	return bytesutil.ToUnsafeString(lc.Compress(nil, labels))
 }
 
 func timeSeriessToString(tss []prompb.TimeSeries) string {


### PR DESCRIPTION
### Describe Your Changes

Fix stale `quantiles(...)` stream aggregation output for series without samples in the current aggregation interval.

Previously, `quantilesAggrConfig` reused the `quantiles` buffer across aggregation values. If `quantilesAggrValue.flush` was called for a series without samples after another series had already calculated quantiles, the stale quantile
values could be emitted for the empty series.

This could produce unrealistic `*_quantiles` output values and make the same aggregated value appear across unrelated labelsets.

The PR skips `quantiles(...)` output when there is no histogram for the current interval and adds a regression test for this case.

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
