### PR TITLE
dashboards: zoom in the "CPU spent on GC" panel.

### DIFF
--- a/dashboards/victoriametrics-cluster.json
+++ b/dashboards/victoriametrics-cluster.json
@@ -3109,7 +3109,6 @@
                   "mode": "off"
                 }
               },
-              "decimals": 0,
               "links": [],
               "mappings": [],
               "min": 0,

--- a/dashboards/victoriametrics.json
+++ b/dashboards/victoriametrics.json
@@ -3406,7 +3406,6 @@
                   "mode": "off"
                 }
               },
-              "decimals": 0,
               "links": [],
               "mappings": [],
               "min": 0,

--- a/dashboards/vm/victoriametrics-cluster.json
+++ b/dashboards/vm/victoriametrics-cluster.json
@@ -3110,7 +3110,6 @@
                   "mode": "off"
                 }
               },
-              "decimals": 0,
               "links": [],
               "mappings": [],
               "min": 0,

--- a/dashboards/vm/victoriametrics.json
+++ b/dashboards/vm/victoriametrics.json
@@ -3407,7 +3407,6 @@
                   "mode": "off"
                 }
               },
-              "decimals": 0,
               "links": [],
               "mappings": [],
               "min": 0,

--- a/dashboards/vm/vmagent.json
+++ b/dashboards/vm/vmagent.json
@@ -2946,7 +2946,6 @@
                   "mode": "off"
                 }
               },
-              "decimals": 0,
               "links": [],
               "mappings": [],
               "min": 0,

--- a/dashboards/vm/vmalert.json
+++ b/dashboards/vm/vmalert.json
@@ -2324,7 +2324,6 @@
                   "mode": "off"
                 }
               },
-              "decimals": 0,
               "links": [],
               "mappings": [],
               "min": 0,

--- a/dashboards/vmagent.json
+++ b/dashboards/vmagent.json
@@ -2945,7 +2945,6 @@
                   "mode": "off"
                 }
               },
-              "decimals": 0,
               "links": [],
               "mappings": [],
               "min": 0,

--- a/dashboards/vmalert.json
+++ b/dashboards/vmalert.json
@@ -2323,7 +2323,6 @@
                   "mode": "off"
                 }
               },
-              "decimals": 0,
               "links": [],
               "mappings": [],
               "min": 0,


### PR DESCRIPTION
The "CPU spent on GC" panel often shows sub-1% GC CPU usage, which is barely visible with the current fixed Y-axis settings. Removing the fixed scale allows Grafana to auto-adjust the Y axis and makes small fluctuations easier to observe.

Before:
<img width="1499" height="477" alt="Screenshot 2026-05-14 at 18 35 14" src="https://github.com/user-attachments/assets/8a78bea4-3dcd-4f26-a40e-304acbf68eb1" />

After:
<img width="1508" height="501" alt="Screenshot 2026-05-14 at 18 34 51" src="https://github.com/user-attachments/assets/aefd2fbc-6b1c-42a9-b45d-e44bcd30be48" />



