### PR TITLE
vmsingle: add the support of vmselect RPC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -471,8 +471,9 @@ test-full-386:
 
 apptest:
 	$(MAKE) victoria-metrics-race vmagent-race vmalert-race vmauth-race vmctl-race vmbackup-race vmrestore-race
-	go test ./apptest/... -skip="^Test(Cluster|Legacy).*"
+	go test ./apptest/... -skip="^Test(Cluster|Mixed|Legacy).*"
 
+# App tests for legacy indexDB
 apptest-legacy: victoria-metrics-race vmbackup-race vmrestore-race
 	OS=$$(uname | tr '[:upper:]' '[:lower:]'); \
 	ARCH=$$(uname -m | tr '[:upper:]' '[:lower:]' | sed 's/x86_64/amd64/'); \
@@ -488,6 +489,20 @@ apptest-legacy: victoria-metrics-race vmbackup-race vmrestore-race
 	VMSINGLE_V1_132_0_PATH=$${DIR}/victoria-metrics-prod \
 	VMSTORAGE_V1_132_0_PATH=$${DIR}/vmstorage-prod \
 	go test ./apptest/tests -run="^TestLegacySingle.*"
+
+# App tests for mixed setups where vmsingle and vmcluster coexist.
+apptest-mixed: victoria-metrics-race
+	OS=$$(uname | tr '[:upper:]' '[:lower:]'); \
+	ARCH=$$(uname -m | tr '[:upper:]' '[:lower:]' | sed 's/x86_64/amd64/'); \
+	VERSION=v1.145.0; \
+	VMCLUSTER=victoria-metrics-$${OS}-$${ARCH}-$${VERSION}-cluster.tar.gz; \
+	URL=https://github.com/VictoriaMetrics/VictoriaMetrics/releases/download/$${VERSION}; \
+	DIR=/tmp/$${VERSION}; \
+	test -d $${DIR} || (mkdir $${DIR} && \
+		curl --output-dir /tmp -LO $${URL}/$${VMCLUSTER} && tar xzf /tmp/$${VMCLUSTER} -C $${DIR} \
+	); \
+	VMSELECT_PATH=$${DIR}/vmselect-prod \
+	go test ./apptest/tests -run="^TestMixed.*"
 
 benchmark:
 	go test -run=NO_TESTS -bench=. ./lib/...

--- a/app/victoria-metrics/main.go
+++ b/app/victoria-metrics/main.go
@@ -89,7 +89,7 @@ func main() {
 	}
 	logger.Infof("starting VictoriaMetrics at %q...", listenAddrs)
 	startTime := time.Now()
-	vmstorage.Init(*vmselectMaxConcurrentRequests, promql.ResetRollupResultCacheIfNeeded)
+	vmstorage.Init(*vmselectMaxConcurrentRequests, *vmselectMaxQueueDuration, promql.ResetRollupResultCacheIfNeeded)
 	vmselect.Init(*vmselectMaxConcurrentRequests, *vmselectMaxQueueDuration)
 	vminsertcommon.StartIngestionRateLimiter(*maxIngestionRate)
 	vminsert.Init()

--- a/app/vmalert-tool/unittest/unittest.go
+++ b/app/vmalert-tool/unittest/unittest.go
@@ -282,7 +282,8 @@ func processFlags() {
 
 func setUp() {
 	const maxConcurrentRequests = 4
-	vmstorage.Init(maxConcurrentRequests, promql.ResetRollupResultCacheIfNeeded)
+	maxQueueDuration := 5 * time.Second
+	vmstorage.Init(maxConcurrentRequests, maxQueueDuration, promql.ResetRollupResultCacheIfNeeded)
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 	readyCheckFunc := func() bool {

--- a/app/vmstorage/main.go
+++ b/app/vmstorage/main.go
@@ -30,6 +30,9 @@ var (
 		"See https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#retention. See also -retentionFilter")
 	futureRetention = flagutil.NewRetentionDuration("futureRetention", "2d", "Data with timestamps bigger than now+futureRetention is automatically deleted. "+
 		"The minimum futureRetention is 2 days. See https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#retention")
+	vmselectAddr                  = flag.String("vmselectAddr", "", "TCP address to accept connections from vmselect services")
+	vmselectDisableRPCCompression = flag.Bool("rpc.disableCompression", false, "Whether to disable compression of the data sent from vmstorage to vmselect. "+
+		"This reduces CPU usage at the cost of higher network bandwidth usage")
 	snapshotAuthKey   = flagutil.NewPassword("snapshotAuthKey", "authKey, which must be passed in query string to /snapshot* pages. It overrides -httpAuth.*")
 	forceMergeAuthKey = flagutil.NewPassword("forceMergeAuthKey", "authKey, which must be passed in query string to /internal/force_merge pages. It overrides -httpAuth.*")
 	forceFlushAuthKey = flagutil.NewPassword("forceFlushAuthKey", "authKey, which must be passed in query string to /internal/force_flush pages. It overrides -httpAuth.*")
@@ -108,7 +111,7 @@ func DataPath() string {
 }
 
 // Init initializes vmstorage.
-func Init(vmselectMaxConcurrentRequests int, resetCacheIfNeeded func(mrs []storage.MetricRow)) {
+func Init(vmselectMaxConcurrentRequests int, vmselectMaxQueueDuration time.Duration, resetCacheIfNeeded func(mrs []storage.MetricRow)) {
 	storage.SetDedupInterval(*minScrapeInterval)
 	storage.SetDataFlushInterval(*inmemoryDataFlushInterval)
 	storage.LegacySetRetentionTimezoneOffset(*retentionTimezoneOffset)
@@ -169,6 +172,21 @@ func Init(vmselectMaxConcurrentRequests int, resetCacheIfNeeded func(mrs []stora
 	storageMetrics.RegisterMetricsWriter(vmStorage.writeStorageMetrics)
 	metrics.RegisterSet(storageMetrics)
 
+	if *vmselectAddr != "" {
+		var err error
+		limits := vmselectapi.Limits{
+			MaxConcurrentRequests:         vmselectMaxConcurrentRequests,
+			MaxConcurrentRequestsFlagName: "search.maxConcurrentRequests",
+			MaxQueueDuration:              vmselectMaxQueueDuration,
+			MaxQueueDurationFlagName:      "search.maxQueueDuration",
+		}
+		api := newVMStorageWithTenantID(vmStorage)
+		vmselectSrv, err = vmselectapi.NewServer(*vmselectAddr, api, limits, *vmselectDisableRPCCompression)
+		if err != nil {
+			logger.Fatalf("cannot create a server with -vmselectAddr=%s: %s", *vmselectAddr, err)
+		}
+	}
+
 	VMInsertAPI = vmStorage
 	VMSelectAPI = vmStorage
 	GetSearch = vmStorage.GetSearch
@@ -191,6 +209,8 @@ var (
 
 	// TODO(@rtm0): Remove this dependency from vmalert-tool unit tests.
 	DebugFlush func()
+
+	vmselectSrv *vmselectapi.Server
 )
 
 // Stop stops the vmstorage
@@ -201,6 +221,10 @@ func Stop() {
 
 	logger.Infof("gracefully closing the storage at %s", *storageDataPath)
 	startTime := time.Now()
+
+	if vmselectSrv != nil {
+		vmselectSrv.MustStop()
+	}
 	vmStorage.Stop()
 	logger.Infof("successfully closed the storage in %.3f seconds", time.Since(startTime).Seconds())
 

--- a/app/vmstorage/vmstorage.go
+++ b/app/vmstorage/vmstorage.go
@@ -164,6 +164,10 @@ func (vms *VMStorage) IsReadOnly() bool {
 }
 
 func (vms *VMStorage) InitSearch(qt *querytracer.Tracer, sq *storage.SearchQuery, deadline uint64) (vmselectapi.BlockIterator, error) {
+	return vms.initSearch(qt, sq, marshalDefault, deadline)
+}
+
+func (vms *VMStorage) initSearch(qt *querytracer.Tracer, sq *storage.SearchQuery, marshal marshalFunc, deadline uint64) (vmselectapi.BlockIterator, error) {
 	vms.wg.Add(1)
 
 	tr := sq.GetTimeRange()
@@ -178,6 +182,7 @@ func (vms *VMStorage) InitSearch(qt *querytracer.Tracer, sq *storage.SearchQuery
 		return nil, fmt.Errorf("missing tag filters")
 	}
 	bi := getBlockIterator()
+	bi.marshal = marshal
 	bi.wgDone = vms.wg.Done
 	bi.sr.Init(qt, vms.s, tfss, tr, maxMetrics, deadline)
 	if err := bi.sr.Error(); err != nil {
@@ -198,11 +203,19 @@ func (vms *VMStorage) getMaxMetrics(searchQueryLimit int) int {
 	return searchQueryLimit
 }
 
+type marshalFunc func(dst []byte, src *storage.MetricBlock) []byte
+
+// marshalDefault is the default implementation of the MetricBlock marshaling.
+func marshalDefault(dst []byte, src *storage.MetricBlock) []byte {
+	return src.Marshal(dst)
+}
+
 // blockIterator implements vmselectapi.BlockIterator
 type blockIterator struct {
-	sr     storage.Search
-	mb     storage.MetricBlock
-	wgDone func()
+	sr      storage.Search
+	mb      storage.MetricBlock
+	marshal marshalFunc
+	wgDone  func()
 }
 
 var blockIteratorsPool sync.Pool
@@ -231,7 +244,7 @@ func (bi *blockIterator) NextBlock(dst []byte) ([]byte, bool) {
 	mb := bi.mb
 	mb.MetricName = bi.sr.MetricBlockRef.MetricName
 	bi.sr.MetricBlockRef.BlockRef.MustReadBlock(&mb.Block)
-	dst = mb.Marshal(dst[:0])
+	dst = bi.marshal(dst[:0], &mb)
 	return dst, true
 }
 

--- a/app/vmstorage/vmstorage_with_tenant_id.go
+++ b/app/vmstorage/vmstorage_with_tenant_id.go
@@ -1,0 +1,282 @@
+package vmstorage
+
+import (
+	"flag"
+	"fmt"
+	"math"
+
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/encoding"
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/logger"
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/querytracer"
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/storage"
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/storage/metricnamestats"
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/storage/metricsmetadata"
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/vmselectapi"
+)
+
+var (
+	accountID = flag.Uint64("accountID", 0, "The accountID of the stored data")
+	projectID = flag.Uint64("projectID", 0, "The projectID of the stored data")
+)
+
+func newVMStorageWithTenantID(vms *VMStorage) *VMStorageWithTenantID {
+	if *accountID > math.MaxUint32 {
+		logger.Fatalf("-accountID must be in the range [0, %d], got %d", uint32(math.MaxUint32), *accountID)
+	}
+	if *projectID > math.MaxUint32 {
+		logger.Fatalf("-projectID must be in the range [0, %d], got %d", uint32(math.MaxUint32), *projectID)
+	}
+	return &VMStorageWithTenantID{
+		vms:       vms,
+		accountID: uint32(*accountID),
+		projectID: uint32(*projectID),
+	}
+}
+
+// VMStorageWithTenantID is a thin wrapper around VMStorage type that overrides
+// its methods to properly serve requests coming from a vmselect (require
+// tenantID).
+//
+// A new instance of this type should be created using
+// newVMStorageWithTenantID(). The created instance does not require closing.
+// The instance also does not take ownership of vms and it is the responsibility
+// of the caller to close vms.
+type VMStorageWithTenantID struct {
+	vms *VMStorage
+
+	accountID uint32
+	projectID uint32
+}
+
+// InitSearch initializes a storage search for a request initiated by a
+// vmselect.
+//
+// The search is initialized only if the search query is either multitenant or
+// its accountID and projectID match -accountID and -projectID flag values.
+// Otherwise, the method returns an interator that will return no data.
+//
+// The method also overrides the data format of the data returned by the
+// iterator by prepending accountID and projectID bytes to the metric name and
+// the data block (a format used in vmcluster).
+func (vmst *VMStorageWithTenantID) InitSearch(qt *querytracer.Tracer, sq *storage.SearchQuery, deadline uint64) (vmselectapi.BlockIterator, error) {
+	if !vmst.hasValidTenantID(sq) {
+		return emptyBI, nil
+	}
+	return vmst.vms.initSearch(qt, sq, vmst.marshalMetricBlock, deadline)
+}
+
+var emptyBI = &emptyBlockIterator{}
+
+// emptyBlockIterator is an implementation of vmselectapi.BlockIterator that
+// always returns no data.
+type emptyBlockIterator struct{}
+
+func (*emptyBlockIterator) MustClose() {}
+
+func (*emptyBlockIterator) NextBlock(dst []byte) ([]byte, bool) {
+	return dst, false
+}
+
+func (*emptyBlockIterator) Error() error {
+	return nil
+}
+
+// marshalMetricBlock serializes a metric block in the format expected by
+// vmselect.
+//
+// vmselect expects metric names and data blocks to have the tenantID but
+// vmsingle does not have it. Therefore the tenantID needs to be included to
+// every metric name and block.
+func (vmst *VMStorageWithTenantID) marshalMetricBlock(dst []byte, src *storage.MetricBlock) []byte {
+	// Marshal metric name:
+	// 1. Marshal metric name length + accountID length + projectID length (in
+	//    bytes).
+	// 2. append accountID and projectID bytes
+	// 3. Finally append metric name bytes
+	dst = encoding.MarshalVarUint64(dst, uint64(len(src.MetricName))+8)
+	dst = encoding.MarshalUint32(dst, vmst.accountID)
+	dst = encoding.MarshalUint32(dst, vmst.projectID)
+	dst = append(dst, src.MetricName...)
+
+	// Marshal data block.
+	dst = encoding.MarshalUint32(dst, vmst.accountID)
+	dst = encoding.MarshalUint32(dst, vmst.projectID)
+	dst = storage.MarshalBlock(dst, &src.Block)
+
+	return dst
+}
+
+// SearchMetricNames searches the storage for metric names that match the query.
+//
+// If the query is not multitenant or the query accountID and projectID do not
+// match the -accoutID and -projectID flag values, the method will return an
+// empty result.
+//
+// Found metric names are prepended with accountID and projectID bytes (a format
+// used in vmcluster).
+func (vmst *VMStorageWithTenantID) SearchMetricNames(qt *querytracer.Tracer, sq *storage.SearchQuery, deadline uint64) ([]string, error) {
+	if !vmst.hasValidTenantID(sq) {
+		return nil, nil
+	}
+
+	metricNames, err := vmst.vms.SearchMetricNames(qt, sq, deadline)
+	if err != nil {
+		return nil, err
+	}
+
+	// vmselect expects metric names to have the tenantID but vmsingle does not
+	// have it. Therefore the tenantID needs to be prepended to every metric
+	// name.
+	dst := make([]byte, 0, 8)
+	dst = encoding.MarshalUint32(dst, vmst.accountID)
+	dst = encoding.MarshalUint32(dst, vmst.projectID)
+	tenantID := string(dst)
+
+	for i, metricName := range metricNames {
+		metricNames[i] = tenantID + metricName
+	}
+	return metricNames, nil
+}
+
+// LabelValues searches the storage for label values that match the query and
+// correspond to a label whose name is `labelName`. The returned result
+// will contain not more than `maxLabelValues`.
+//
+// If the query is not multitenant or the query accountID and projectID do not
+// match the -accoutID and -projectID flag values, the method will return an
+// empty result.
+func (vmst *VMStorageWithTenantID) LabelValues(qt *querytracer.Tracer, sq *storage.SearchQuery, labelName string, maxLabelValues int, deadline uint64) ([]string, error) {
+	if !vmst.hasValidTenantID(sq) {
+		return nil, nil
+	}
+	return vmst.vms.LabelValues(qt, sq, labelName, maxLabelValues, deadline)
+}
+
+// TagValueSuffixes searches the storage for Graphite tag value suffixes. The
+// returned result will contain not more than `maxSuffixes`.
+//
+// If the query is not multitenant or the query accountID and projectID do not
+// match the -accoutID and -projectID flag values, the method will return an
+// empty result.
+func (vmst *VMStorageWithTenantID) TagValueSuffixes(qt *querytracer.Tracer, accountID, projectID uint32, tr storage.TimeRange, tagKey, tagValuePrefix string, delimiter byte, maxSuffixes int, deadline uint64) ([]string, error) {
+	if !vmst.isValidTenantID(accountID, projectID) {
+		return nil, nil
+	}
+	return vmst.vms.TagValueSuffixes(qt, accountID, projectID, tr, tagKey, tagValuePrefix, delimiter, maxSuffixes, deadline)
+}
+
+// LabelNames searches the storage for label names that match the query.
+// The returned result will contain not more than `maxLabelNames`.
+//
+// If the query is not multitenant or the query accountID and projectID do not
+// match the -accoutID and -projectID flag values, the method will return an
+// empty result.
+func (vmst *VMStorageWithTenantID) LabelNames(qt *querytracer.Tracer, sq *storage.SearchQuery, maxLabelNames int, deadline uint64) ([]string, error) {
+	if !vmst.hasValidTenantID(sq) {
+		return nil, nil
+	}
+	return vmst.vms.LabelNames(qt, sq, maxLabelNames, deadline)
+}
+
+// SeriesCount returns the total number of metrics stored in the database.
+//
+// The method may return inflated numbers. How inflated the count depends
+// on the churn rate and the retention period. For example, if a metric lasts
+// for 2 months, it will be counted twice.
+//
+// The method also counts the deleted metrics.
+//
+// If the query is not multitenant or the query accountID and projectID do not
+// match the -accoutID and -projectID flag values, the method will return 0.
+func (vmst *VMStorageWithTenantID) SeriesCount(qt *querytracer.Tracer, accountID, projectID uint32, deadline uint64) (uint64, error) {
+	if !vmst.isValidTenantID(accountID, projectID) {
+		return 0, nil
+	}
+	return vmst.vms.SeriesCount(qt, accountID, projectID, deadline)
+}
+
+// Tenants returns just one tenant consisting of the -accountID and -projectID
+// flag values.
+func (vmst *VMStorageWithTenantID) Tenants(qt *querytracer.Tracer, tr storage.TimeRange, deadline uint64) ([]string, error) {
+	tenantID := fmt.Sprintf("%d:%d", vmst.accountID, vmst.projectID)
+	return []string{tenantID}, nil
+}
+
+// TSDBStatus retrieves the status for metrics that match to the search query.
+//
+// If the query is not multitenant or the query accountID and projectID do not
+// match the -accoutID and -projectID flag values, the method will return empty
+// status.
+func (vmst *VMStorageWithTenantID) TSDBStatus(qt *querytracer.Tracer, sq *storage.SearchQuery, focusLabel string, topN int, deadline uint64) (*storage.TSDBStatus, error) {
+	if !vmst.hasValidTenantID(sq) {
+		return &storage.TSDBStatus{}, nil
+	}
+	return vmst.vms.TSDBStatus(qt, sq, focusLabel, topN, deadline)
+}
+
+// DeleteSeries marks as deleted metrics that match the search query.
+// The method returns the number of deleted metrics.
+//
+// If the query is not multitenant or the query accountID and projectID do not
+// match the -accoutID and -projectID flag values, no metrics will be deleted
+// and the method will return 0.
+func (vmst *VMStorageWithTenantID) DeleteSeries(qt *querytracer.Tracer, sq *storage.SearchQuery, deadline uint64) (int, error) {
+	if !vmst.hasValidTenantID(sq) {
+		return 0, nil
+	}
+	return vmst.vms.DeleteSeries(qt, sq, deadline)
+}
+
+// RegisterMetricNames registers metric names in the index, the sample values
+// and timestamps are ignored.
+func (vmst *VMStorageWithTenantID) RegisterMetricNames(qt *querytracer.Tracer, mrs []storage.MetricRow, deadline uint64) error {
+	return vmst.vms.RegisterMetricNames(qt, mrs, deadline)
+}
+
+// GetMetricNamesUsageStats retrieves the usage stats for metrics whose name
+// matches the pattern.
+//
+// If the request is not multitenant or the request accountID and projectID do
+// not match the -accoutID and -projectID flag values, no metrics will be
+// deleted and the method will return 0.
+func (vmst *VMStorageWithTenantID) GetMetricNamesUsageStats(qt *querytracer.Tracer, tt *storage.TenantToken, limit, le int, matchPattern string, deadline uint64) (metricnamestats.StatsResult, error) {
+	if !vmst.isValidTenantToken(tt) {
+		return metricnamestats.StatsResult{}, nil
+	}
+	return vmst.vms.GetMetricNamesUsageStats(qt, tt, limit, le, matchPattern, deadline)
+}
+
+// ResetMetricNamesUsageStats resets the metric name usage stats.
+func (vmst *VMStorageWithTenantID) ResetMetricNamesUsageStats(qt *querytracer.Tracer, deadline uint64) error {
+	return vmst.vms.ResetMetricNamesUsageStats(qt, deadline)
+}
+
+// GetMetadataRecords retrieves the metadata for the metricName.
+//
+// If the request is not multitenant or the request accountID and projectID do
+// not match the -accoutID and -projectID flag values, no metrics will be
+// deleted and the method will return 0.
+func (vmst *VMStorageWithTenantID) GetMetadataRecords(qt *querytracer.Tracer, tt *storage.TenantToken, limit int, metricName string, deadline uint64) ([]*metricsmetadata.Row, error) {
+	if !vmst.isValidTenantToken(tt) {
+		return nil, nil
+	}
+	return vmst.vms.GetMetadataRecords(qt, tt, limit, metricName, deadline)
+}
+
+// hasValidTenantID returns true if the search query is either multitenant or
+// its accountID and projectID match -accountID and -projectID flag values.
+func (vmst *VMStorageWithTenantID) hasValidTenantID(sq *storage.SearchQuery) bool {
+	return sq.IsMultiTenant || vmst.isValidTenantID(sq.AccountID, sq.ProjectID)
+}
+
+// isValidTenantToken returns true if the TenantToken is either multitenant or
+// its accountID and projectID match -accountID and -projectID flag values.
+func (vmst *VMStorageWithTenantID) isValidTenantToken(tt *storage.TenantToken) bool {
+	return tt == nil || vmst.isValidTenantID(tt.AccountID, tt.ProjectID)
+}
+
+// isValidTenantID returns true if the accountID and projectID match -accountID
+// and -projectID flag values.
+func (vmst *VMStorageWithTenantID) isValidTenantID(accountID, projectID uint32) bool {
+	return accountID == vmst.accountID && projectID == vmst.projectID
+}

--- a/apptest/testdata.go
+++ b/apptest/testdata.go
@@ -1,0 +1,358 @@
+package apptest
+
+import (
+	"fmt"
+	"slices"
+)
+
+type TestData struct {
+	Samples              []string
+	Step                 int64
+	WantSeries           []map[string]string
+	WantLabels           []string
+	WantLabelValues      []string
+	WantQueryResults     []*QueryResult
+	WantMetadata         map[string][]MetadataEntry
+	WantMetricNamesStats []MetricNamesStatsRecord
+}
+
+func GenerateTestData(prefix string, numMetrics, start, end int64) TestData {
+	d := TestData{
+		Samples:              []string{},
+		Step:                 (end - start) / numMetrics,
+		WantSeries:           make([]map[string]string, numMetrics),
+		WantLabels:           make([]string, numMetrics),
+		WantLabelValues:      make([]string, numMetrics),
+		WantQueryResults:     make([]*QueryResult, numMetrics),
+		WantMetadata:         make(map[string][]MetadataEntry),
+		WantMetricNamesStats: make([]MetricNamesStatsRecord, numMetrics),
+	}
+	for i := range numMetrics {
+		metricName := fmt.Sprintf("%s_%04d", prefix, i)
+		metricHelp := fmt.Sprintf("# HELP %s some help message", metricName)
+		metricType := fmt.Sprintf("# TYPE %s gauge", metricName)
+		labelName := fmt.Sprintf("label_%04d", i)
+		labelValue := fmt.Sprintf("value_%04d", i)
+		value := i
+		timestamp := start + i*d.Step
+		sample := fmt.Sprintf(`%s{%s="value", label="%s"} %d %d`, metricName, labelName, labelValue, value, timestamp)
+
+		d.Samples = append(d.Samples, metricHelp, metricType, sample)
+		d.WantSeries[i] = map[string]string{
+			"__name__": metricName,
+			labelName:  "value",
+			"label":    labelValue,
+		}
+		d.WantLabels[i] = labelName
+		d.WantLabelValues[i] = labelValue
+		d.WantQueryResults[i] = &QueryResult{
+			Metric: map[string]string{
+				"__name__": metricName,
+				labelName:  "value",
+				"label":    labelValue,
+			},
+			Samples: []*Sample{{Timestamp: timestamp, Value: float64(value)}},
+		}
+		d.WantMetadata[metricName] = []MetadataEntry{{Help: "some help message", Type: "gauge"}}
+		d.WantMetricNamesStats[i].MetricName = metricName
+	}
+	d.WantLabels = append(d.WantLabels, "__name__", "label")
+	slices.Sort(d.WantLabels)
+	return d
+}
+
+// AssertSeries retrieves metric names from the storage and compares the result
+// with the expected one.
+func AssertSeries(tc *TestCase, app PrometheusQuerier, metricNameRE, tenantID string, start, end int64, want []map[string]string) {
+	tc.T().Helper()
+
+	query := fmt.Sprintf(`{__name__=~"%s"}`, metricNameRE)
+	tc.Assert(&AssertOptions{
+		Msg: "unexpected /prometheus/api/v1/series response",
+		Got: func() any {
+			tc.T().Helper()
+			return app.PrometheusAPIV1Series(tc.T(), query, QueryOpts{
+				Tenant: tenantID,
+				Start:  fmt.Sprintf("%d", start),
+				End:    fmt.Sprintf("%d", end),
+			}).Sort()
+		},
+		Want: &PrometheusAPIV1SeriesResponse{
+			Status: "success",
+			Data:   want,
+		},
+		Retries: 1000,
+		FailNow: true,
+	})
+}
+
+// AssertSeriesCount retrieves series count and compares it with expected one.
+func AssertSeriesCount(tc *TestCase, app PrometheusQuerier, tenantID string, start, end int64, want uint64) {
+	tc.T().Helper()
+
+	tc.Assert(&AssertOptions{
+		Msg: "unexpected /prometheus/api/v1/series/count response",
+		Got: func() any {
+			tc.T().Helper()
+			return app.PrometheusAPIV1SeriesCount(tc.T(), QueryOpts{
+				Tenant: tenantID,
+				Start:  fmt.Sprintf("%d", start),
+				End:    fmt.Sprintf("%d", end),
+			})
+		},
+		Want: &PrometheusAPIV1SeriesCountResponse{
+			Status: "success",
+			Data:   []uint64{want},
+		},
+		FailNow: true,
+	})
+}
+
+// AssertLabels retrieves label names from the storage and compares the result
+// with the expected one.
+func AssertLabels(tc *TestCase, app PrometheusQuerier, metricNameRE, tenantID string, start, end int64, want []string) {
+	tc.T().Helper()
+
+	query := fmt.Sprintf(`{__name__=~"%s"}`, metricNameRE)
+	tc.Assert(&AssertOptions{
+		Msg: "unexpected /prometheus/api/v1/labels response",
+		Got: func() any {
+			tc.T().Helper()
+			res := app.PrometheusAPIV1Labels(tc.T(), query, QueryOpts{
+				Tenant: tenantID,
+				Start:  fmt.Sprintf("%d", start),
+				End:    fmt.Sprintf("%d", end),
+			})
+			slices.Sort(res.Data)
+			return res
+		},
+		Want: &PrometheusAPIV1LabelsResponse{
+			Status: "success",
+			Data:   want,
+		},
+		FailNow: true,
+	})
+}
+
+// AssertLabelValues retrieves values for the label whose name is labelName for
+// the series whose name mathes metricNameRE, compares the result with the
+// expected one.
+func AssertLabelValues(tc *TestCase, app PrometheusQuerier, metricNameRE, labelName, tenantID string, start, end int64, want []string) {
+	tc.T().Helper()
+
+	query := fmt.Sprintf(`{__name__=~"%s"}`, metricNameRE)
+	tc.Assert(&AssertOptions{
+		Msg: "unexpected /prometheus/api/v1/labels/.../values response",
+		Got: func() any {
+			tc.T().Helper()
+			res := app.PrometheusAPIV1LabelValues(tc.T(), labelName, query, QueryOpts{
+				Tenant: tenantID,
+				Start:  fmt.Sprintf("%d", start),
+				End:    fmt.Sprintf("%d", end),
+			})
+			slices.Sort(res.Data)
+			return res
+		},
+		Want: &PrometheusAPIV1LabelValuesResponse{
+			Status: "success",
+			Data:   want,
+		},
+		FailNow: true,
+	})
+}
+
+// AssertQueryResults sends a data query to storage and compares the query
+// result with the expected one.
+func AssertQueryResults(tc *TestCase, app PrometheusQuerier, metricNameRE, tenantID string, start, end, step int64, want []*QueryResult) {
+	tc.T().Helper()
+
+	query := fmt.Sprintf(`{__name__=~"%s"}`, metricNameRE)
+	tc.Assert(&AssertOptions{
+		Msg: "unexpected /prometheus/api/v1/query_range response",
+		Got: func() any {
+			tc.T().Helper()
+			return app.PrometheusAPIV1QueryRange(tc.T(), query, QueryOpts{
+				Tenant:      tenantID,
+				Start:       fmt.Sprintf("%d", start),
+				End:         fmt.Sprintf("%d", end),
+				Step:        fmt.Sprintf("%dms", step),
+				MaxLookback: fmt.Sprintf("%dms", step-1),
+				NoCache:     "1",
+			})
+		},
+		Want: &PrometheusAPIV1QueryResponse{
+			Status: "success",
+			Data: &QueryData{
+				ResultType: "matrix",
+				Result:     want,
+			},
+		},
+		FailNow: true,
+	})
+}
+
+func AssertMetadata(tc *TestCase, app PrometheusQuerier, metricName, tenantID string, want map[string][]MetadataEntry) {
+	tc.T().Helper()
+
+	tc.Assert(&AssertOptions{
+		Msg: "unexpected /prometheus/api/v1/metadata response",
+		Got: func() any {
+			tc.T().Helper()
+			return app.PrometheusAPIV1Metadata(tc.T(), metricName, 0, QueryOpts{
+				Tenant: tenantID,
+			})
+		},
+		Want: &PrometheusAPIV1Metadata{
+			Status: "success",
+			Data:   want,
+		},
+		FailNow: true,
+	})
+}
+
+func AssertMetricNamesStats(tc *TestCase, app PrometheusQuerier, metricNameRE, tenantID string, want []MetricNamesStatsRecord) {
+	tc.T().Helper()
+
+	tc.Assert(&AssertOptions{
+		Msg: "unexpected /prometheus/api/v1/status/metric_names_stats response",
+		Got: func() any {
+			tc.T().Helper()
+			return app.PrometheusAPIV1StatusMetricNamesStats(tc.T(), "", "", metricNameRE, QueryOpts{
+				Tenant: tenantID,
+			})
+		},
+		Want: MetricNamesStatsResponse{
+			Records: want,
+		},
+		FailNow: true,
+	})
+
+}
+
+// GraphiteTestData holds the data samples in Graphite Pickle format, distance
+// between samples in milliseconds and expected responses for various Graphite
+// API endpoints.
+type GraphiteTestData struct {
+	Samples             []string
+	Step                int64
+	WantMetricsIndex    []string
+	WantMetricsFind     []GraphiteMetric
+	WantMetricsExpand   []string
+	WantRenderedTargets []GraphiteRenderedTarget
+}
+
+// GenerateGraphiteTestData generates Graphite test data.
+func GenerateGraphiteTestData(prefix string, numMetrics, start, end int64) GraphiteTestData {
+	d := GraphiteTestData{
+		Samples:             make([]string, numMetrics),
+		Step:                (end - start) / numMetrics,
+		WantMetricsIndex:    make([]string, numMetrics),
+		WantMetricsFind:     make([]GraphiteMetric, numMetrics),
+		WantMetricsExpand:   make([]string, numMetrics),
+		WantRenderedTargets: make([]GraphiteRenderedTarget, numMetrics),
+	}
+
+	datapoints := make([][2]float64, numMetrics)
+	for i := range numMetrics {
+		timestamp := (start + i*d.Step) / 1000
+		datapoints[i][1] = float64(timestamp)
+	}
+
+	for i := range numMetrics {
+		suffix := fmt.Sprintf("%04d", i)
+		metricName := fmt.Sprintf("%s.%s", prefix, suffix)
+		value := i
+		timestamp := (start + i*d.Step) / 1000
+		sample := fmt.Sprintf(`%s %d %d`, metricName, value, timestamp)
+
+		d.Samples[i] = sample
+		d.WantMetricsIndex[i] = metricName
+		d.WantMetricsFind[i].Id = metricName
+		d.WantMetricsFind[i].Text = suffix
+		d.WantMetricsFind[i].Leaf = 1
+		d.WantMetricsExpand[i] = metricName
+		d.WantRenderedTargets[i].Target = metricName
+		d.WantRenderedTargets[i].Datapoints = slices.Clone(datapoints)
+		d.WantRenderedTargets[i].Datapoints[i][0] = float64(value)
+	}
+	return d
+}
+
+// AssertGraphiteMetricsIndex retrieves all metrics by sending a request to
+// /graphite/metrics/index.json and compares the result with the expected one.
+func AssertGraphiteMetricsIndex(tc *TestCase, app PrometheusQuerier, tenantID string, want []string) {
+	tc.T().Helper()
+
+	tc.Assert(&AssertOptions{
+		Msg: "unexpected /graphite/metrics/index.json response",
+		Got: func() any {
+			tc.T().Helper()
+			return app.GraphiteMetricsIndex(tc.T(), QueryOpts{
+				Tenant: tenantID,
+			})
+		},
+		Want:    want,
+		Retries: 30,
+		FailNow: true,
+	})
+
+}
+
+// AssertGraphiteMetricsFind finds metric names by sending a request to
+// /graphite/metrics/find and compares the result with the expected one.
+func AssertGraphiteMetricsFind(tc *TestCase, app PrometheusQuerier, query, tenantID string, want []GraphiteMetric) {
+	tc.T().Helper()
+
+	tc.Assert(&AssertOptions{
+		Msg: "unexpected /graphite/metrics/find response",
+		Got: func() any {
+			tc.T().Helper()
+			return app.GraphiteMetricsFind(tc.T(), query, QueryOpts{
+				Tenant: tenantID,
+			})
+		},
+		Want:    want,
+		FailNow: true,
+	})
+
+}
+
+// AssertGraphiteMetricsFind expands metric names by sending a request to
+// /graphite/metrics/expand and compares the result with the expected one.
+func AssertGraphiteMetricsExpand(tc *TestCase, app PrometheusQuerier, query, tenantID string, want []string) {
+	tc.T().Helper()
+
+	tc.Assert(&AssertOptions{
+		Msg: "unexpected /graphite/metrics/expand response",
+		Got: func() any {
+			tc.T().Helper()
+			return app.GraphiteMetricsExpand(tc.T(), query, QueryOpts{
+				Tenant: tenantID,
+			})
+		},
+		Want:    want,
+		FailNow: true,
+	})
+
+}
+
+// AssertGraphiteRender retieves metric raw data by sending a request to
+// /graphite/render and compares the result with the expected one.
+func AssertGraphiteRender(tc *TestCase, app PrometheusQuerier, target, tenantID string, from, until, step int64, want []GraphiteRenderedTarget) {
+	tc.T().Helper()
+
+	tc.Assert(&AssertOptions{
+		Msg: "unexpected /graphite/render response",
+		Got: func() any {
+			tc.T().Helper()
+			return app.GraphiteRender(tc.T(), target, QueryOpts{
+				Tenant:      tenantID,
+				From:        fmt.Sprintf("%d", from/1000),
+				Until:       fmt.Sprintf("%d", until/1000),
+				StorageStep: fmt.Sprintf("%dms", step),
+			})
+		},
+		Want:    want,
+		FailNow: true,
+	})
+}

--- a/apptest/tests/vmsingle_vmselect_rpc_test.go
+++ b/apptest/tests/vmsingle_vmselect_rpc_test.go
@@ -1,0 +1,216 @@
+package tests
+
+import (
+	"fmt"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/VictoriaMetrics/VictoriaMetrics/apptest"
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestMixedPrometheusQueries(t *testing.T) {
+	tc := apptest.NewTestCase(t)
+	defer tc.Stop()
+
+	const (
+		accountID1 = 12
+		projectID1 = 34
+		accountID2 = 56
+		projectID2 = 78
+		numMetrics = 10
+	)
+	tenantID1 := fmt.Sprintf("%d:%d", accountID1, projectID1)
+	tenantID2 := fmt.Sprintf("%d:%d", accountID2, projectID2)
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC).UnixMilli()
+	end := time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC).UnixMilli()
+	data := apptest.GenerateTestData("metric", numMetrics, start, end)
+	emptySeries := []map[string]string{}
+	emptyLabels := []string{}
+	emptyLabelValues := []string{}
+	emptyQueryResults := []*apptest.QueryResult{}
+	emptyMetadata := map[string][]apptest.MetadataEntry{}
+	emptyMetricNamesStats := []apptest.MetricNamesStatsRecord{}
+
+	vmsingle := tc.MustStartVmsingle("vmsingle", []string{
+		"-storageDataPath=" + filepath.Join(tc.Dir(), "vmsingle"),
+		"-retentionPeriod=100y",
+		fmt.Sprintf("-accountID=%d", accountID1),
+		fmt.Sprintf("-projectID=%d", projectID1),
+	})
+	vmselect := tc.MustStartVmselect("vmselect", []string{
+		"-storageNode=" + vmsingle.VmselectAddr(),
+	})
+
+	vmsingle.PrometheusAPIV1ImportPrometheus(tc.T(), data.Samples, apptest.QueryOpts{})
+	vmsingle.ForceFlush(t)
+
+	// Ensure vmsingle returns data.
+	apptest.AssertSeries(tc, vmsingle, "metric.*", "", start, end, data.WantSeries)
+	apptest.AssertSeriesCount(tc, vmsingle, "", start, end, numMetrics)
+	apptest.AssertLabels(tc, vmsingle, "metric.*", "", start, end, data.WantLabels)
+	apptest.AssertLabelValues(tc, vmsingle, "metric.*", "label", "", start, end, data.WantLabelValues)
+	apptest.AssertQueryResults(tc, vmsingle, "metric.*", "", start, end, data.Step, data.WantQueryResults)
+	apptest.AssertMetadata(tc, vmsingle, "", "", data.WantMetadata)
+	for i := range data.WantMetricNamesStats {
+		data.WantMetricNamesStats[i].QueryRequestsCount = 1
+	}
+	apptest.AssertMetricNamesStats(tc, vmsingle, "", "", data.WantMetricNamesStats)
+
+	// Check that current vmsingle tenant (configured via flags) is tenant1.
+	gotAdminTenantsResponse := vmselect.APIV1AdminTenants(t, apptest.QueryOpts{})
+	wantAdminTenantsResponse := &apptest.AdminTenantsResponse{
+		Status: "success",
+		Data:   []string{tenantID1},
+	}
+	if diff := cmp.Diff(wantAdminTenantsResponse, gotAdminTenantsResponse); diff != "" {
+		t.Fatalf("unexpected tenants (-want, +got):\n%s", diff)
+	}
+
+	// Ensure vmselect returns data for tenant1.
+	apptest.AssertSeries(tc, vmselect, "metric.*", tenantID1, start, end, data.WantSeries)
+	apptest.AssertSeriesCount(tc, vmselect, tenantID1, start, end, numMetrics)
+	apptest.AssertLabels(tc, vmselect, "metric.*", tenantID1, start, end, data.WantLabels)
+	apptest.AssertLabelValues(tc, vmselect, "metric.*", "label", tenantID1, start, end, data.WantLabelValues)
+	apptest.AssertQueryResults(tc, vmselect, "metric.*", tenantID1, start, end, data.Step, data.WantQueryResults)
+	apptest.AssertMetadata(tc, vmselect, "", tenantID1, data.WantMetadata)
+	for i := range data.WantMetricNamesStats {
+		data.WantMetricNamesStats[i].QueryRequestsCount = 2
+	}
+	apptest.AssertMetricNamesStats(tc, vmselect, "", tenantID1, data.WantMetricNamesStats)
+
+	// Ensure vmselect does not return any data for tenant2.
+	apptest.AssertSeries(tc, vmselect, "metric.*", tenantID2, start, end, emptySeries)
+	apptest.AssertSeriesCount(tc, vmselect, tenantID2, start, end, 0)
+	apptest.AssertLabels(tc, vmselect, "metric.*", tenantID2, start, end, emptyLabels)
+	apptest.AssertLabelValues(tc, vmselect, "metric.*", "label", tenantID2, start, end, emptyLabelValues)
+	apptest.AssertQueryResults(tc, vmselect, "metric.*", tenantID2, start, end, data.Step, emptyQueryResults)
+	apptest.AssertMetadata(tc, vmselect, "", tenantID2, emptyMetadata)
+	apptest.AssertMetricNamesStats(tc, vmselect, "", tenantID2, emptyMetricNamesStats)
+
+	// Ensure vmselect returns data for multitenant.
+	for _, v := range data.WantSeries {
+		v["vm_account_id"] = strconv.Itoa(accountID1)
+		v["vm_project_id"] = strconv.Itoa(projectID1)
+	}
+	apptest.AssertSeries(tc, vmselect, "metric.*", "multitenant", start, end, data.WantSeries)
+	data.WantLabels = append(data.WantLabels, "vm_account_id", "vm_project_id")
+	apptest.AssertLabels(tc, vmselect, "metric.*", "multitenant", start, end, data.WantLabels)
+	apptest.AssertLabelValues(tc, vmselect, "metric.*", "label", "multitenant", start, end, data.WantLabelValues)
+	for _, v := range data.WantQueryResults {
+		v.Metric["vm_account_id"] = strconv.Itoa(accountID1)
+		v.Metric["vm_project_id"] = strconv.Itoa(projectID1)
+	}
+	apptest.AssertQueryResults(tc, vmselect, "metric.*", "multitenant", start, end, data.Step, data.WantQueryResults)
+	apptest.AssertMetadata(tc, vmselect, "", "multitenant", data.WantMetadata)
+	for i := range data.WantMetricNamesStats {
+		data.WantMetricNamesStats[i].QueryRequestsCount = 3
+	}
+	apptest.AssertMetricNamesStats(tc, vmselect, "", "multitenant", data.WantMetricNamesStats)
+}
+
+func TestMixedDeleteSeries(t *testing.T) {
+	tc := apptest.NewTestCase(t)
+	defer tc.Stop()
+
+	const (
+		accountID1 = 12
+		projectID1 = 34
+		accountID2 = 56
+		projectID2 = 78
+		numMetrics = 10
+	)
+	tenantID1 := fmt.Sprintf("%d:%d", accountID1, projectID1)
+	tenantID2 := fmt.Sprintf("%d:%d", accountID2, projectID2)
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC).UnixMilli()
+	end := time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC).UnixMilli()
+	data1 := apptest.GenerateTestData("metric1", numMetrics, start, end)
+	data2 := apptest.GenerateTestData("metric2", numMetrics, start, end)
+	emptySeries := []map[string]string{}
+
+	vmsingle := tc.MustStartVmsingle("vmsingle", []string{
+		"-storageDataPath=" + filepath.Join(tc.Dir(), "vmsingle"),
+		"-retentionPeriod=100y",
+		fmt.Sprintf("-accountID=%d", accountID1),
+		fmt.Sprintf("-projectID=%d", projectID1),
+	})
+	vmselect := tc.MustStartVmselect("vmselect", []string{
+		"-storageNode=" + vmsingle.VmselectAddr(),
+	})
+
+	vmsingle.PrometheusAPIV1ImportPrometheus(tc.T(), data1.Samples, apptest.QueryOpts{})
+	vmsingle.PrometheusAPIV1ImportPrometheus(tc.T(), data2.Samples, apptest.QueryOpts{})
+	vmsingle.ForceFlush(t)
+
+	wantSeries12 := slices.Concat(data1.WantSeries, data2.WantSeries)
+	apptest.AssertSeries(tc, vmsingle, "metric.*", "", start, end, wantSeries12)
+
+	vmselect.PrometheusAPIV1AdminTSDBDeleteSeries(tc.T(), `{__name__=~"metric1.*"}`, apptest.QueryOpts{
+		Tenant: tenantID1,
+	})
+	apptest.AssertSeries(tc, vmsingle, "metric.*", "", start, end, data2.WantSeries)
+	vmselect.PrometheusAPIV1AdminTSDBDeleteSeries(tc.T(), `{__name__=~"metric2.*"}`, apptest.QueryOpts{
+		Tenant: tenantID2,
+	})
+	apptest.AssertSeries(tc, vmsingle, "metric.*", "", start, end, data2.WantSeries)
+	vmselect.PrometheusAPIV1AdminTSDBDeleteSeries(tc.T(), `{__name__=~"metric2.*"}`, apptest.QueryOpts{
+		Tenant: "multitenant",
+	})
+	apptest.AssertSeries(tc, vmsingle, "metric.*", "", start, end, emptySeries)
+}
+
+func TestMixedGraphiteQueries(t *testing.T) {
+	tc := apptest.NewTestCase(t)
+	defer tc.Stop()
+
+	const (
+		accountID1 = 12
+		projectID1 = 34
+		accountID2 = 56
+		projectID2 = 78
+		numMetrics = 10
+	)
+	tenantID1 := fmt.Sprintf("%d:%d", accountID1, projectID1)
+	tenantID2 := fmt.Sprintf("%d:%d", accountID2, projectID2)
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC).UnixMilli()
+	end := time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC).UnixMilli()
+	data := apptest.GenerateGraphiteTestData("metric", numMetrics, start, end)
+	emptyMetricsIndex := []string{}
+	emptyMetricsFind := []apptest.GraphiteMetric{}
+	emptyMetricsExpand := []string{}
+	emptyRenderedTargets := []apptest.GraphiteRenderedTarget{}
+
+	vmsingle := tc.MustStartVmsingle("vmsingle", []string{
+		"-storageDataPath=" + filepath.Join(tc.Dir(), "vmsingle"),
+		"-retentionPeriod=100y",
+		fmt.Sprintf("-accountID=%d", accountID1),
+		fmt.Sprintf("-projectID=%d", projectID1),
+	})
+	vmselect := tc.MustStartVmselect("vmselect", []string{
+		"-storageNode=" + vmsingle.VmselectAddr(),
+	})
+
+	vmsingle.GraphiteWrite(tc.T(), data.Samples, apptest.QueryOpts{})
+	vmsingle.ForceFlush(t)
+
+	// Ensure vmsingle returns data.
+	apptest.AssertGraphiteMetricsIndex(tc, vmsingle, "", data.WantMetricsIndex)
+	apptest.AssertGraphiteMetricsFind(tc, vmsingle, "metric.*", "", data.WantMetricsFind)
+	apptest.AssertGraphiteMetricsExpand(tc, vmsingle, "metric.*", "", data.WantMetricsExpand)
+	apptest.AssertGraphiteRender(tc, vmsingle, "metric.*", "", start, end, data.Step, data.WantRenderedTargets)
+
+	// Ensure vmselect returns data for tenant1.
+	apptest.AssertGraphiteMetricsIndex(tc, vmselect, tenantID1, data.WantMetricsIndex)
+	apptest.AssertGraphiteMetricsFind(tc, vmselect, "metric.*", tenantID1, data.WantMetricsFind)
+	apptest.AssertGraphiteMetricsExpand(tc, vmselect, "metric.*", tenantID1, data.WantMetricsExpand)
+	apptest.AssertGraphiteRender(tc, vmselect, "metric.*", tenantID1, start, end, data.Step, data.WantRenderedTargets)
+
+	// Ensure vmselect does not return any data for tenant2.
+	apptest.AssertGraphiteMetricsIndex(tc, vmselect, tenantID2, emptyMetricsIndex)
+	apptest.AssertGraphiteMetricsFind(tc, vmselect, "metric.*", tenantID2, emptyMetricsFind)
+	apptest.AssertGraphiteMetricsExpand(tc, vmselect, "metric.*", tenantID2, emptyMetricsExpand)
+	apptest.AssertGraphiteRender(tc, vmselect, "metric.*", tenantID2, start, end, data.Step, emptyRenderedTargets)
+}

--- a/apptest/vmsingle.go
+++ b/apptest/vmsingle.go
@@ -25,12 +25,14 @@ func StartVmsingle(instance string, flags []string, cli *Client, output io.Write
 			"-httpListenAddr":     "127.0.0.1:0",
 			"-graphiteListenAddr": "127.0.0.1:0",
 			"-opentsdbListenAddr": "127.0.0.1:0",
+			"-vmselectAddr":       "127.0.0.1:0",
 		},
 		extractREs: []*regexp.Regexp{
 			storageDataPathRE,
 			httpListenAddrRE,
 			graphiteListenAddrRE,
 			openTSDBListenAddrRE,
+			vmselectAddrRE,
 		},
 		output: output,
 	})
@@ -43,6 +45,7 @@ func StartVmsingle(instance string, flags []string, cli *Client, output io.Write
 		httpListenAddr:     stderrExtracts[1],
 		graphiteListenAddr: stderrExtracts[2],
 		openTSDBListenAddr: stderrExtracts[3],
+		vmselectAddr:       stderrExtracts[4],
 	}), nil
 }
 
@@ -51,6 +54,7 @@ type vmsingleRuntimeValues struct {
 	httpListenAddr     string
 	graphiteListenAddr string
 	openTSDBListenAddr string
+	vmselectAddr       string
 }
 
 func newVmsingle(app *app, cli *Client, rt vmsingleRuntimeValues) *Vmsingle {
@@ -85,6 +89,7 @@ func newVmsingle(app *app, cli *Client, rt vmsingleRuntimeValues) *Vmsingle {
 		},
 		storageDataPath: rt.storageDataPath,
 		httpListenAddr:  rt.httpListenAddr,
+		vmselectAddr:    rt.vmselectAddr,
 	}
 }
 
@@ -99,12 +104,19 @@ type Vmsingle struct {
 
 	storageDataPath string
 	httpListenAddr  string
+	vmselectAddr    string
 }
 
 // HTTPAddr returns the address at which the vminsert process is
 // listening for incoming HTTP requests.
 func (app *Vmsingle) HTTPAddr() string {
 	return app.httpListenAddr
+}
+
+// VmselectAddr returns the address at which the vmsingle process is listening
+// for vmselect connections.
+func (app *Vmsingle) VmselectAddr() string {
+	return app.vmselectAddr
 }
 
 // String returns the string representation of the vmsingle app state.

--- a/docs/victoriametrics/changelog/CHANGELOG.md
+++ b/docs/victoriametrics/changelog/CHANGELOG.md
@@ -40,6 +40,8 @@ See also [LTS releases](https://docs.victoriametrics.com/victoriametrics/lts-rel
 * BUGFIX: `vmselect` in [VictoriaMetrics cluster](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/): propagate cache reset operation to `selectNode` when `/internal/resetRollupResultCache` is called. Previously, the propagation only happened when the `delete_series` API was called. See [#11112](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/11112).
 * BUGFIX: [stream aggregation](https://docs.victoriametrics.com/victoriametrics/stream-aggregation/): fix possible unexpected increases in `rate_avg` and `rate_sum` if an out-of-order sample is ingested after the previous flush. See [#11140](https://github.com/VictoriaMetrics/VictoriaMetrics/pull/11140).
 
+* FEATURE: [vmsingle](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/): Add the support of vmselect RPC to vmsingle so that single node can be queried by a vmselect from a vmcluster deployment. See [4328](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/4328) and [10926](https://github.com/VictoriaMetrics/VictoriaMetrics/pull/10926).
+
 ## [v1.146.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.146.0)
 
 Released at 2026-06-22

--- a/lib/handshake/buffered_conn.go
+++ b/lib/handshake/buffered_conn.go
@@ -1,0 +1,140 @@
+package handshake
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"time"
+
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/encoding/zstd"
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/fasttime"
+)
+
+type bufferedWriter interface {
+	Write(p []byte) (int, error)
+	Flush() error
+}
+
+// BufferedConn is a net.Conn with Flush suport.
+type BufferedConn struct {
+	net.Conn
+
+	// IsLegacy defines if BufferedConn operates in legacy mode
+	// and doesn't support RPC protocol
+	IsLegacy bool
+
+	br io.Reader
+	bw bufferedWriter
+
+	readDeadline  time.Time
+	writeDeadline time.Time
+}
+
+const bufferSize = 64 * 1024
+
+// newBufferedConn returns buffered connection with the given compression level.
+func newBufferedConn(c net.Conn, compressionLevel int, isReadCompressed bool) *BufferedConn {
+	bc := &BufferedConn{
+		Conn: c,
+	}
+	if compressionLevel <= 0 {
+		bc.bw = bufio.NewWriterSize(c, bufferSize)
+	} else {
+		bc.bw = zstd.NewWriterLevel(c, compressionLevel)
+	}
+	if !isReadCompressed {
+		bc.br = bufio.NewReaderSize(c, bufferSize)
+	} else {
+		bc.br = zstd.NewReader(c)
+	}
+	return bc
+}
+
+// SetDeadline sets read and write deadlines for bc to t.
+//
+// Deadline is checked on each Read and Write call.
+func (bc *BufferedConn) SetDeadline(t time.Time) error {
+	bc.readDeadline = t
+	bc.writeDeadline = t
+	return bc.Conn.SetDeadline(t)
+}
+
+// SetReadDeadline sets read deadline for bc to t.
+//
+// Deadline is checked on each Read call.
+func (bc *BufferedConn) SetReadDeadline(t time.Time) error {
+	bc.readDeadline = t
+	return bc.Conn.SetReadDeadline(t)
+}
+
+// SetWriteDeadline sets write deadline for bc to t.
+//
+// Deadline is checked on each Write call.
+func (bc *BufferedConn) SetWriteDeadline(t time.Time) error {
+	bc.writeDeadline = t
+	return bc.Conn.SetWriteDeadline(t)
+}
+
+// Read reads up to len(p) from bc to p.
+func (bc *BufferedConn) Read(p []byte) (int, error) {
+	startTime := fasttime.UnixTimestamp()
+	if deadlineExceeded(bc.readDeadline, startTime) {
+		return 0, os.ErrDeadlineExceeded
+	}
+	n, err := bc.br.Read(p)
+	if err != nil && err != io.EOF {
+		err = fmt.Errorf("cannot read data in %d seconds: %w", fasttime.UnixTimestamp()-startTime, err)
+	}
+	return n, err
+}
+
+// Write writes p to bc.
+//
+// Do not forget to call Flush if needed.
+func (bc *BufferedConn) Write(p []byte) (int, error) {
+	startTime := fasttime.UnixTimestamp()
+	if deadlineExceeded(bc.writeDeadline, startTime) {
+		return 0, os.ErrDeadlineExceeded
+	}
+	n, err := bc.bw.Write(p)
+	if err != nil {
+		err = fmt.Errorf("cannot write data in %d seconds: %w", fasttime.UnixTimestamp()-startTime, err)
+	}
+	return n, err
+}
+
+func deadlineExceeded(deadline time.Time, currentTimestamp uint64) bool {
+	if deadline.IsZero() {
+		return false
+	}
+	return currentTimestamp > uint64(deadline.Unix())
+}
+
+// Close closes bc.
+func (bc *BufferedConn) Close() error {
+	// Close the Conn at first. It is expected that all the required data
+	// is already flushed to the Conn.
+	err := bc.Conn.Close()
+	bc.Conn = nil
+
+	if zr, ok := bc.br.(*zstd.Reader); ok {
+		zr.Release()
+	}
+	bc.br = nil
+
+	if zw, ok := bc.bw.(*zstd.Writer); ok {
+		// Do not call zw.Close(), since we already closed the underlying conn.
+		zw.Release()
+	}
+	bc.bw = nil
+
+	bc.IsLegacy = false
+	return err
+}
+
+// Flush flushes internal write buffers to the underlying conn.
+func (bc *BufferedConn) Flush() error {
+	return bc.bw.Flush()
+}

--- a/lib/handshake/handshake.go
+++ b/lib/handshake/handshake.go
@@ -1,0 +1,319 @@
+package handshake
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"net"
+	"strings"
+	"time"
+
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/logger"
+)
+
+var rpcHandshakeTimeout = flag.Duration("rpc.handshakeTimeout", 5*time.Second, "Timeout for RPC handshake between vminsert/vmselect and vmstorage. Increase this value if transient handshake failures occur. See https://docs.victoriametrics.com/victoriametrics/troubleshooting/#cluster-instability section for more details.")
+
+const (
+	vminsertHelloLegacyVersion = "vminsert.02"
+	vminsertHello              = "vminsert.03"
+	vmselectHello              = "vmselect.01"
+
+	successResponse = "ok"
+)
+
+// Func must perform handshake on the given c using the given compressionLevel.
+//
+// It must return BufferedConn wrapper for c on successful handshake.
+type Func func(c net.Conn, compressionLevel int) (*BufferedConn, error)
+
+// VMInsertClientWithDialer performs client-side handshake for vminsert protocol.
+//
+// it uses provided dial func to establish connection to the server.
+// compressionLevel is a legacy option which defines the level used for compression of the data sent
+// to the server.
+// compressionLevel <= 0 means 'no compression'
+func VMInsertClientWithDialer(dial func() (net.Conn, error), compressionLevel int) (*BufferedConn, error) {
+	c, err := dial()
+	if err != nil {
+		return nil, fmt.Errorf("dial error: %w", err)
+	}
+	bc, err := vminsertClient(c, 0)
+	if err == nil {
+		return bc, nil
+	}
+	_ = c.Close()
+	// fallback only if vmstorage closed connection at read success response
+	if !errors.Is(err, io.EOF) && !strings.Contains(err.Error(), "cannot read success response after sending hello") {
+		return nil, err
+	}
+	// try to fallback to the prev non-RPC API version
+	// we cannot re-use exist connection, since vmstorage already closed it
+	c, err = dial()
+	if err != nil {
+		return nil, fmt.Errorf("dial error: %w", err)
+	}
+	bc, err = genericClient(c, vminsertHelloLegacyVersion, compressionLevel)
+	if err != nil {
+		_ = c.Close()
+		return nil, fmt.Errorf("legacy handshake error: %w", err)
+	}
+	bc.IsLegacy = true
+	logger.Infof("server=%q doesn't support new RPC version, fallback to the legacy format", c.RemoteAddr())
+	return bc, nil
+}
+
+func vminsertClient(c net.Conn, compressionLevel int) (*BufferedConn, error) {
+	return genericClient(c, vminsertHello, compressionLevel)
+}
+
+// VMInsertClientWithHello performs client-side handshake for vminsert protocol.
+//
+// should be used for testing only
+func VMInsertClientWithHello(c net.Conn, helloMsg string, compressionLevel int) (*BufferedConn, error) {
+	return genericClient(c, helloMsg, compressionLevel)
+}
+
+// VMInsertServer performs server-side handshake for vminsert protocol.
+//
+// compressionLevel is the level used for compression of the data sent
+// to the client.
+// compressionLevel <= 0 means 'no compression'
+func VMInsertServer(c net.Conn, compressionLevel int) (*BufferedConn, error) {
+
+	var isRPCSupported bool
+	bc, err := genericServer(c, compressionLevel, func(c net.Conn) error {
+		buf, err := readData(c, len(vminsertHello))
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				// This is likely a TCP healthcheck, which must be ignored in order to prevent logs pollution.
+				// See https://github.com/VictoriaMetrics/VictoriaMetrics/issues/1762
+				return errTCPHealthcheck
+			}
+			return fmt.Errorf("cannot read hello: %w", err)
+		}
+		isRPCSupported = string(buf) == vminsertHello
+		if !isRPCSupported {
+			// try to fallback to the previous protocol version
+			if string(buf) != vminsertHelloLegacyVersion {
+				return fmt.Errorf("unexpected message obtained; got %q; want %q", buf, vminsertHello)
+			}
+			logger.Infof("client=%q doesn't support new RPC version, fallback to the legacy format", c.RemoteAddr())
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	bc.IsLegacy = !isRPCSupported
+	return bc, nil
+}
+
+// VMInsertServerWithLegacyHello performs server-side handshake for vminsert protocol
+// with legacy hello  message
+//
+// should be used for testing only
+func VMInsertServerWithLegacyHello(c net.Conn, compressionLevel int) (*BufferedConn, error) {
+
+	bc, err := genericServer(c, compressionLevel, func(c net.Conn) error {
+		return readMessage(c, vminsertHelloLegacyVersion)
+	})
+	if err != nil {
+		return nil, err
+	}
+	bc.IsLegacy = true
+	return bc, nil
+}
+
+// VMSelectClient performs client-side handshake for vmselect protocol.
+//
+// compressionLevel is the level used for compression of the data sent
+// to the server.
+// compressionLevel <= 0 means 'no compression'
+func VMSelectClient(c net.Conn, compressionLevel int) (*BufferedConn, error) {
+	return genericClient(c, vmselectHello, compressionLevel)
+}
+
+// VMSelectServer performs server-side handshake for vmselect protocol.
+//
+// compressionLevel is the level used for compression of the data sent
+// to the client.
+// compressionLevel <= 0 means 'no compression'
+func VMSelectServer(c net.Conn, compressionLevel int) (*BufferedConn, error) {
+	return genericServer(c, compressionLevel, func(c net.Conn) error {
+		err := readMessage(c, vmselectHello)
+		if errors.Is(err, io.EOF) {
+			// This is likely a TCP healthcheck, which must be ignored in order to prevent logs pollution.
+			// See https://github.com/VictoriaMetrics/VictoriaMetrics/issues/1762 and https://github.com/VictoriaMetrics/VictoriaMetrics/issues/10786
+			return errTCPHealthcheck
+		}
+		return err
+	})
+}
+
+// errTCPHealthcheck indicates that the connection was opened as part of a TCP health check
+// and was closed immediately after being established.
+//
+// This is expected behavior and can be safely ignored.
+var errTCPHealthcheck = fmt.Errorf("TCP health check connection – safe to ignore")
+
+// IsTCPHealthcheck determines whether the provided error is a TCP health check
+func IsTCPHealthcheck(err error) bool {
+	return errors.Is(err, errTCPHealthcheck)
+}
+
+// IsClientNetworkError determines whether the provided error is a client-side network error,
+// such as io.EOF, io.ErrUnexpectedEOF, or a timeout.
+// These errors typically occur when a client disconnects abruptly or fails during the handshake,
+// and are generally non-actionable from the server point of view.
+// This function helps distinguish such errors from critical ones during the handshake process
+// and adjust logging accordingly.
+//
+// See: https://github.com/VictoriaMetrics/VictoriaMetrics-enterprise/pull/880
+func IsClientNetworkError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+		return true
+	}
+
+	if IsTimeoutNetworkError(err) {
+		return true
+	}
+
+	if errMsg := err.Error(); strings.Contains(errMsg, "broken pipe") || strings.Contains(errMsg, "reset by peer") {
+		return true
+	}
+
+	return false
+}
+
+// IsTimeoutNetworkError determines whether the provided error is a network error with a timeout.
+func IsTimeoutNetworkError(err error) bool {
+	var ne net.Error
+	if errors.As(err, &ne) && ne.Timeout() {
+		return true
+	}
+
+	return false
+}
+
+func genericServer(c net.Conn, compressionLevel int, readHelloMessage func(c net.Conn) error) (*BufferedConn, error) {
+	if err := c.SetDeadline(time.Now().Add(*rpcHandshakeTimeout)); err != nil {
+		return nil, fmt.Errorf("cannot set deadline: %w", err)
+	}
+
+	if err := readHelloMessage(c); err != nil {
+		return nil, fmt.Errorf("cannot read hello message : %w", err)
+	}
+	if err := writeMessage(c, successResponse); err != nil {
+		return nil, fmt.Errorf("cannot write success response on isCompressed: %w", err)
+	}
+	isRemoteCompressed, err := readIsCompressed(c)
+	if err != nil {
+		return nil, fmt.Errorf("cannot read isCompressed flag: %w", err)
+	}
+	if err := writeMessage(c, successResponse); err != nil {
+		return nil, fmt.Errorf("cannot write success response on isCompressed: %w", err)
+	}
+	if err := writeIsCompressed(c, compressionLevel > 0); err != nil {
+		return nil, fmt.Errorf("cannot write isCompressed flag: %w", err)
+	}
+	if err := readMessage(c, successResponse); err != nil {
+		return nil, fmt.Errorf("cannot read success response on isCompressed: %w", err)
+	}
+
+	if err := c.SetDeadline(time.Time{}); err != nil {
+		return nil, fmt.Errorf("cannot reset deadline: %w", err)
+	}
+
+	bc := newBufferedConn(c, compressionLevel, isRemoteCompressed)
+	return bc, nil
+}
+
+func genericClient(c net.Conn, msg string, compressionLevel int) (*BufferedConn, error) {
+	if err := c.SetDeadline(time.Now().Add(*rpcHandshakeTimeout)); err != nil {
+		return nil, fmt.Errorf("cannot set deadline: %w", err)
+	}
+
+	if err := writeMessage(c, msg); err != nil {
+		return nil, fmt.Errorf("cannot write hello: %w", err)
+	}
+	if err := readMessage(c, successResponse); err != nil {
+		return nil, fmt.Errorf("cannot read success response after sending hello: %w", err)
+	}
+	if err := writeIsCompressed(c, compressionLevel > 0); err != nil {
+		return nil, fmt.Errorf("cannot write isCompressed flag: %w", err)
+	}
+	if err := readMessage(c, successResponse); err != nil {
+		return nil, fmt.Errorf("cannot read success response on isCompressed: %w", err)
+	}
+	isRemoteCompressed, err := readIsCompressed(c)
+	if err != nil {
+		return nil, fmt.Errorf("cannot read isCompressed flag: %w", err)
+	}
+	if err := writeMessage(c, successResponse); err != nil {
+		return nil, fmt.Errorf("cannot write success response on isCompressed: %w", err)
+	}
+
+	if err := c.SetDeadline(time.Time{}); err != nil {
+		return nil, fmt.Errorf("cannot reset deadline: %w", err)
+	}
+
+	bc := newBufferedConn(c, compressionLevel, isRemoteCompressed)
+	return bc, nil
+}
+
+func writeIsCompressed(c net.Conn, isCompressed bool) error {
+	var buf [1]byte
+	if isCompressed {
+		buf[0] = 1
+	}
+	return writeMessage(c, string(buf[:]))
+}
+
+func readIsCompressed(c net.Conn) (bool, error) {
+	buf, err := readData(c, 1)
+	if err != nil {
+		return false, err
+	}
+	isCompressed := buf[0] != 0
+	return isCompressed, nil
+}
+
+func writeMessage(c net.Conn, msg string) error {
+	if _, err := io.WriteString(c, msg); err != nil {
+		return fmt.Errorf("cannot write %q to server: %w", msg, err)
+	}
+	if fc, ok := c.(flusher); ok {
+		if err := fc.Flush(); err != nil {
+			return fmt.Errorf("cannot flush %q to server: %w", msg, err)
+		}
+	}
+	return nil
+}
+
+type flusher interface {
+	Flush() error
+}
+
+func readMessage(c net.Conn, msg string) error {
+	buf, err := readData(c, len(msg))
+	if err != nil {
+		return err
+	}
+	if string(buf) != msg {
+		return fmt.Errorf("unexpected message obtained; got %q; want %q", buf, msg)
+	}
+	return nil
+}
+
+func readData(c net.Conn, dataLen int) ([]byte, error) {
+	data := make([]byte, dataLen)
+	if n, err := io.ReadFull(c, data); err != nil {
+		return nil, fmt.Errorf("cannot read message with size %d: %w; read only %d bytes", dataLen, err, n)
+	}
+	return data, nil
+}

--- a/lib/handshake/handshake_test.go
+++ b/lib/handshake/handshake_test.go
@@ -1,0 +1,83 @@
+package handshake
+
+import (
+	"fmt"
+	"net"
+	"testing"
+	"time"
+)
+
+func TestVMInsertHandshake(t *testing.T) {
+	testHandshake(t, vminsertClient, VMInsertServer)
+}
+
+func TestVMSelectHandshake(t *testing.T) {
+	testHandshake(t, VMSelectClient, VMSelectServer)
+}
+
+func TestVMSelectServerTCPHealthcheck(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("cannot start listener: %s", err)
+	}
+
+	c, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatalf("cannot dial: %s", err)
+	}
+	if err := c.Close(); err != nil {
+		t.Fatalf("cannot close client conn: %s", err)
+	}
+	s, err := ln.Accept()
+	if err != nil {
+		t.Fatalf("cannot accept conn: %s", err)
+	}
+	if _, err := VMSelectServer(s, 0); !IsTCPHealthcheck(err) {
+		t.Fatalf("unexpected error; got %v; want TCP healthcheck error", err)
+	}
+}
+
+func testHandshake(t *testing.T, clientFunc, serverFunc Func) {
+	t.Helper()
+
+	c, s := net.Pipe()
+	ch := make(chan error, 1)
+	go func() {
+		bcs, err := serverFunc(s, 3)
+		if err != nil {
+			ch <- fmt.Errorf("error on outer handshake: %w", err)
+			return
+		}
+		bcc, err := clientFunc(bcs, 3)
+		if err != nil {
+			ch <- fmt.Errorf("error on inner handshake: %w", err)
+			return
+		}
+		if bcc == nil {
+			ch <- fmt.Errorf("expecting non-nil conn")
+			return
+		}
+		ch <- nil
+	}()
+
+	bcc, err := clientFunc(c, 0)
+	if err != nil {
+		t.Fatalf("error on outer handshake: %s", err)
+	}
+	bcs, err := serverFunc(bcc, 0)
+	if err != nil {
+		t.Fatalf("error on inner handshake: %s", err)
+	}
+	if bcs == nil {
+		t.Fatalf("expecting non-nil conn")
+	}
+
+	select {
+	case <-time.After(5 * time.Second):
+		t.Fatalf("timeout")
+	case err := <-ch:
+		if err != nil {
+			t.Fatalf("unexpected error on the server side: %s", err)
+		}
+	}
+}

--- a/lib/storage/search.go
+++ b/lib/storage/search.go
@@ -325,6 +325,17 @@ func (s *Search) NextMetricBlock() bool {
 
 // SearchQuery is used for sending search queries from vmselect to vmstorage.
 type SearchQuery struct {
+	AccountID uint32
+	ProjectID uint32
+
+	// TenantTokens and IsMultiTenant is artificial fields
+	// they're only exist at runtime and cannot be transferred
+	// via network calls for keeping communication protocol compatibility
+	// TODO:@f41gh7 introduce breaking change to the protocol later
+	// and use TenantTokens instead of AccountID and ProjectID
+	TenantTokens  []TenantToken
+	IsMultiTenant bool
+
 	// The time range for searching time series
 	MinTimestamp int64
 	MaxTimestamp int64
@@ -473,7 +484,16 @@ func (sq *SearchQuery) String() string {
 	start := TimestampToHumanReadableFormat(sq.MinTimestamp)
 	end := TimestampToHumanReadableFormat(sq.MaxTimestamp)
 	a := sq.FiltersString()
-	return fmt.Sprintf("filters=%s, timeRange=[%s..%s]", a, start, end)
+	if !sq.IsMultiTenant {
+		return fmt.Sprintf("accountID=%d, projectID=%d, filters=%s, timeRange=[%s..%s]", sq.AccountID, sq.ProjectID, a, start, end)
+	}
+	tts := make([]string, len(sq.TenantTokens))
+	for i, tt := range sq.TenantTokens {
+		tts[i] = tt.String()
+	}
+
+	return fmt.Sprintf("tenants=[%s], filters=%s, timeRange=[%s..%s]", strings.Join(tts, ","), a, start, end)
+
 }
 
 // FiltersString returns string representation of the tag filters.
@@ -493,8 +513,9 @@ func tagFiltersToString(tfs []TagFilter) string {
 	return "{" + strings.Join(a, ",") + "}"
 }
 
-// Marshal appends marshaled sq to dst and returns the result.
-func (sq *SearchQuery) Marshal(dst []byte) []byte {
+// MarshalWithoutTenant appends marshaled sq without AccountID/ProjectID to dst and returns the result.
+// It is expected that TenantToken is already marshaled to dst.
+func (sq *SearchQuery) MarshalWithoutTenant(dst []byte) []byte {
 	dst = encoding.MarshalVarInt64(dst, sq.MinTimestamp)
 	dst = encoding.MarshalVarInt64(dst, sq.MaxTimestamp)
 	dst = encoding.MarshalVarUint64(dst, uint64(len(sq.TagFilterss)))
@@ -504,11 +525,25 @@ func (sq *SearchQuery) Marshal(dst []byte) []byte {
 			dst = tagFilters[i].Marshal(dst)
 		}
 	}
+	dst = encoding.MarshalUint32(dst, uint32(sq.MaxMetrics))
 	return dst
 }
 
 // Unmarshal unmarshals sq from src and returns the tail.
 func (sq *SearchQuery) Unmarshal(src []byte) ([]byte, error) {
+	if len(src) < 4 {
+		return src, fmt.Errorf("cannot unmarshal AccountID: too short src len: %d; must be at least %d bytes", len(src), 4)
+	}
+	sq.AccountID = encoding.UnmarshalUint32(src)
+	src = src[4:]
+
+	if len(src) < 4 {
+		return src, fmt.Errorf("cannot unmarshal ProjectID: too short src len: %d; must be at least %d bytes", len(src), 4)
+	}
+	sq.ProjectID = encoding.UnmarshalUint32(src)
+	src = src[4:]
+
+	sq.TenantTokens = []TenantToken{{AccountID: sq.AccountID, ProjectID: sq.ProjectID}}
 	minTs, nSize := encoding.UnmarshalVarInt64(src)
 	if nSize <= 0 {
 		return src, fmt.Errorf("cannot unmarshal MinTimestamp from varint")
@@ -548,6 +583,12 @@ func (sq *SearchQuery) Unmarshal(src []byte) ([]byte, error) {
 		}
 		sq.TagFilterss[i] = tagFilters
 	}
+
+	if len(src) < 4 {
+		return src, fmt.Errorf("cannot unmarshal MaxMetrics: too short src len: %d; must be at least %d bytes", len(src), 4)
+	}
+	sq.MaxMetrics = int(encoding.UnmarshalUint32(src))
+	src = src[4:]
 
 	return src, nil
 }

--- a/lib/storage/search_test.go
+++ b/lib/storage/search_test.go
@@ -32,7 +32,12 @@ func TestSearchQueryMarshalUnmarshal(t *testing.T) {
 			// Skip nil sq1.
 			continue
 		}
-		buf = sq1.Marshal(buf[:0])
+		tt := TenantToken{
+			AccountID: sq1.AccountID,
+			ProjectID: sq1.ProjectID,
+		}
+		buf = tt.Marshal(buf[:0])
+		buf = sq1.MarshalWithoutTenant(buf)
 
 		tail, err := sq2.Unmarshal(buf)
 		if err != nil {
@@ -40,6 +45,12 @@ func TestSearchQueryMarshalUnmarshal(t *testing.T) {
 		}
 		if len(tail) > 0 {
 			t.Fatalf("unexpected tail left after SearchQuery unmarshaling; tail (len=%d): %q", len(tail), tail)
+		}
+		if sq2.AccountID != sq1.AccountID {
+			t.Fatalf("unexpected AccountID; got %d; want %d", sq2.AccountID, sq1.AccountID)
+		}
+		if sq2.ProjectID != sq1.ProjectID {
+			t.Fatalf("unexpected ProjectID; got %d; want %d", sq2.ProjectID, sq1.ProjectID)
 		}
 		if sq1.MinTimestamp != sq2.MinTimestamp {
 			t.Fatalf("unexpected MinTimestamp; got %d; want %d", sq2.MinTimestamp, sq1.MinTimestamp)

--- a/lib/vmselectapi/server.go
+++ b/lib/vmselectapi/server.go
@@ -1,0 +1,1226 @@
+package vmselectapi
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/VictoriaMetrics/metrics"
+
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/bytesutil"
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/encoding"
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/fasttime"
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/handshake"
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/ingestserver"
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/logger"
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/netutil"
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/querytracer"
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/storage"
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/storage/metricnamestats"
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/storage/metricsmetadata"
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/timerpool"
+)
+
+// Server processes vmselect requests.
+type Server struct {
+	// api contains the implementation of the server API for vmselect requests.
+	api API
+
+	// limits contains various limits for the Server.
+	limits Limits
+
+	// disableResponseCompression controls whether vmselect server must compress responses.
+	disableResponseCompression bool
+
+	// ln is the listener for incoming connections to the server.
+	ln net.Listener
+
+	// The channel for limiting the number of concurrently executed requests.
+	concurrencyLimitCh chan struct{}
+
+	// connsMap is a map of currently established connections to the server.
+	// It is used for closing the connections when MustStop() is called.
+	connsMap ingestserver.ConnsMap
+
+	// wg is used for waiting for worker goroutines to stop when MustStop() is called.
+	wg sync.WaitGroup
+
+	// stopFlag is set to true when the server needs to stop.
+	stopFlag atomic.Bool
+
+	concurrencyLimitReached *metrics.Counter
+	concurrencyLimitTimeout *metrics.Counter
+
+	vmselectConns      *metrics.Counter
+	vmselectConnErrors *metrics.Counter
+
+	registerMetricNamesRequests *metrics.Counter
+	deleteSeriesRequests        *metrics.Counter
+	labelNamesRequests          *metrics.Counter
+	labelValuesRequests         *metrics.Counter
+	tagValueSuffixesRequests    *metrics.Counter
+	seriesCountRequests         *metrics.Counter
+	tsdbStatusRequests          *metrics.Counter
+	searchMetricNamesRequests   *metrics.Counter
+	searchRequests              *metrics.Counter
+	tenantsRequests             *metrics.Counter
+	searchMetadataRequests      *metrics.Counter
+
+	metricBlocksRead *metrics.Counter
+}
+
+// Limits contains various limits for Server.
+type Limits struct {
+	// MaxConcurrentRequests is the maximum number of concurrent requests a server can process.
+	//
+	// The remaining requests wait for up to MaxQueueDuration for their execution.
+	MaxConcurrentRequests int
+
+	// MaxConcurrentRequestsFlagName is the name for the flag containing the MaxConcurrentRequests value.
+	MaxConcurrentRequestsFlagName string
+
+	// MaxQueueDuration is the maximum duration to wait if MaxConcurrentRequests are executed.
+	MaxQueueDuration time.Duration
+
+	// MaxQueueDurationFlagName is the name for the flag containing the MaxQueueDuration value.
+	MaxQueueDurationFlagName string
+}
+
+// NewServer starts new Server at the given addr, which serves the given api with the given limits.
+//
+// If disableResponseCompression is set to true, then the returned server doesn't compress responses.
+func NewServer(addr string, api API, limits Limits, disableResponseCompression bool) (*Server, error) {
+	ln, err := netutil.NewTCPListener("vmselect", addr, false, nil)
+	if err != nil {
+		return nil, fmt.Errorf("unable to listen vmselectAddr %s: %w", addr, err)
+	}
+	concurrencyLimitCh := make(chan struct{}, limits.MaxConcurrentRequests)
+	_ = metrics.NewGauge(`vm_vmselect_concurrent_requests_capacity`, func() float64 {
+		return float64(cap(concurrencyLimitCh))
+	})
+	_ = metrics.NewGauge(`vm_vmselect_concurrent_requests_current`, func() float64 {
+		return float64(len(concurrencyLimitCh))
+	})
+	s := &Server{
+		api:                        api,
+		limits:                     limits,
+		disableResponseCompression: disableResponseCompression,
+		ln:                         ln,
+
+		concurrencyLimitCh: concurrencyLimitCh,
+
+		concurrencyLimitReached: metrics.NewCounter(fmt.Sprintf(`vm_vmselect_concurrent_requests_limit_reached_total{addr=%q}`, addr)),
+		concurrencyLimitTimeout: metrics.NewCounter(fmt.Sprintf(`vm_vmselect_concurrent_requests_limit_timeout_total{addr=%q}`, addr)),
+
+		vmselectConns:      metrics.NewCounter(fmt.Sprintf(`vm_vmselect_conns{addr=%q}`, addr)),
+		vmselectConnErrors: metrics.NewCounter(fmt.Sprintf(`vm_vmselect_conn_errors_total{addr=%q}`, addr)),
+
+		registerMetricNamesRequests: metrics.NewCounter(fmt.Sprintf(`vm_vmselect_rpc_requests_total{action="registerMetricNames",addr=%q}`, addr)),
+		deleteSeriesRequests:        metrics.NewCounter(fmt.Sprintf(`vm_vmselect_rpc_requests_total{action="deleteSeries",addr=%q}`, addr)),
+		labelNamesRequests:          metrics.NewCounter(fmt.Sprintf(`vm_vmselect_rpc_requests_total{action="labelNames",addr=%q}`, addr)),
+		labelValuesRequests:         metrics.NewCounter(fmt.Sprintf(`vm_vmselect_rpc_requests_total{action="labelValues",addr=%q}`, addr)),
+		tagValueSuffixesRequests:    metrics.NewCounter(fmt.Sprintf(`vm_vmselect_rpc_requests_total{action="tagValueSuffixes",addr=%q}`, addr)),
+		seriesCountRequests:         metrics.NewCounter(fmt.Sprintf(`vm_vmselect_rpc_requests_total{action="seriesCount",addr=%q}`, addr)),
+		tsdbStatusRequests:          metrics.NewCounter(fmt.Sprintf(`vm_vmselect_rpc_requests_total{action="tsdbStatus",addr=%q}`, addr)),
+		searchMetricNamesRequests:   metrics.NewCounter(fmt.Sprintf(`vm_vmselect_rpc_requests_total{action="searchMetricNames",addr=%q}`, addr)),
+		searchRequests:              metrics.NewCounter(fmt.Sprintf(`vm_vmselect_rpc_requests_total{action="search",addr=%q}`, addr)),
+		tenantsRequests:             metrics.NewCounter(fmt.Sprintf(`vm_vmselect_rpc_requests_total{action="tenants",addr=%q}`, addr)),
+		searchMetadataRequests:      metrics.NewCounter(fmt.Sprintf(`vm_vmselect_rpc_requests_total{action="searchMetadata",addr=%q}`, addr)),
+
+		metricBlocksRead: metrics.NewCounter(fmt.Sprintf(`vm_vmselect_metric_blocks_read_total{addr=%q}`, addr)),
+	}
+
+	s.connsMap.Init("vmselect")
+	s.wg.Go(s.run)
+	return s, nil
+}
+
+func (s *Server) run() {
+	logger.Infof("accepting vmselect conns at %s", s.ln.Addr())
+	for {
+		c, err := s.ln.Accept()
+		if err != nil {
+			if pe, ok := err.(net.Error); ok && pe.Temporary() {
+				continue
+			}
+			if s.isStopping() {
+				return
+			}
+			logger.Panicf("FATAL: cannot process vmselect conns at %s: %s", s.ln.Addr(), err)
+		}
+		// Do not log connection accept from vmselect, since this can generate too many lines
+		// in the log because vmselect tends to re-establish idle connections.
+
+		if !s.connsMap.Add(c) {
+			// The server is closed.
+			_ = c.Close()
+			return
+		}
+		s.vmselectConns.Inc()
+		s.wg.Go(func() {
+			defer func() {
+				s.connsMap.Delete(c)
+				s.vmselectConns.Dec()
+			}()
+
+			// Compress responses to vmselect even if they already contain compressed blocks.
+			// Responses contain uncompressed metric names, which should compress well
+			// when the response contains high number of time series.
+			// Additionally, recently added metric blocks are usually uncompressed, so the compression
+			// should save network bandwidth.
+			compressionLevel := 1
+			if s.disableResponseCompression {
+				compressionLevel = 0
+			}
+			bc, err := handshake.VMSelectServer(c, compressionLevel)
+			if err != nil {
+				if s.isStopping() {
+					// c is closed inside Server.MustStop
+					return
+				}
+				if handshake.IsTimeoutNetworkError(err) {
+					logger.Warnf("cannot complete vmselect handshake due to network timeout error with client %q: %s. "+
+						"If errors are transient and infrequent increase -rpc.handshakeTimeout and -vmstorageDialTimeout on client and server side. Check vmselect logs for errors", c.RemoteAddr(), err)
+				} else if handshake.IsClientNetworkError(err) {
+					logger.Warnf("cannot complete vmselect handshake due to network error with client %q: %s. "+
+						"Check vmselect logs for errors", c.RemoteAddr(), err)
+				} else if !handshake.IsTCPHealthcheck(err) {
+					logger.Errorf("cannot perform vmselect handshake with client %q: %s", c.RemoteAddr(), err)
+				}
+
+				_ = c.Close()
+				return
+			}
+
+			defer func() {
+				_ = bc.Close()
+			}()
+			if err := s.processConn(bc); err != nil {
+				if s.isStopping() {
+					return
+				}
+				s.vmselectConnErrors.Inc()
+				logger.Errorf("cannot process vmselect conn %s: %s", c.RemoteAddr(), err)
+			}
+		})
+	}
+}
+
+// MustStop gracefully stops s, so it no longer touches s.api after returning.
+func (s *Server) MustStop() {
+	// Mark the server as stoping.
+	s.setIsStopping()
+
+	// Stop accepting new connections from vmselect.
+	if err := s.ln.Close(); err != nil {
+		logger.Panicf("FATAL: cannot close vmselect listener: %s", err)
+	}
+
+	// Close existing connections from vmselect, so the goroutines
+	// processing these connections are finished.
+	s.connsMap.CloseAll(0)
+
+	// Wait until all the goroutines processing vmselect conns are finished.
+	s.wg.Wait()
+}
+
+func (s *Server) setIsStopping() {
+	s.stopFlag.Store(true)
+}
+
+func (s *Server) isStopping() bool {
+	return s.stopFlag.Load()
+}
+
+func (s *Server) processConn(bc *handshake.BufferedConn) error {
+	ctx := &vmselectRequestCtx{
+		bc:      bc,
+		sizeBuf: make([]byte, 8),
+	}
+	for {
+		if err := s.processRequest(ctx); err != nil {
+			if isExpectedError(err) {
+				return nil
+			}
+			if errors.Is(err, storage.ErrDeadlineExceeded) {
+				return fmt.Errorf("cannot process vmselect request in %d seconds: %w", ctx.timeout, err)
+			}
+			return fmt.Errorf("cannot process vmselect request: %w", err)
+		}
+		if err := bc.Flush(); err != nil {
+			return fmt.Errorf("cannot flush compressed buffers: %w", err)
+		}
+	}
+}
+
+func isExpectedError(err error) bool {
+	if err == io.EOF {
+		// Remote client gracefully closed the connection.
+		return true
+	}
+	if errors.Is(err, net.ErrClosed) {
+		return true
+	}
+	errStr := err.Error()
+	if strings.Contains(errStr, "broken pipe") || strings.Contains(errStr, "connection reset by peer") {
+		// The connection has been interrupted abruptly.
+		// It could happen due to unexpected network glitch or because connection was
+		// interrupted by remote client. In both cases, remote client will notice
+		// connection breach and handle it on its own. No need in mirroring the error here.
+		return true
+	}
+	return false
+}
+
+type vmselectRequestCtx struct {
+	bc      *handshake.BufferedConn
+	sizeBuf []byte
+	dataBuf []byte
+
+	qt *querytracer.Tracer
+	sq storage.SearchQuery
+
+	// timeout in seconds for the current request
+	timeout uint64
+
+	// deadline in unix timestamp seconds for the current request.
+	deadline uint64
+}
+
+func (ctx *vmselectRequestCtx) readTimeRange() (storage.TimeRange, error) {
+	var tr storage.TimeRange
+	minTimestamp, err := ctx.readUint64()
+	if err != nil {
+		return tr, fmt.Errorf("cannot read minTimestamp: %w", err)
+	}
+	maxTimestamp, err := ctx.readUint64()
+	if err != nil {
+		return tr, fmt.Errorf("cannot read maxTimestamp: %w", err)
+	}
+	tr.MinTimestamp = int64(minTimestamp)
+	tr.MaxTimestamp = int64(maxTimestamp)
+	return tr, nil
+}
+
+func (ctx *vmselectRequestCtx) readLimit() (int, error) {
+	n, err := ctx.readUint32()
+	if err != nil {
+		return 0, fmt.Errorf("cannot read limit: %w", err)
+	}
+	if n > 1<<31-1 {
+		n = 1<<31 - 1
+	}
+	return int(n), nil
+}
+
+func (ctx *vmselectRequestCtx) readUint32() (uint32, error) {
+	ctx.sizeBuf = bytesutil.ResizeNoCopyMayOverallocate(ctx.sizeBuf, 4)
+	if _, err := io.ReadFull(ctx.bc, ctx.sizeBuf); err != nil {
+		if err == io.EOF {
+			return 0, err
+		}
+		return 0, fmt.Errorf("cannot read uint32: %w", err)
+	}
+	n := encoding.UnmarshalUint32(ctx.sizeBuf)
+	return n, nil
+}
+
+func (ctx *vmselectRequestCtx) readUint64() (uint64, error) {
+	ctx.sizeBuf = bytesutil.ResizeNoCopyMayOverallocate(ctx.sizeBuf, 8)
+	if _, err := io.ReadFull(ctx.bc, ctx.sizeBuf); err != nil {
+		if err == io.EOF {
+			return 0, err
+		}
+		return 0, fmt.Errorf("cannot read uint64: %w", err)
+	}
+	n := encoding.UnmarshalUint64(ctx.sizeBuf)
+	return n, nil
+}
+
+func (ctx *vmselectRequestCtx) readInt64() (int64, error) {
+	ctx.sizeBuf = bytesutil.ResizeNoCopyMayOverallocate(ctx.sizeBuf, 8)
+	if _, err := io.ReadFull(ctx.bc, ctx.sizeBuf); err != nil {
+		if err == io.EOF {
+			return 0, err
+		}
+		return 0, fmt.Errorf("cannot read int64: %w", err)
+	}
+	n := encoding.UnmarshalInt64(ctx.sizeBuf)
+	return n, nil
+}
+
+func (ctx *vmselectRequestCtx) readAccountIDProjectID() (uint32, uint32, error) {
+	accountID, err := ctx.readUint32()
+	if err != nil {
+		return 0, 0, fmt.Errorf("cannot read accountID: %w", err)
+	}
+	projectID, err := ctx.readUint32()
+	if err != nil {
+		return 0, 0, fmt.Errorf("cannot read projectID: %w", err)
+	}
+	return accountID, projectID, nil
+}
+
+// maxSearchQuerySize is the maximum size of SearchQuery packet in bytes.
+// see https://github.com/VictoriaMetrics/VictoriaMetrics/issues/5154#issuecomment-1757216612
+const maxSearchQuerySize = 5 * 1024 * 1024
+
+func (ctx *vmselectRequestCtx) readSearchQuery() error {
+	if err := ctx.readDataBufBytes(maxSearchQuerySize); err != nil {
+		return fmt.Errorf("cannot read searchQuery: %w", err)
+	}
+	tail, err := ctx.sq.Unmarshal(ctx.dataBuf)
+	if err != nil {
+		return fmt.Errorf("cannot unmarshal SearchQuery: %w", err)
+	}
+	if len(tail) > 0 {
+		return fmt.Errorf("unexpected non-zero tail left after unmarshaling SearchQuery: (len=%d) %q", len(tail), tail)
+	}
+	return nil
+}
+
+func (ctx *vmselectRequestCtx) readDataBufBytes(maxDataSize int) error {
+	ctx.sizeBuf = bytesutil.ResizeNoCopyMayOverallocate(ctx.sizeBuf, 8)
+	if _, err := io.ReadFull(ctx.bc, ctx.sizeBuf); err != nil {
+		if err == io.EOF {
+			return err
+		}
+		return fmt.Errorf("cannot read data size: %w", err)
+	}
+	dataSize := encoding.UnmarshalUint64(ctx.sizeBuf)
+	if dataSize > uint64(maxDataSize) {
+		return fmt.Errorf("too big data size: %d; it mustn't exceed %d bytes", dataSize, maxDataSize)
+	}
+	ctx.dataBuf = bytesutil.ResizeNoCopyMayOverallocate(ctx.dataBuf, int(dataSize))
+	if dataSize == 0 {
+		return nil
+	}
+	if n, err := io.ReadFull(ctx.bc, ctx.dataBuf); err != nil {
+		return fmt.Errorf("cannot read data with size %d: %w; read only %d bytes", dataSize, err, n)
+	}
+	return nil
+}
+
+func (ctx *vmselectRequestCtx) readBool() (bool, error) {
+	ctx.dataBuf = bytesutil.ResizeNoCopyMayOverallocate(ctx.dataBuf, 1)
+	if _, err := io.ReadFull(ctx.bc, ctx.dataBuf); err != nil {
+		if err == io.EOF {
+			return false, err
+		}
+		return false, fmt.Errorf("cannot read bool: %w", err)
+	}
+	v := ctx.dataBuf[0] != 0
+	return v, nil
+}
+
+func (ctx *vmselectRequestCtx) readByte() (byte, error) {
+	ctx.dataBuf = bytesutil.ResizeNoCopyMayOverallocate(ctx.dataBuf, 1)
+	if _, err := io.ReadFull(ctx.bc, ctx.dataBuf); err != nil {
+		if err == io.EOF {
+			return 0, err
+		}
+		return 0, fmt.Errorf("cannot read byte: %w", err)
+	}
+	b := ctx.dataBuf[0]
+	return b, nil
+}
+
+func (ctx *vmselectRequestCtx) writeDataBufBytes() error {
+	if err := ctx.writeUint64(uint64(len(ctx.dataBuf))); err != nil {
+		return fmt.Errorf("cannot write data size: %w", err)
+	}
+	if len(ctx.dataBuf) == 0 {
+		return nil
+	}
+	if _, err := ctx.bc.Write(ctx.dataBuf); err != nil {
+		return fmt.Errorf("cannot write data with size %d: %w", len(ctx.dataBuf), err)
+	}
+	return nil
+}
+
+// maxErrorMessageSize is the maximum size of error message to send to clients.
+const maxErrorMessageSize = 64 * 1024
+
+func (ctx *vmselectRequestCtx) writeErrorMessage(err error) error {
+	if errors.Is(err, storage.ErrDeadlineExceeded) {
+		err = fmt.Errorf("cannot execute request in %d seconds: %w", ctx.timeout, err)
+	}
+	errMsg := err.Error()
+	if len(errMsg) > maxErrorMessageSize {
+		// Trim too long error message.
+		errMsg = errMsg[:maxErrorMessageSize]
+	}
+	if err := ctx.writeString(errMsg); err != nil {
+		return fmt.Errorf("cannot send error message %q to client: %w", errMsg, err)
+	}
+	return nil
+}
+
+func (ctx *vmselectRequestCtx) writeString(s string) error {
+	ctx.dataBuf = append(ctx.dataBuf[:0], s...)
+	return ctx.writeDataBufBytes()
+}
+
+func (ctx *vmselectRequestCtx) writeUint64(n uint64) error {
+	ctx.sizeBuf = encoding.MarshalUint64(ctx.sizeBuf[:0], n)
+	if _, err := ctx.bc.Write(ctx.sizeBuf); err != nil {
+		return fmt.Errorf("cannot write uint64 %d: %w", n, err)
+	}
+	return nil
+}
+
+const maxRPCNameSize = 128
+
+func (s *Server) processRequest(ctx *vmselectRequestCtx) error {
+	// Read rpcName
+	// Do not set deadline on reading rpcName, since it may take a
+	// lot of time for idle connection.
+	if err := ctx.readDataBufBytes(maxRPCNameSize); err != nil {
+		if err == io.EOF {
+			// Remote client gracefully closed the connection.
+			return err
+		}
+		return fmt.Errorf("cannot read rpcName: %w", err)
+	}
+	rpcName := string(ctx.dataBuf)
+
+	// Limit the time required for reading request args.
+	if err := ctx.bc.SetReadDeadline(time.Now().Add(5 * time.Second)); err != nil {
+		return fmt.Errorf("cannot set read deadline for reading request args: %w", err)
+	}
+	defer func() {
+		_ = ctx.bc.SetReadDeadline(time.Time{})
+	}()
+
+	// Initialize query tracing.
+	traceEnabled, err := ctx.readBool()
+	if err != nil {
+		return fmt.Errorf("cannot read traceEnabled: %w", err)
+	}
+	ctx.qt = querytracer.New(traceEnabled, "rpc call %s() at vmstorage", rpcName)
+
+	// Read the timeout for request execution.
+	timeout, err := ctx.readUint32()
+	if err != nil {
+		return fmt.Errorf("cannot read timeout for the request %q: %w", rpcName, err)
+	}
+	ctx.timeout = uint64(timeout)
+	ctx.deadline = fasttime.UnixTimestamp() + uint64(timeout)
+
+	// Process the rpcName call.
+	if err := s.processRPC(ctx, rpcName); err != nil {
+		return fmt.Errorf("cannot execute %q: %w", rpcName, err)
+	}
+
+	// Finish query trace.
+	ctx.qt.Done()
+	traceJSON := ctx.qt.ToJSON()
+	if err := ctx.writeString(traceJSON); err != nil {
+		return fmt.Errorf("cannot send trace with length %d bytes to vmselect: %w", len(traceJSON), err)
+	}
+	return nil
+}
+
+func (s *Server) beginConcurrentRequest(ctx *vmselectRequestCtx) error {
+	select {
+	case s.concurrencyLimitCh <- struct{}{}:
+		return nil
+	default:
+		d := min(time.Duration(ctx.timeout)*time.Second, s.limits.MaxQueueDuration)
+		t := timerpool.Get(d)
+		s.concurrencyLimitReached.Inc()
+		select {
+		case s.concurrencyLimitCh <- struct{}{}:
+			timerpool.Put(t)
+			ctx.qt.Printf("wait in queue because -%s=%d concurrent requests are executed", s.limits.MaxConcurrentRequestsFlagName, s.limits.MaxConcurrentRequests)
+			return nil
+		case <-t.C:
+			timerpool.Put(t)
+			s.concurrencyLimitTimeout.Inc()
+			return fmt.Errorf("couldn't start executing the request in %.3f seconds, since -%s=%d concurrent requests "+
+				"are already executed. Possible solutions: to reduce the query load; to add more compute resources to the server; "+
+				"to increase -%s=%d; to increase -%s",
+				d.Seconds(), s.limits.MaxConcurrentRequestsFlagName, s.limits.MaxConcurrentRequests,
+				s.limits.MaxQueueDurationFlagName, s.limits.MaxQueueDuration, s.limits.MaxConcurrentRequestsFlagName)
+		}
+	}
+}
+
+func (s *Server) endConcurrentRequest() {
+	<-s.concurrencyLimitCh
+}
+
+func (s *Server) processRPC(ctx *vmselectRequestCtx, rpcName string) error {
+	switch rpcName {
+	case "search_v7":
+		return s.processSearch(ctx)
+	case "searchMetricNames_v3":
+		return s.processSearchMetricNames(ctx)
+	case "labelValues_v5":
+		return s.processLabelValues(ctx)
+	case "tagValueSuffixes_v4":
+		return s.processTagValueSuffixes(ctx)
+	case "labelNames_v5":
+		return s.processLabelNames(ctx)
+	case "seriesCount_v4":
+		return s.processSeriesCount(ctx)
+	case "tsdbStatus_v6":
+		return s.processTSDBStatus(ctx)
+	case "deleteSeries_v5":
+		return s.processDeleteSeries(ctx)
+	case "registerMetricNames_v3":
+		return s.processRegisterMetricNames(ctx)
+	case "tenants_v1":
+		return s.processTenants(ctx)
+	case "metricNamesUsageStats_v1":
+		return s.processMetricNamesUsageStats(ctx)
+	case "resetMetricNamesStats_v1":
+		return s.processResetMetricUsageStats(ctx)
+	case "searchMetadata_v1":
+		return s.processSearchMetadata(ctx)
+	default:
+		return fmt.Errorf("unsupported rpcName: %q", rpcName)
+	}
+}
+
+const maxMetricNameRawSize = 1024 * 1024
+const maxMetricNamesPerRequest = 1024 * 1024
+
+func (s *Server) processRegisterMetricNames(ctx *vmselectRequestCtx) error {
+	s.registerMetricNamesRequests.Inc()
+
+	// Read request
+	metricsCount, err := ctx.readUint64()
+	if err != nil {
+		return fmt.Errorf("cannot read metricsCount: %w", err)
+	}
+	if metricsCount > maxMetricNamesPerRequest {
+		return fmt.Errorf("too many metric names in a single request; got %d; mustn't exceed %d", metricsCount, maxMetricNamesPerRequest)
+	}
+	mrs := make([]storage.MetricRow, metricsCount)
+	for i := range int(metricsCount) {
+		if err := ctx.readDataBufBytes(maxMetricNameRawSize); err != nil {
+			return fmt.Errorf("cannot read metricNameRaw: %w", err)
+		}
+		mr := &mrs[i]
+		mr.MetricNameRaw = append(mr.MetricNameRaw[:0], ctx.dataBuf...)
+		n, err := ctx.readUint64()
+		if err != nil {
+			return fmt.Errorf("cannot read timestamp: %w", err)
+		}
+		mr.Timestamp = int64(n)
+	}
+
+	if err := s.beginConcurrentRequest(ctx); err != nil {
+		return ctx.writeErrorMessage(err)
+	}
+	defer s.endConcurrentRequest()
+
+	// Register metric names from mrs.
+	if err := s.api.RegisterMetricNames(ctx.qt, mrs, ctx.deadline); err != nil {
+		return ctx.writeErrorMessage(err)
+	}
+
+	// Send an empty error message to vmselect.
+	if err := ctx.writeString(""); err != nil {
+		return fmt.Errorf("cannot send empty error message: %w", err)
+	}
+	return nil
+}
+
+func (s *Server) processDeleteSeries(ctx *vmselectRequestCtx) error {
+	s.deleteSeriesRequests.Inc()
+
+	// Read request
+	if err := ctx.readSearchQuery(); err != nil {
+		return err
+	}
+
+	if err := s.beginConcurrentRequest(ctx); err != nil {
+		return ctx.writeErrorMessage(err)
+	}
+	defer s.endConcurrentRequest()
+
+	// Execute the request.
+	deletedCount, err := s.api.DeleteSeries(ctx.qt, &ctx.sq, ctx.deadline)
+	if err != nil {
+		return ctx.writeErrorMessage(err)
+	}
+
+	// Send an empty error message to vmselect.
+	if err := ctx.writeString(""); err != nil {
+		return fmt.Errorf("cannot send empty error message: %w", err)
+	}
+	// Send deletedCount to vmselect.
+	if err := ctx.writeUint64(uint64(deletedCount)); err != nil {
+		return fmt.Errorf("cannot send deletedCount=%d: %w", deletedCount, err)
+	}
+	return nil
+}
+
+func (s *Server) processLabelNames(ctx *vmselectRequestCtx) error {
+	s.labelNamesRequests.Inc()
+
+	// Read request
+	if err := ctx.readSearchQuery(); err != nil {
+		return err
+	}
+	maxLabelNames, err := ctx.readLimit()
+	if err != nil {
+		return fmt.Errorf("cannot read maxLabelNames: %w", err)
+	}
+
+	if err := s.beginConcurrentRequest(ctx); err != nil {
+		return ctx.writeErrorMessage(err)
+	}
+	defer s.endConcurrentRequest()
+
+	// Execute the request
+	labelNames, err := s.api.LabelNames(ctx.qt, &ctx.sq, maxLabelNames, ctx.deadline)
+	if err != nil {
+		return ctx.writeErrorMessage(err)
+	}
+
+	// Send an empty error message to vmselect.
+	if err := ctx.writeString(""); err != nil {
+		return fmt.Errorf("cannot send empty error message: %w", err)
+	}
+
+	// Send labelNames to vmselect
+	for _, labelName := range labelNames {
+		if len(labelName) == 0 {
+			// Skip empty label names, since they may break RPC communication with vmselect
+			continue
+		}
+		if err := ctx.writeString(labelName); err != nil {
+			return fmt.Errorf("cannot write label name %q: %w", labelName, err)
+		}
+	}
+	// Send 'end of response' marker
+	if err := ctx.writeString(""); err != nil {
+		return fmt.Errorf("cannot send 'end of response' marker")
+	}
+	return nil
+}
+
+const maxLabelValueSize = 16 * 1024
+
+func (s *Server) processLabelValues(ctx *vmselectRequestCtx) error {
+	s.labelValuesRequests.Inc()
+
+	// Read request
+	if err := ctx.readDataBufBytes(maxLabelValueSize); err != nil {
+		return fmt.Errorf("cannot read labelName: %w", err)
+	}
+	labelName := string(ctx.dataBuf)
+	if err := ctx.readSearchQuery(); err != nil {
+		return err
+	}
+	maxLabelValues, err := ctx.readLimit()
+	if err != nil {
+		return fmt.Errorf("cannot read maxLabelValues: %w", err)
+	}
+
+	if err := s.beginConcurrentRequest(ctx); err != nil {
+		return ctx.writeErrorMessage(err)
+	}
+	defer s.endConcurrentRequest()
+
+	// Execute the request
+	labelValues, err := s.api.LabelValues(ctx.qt, &ctx.sq, labelName, maxLabelValues, ctx.deadline)
+	if err != nil {
+		return ctx.writeErrorMessage(err)
+	}
+
+	// Send an empty error message to vmselect.
+	if err := ctx.writeString(""); err != nil {
+		return fmt.Errorf("cannot send empty error message: %w", err)
+	}
+
+	// Send labelValues to vmselect
+	for _, labelValue := range labelValues {
+		if len(labelValue) == 0 {
+			// Skip empty label values, since they may break RPC communication with vmselect
+			continue
+		}
+		if err := ctx.writeString(labelValue); err != nil {
+			return fmt.Errorf("cannot write labelValue %q: %w", labelValue, err)
+		}
+	}
+	// Send 'end of label values' marker
+	if err := ctx.writeString(""); err != nil {
+		return fmt.Errorf("cannot send 'end of response' marker")
+	}
+	return nil
+}
+
+func (s *Server) processTagValueSuffixes(ctx *vmselectRequestCtx) error {
+	s.tagValueSuffixesRequests.Inc()
+
+	// read request
+	accountID, projectID, err := ctx.readAccountIDProjectID()
+	if err != nil {
+		return err
+	}
+	tr, err := ctx.readTimeRange()
+	if err != nil {
+		return err
+	}
+	if err := ctx.readDataBufBytes(maxLabelValueSize); err != nil {
+		return fmt.Errorf("cannot read tagKey: %w", err)
+	}
+	tagKey := string(ctx.dataBuf)
+	if err := ctx.readDataBufBytes(maxLabelValueSize); err != nil {
+		return fmt.Errorf("cannot read tagValuePrefix: %w", err)
+	}
+	tagValuePrefix := string(ctx.dataBuf)
+	delimiter, err := ctx.readByte()
+	if err != nil {
+		return fmt.Errorf("cannot read delimiter: %w", err)
+	}
+	maxSuffixes, err := ctx.readLimit()
+	if err != nil {
+		return fmt.Errorf("cannot read maxTagValueSuffixes: %w", err)
+	}
+
+	if err := s.beginConcurrentRequest(ctx); err != nil {
+		return ctx.writeErrorMessage(err)
+	}
+	defer s.endConcurrentRequest()
+
+	// Execute the request
+	suffixes, err := s.api.TagValueSuffixes(ctx.qt, accountID, projectID, tr, tagKey, tagValuePrefix, delimiter, maxSuffixes, ctx.deadline)
+	if err != nil {
+		return ctx.writeErrorMessage(err)
+	}
+
+	// Send an empty error message to vmselect.
+	if err := ctx.writeString(""); err != nil {
+		return fmt.Errorf("cannot send empty error message: %w", err)
+	}
+
+	// Send suffixes to vmselect.
+	// Suffixes may contain empty string, so prepend suffixes with suffixCount.
+	if err := ctx.writeUint64(uint64(len(suffixes))); err != nil {
+		return fmt.Errorf("cannot write suffixesCount: %w", err)
+	}
+	for i, suffix := range suffixes {
+		if err := ctx.writeString(suffix); err != nil {
+			return fmt.Errorf("cannot write suffix #%d: %w", i+1, err)
+		}
+	}
+	return nil
+}
+
+func (s *Server) processSeriesCount(ctx *vmselectRequestCtx) error {
+	s.seriesCountRequests.Inc()
+
+	// Read request
+	accountID, projectID, err := ctx.readAccountIDProjectID()
+	if err != nil {
+		return err
+	}
+
+	if err := s.beginConcurrentRequest(ctx); err != nil {
+		return ctx.writeErrorMessage(err)
+	}
+	defer s.endConcurrentRequest()
+
+	// Execute the request
+	n, err := s.api.SeriesCount(ctx.qt, accountID, projectID, ctx.deadline)
+	if err != nil {
+		return ctx.writeErrorMessage(err)
+	}
+
+	// Send an empty error message to vmselect.
+	if err := ctx.writeString(""); err != nil {
+		return fmt.Errorf("cannot send empty error message: %w", err)
+	}
+
+	// Send series count to vmselect.
+	if err := ctx.writeUint64(n); err != nil {
+		return fmt.Errorf("cannot write series count to vmselect: %w", err)
+	}
+	return nil
+}
+
+func (s *Server) processTSDBStatus(ctx *vmselectRequestCtx) error {
+	s.tsdbStatusRequests.Inc()
+
+	// Read request
+	if err := ctx.readSearchQuery(); err != nil {
+		return err
+	}
+	if err := ctx.readDataBufBytes(maxLabelValueSize); err != nil {
+		return fmt.Errorf("cannot read focusLabel: %w", err)
+	}
+	focusLabel := string(ctx.dataBuf)
+	topN, err := ctx.readUint32()
+	if err != nil {
+		return fmt.Errorf("cannot read topN: %w", err)
+	}
+
+	if err := s.beginConcurrentRequest(ctx); err != nil {
+		return ctx.writeErrorMessage(err)
+	}
+	defer s.endConcurrentRequest()
+
+	// Execute the request
+	status, err := s.api.TSDBStatus(ctx.qt, &ctx.sq, focusLabel, int(topN), ctx.deadline)
+	if err != nil {
+		return ctx.writeErrorMessage(err)
+	}
+
+	// Send an empty error message to vmselect.
+	if err := ctx.writeString(""); err != nil {
+		return fmt.Errorf("cannot send empty error message: %w", err)
+	}
+
+	// Send status to vmselect.
+	return writeTSDBStatus(ctx, status)
+}
+
+func (s *Server) processTenants(ctx *vmselectRequestCtx) error {
+	s.tenantsRequests.Inc()
+
+	// Read request
+	tr, err := ctx.readTimeRange()
+	if err != nil {
+		return err
+	}
+
+	if err := s.beginConcurrentRequest(ctx); err != nil {
+		return ctx.writeErrorMessage(err)
+	}
+	defer s.endConcurrentRequest()
+
+	// Execute the request
+	tenants, err := s.api.Tenants(ctx.qt, tr, ctx.deadline)
+	if err != nil {
+		return ctx.writeErrorMessage(err)
+	}
+
+	// Send an empty error message to vmselect.
+	if err := ctx.writeString(""); err != nil {
+		return fmt.Errorf("cannot send empty error message: %w", err)
+	}
+
+	// Send tenants to vmselect
+	for _, tenant := range tenants {
+		if len(tenant) == 0 {
+			logger.Panicf("BUG: unexpected empty tenant name")
+		}
+		if err := ctx.writeString(tenant); err != nil {
+			return fmt.Errorf("cannot write tenant %q: %w", tenant, err)
+		}
+	}
+	// Send 'end of response' marker
+	if err := ctx.writeString(""); err != nil {
+		return fmt.Errorf("cannot send 'end of response' marker")
+	}
+	return nil
+}
+
+func writeTSDBStatus(ctx *vmselectRequestCtx, status *storage.TSDBStatus) error {
+	if err := ctx.writeUint64(status.TotalSeries); err != nil {
+		return fmt.Errorf("cannot write totalSeries to vmselect: %w", err)
+	}
+	if err := ctx.writeUint64(status.TotalLabelValuePairs); err != nil {
+		return fmt.Errorf("cannot write totalLabelValuePairs to vmselect: %w", err)
+	}
+	if err := writeTopHeapEntries(ctx, status.SeriesCountByMetricName); err != nil {
+		return fmt.Errorf("cannot write seriesCountByMetricName to vmselect: %w", err)
+	}
+	if err := writeTopHeapEntries(ctx, status.SeriesCountByLabelName); err != nil {
+		return fmt.Errorf("cannot write seriesCountByLabelName to vmselect: %w", err)
+	}
+	if err := writeTopHeapEntries(ctx, status.SeriesCountByFocusLabelValue); err != nil {
+		return fmt.Errorf("cannot write seriesCountByFocusLabelValue to vmselect: %w", err)
+	}
+	if err := writeTopHeapEntries(ctx, status.SeriesCountByLabelValuePair); err != nil {
+		return fmt.Errorf("cannot write seriesCountByLabelValuePair to vmselect: %w", err)
+	}
+	if err := writeTopHeapEntries(ctx, status.LabelValueCountByLabelName); err != nil {
+		return fmt.Errorf("cannot write labelValueCountByLabelName to vmselect: %w", err)
+	}
+	if err := writeMetricNameStatRecords(ctx, status.SeriesQueryStatsByMetricName); err != nil {
+		return fmt.Errorf("cannot write SeriesMetricNamesStats: %w", err)
+	}
+	return nil
+}
+
+func writeTopHeapEntries(ctx *vmselectRequestCtx, a []storage.TopHeapEntry) error {
+	if err := ctx.writeUint64(uint64(len(a))); err != nil {
+		return fmt.Errorf("cannot write topHeapEntries size: %w", err)
+	}
+	for _, e := range a {
+		if err := ctx.writeString(e.Name); err != nil {
+			return fmt.Errorf("cannot write topHeapEntry name: %w", err)
+		}
+		if err := ctx.writeUint64(e.Count); err != nil {
+			return fmt.Errorf("cannot write topHeapEntry count: %w", err)
+		}
+	}
+	return nil
+}
+
+func (s *Server) processSearchMetricNames(ctx *vmselectRequestCtx) error {
+	s.searchMetricNamesRequests.Inc()
+
+	// Read request.
+	if err := ctx.readSearchQuery(); err != nil {
+		return err
+	}
+
+	if err := s.beginConcurrentRequest(ctx); err != nil {
+		return ctx.writeErrorMessage(err)
+	}
+	defer s.endConcurrentRequest()
+
+	// Execute request.
+	metricNames, err := s.api.SearchMetricNames(ctx.qt, &ctx.sq, ctx.deadline)
+	if err != nil {
+		return ctx.writeErrorMessage(err)
+	}
+
+	// Send empty error message to vmselect.
+	if err := ctx.writeString(""); err != nil {
+		return fmt.Errorf("cannot send empty error message: %w", err)
+	}
+
+	// Send response.
+	metricNamesCount := len(metricNames)
+	if err := ctx.writeUint64(uint64(metricNamesCount)); err != nil {
+		return fmt.Errorf("cannot send metricNamesCount: %w", err)
+	}
+	for i, metricName := range metricNames {
+		if err := ctx.writeString(metricName); err != nil {
+			return fmt.Errorf("cannot send metricName #%d: %w", i+1, err)
+		}
+	}
+	ctx.qt.Printf("sent %d series to vmselect", len(metricNames))
+	return nil
+}
+
+func (s *Server) processSearch(ctx *vmselectRequestCtx) error {
+	s.searchRequests.Inc()
+
+	// Read request.
+	if err := ctx.readSearchQuery(); err != nil {
+		return err
+	}
+	if err := s.beginConcurrentRequest(ctx); err != nil {
+		return ctx.writeErrorMessage(err)
+	}
+	defer s.endConcurrentRequest()
+
+	// Initiaialize the search.
+	bi, err := s.api.InitSearch(ctx.qt, &ctx.sq, ctx.deadline)
+	if err != nil {
+		return ctx.writeErrorMessage(err)
+	}
+	defer bi.MustClose()
+
+	// Send empty error message to vmselect.
+	if err := ctx.writeString(""); err != nil {
+		return fmt.Errorf("cannot send empty error message: %w", err)
+	}
+
+	// Send found blocks to vmselect.
+	blocksRead := 0
+	var ok bool
+	for {
+		ctx.dataBuf, ok = bi.NextBlock(ctx.dataBuf[:0])
+		if !ok {
+			break
+		}
+		blocksRead++
+		s.metricBlocksRead.Inc()
+		if err := ctx.writeDataBufBytes(); err != nil {
+			return fmt.Errorf("cannot send MetricBlock: %w", err)
+		}
+	}
+
+	if err := bi.Error(); err != nil {
+		return fmt.Errorf("search error: %w", err)
+	}
+	ctx.qt.Printf("sent %d blocks to vmselect", blocksRead)
+
+	// Send 'end of response' marker
+	if err := ctx.writeString(""); err != nil {
+		return fmt.Errorf("cannot send 'end of response' marker")
+	}
+	return nil
+}
+
+func (s *Server) processMetricNamesUsageStats(ctx *vmselectRequestCtx) error {
+	// Read request.
+	hasTenant, err := ctx.readBool()
+	if err != nil {
+		return fmt.Errorf("cannot read hasTenant: %w", err)
+	}
+	var at *storage.TenantToken
+	if hasTenant {
+		accountID, err := ctx.readUint32()
+		if err != nil {
+			return fmt.Errorf("cannot read accountID: %w", err)
+		}
+		projectID, err := ctx.readUint32()
+		if err != nil {
+			return fmt.Errorf("cannot read projectID: %w", err)
+		}
+		at = &storage.TenantToken{
+			AccountID: accountID,
+			ProjectID: projectID,
+		}
+	}
+	limit, err := ctx.readLimit()
+	if err != nil {
+		return fmt.Errorf("cannot read limit: %w", err)
+	}
+	le, err := ctx.readInt64()
+	if err != nil {
+		return fmt.Errorf("cannot read le: %w", err)
+	}
+	if err := ctx.readDataBufBytes(256); err != nil {
+		return fmt.Errorf("cannot read matchPattern: %w", err)
+	}
+	matchPattern := string(ctx.dataBuf)
+
+	if err := s.beginConcurrentRequest(ctx); err != nil {
+		return ctx.writeErrorMessage(err)
+	}
+	defer s.endConcurrentRequest()
+
+	result, err := s.api.GetMetricNamesUsageStats(ctx.qt, at, limit, int(le), matchPattern, ctx.deadline)
+	if err != nil {
+		return ctx.writeErrorMessage(err)
+	}
+
+	// Send an empty error message to vmselect.
+	if err := ctx.writeString(""); err != nil {
+		return fmt.Errorf("cannot send empty error message: %w", err)
+	}
+
+	if err := ctx.writeUint64(result.CollectedSinceTs); err != nil {
+		return fmt.Errorf("cannot write CollectedSinceTs: %w", err)
+	}
+	if err := ctx.writeUint64(result.TotalRecords); err != nil {
+		return fmt.Errorf("cannot write TotalRecords: %w", err)
+	}
+	if err := ctx.writeUint64(result.CurrentSizeBytes); err != nil {
+		return fmt.Errorf("cannot write CurrentSizeBytes: %w", err)
+	}
+	if err := ctx.writeUint64(result.MaxSizeBytes); err != nil {
+		return fmt.Errorf("cannot write MaxSizeBytes: %w", err)
+	}
+	if err := writeMetricNameStatRecords(ctx, result.Records); err != nil {
+		return fmt.Errorf("cannot write Records: %w", err)
+	}
+	return nil
+}
+
+func writeMetricNameStatRecords(ctx *vmselectRequestCtx, records []metricnamestats.StatRecord) error {
+	if err := ctx.writeUint64(uint64(len(records))); err != nil {
+		return fmt.Errorf("cannot write MetricNamesStatsRecord size: %w", err)
+	}
+	for _, r := range records {
+		if err := ctx.writeString(r.MetricName); err != nil {
+			return fmt.Errorf("cannot write MetricName=%q record: %w", r.MetricName, err)
+		}
+		if err := ctx.writeUint64(r.LastRequestTs); err != nil {
+			return fmt.Errorf("cannot write record LastRequestTs: %w", err)
+		}
+		if err := ctx.writeUint64(r.RequestsCount); err != nil {
+			return fmt.Errorf("cannot write record RequestCount: %w", err)
+		}
+	}
+	return nil
+}
+
+func (s *Server) processResetMetricUsageStats(ctx *vmselectRequestCtx) error {
+
+	if err := s.beginConcurrentRequest(ctx); err != nil {
+		return ctx.writeErrorMessage(err)
+	}
+	defer s.endConcurrentRequest()
+	if err := s.api.ResetMetricNamesUsageStats(ctx.qt, ctx.deadline); err != nil {
+		return fmt.Errorf("cannot reset state of the metric names usage tracker: %w", err)
+	}
+	return nil
+}
+
+func (s *Server) processSearchMetadata(ctx *vmselectRequestCtx) error {
+	s.searchMetadataRequests.Inc()
+
+	// Read request.
+	hasTenant, err := ctx.readBool()
+	if err != nil {
+		return fmt.Errorf("cannot read hasTenant: %w", err)
+	}
+	var at *storage.TenantToken
+	if hasTenant {
+		accountID, err := ctx.readUint32()
+		if err != nil {
+			return fmt.Errorf("cannot read accountID: %w", err)
+		}
+		projectID, err := ctx.readUint32()
+		if err != nil {
+			return fmt.Errorf("cannot read projectID: %w", err)
+		}
+		at = &storage.TenantToken{
+			AccountID: accountID,
+			ProjectID: projectID,
+		}
+	}
+	limit, err := ctx.readLimit()
+	if err != nil {
+		return fmt.Errorf("cannot read limit: %w", err)
+	}
+	if err := ctx.readDataBufBytes(1024); err != nil {
+		return fmt.Errorf("cannot read metric name: %w", err)
+	}
+	metricName := string(ctx.dataBuf)
+
+	if err := s.beginConcurrentRequest(ctx); err != nil {
+		return ctx.writeErrorMessage(err)
+	}
+	defer s.endConcurrentRequest()
+
+	result, err := s.api.GetMetadataRecords(ctx.qt, at, limit, metricName, ctx.deadline)
+	if err != nil {
+		return ctx.writeErrorMessage(err)
+	}
+
+	// Send an empty error message to vmselect.
+	if err := ctx.writeString(""); err != nil {
+		return fmt.Errorf("cannot send empty error message: %w", err)
+	}
+	if err := writeMetadataRows(ctx, result); err != nil {
+		return fmt.Errorf("cannot write metadata rows: %w", err)
+	}
+	return nil
+}
+
+func writeMetadataRows(ctx *vmselectRequestCtx, records []*metricsmetadata.Row) error {
+	if err := ctx.writeUint64(uint64(len(records))); err != nil {
+		return fmt.Errorf("cannot write metadata rows count: %w", err)
+	}
+	var err error
+	for _, r := range records {
+		ctx.dataBuf, err = r.MarshalTo(ctx.dataBuf[:0])
+		if err != nil {
+			return err
+		}
+		if err := ctx.writeDataBufBytes(); err != nil {
+			return fmt.Errorf("cannot write metadata rows: %w", err)
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
The PR adds the support of vmselect RPC to vmsingle.

- The RPC server was copied from cluster branch as is and is disabled by default. To enable, users must provide the listen address explicitly via `-vmselectAddr` flag.
- Users must also specify which accountID and projectID the vmsingle data corresponds to. To do this, `-accountID` and `-projectID` flags. By default, these flags are 0. So the default tenantID is `"0:0"`.

Copying RPC server from cluster branch also required copying its dependencies:
- Code located in `lib/handshake` (copied as is)
- Some parts of `SearchQuery` type from `lib/storage/search.go`.

The entire API surface is tested with an app test.

Implements #4328.