### PR TITLE
app/vmui: refactor top queries table rendering

### DIFF
--- a/app/vmui/packages/vmui/src/pages/TopQueries/TopQueryPanel/TopQueryPanel.tsx
+++ b/app/vmui/packages/vmui/src/pages/TopQueries/TopQueryPanel/TopQueryPanel.tsx
@@ -1,4 +1,4 @@
-import { FC, useState } from "react";
+import { FC, ReactNode, useState } from "react";
 import { TopQuery } from "../../../types";
 import JsonView from "../../../components/Views/JsonView/JsonView";
 import { CodeIcon, TableIcon } from "../../../components/Main/Icons";
@@ -8,10 +8,18 @@ import "./style.scss";
 import classNames from "classnames";
 import useDeviceDetect from "../../../hooks/useDeviceDetect";
 
+export interface TopQueryColumn {
+  title?: string;
+  tooltip?: string;
+  key: keyof TopQuery;
+  sortBy?: keyof TopQuery;
+  format?: (row: TopQuery) => ReactNode;
+}
+
 export interface TopQueryPanelProps {
   rows: TopQuery[],
   title?: string,
-  columns: {title?: string, tooltip?: string, key: (keyof TopQuery), sortBy?: (keyof TopQuery), format?: (val: TopQuery[keyof TopQuery]) => string}[],
+  columns: TopQueryColumn[],
   defaultOrderBy?: keyof TopQuery,
 }
 const tabs = ["table", "JSON"].map((t, i) => ({

--- a/app/vmui/packages/vmui/src/pages/TopQueries/TopQueryTable/TopQueryTable.tsx
+++ b/app/vmui/packages/vmui/src/pages/TopQueries/TopQueryTable/TopQueryTable.tsx
@@ -44,11 +44,11 @@ const TopQueryTable:FC<TopQueryPanelProps> = ({ rows, columns, defaultOrderBy })
               <div className="vm-table-cell__content">
                 {col.title || col.key}
                 {col.tooltip && (
-                  <Tooltip title={col.tooltip}>
-                    <span
-                      className="vm-top-queries-table__info-icon"
-                      onClick={(e) => e.stopPropagation()}
-                    >
+                  <Tooltip
+                    placement="top-center"
+                    title={col.tooltip}
+                  >
+                    <span className="vm-top-queries-table__info-icon">
                       <InfoOutlinedIcon/>
                     </span>
                   </Tooltip>
@@ -79,7 +79,7 @@ const TopQueryTable:FC<TopQueryPanelProps> = ({ rows, columns, defaultOrderBy })
                 className="vm-table-cell"
                 key={col.key}
               >
-                {col.format ? col.format(row[col.key]) : (row[col.key] || "-")}
+                {col.format?.(row) ?? row[col.key] ?? "-"}
               </td>
             ))}
             <td className="vm-table-cell vm-table-cell_no-padding">

--- a/app/vmui/packages/vmui/src/pages/TopQueries/hooks/useTopQueriesColumns.ts
+++ b/app/vmui/packages/vmui/src/pages/TopQueries/hooks/useTopQueriesColumns.ts
@@ -1,0 +1,77 @@
+import { useMemo } from "react";
+import { TopQueryColumn } from "../TopQueryPanel/TopQueryPanel";
+import { humanizeSeconds } from "../../../utils/time";
+import { formatBytes } from "../../../utils/bytes";
+
+type UseTopQueriesColumns = {
+  maxLifetime: string;
+};
+
+export const useTopQueriesColumns = ({ maxLifetime }: UseTopQueriesColumns) => {
+  return useMemo(() => {
+    const queryCol: TopQueryColumn = {
+      key: "query"
+    };
+
+    const timeRangeCol: TopQueryColumn = {
+      key: "timeRange",
+      sortBy: "timeRangeSeconds",
+      title: "range",
+      tooltip: "The time range between start and end of the query request. 'instant' means the query was executed at a single point in time without a time range"
+    };
+
+    const countCol: TopQueryColumn = {
+      key: "count",
+      tooltip: `The number of times the query was executed over the last ${maxLifetime}`,
+    };
+
+    const topBySumDuration: TopQueryColumn[] = [
+      queryCol,
+      {
+        key: "sumDurationSeconds",
+        title: "duration",
+        tooltip: `Cumulative time spent executing the query across all its invocations over the last ${maxLifetime}`,
+        format: (row) => humanizeSeconds(row.sumDurationSeconds)
+      },
+      timeRangeCol,
+      countCol,
+    ];
+
+    const topByAvgDuration: TopQueryColumn[] = [
+      queryCol,
+      {
+        key: "avgDurationSeconds",
+        title: "duration",
+        tooltip: `Average time spent executing the query over the last ${maxLifetime}`,
+        format: (row) => humanizeSeconds(row.avgDurationSeconds)
+      },
+      timeRangeCol,
+      countCol,
+    ];
+
+    const topByCount: TopQueryColumn[] = [
+      queryCol,
+      timeRangeCol,
+      countCol,
+    ];
+
+    const topByAvgMemoryUsage: TopQueryColumn[] = [
+      queryCol,
+      {
+        key: "avgMemoryBytes",
+        title: "memory",
+        tooltip: `Average memory used during query execution over the last ${maxLifetime}`,
+        format: (row) => formatBytes(row.avgMemoryBytes)
+      },
+      timeRangeCol,
+      countCol,
+    ];
+
+    return {
+      topBySumDuration,
+      topByAvgDuration,
+      topByCount,
+      topByAvgMemoryUsage,
+    };
+  }, [maxLifetime]);
+};

--- a/app/vmui/packages/vmui/src/pages/TopQueries/index.tsx
+++ b/app/vmui/packages/vmui/src/pages/TopQueries/index.tsx
@@ -3,7 +3,7 @@ import { useFetchTopQueries } from "./hooks/useFetchTopQueries";
 import Spinner from "../../components/Main/Spinner/Spinner";
 import TopQueryPanel from "./TopQueryPanel/TopQueryPanel";
 import { formatPrettyNumber } from "../../utils/uplot";
-import { humanizeSeconds, parseSupportedDuration } from "../../utils/time";
+import { parseSupportedDuration } from "../../utils/time";
 import dayjs from "dayjs";
 import { TopQueryStats } from "../../types";
 import Button from "../../components/Main/Button/Button";
@@ -15,21 +15,16 @@ import "./style.scss";
 import useDeviceDetect from "../../hooks/useDeviceDetect";
 import classNames from "classnames";
 import useStateSearchParams from "../../hooks/useStateSearchParams";
+import { useTopQueriesColumns } from "./hooks/useTopQueriesColumns";
 
 const exampleDuration = "30ms, 15s, 3d4h, 1y2w";
-
-const formatBytes = (bytes: number): string => {
-  if (bytes === 0) return "0 B";
-  const units = ["B", "KB", "MB", "GB", "TB"];
-  const i = Math.floor(Math.log(bytes) / Math.log(1024));
-  return `${(bytes / Math.pow(1024, i)).toFixed(2)} ${units[i]}`;
-};
 
 const TopQueries: FC = () => {
   const { isMobile } = useDeviceDetect();
 
   const [topN, setTopN] = useStateSearchParams(10, "topN");
   const [maxLifetime, setMaxLifetime] = useStateSearchParams("10m", "maxLifetime");
+  const columns = useTopQueriesColumns({ maxLifetime });
 
   const { data, error, loading, fetch } = useFetchTopQueries({ topN, maxLifetime });
 
@@ -152,52 +147,33 @@ const TopQueries: FC = () => {
 
       {error && <Alert variant="error">{error}</Alert>}
 
-      {data && (<>
+      {data && (
         <div className="vm-top-queries-panels">
           <TopQueryPanel
+            title="Queries with most summary time to execute"
             rows={data.topBySumDuration}
-            title={"Queries with most summary time to execute"}
-            columns={[
-              { key: "query" },
-              { key: "sumDurationSeconds", title: "duration", tooltip: `Cumulative time spent executing the query across all its invocations over the last ${maxLifetime}`, format: (val) => humanizeSeconds(val as number) },
-              { key: "timeRange", sortBy: "timeRangeSeconds", title: "range", tooltip: "The time range between start and end of the query request. 'instant' means the query was executed at a single point in time without a time range" },
-              { key: "count", tooltip: `The number of times the query was executed over the last ${maxLifetime}` }
-            ]}
-            defaultOrderBy={"sumDurationSeconds"}
+            columns={columns.topBySumDuration}
+            defaultOrderBy="sumDurationSeconds"
           />
           <TopQueryPanel
+            title="Most heavy queries"
             rows={data.topByAvgDuration}
-            title={"Most heavy queries"}
-            columns={[
-              { key: "query" },
-              { key: "avgDurationSeconds", title: "duration", tooltip: `Average time spent executing the query over the last ${maxLifetime}`, format: (val) => humanizeSeconds(val as number) },
-              { key: "timeRange", sortBy: "timeRangeSeconds", title: "range", tooltip: "The time range between start and end of the query request. 'instant' means the query was executed at a single point in time without a time range" },
-              { key: "count", tooltip: `The number of times the query was executed over the last ${maxLifetime}` }
-            ]}
-            defaultOrderBy={"avgDurationSeconds"}
+            columns={columns.topByAvgDuration}
+            defaultOrderBy="avgDurationSeconds"
           />
           <TopQueryPanel
+            title="Most frequently executed queries"
             rows={data.topByCount}
-            title={"Most frequently executed queries"}
-            columns={[
-              { key: "query" },
-              { key: "timeRange", sortBy: "timeRangeSeconds", title: "range", tooltip: "The time range between start and end of the query request. 'instant' means the query was executed at a single point in time without a time range" },
-              { key: "count", tooltip: `The number of times the query was executed over the last ${maxLifetime}` }
-            ]}
+            columns={columns.topByCount}
           />
           <TopQueryPanel
+            title="Queries with most memory to execute"
             rows={data.topByAvgMemoryUsage}
-            title={"Queries with most memory to execute"}
-            columns={[
-              { key: "query" },
-              { key: "avgMemoryBytes", title: "memory", tooltip: `Average memory used during query execution over the last ${maxLifetime}`, format: (val) => formatBytes(val as number) },
-              { key: "timeRange", sortBy: "timeRangeSeconds", title: "range", tooltip: "The time range between start and end of the query request. 'instant' means the query was executed at a single point in time without a time range" },
-              { key: "count", tooltip: `The number of times the query was executed over the last ${maxLifetime}` }
-            ]}
-            defaultOrderBy={"avgMemoryBytes"}
+            columns={columns.topByAvgMemoryUsage}
+            defaultOrderBy="avgMemoryBytes"
           />
         </div>
-      </>)}
+      )}
     </div>
   );
 };

--- a/app/vmui/packages/vmui/src/pages/TopQueries/style.scss
+++ b/app/vmui/packages/vmui/src/pages/TopQueries/style.scss
@@ -5,8 +5,6 @@
     display: inline-flex;
     align-items: center;
     color: $color-text-secondary;
-    cursor: default;
-
     margin-left: 4px;
 
     svg {

--- a/app/vmui/packages/vmui/src/utils/bytes.test.ts
+++ b/app/vmui/packages/vmui/src/utils/bytes.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { formatBytes } from "./bytes";
+
+describe("formatBytes", () => {
+  it("returns null for invalid values", () => {
+    expect(formatBytes(-1)).toBeNull();
+    expect(formatBytes(Number.NaN)).toBeNull();
+    expect(formatBytes(Number.POSITIVE_INFINITY)).toBeNull();
+    expect(formatBytes(Number.NEGATIVE_INFINITY)).toBeNull();
+  });
+
+  it("formats zero bytes", () => {
+    expect(formatBytes(0)).toBe("0 B");
+  });
+
+  it("formats bytes", () => {
+    expect(formatBytes(0.5)).toBe("0.5 B");
+    expect(formatBytes(1)).toBe("1 B");
+    expect(formatBytes(512)).toBe("512 B");
+    expect(formatBytes(1023)).toBe("1023 B");
+  });
+
+  it("formats kilobytes", () => {
+    expect(formatBytes(1024)).toBe("1 KB");
+    expect(formatBytes(1536)).toBe("1.5 KB");
+  });
+
+  it("formats megabytes", () => {
+    expect(formatBytes(1024 ** 2)).toBe("1 MB");
+    expect(formatBytes(2.5 * 1024 ** 2)).toBe("2.5 MB");
+  });
+
+  it("formats gigabytes, terabytes and petabytes", () => {
+    expect(formatBytes(1024 ** 3)).toBe("1 GB");
+    expect(formatBytes(1024 ** 4)).toBe("1 TB");
+    expect(formatBytes(1024 ** 5)).toBe("1 PB");
+  });
+
+  it("caps values above PB to PB unit", () => {
+    expect(formatBytes(1024 ** 6)).toBe("1024 PB");
+  });
+
+  it("rounds to two decimals", () => {
+    expect(formatBytes(1234)).toBe("1.21 KB");
+    expect(formatBytes(1234567)).toBe("1.18 MB");
+  });
+});

--- a/app/vmui/packages/vmui/src/utils/bytes.ts
+++ b/app/vmui/packages/vmui/src/utils/bytes.ts
@@ -1,0 +1,14 @@
+const LOG_1024 = Math.log(1024);
+const UNITS = ["B", "KB", "MB", "GB", "TB", "PB"] as const;
+
+export const formatBytes = (bytes: number): string | null => {
+  if (!Number.isFinite(bytes) || bytes < 0) return null;
+  if (bytes === 0) return "0 B";
+
+  const unitIndex = Math.min(
+    Math.max(Math.floor(Math.log(bytes) / LOG_1024), 0),
+    UNITS.length - 1
+  );
+
+  return `${parseFloat((bytes / 1024 ** unitIndex).toFixed(2))} ${UNITS[unitIndex]}`;
+};


### PR DESCRIPTION
### Describe Your Changes

Refactors and polishes the `Top Queries` table implementation based on PR #10790.

- Move `formatBytes` to `utils/bytes`
- Improve `formatBytes` handling for invalid values
- Extract `TopQueryColumn` typing
- Change column `format` callback to receive the full row
- Add `useTopQueriesColumns` hook
- Deduplicate repeated Top Queries column definitions
- Move tooltip placement from bottom to top