### PR TITLE
Add clarification for when license expires

### DIFF
--- a/docs/victoriametrics/enterprise.md
+++ b/docs/victoriametrics/enterprise.md
@@ -363,7 +363,7 @@ This means you don't need to restart components to install a new license. The co
 
 If your license has expired and you decide to not renew it, you can switch to the VictoriaMetrics Open Source version without data loss, as both versions share the same data model. In doing so, however, you will lose access to the [VictoriaMetrics Enterprise features](https://docs.victoriametrics.com/victoriametrics/enterprise/#victoriametrics-enterprise-features).
 
-See [updating the license key](#updating-the-license-key) for more details.
+See [updating the license key](https://docs.victoriametrics.com/victoriametrics/enterprise/#updating-the-license-key) for more details.
 
 ## Monitoring license expiration
 

--- a/docs/victoriametrics/enterprise.md
+++ b/docs/victoriametrics/enterprise.md
@@ -353,6 +353,16 @@ Example Docker image:
 
 `victoriametrics/victoria-metrics:v1.143.0-enterprise-fips` – uses the FIPS-compatible binary and based on `scratch` image.
 
+## When Enterprise License Expires
+
+All components will continue to function until a restart occures.
+
+License checks happen only at startup, if the license expires while the component is running, nothing will happen; everything will continue to function as expected.
+License updates generally do not require a restart because the component will simply pick up the new license next time it does restart. See [Updating the license key](#updating-the-license-key).
+The only case this doesn't apply to is with the `-license` flag.
+
+VictoriaMetrics Open Source and VictoriaMetrics Enterprise share the same data model; you can switch between versions and retain your data. No need to export and import data.
+
 ## Monitoring license expiration
 
 All the Enterprise components expose the following metrics at the `/metrics` page:

--- a/docs/victoriametrics/enterprise.md
+++ b/docs/victoriametrics/enterprise.md
@@ -359,7 +359,7 @@ When a license expires, all licensed components continue to function normally un
 
 License checks happen only at startup. If a license expires while the component is running, nothing changes; the component continues to run until the next restart. 
 
-This means you don't need to restart components to install a new license. The component automatically picks up the new license the next time it restarts. The exception is when the `-license` flag is used, because the license is provided through the env directly it cannot be modified while VictoriaMetrics is running and requires a restart to apply the new license. 
+This means you don't need to restart components to install a new license. The component automatically picks up the new license the next time it restarts. The exception is when the `-license` flag is used, because the license is supplied at startup and changing it requires restarting VictoriaMetrics with the updated flag value.
 
 See [updating the license key](#updating-the-license-key) for more details.
 

--- a/docs/victoriametrics/enterprise.md
+++ b/docs/victoriametrics/enterprise.md
@@ -359,7 +359,7 @@ When a license expires, all licensed components continue to function normally un
 
 License checks happen only at startup. If a license expires while the component is running, nothing changes; the component continues to run until the next restart. 
 
-This means you don't need to restart components to install a new license. The component simply picks up the new license the next time it restarts. The exception is when the `-license` flag is used.
+This means you don't need to restart components to install a new license. The component automatically picks up the new license the next time it restarts. The exception is when the `-license` flag is used, because the license is provided at startup and must be valid when the component restarts.
 
 See [updating the license key](#updating-the-license-key) for more details.
 

--- a/docs/victoriametrics/enterprise.md
+++ b/docs/victoriametrics/enterprise.md
@@ -359,7 +359,7 @@ When a license expires, all licensed components continue to function normally un
 
 License checks happen only at startup. If a license expires while the component is running, nothing changes; the component continues to run until the next restart. 
 
-This means you don't need to restart components to install a new license. The component automatically picks up the new license the next time it restarts. The exception is when the `-license` flag is used, because the license is provided at startup and must be valid when the component restarts.
+This means you don't need to restart components to install a new license. The component automatically picks up the new license the next time it restarts. The exception is when the `-license` flag is used, because the license is provided through the env directly it cannot be modified while VictoriaMetrics is running and requires a restart to apply the new license. 
 
 See [updating the license key](#updating-the-license-key) for more details.
 

--- a/docs/victoriametrics/enterprise.md
+++ b/docs/victoriametrics/enterprise.md
@@ -355,13 +355,15 @@ Example Docker image:
 
 ## When Enterprise License Expires
 
-All components will continue to function until a restart occures.
+When a license expires, all licensed components continue to function normally until a restart occurs.
 
-License checks happen only at startup, if the license expires while the component is running, nothing will happen; everything will continue to function as expected.
-License updates generally do not require a restart because the component will simply pick up the new license next time it does restart. See [Updating the license key](#updating-the-license-key).
-The only case this doesn't apply to is with the `-license` flag.
+License checks happen only at startup. If a license expires while the component is running, nothing changes; the component continues to run until the next restart. 
 
-VictoriaMetrics Open Source and VictoriaMetrics Enterprise share the same data model; you can switch between versions and retain your data. No need to export and import data.
+This means you don't need to restart components to install a new license. The component simply picks up the new license the next time it restarts. The exception is when the `-license` flag is used.
+
+See [updating the license key](#updating-the-license-key) for more details.
+
+VictoriaMetrics Open Source and VictoriaMetrics Enterprise share the same data model; you can switch between versions and retain your data. There is no need to export and import data when migrating between versions.
 
 ## Monitoring license expiration
 

--- a/docs/victoriametrics/enterprise.md
+++ b/docs/victoriametrics/enterprise.md
@@ -353,7 +353,7 @@ Example Docker image:
 
 `victoriametrics/victoria-metrics:v1.143.0-enterprise-fips` – uses the FIPS-compatible binary and based on `scratch` image.
 
-## When Enterprise License Expires
+## What Happens to Licensed Components When a License Expires
 
 When a license expires, all licensed components continue to function normally until a restart occurs.
 
@@ -361,9 +361,9 @@ License checks happen only at startup. If a license expires while the component 
 
 This means you don't need to restart components to install a new license. The component automatically picks up the new license the next time it restarts. The exception is when the `-license` flag is used, because the license is provided at startup and must be valid when the component restarts.
 
-See [updating the license key](#updating-the-license-key) for more details.
+If your license has expired and you decide to not renew it, you can switch to the VictoriaMetrics Open Source version without data loss, as both versions share the same data model. In doing so, however, you will lose access to the [VictoriaMetrics Enterprise features](https://docs.victoriametrics.com/victoriametrics/enterprise/#victoriametrics-enterprise-features).
 
-VictoriaMetrics Open Source and VictoriaMetrics Enterprise share the same data model; you can switch between versions and retain your data. There is no need to export and import data when migrating between versions.
+See [updating the license key](#updating-the-license-key) for more details.
 
 ## Monitoring license expiration
 


### PR DESCRIPTION
Many people are concerned about what happens when the license expires on a VictoriaMetrics component. This aims to address those concerns.