### PR TITLE
lib/protoparser/opentelemetry: support disable scope and resource attributes label promotions

### DIFF
--- a/app/vmagent/main.go
+++ b/app/vmagent/main.go
@@ -118,6 +118,7 @@ func main() {
 	remotewrite.InitSecretFlags()
 	buildinfo.Init()
 	logger.Init()
+	opentelemetry.Init()
 	timeserieslimits.Init(*maxLabelsPerTimeseries, *maxLabelNameLen, *maxLabelValueLen)
 
 	if promscrape.IsDryRun() {

--- a/app/vmagent/opentelemetry/request_handler.go
+++ b/app/vmagent/opentelemetry/request_handler.go
@@ -11,7 +11,6 @@ import (
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/prommetadata"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/prompb"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/protoparser/opentelemetry/firehose"
-	"github.com/VictoriaMetrics/VictoriaMetrics/lib/protoparser/opentelemetry/pb"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/protoparser/opentelemetry/stream"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/protoparser/protoparserutil"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/tenantmetrics"
@@ -27,7 +26,7 @@ var (
 )
 
 func Init() {
-	pb.ValidateFlags()
+	stream.InitDecodeOptions()
 }
 
 // InsertHandlerForReader processes metrics from given reader.

--- a/app/vmagent/opentelemetry/request_handler.go
+++ b/app/vmagent/opentelemetry/request_handler.go
@@ -25,6 +25,7 @@ var (
 	rowsPerInsert          = metrics.NewHistogram(`vmagent_rows_per_insert{type="opentelemetry"}`)
 )
 
+// Init must be called after flag.Parse and before using the opentelemetry package.
 func Init() {
 	stream.InitDecodeOptions()
 }

--- a/app/vmagent/opentelemetry/request_handler.go
+++ b/app/vmagent/opentelemetry/request_handler.go
@@ -11,6 +11,7 @@ import (
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/prommetadata"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/prompb"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/protoparser/opentelemetry/firehose"
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/protoparser/opentelemetry/pb"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/protoparser/opentelemetry/stream"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/protoparser/protoparserutil"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/tenantmetrics"
@@ -24,6 +25,10 @@ var (
 	metadataTenantInserted = tenantmetrics.NewCounterMap(`vmagent_tenant_inserted_metadata_total{type="opentelemetry"}`)
 	rowsPerInsert          = metrics.NewHistogram(`vmagent_rows_per_insert{type="opentelemetry"}`)
 )
+
+func Init() {
+	pb.ValidateFlags()
+}
 
 // InsertHandlerForReader processes metrics from given reader.
 func InsertHandlerForReader(at *auth.Token, r io.Reader, encoding string) error {

--- a/app/vminsert/main.go
+++ b/app/vminsert/main.go
@@ -89,6 +89,7 @@ var staticServer = http.FileServer(http.FS(staticFiles))
 func Init() {
 	relabel.Init()
 	common.InitStreamAggr()
+	opentelemetry.Init()
 	protoparserutil.StartUnmarshalWorkers()
 	if len(*graphiteListenAddr) > 0 {
 		graphiteServer = graphiteserver.MustStart(*graphiteListenAddr, *graphiteUseProxyProtocol, graphite.InsertHandler)

--- a/app/vminsert/opentelemetry/request_handler.go
+++ b/app/vminsert/opentelemetry/request_handler.go
@@ -9,7 +9,6 @@ import (
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/prommetadata"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/prompb"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/protoparser/opentelemetry/firehose"
-	"github.com/VictoriaMetrics/VictoriaMetrics/lib/protoparser/opentelemetry/pb"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/protoparser/opentelemetry/stream"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/protoparser/protoparserutil"
 	"github.com/VictoriaMetrics/metrics"
@@ -22,7 +21,7 @@ var (
 )
 
 func Init() {
-	pb.ValidateFlags()
+	stream.InitDecodeOptions()
 }
 
 // InsertHandler processes opentelemetry metrics.

--- a/app/vminsert/opentelemetry/request_handler.go
+++ b/app/vminsert/opentelemetry/request_handler.go
@@ -9,6 +9,7 @@ import (
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/prommetadata"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/prompb"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/protoparser/opentelemetry/firehose"
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/protoparser/opentelemetry/pb"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/protoparser/opentelemetry/stream"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/protoparser/protoparserutil"
 	"github.com/VictoriaMetrics/metrics"
@@ -19,6 +20,10 @@ var (
 	rowsPerInsert    = metrics.NewHistogram(`vm_rows_per_insert{type="opentelemetry"}`)
 	metadataInserted = metrics.NewCounter(`vm_metadata_rows_inserted_total{type="opentelemetry"}`)
 )
+
+func Init() {
+	pb.ValidateFlags()
+}
 
 // InsertHandler processes opentelemetry metrics.
 func InsertHandler(req *http.Request) error {

--- a/app/vminsert/opentelemetry/request_handler.go
+++ b/app/vminsert/opentelemetry/request_handler.go
@@ -20,6 +20,7 @@ var (
 	metadataInserted = metrics.NewCounter(`vm_metadata_rows_inserted_total{type="opentelemetry"}`)
 )
 
+// Init must be called after flag.Parse and before using the opentelemetry package.
 func Init() {
 	stream.InitDecodeOptions()
 }

--- a/docs/victoriametrics/changelog/CHANGELOG.md
+++ b/docs/victoriametrics/changelog/CHANGELOG.md
@@ -26,6 +26,8 @@ See also [LTS releases](https://docs.victoriametrics.com/victoriametrics/lts-rel
 
 ## tip
 
+* FEATURE: [vmagent](https://docs.victoriametrics.com/victoriametrics/vmagent/), [vmsingle](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/) and `vminsert` in [VictoriaMetrics cluster](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/): add `-opentelemetry.promoteAllResourceAttributes` and `-opentelemetry.promoteScopeMetadata` command-line flags to allow managing label promotion for resource attributes and OTel scope metadata. See [OpenTelemetry](https://docs.victoriametrics.com/victoriametrics/integrations/opentelemetry/) docs and [#10931](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/10931).
+
 ## [v1.144.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.144.0)
 
 Released at 2026-05-22

--- a/docs/victoriametrics/integrations/opentelemetry.md
+++ b/docs/victoriametrics/integrations/opentelemetry.md
@@ -28,9 +28,17 @@ The following label sanitization options can be enabled:
 
 > These flags can be applied on vmagent, vminsert or VictoriaMetrics single-node.
 
+## Instrumentation Scope
+
+By default, VictoriaMetrics promotes [OTel scope metadata](https://opentelemetry.io/docs/specs/otel/common/instrumentation-scope/) to metric labels. This behavior can be disabled via `-opentelemetry.promoteScopeMetadata`.
+
 ## Resource Attributes
 
 By default, VictoriaMetrics promotes all [OpenTelemetry resource](https://opentelemetry.io/docs/specs/otel/resource/data-model/) attributes to labels and attaches them to all ingested OTLP metrics.
+The following attribute promotion options can be configured:
+- `opentelemetry.promoteAllResourceAttributes` - promotes all resource attributes to labels, except for the ones configured with `-opentelemetry.ignoreResourceAttributes`.
+- `opentelemetry.promoteResourceAttributes` - promotes specific list of resource attributes to labels. It cannot be configured simultaneously with `opentelemetry.promoteAllResourceAttributes`. 
+- `opentelemetry.ignoreResourceAttributes` - controls which resource attributes to ignore, can only be set when `opentelemetry.promoteAllResourceAttributes` is true.
 
 ## Exponential histograms
 

--- a/docs/victoriametrics/integrations/opentelemetry.md
+++ b/docs/victoriametrics/integrations/opentelemetry.md
@@ -36,9 +36,9 @@ By default, VictoriaMetrics promotes [OTel scope metadata](https://opentelemetry
 
 By default, VictoriaMetrics promotes all [OpenTelemetry resource](https://opentelemetry.io/docs/specs/otel/resource/data-model/) attributes to labels and attaches them to all ingested OTLP metrics.
 The following attribute promotion options can be configured:
-- `opentelemetry.promoteAllResourceAttributes` - promotes all resource attributes to labels, except for the ones configured with `-opentelemetry.ignoreResourceAttributes`.
-- `opentelemetry.promoteResourceAttributes` - promotes specific list of resource attributes to labels. It cannot be configured simultaneously with `opentelemetry.promoteAllResourceAttributes`. 
-- `opentelemetry.ignoreResourceAttributes` - controls which resource attributes to ignore, can only be set when `opentelemetry.promoteAllResourceAttributes` is true.
+* `-opentelemetry.promoteAllResourceAttributes` - promotes all resource attributes to labels, except for the ones configured with `-opentelemetry.ignoreResourceAttributes`.
+* `-opentelemetry.promoteResourceAttributes` - promotes specific list of resource attributes to labels. It cannot be configured simultaneously with `-opentelemetry.promoteAllResourceAttributes`.
+* `-opentelemetry.ignoreResourceAttributes` - controls which resource attributes to ignore, can only be set when `-opentelemetry.promoteAllResourceAttributes` is true.
 
 ## Exponential histograms
 

--- a/docs/victoriametrics/victoria_metrics_common_flags.md
+++ b/docs/victoriametrics/victoria_metrics_common_flags.md
@@ -224,10 +224,10 @@ See the docs at https://docs.victoriametrics.com/victoriametrics/
   -opentelemetry.maxRequestSize size
      The maximum size in bytes of a single OpenTelemetry request
      Supports the following optional suffixes for size values: KB, MB, GB, TB, KiB, MiB, GiB, TiB (default 67108864)
-  -opentelemetry.promoteAllResourceAttributes array
-     Promote specific list of resource attributes to labels.
-  -opentelemetry.promoteResourceAttributes
+  -opentelemetry.promoteAllResourceAttributes
      Whether to promote all resource attributes to labels, except for the ones configured with 'opentelemetry.ignoreResourceAttributes'.
+  -opentelemetry.promoteResourceAttributes array
+     Promote specific list of resource attributes to labels.
   -opentelemetry.promoteScopeMetadata
      Whether to promote OTel scope metadata (i.e. name, version, schema URL, and attributes) to metric labels.
   -opentelemetry.usePrometheusNaming

--- a/docs/victoriametrics/victoria_metrics_common_flags.md
+++ b/docs/victoriametrics/victoria_metrics_common_flags.md
@@ -217,11 +217,19 @@ See the docs at https://docs.victoriametrics.com/victoriametrics/
      Supports the following optional suffixes for size values: KB, MB, GB, TB, KiB, MiB, GiB, TiB (default 67108864)
   -opentelemetry.convertMetricNamesToPrometheus
      Whether to convert only metric names into Prometheus-compatible format for the metrics ingested via OpenTelemetry protocol; see https://docs.victoriametrics.com/victoriametrics/integrations/opentelemetry/
+  -opentelemetry.ignoreResourceAttributes array
+     Control which resource attributes to ignore, can only be set when 'opentelemetry.promoteAllResourceAttributes' is true.
   -opentelemetry.labelNameUnderscoreSanitization
      Whether to enable prepending of 'key' to labels starting with '_' when -opentelemetry.usePrometheusNaming is enabled. Reserved labels starting with '__' are not modified. See https://docs.victoriametrics.com/victoriametrics/integrations/opentelemetry/ (default true)
   -opentelemetry.maxRequestSize size
      The maximum size in bytes of a single OpenTelemetry request
      Supports the following optional suffixes for size values: KB, MB, GB, TB, KiB, MiB, GiB, TiB (default 67108864)
+  -opentelemetry.promoteAllResourceAttributes array
+     Promote specific list of resource attributes to labels.
+  -opentelemetry.promoteResourceAttributes
+     Whether to promote all resource attributes to labels, except for the ones configured with 'opentelemetry.ignoreResourceAttributes'.
+  -opentelemetry.promoteScopeMetadata
+     Whether to promote OTel scope metadata (i.e. name, version, schema URL, and attributes) to metric labels.
   -opentelemetry.usePrometheusNaming
      Whether to convert metric names and labels into Prometheus-compatible format for the metrics ingested via OpenTelemetry protocol; see https://docs.victoriametrics.com/victoriametrics/integrations/opentelemetry/
   -opentsdbHTTPListenAddr string

--- a/docs/victoriametrics/vmagent_common_flags.md
+++ b/docs/victoriametrics/vmagent_common_flags.md
@@ -191,10 +191,10 @@ See the docs at https://docs.victoriametrics.com/victoriametrics/vmagent/ .
   -opentelemetry.maxRequestSize size
      The maximum size in bytes of a single OpenTelemetry request
      Supports the following optional suffixes for size values: KB, MB, GB, TB, KiB, MiB, GiB, TiB (default 67108864)
-  -opentelemetry.promoteAllResourceAttributes array
-     Promote specific list of resource attributes to labels.
-  -opentelemetry.promoteResourceAttributes
+  -opentelemetry.promoteAllResourceAttributes
      Whether to promote all resource attributes to labels, except for the ones configured with 'opentelemetry.ignoreResourceAttributes'.
+  -opentelemetry.promoteResourceAttributes array
+     Promote specific list of resource attributes to labels.
   -opentelemetry.promoteScopeMetadata
      Whether to promote OTel scope metadata (i.e. name, version, schema URL, and attributes) to metric labels.
   -opentelemetry.usePrometheusNaming

--- a/docs/victoriametrics/vmagent_common_flags.md
+++ b/docs/victoriametrics/vmagent_common_flags.md
@@ -184,11 +184,19 @@ See the docs at https://docs.victoriametrics.com/victoriametrics/vmagent/ .
      Supports the following optional suffixes for size values: KB, MB, GB, TB, KiB, MiB, GiB, TiB (default 67108864)
   -opentelemetry.convertMetricNamesToPrometheus
      Whether to convert only metric names into Prometheus-compatible format for the metrics ingested via OpenTelemetry protocol; see https://docs.victoriametrics.com/victoriametrics/integrations/opentelemetry/
+  -opentelemetry.ignoreResourceAttributes array
+     Control which resource attributes to ignore, can only be set when 'opentelemetry.promoteAllResourceAttributes' is true.
   -opentelemetry.labelNameUnderscoreSanitization
      Whether to enable prepending of 'key' to labels starting with '_' when -opentelemetry.usePrometheusNaming is enabled. Reserved labels starting with '__' are not modified. See https://docs.victoriametrics.com/victoriametrics/integrations/opentelemetry/ (default true)
   -opentelemetry.maxRequestSize size
      The maximum size in bytes of a single OpenTelemetry request
      Supports the following optional suffixes for size values: KB, MB, GB, TB, KiB, MiB, GiB, TiB (default 67108864)
+  -opentelemetry.promoteAllResourceAttributes array
+     Promote specific list of resource attributes to labels.
+  -opentelemetry.promoteResourceAttributes
+     Whether to promote all resource attributes to labels, except for the ones configured with 'opentelemetry.ignoreResourceAttributes'.
+  -opentelemetry.promoteScopeMetadata
+     Whether to promote OTel scope metadata (i.e. name, version, schema URL, and attributes) to metric labels.
   -opentelemetry.usePrometheusNaming
      Whether to convert metric names and labels into Prometheus-compatible format for the metrics ingested via OpenTelemetry protocol; see https://docs.victoriametrics.com/victoriametrics/integrations/opentelemetry/
   -opentsdbHTTPListenAddr string

--- a/docs/victoriametrics/vminsert_common_flags.md
+++ b/docs/victoriametrics/vminsert_common_flags.md
@@ -191,10 +191,10 @@ See the docs at https://docs.victoriametrics.com/victoriametrics/cluster-victori
   -opentelemetry.maxRequestSize size
      The maximum size in bytes of a single OpenTelemetry request
      Supports the following optional suffixes for size values: KB, MB, GB, TB, KiB, MiB, GiB, TiB (default 67108864)
-  -opentelemetry.promoteAllResourceAttributes array
-     Promote specific list of resource attributes to labels.
-  -opentelemetry.promoteResourceAttributes
+  -opentelemetry.promoteAllResourceAttributes
      Whether to promote all resource attributes to labels, except for the ones configured with 'opentelemetry.ignoreResourceAttributes'.
+  -opentelemetry.promoteResourceAttributes array
+     Promote specific list of resource attributes to labels.
   -opentelemetry.promoteScopeMetadata
      Whether to promote OTel scope metadata (i.e. name, version, schema URL, and attributes) to metric labels.
   -opentelemetry.usePrometheusNaming

--- a/docs/victoriametrics/vminsert_common_flags.md
+++ b/docs/victoriametrics/vminsert_common_flags.md
@@ -184,11 +184,19 @@ See the docs at https://docs.victoriametrics.com/victoriametrics/cluster-victori
      Supports the following optional suffixes for size values: KB, MB, GB, TB, KiB, MiB, GiB, TiB (default 67108864)
   -opentelemetry.convertMetricNamesToPrometheus
      Whether to convert only metric names into Prometheus-compatible format for the metrics ingested via OpenTelemetry protocol; see https://docs.victoriametrics.com/victoriametrics/integrations/opentelemetry/
+  -opentelemetry.ignoreResourceAttributes array
+     Control which resource attributes to ignore, can only be set when 'opentelemetry.promoteAllResourceAttributes' is true.
   -opentelemetry.labelNameUnderscoreSanitization
      Whether to enable prepending of 'key' to labels starting with '_' when -opentelemetry.usePrometheusNaming is enabled. Reserved labels starting with '__' are not modified. See https://docs.victoriametrics.com/victoriametrics/integrations/opentelemetry/ (default true)
   -opentelemetry.maxRequestSize size
      The maximum size in bytes of a single OpenTelemetry request
      Supports the following optional suffixes for size values: KB, MB, GB, TB, KiB, MiB, GiB, TiB (default 67108864)
+  -opentelemetry.promoteAllResourceAttributes array
+     Promote specific list of resource attributes to labels.
+  -opentelemetry.promoteResourceAttributes
+     Whether to promote all resource attributes to labels, except for the ones configured with 'opentelemetry.ignoreResourceAttributes'.
+  -opentelemetry.promoteScopeMetadata
+     Whether to promote OTel scope metadata (i.e. name, version, schema URL, and attributes) to metric labels.
   -opentelemetry.usePrometheusNaming
      Whether to convert metric names and labels into Prometheus-compatible format for the metrics ingested via OpenTelemetry protocol; see https://docs.victoriametrics.com/victoriametrics/integrations/opentelemetry/
   -opentsdbHTTPListenAddr string

--- a/lib/protoparser/opentelemetry/pb/pb.go
+++ b/lib/protoparser/opentelemetry/pb/pb.go
@@ -14,6 +14,7 @@ import (
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/promutil"
 )
 
+// DecodeMetricsOptions defines options for DecodeMetricsData
 type DecodeMetricsOptions struct {
 	DisableScopeMetadata      bool
 	DisableResourceAttributes bool
@@ -80,7 +81,7 @@ func (r *MetricsData) marshalProtobuf(mm *easyproto.MessageMarshaler) {
 	}
 }
 
-// DecodeMetricsData decodes metricsData from src and sends the decoded data to mp.
+// DecodeMetricsData decodes metricsData with given options from src and sends the decoded data to mp.
 func DecodeMetricsData(src []byte, mp MetricPusher, options DecodeMetricsOptions) (err error) {
 	// See https://github.com/open-telemetry/opentelemetry-proto/blob/049d4332834935792fd4dbd392ecd31904f99ba2/opentelemetry/proto/metrics/v1/metrics.proto#L56
 	//

--- a/lib/protoparser/opentelemetry/pb/pb.go
+++ b/lib/protoparser/opentelemetry/pb/pb.go
@@ -1,7 +1,6 @@
 package pb
 
 import (
-	"flag"
 	"fmt"
 	"math"
 	"strconv"
@@ -10,26 +9,16 @@ import (
 
 	"github.com/VictoriaMetrics/easyproto"
 
-	"github.com/VictoriaMetrics/VictoriaMetrics/lib/flagutil"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/logger"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/prompb"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/promutil"
 )
 
-var (
-	promoteScopeMetadata         = flag.Bool("opentelemetry.promoteScopeMetadata", true, "Whether to promote OTel scope metadata (i.e. name, version, schema URL, and attributes) to metric labels.")
-	promoteAllResourceAttributes = flag.Bool("opentelemetry.promoteAllResourceAttributes", true, "Whether to promote all resource attributes to labels, except for the ones configured with 'opentelemetry.ignoreResourceAttributes'.")
-	promoteResourceAttributes    = flagutil.NewArrayString("opentelemetry.promoteResourceAttributes", "Promote specific list of resource attributes to labels.")
-	ignoreResourceAttributes     = flagutil.NewArrayString("opentelemetry.ignoreResourceAttributes", "Control which resource attributes to ignore, can only be set when 'opentelemetry.promoteAllResourceAttributes' is true.")
-)
-
-func ValidateFlags() {
-	if *promoteAllResourceAttributes && len(*promoteResourceAttributes) > 0 {
-		logger.Fatalf("cannot set both '-opentelemetry.promoteAllResourceAttributes' and '-opentelemetry.promoteResourceAttributes'")
-	}
-	if !*promoteAllResourceAttributes && len(*ignoreResourceAttributes) > 0 {
-		logger.Fatalf("'-opentelemetry.ignoreResourceAttributes' can only be set when '-opentelemetry.promoteAllResourceAttributes' is true.")
-	}
+type DecodeMetricsOptions struct {
+	DisableScopeMetadata      bool
+	DisableResourceAttributes bool
+	// ResourceAttributesList stored a list of resource attributes to ignore or promote based on the value of DisableResourceAttributes.
+	ResourceAttributesList map[string]struct{}
 }
 
 // MetricPusher must push the parsed samples and metric metadata to the underlying storage.
@@ -92,7 +81,7 @@ func (r *MetricsData) marshalProtobuf(mm *easyproto.MessageMarshaler) {
 }
 
 // DecodeMetricsData decodes metricsData from src and sends the decoded data to mp.
-func DecodeMetricsData(src []byte, mp MetricPusher) (err error) {
+func DecodeMetricsData(src []byte, mp MetricPusher, options DecodeMetricsOptions) (err error) {
 	// See https://github.com/open-telemetry/opentelemetry-proto/blob/049d4332834935792fd4dbd392ecd31904f99ba2/opentelemetry/proto/metrics/v1/metrics.proto#L56
 	//
 	// message MetricsData {
@@ -114,7 +103,7 @@ func DecodeMetricsData(src []byte, mp MetricPusher) (err error) {
 			if !ok {
 				return fmt.Errorf("cannot read ResourceMetrics data")
 			}
-			if err := dctx.decodeResourceMetrics(data); err != nil {
+			if err := dctx.decodeResourceMetrics(data, options); err != nil {
 				return fmt.Errorf("cannot unmarshal ResourceMetrics: %w", err)
 			}
 		}
@@ -139,7 +128,7 @@ func (rm *ResourceMetrics) marshalProtobuf(mm *easyproto.MessageMarshaler) {
 	}
 }
 
-func (dctx *decoderContext) decodeResourceMetrics(src []byte) error {
+func (dctx *decoderContext) decodeResourceMetrics(src []byte, options DecodeMetricsOptions) error {
 	// See https://github.com/open-telemetry/opentelemetry-proto/blob/049d4332834935792fd4dbd392ecd31904f99ba2/opentelemetry/proto/metrics/v1/metrics.proto#L66
 	//
 	// message ResourceMetrics {
@@ -150,20 +139,12 @@ func (dctx *decoderContext) decodeResourceMetrics(src []byte) error {
 	dctx.ls.Reset()
 	dctx.fb.reset()
 
-	attributes := *ignoreResourceAttributes
-	if !*promoteAllResourceAttributes {
-		attributes = *promoteResourceAttributes
-	}
-	attributeKeys := make(map[string]struct{}, len(attributes))
-	for _, a := range attributes {
-		attributeKeys[a] = struct{}{}
-	}
 	resourceData, ok, err := easyproto.GetMessageData(src, 1)
 	if err != nil {
 		return fmt.Errorf("cannot read Resource data: %w", err)
 	}
 	if ok {
-		if err := dctx.decodeResource(resourceData, *promoteAllResourceAttributes, attributeKeys); err != nil {
+		if err := dctx.decodeResource(resourceData, options.DisableResourceAttributes, options.ResourceAttributesList); err != nil {
 			return fmt.Errorf("cannot decode Resource: %w", err)
 		}
 	}
@@ -183,7 +164,7 @@ func (dctx *decoderContext) decodeResourceMetrics(src []byte) error {
 				return fmt.Errorf("cannot read ScopeMetrics data")
 			}
 
-			if err := dctx.decodeScopeMetrics(data); err != nil {
+			if err := dctx.decodeScopeMetrics(data, options.DisableScopeMetadata); err != nil {
 				return fmt.Errorf("cannot unmarshal ScopeMetrics: %w", err)
 			}
 
@@ -206,7 +187,7 @@ func (r *Resource) marshalProtobuf(mm *easyproto.MessageMarshaler) {
 	}
 }
 
-func (dctx *decoderContext) decodeResource(src []byte, promoteAllResourceAttributes bool, attributeKeys map[string]struct{}) (err error) {
+func (dctx *decoderContext) decodeResource(src []byte, disableResourceAttributes bool, attributeKeys map[string]struct{}) (err error) {
 	// See https://github.com/open-telemetry/opentelemetry-proto/blob/049d4332834935792fd4dbd392ecd31904f99ba2/opentelemetry/proto/resource/v1/resource.proto#L28
 	//
 	// message Resource {
@@ -234,10 +215,10 @@ func (dctx *decoderContext) decodeResource(src []byte, promoteAllResourceAttribu
 				// See https://github.com/VictoriaMetrics/VictoriaLogs/issues/869#issuecomment-3631307996
 				continue
 			}
-			if _, ok := attributeKeys[keySuffix]; ok == promoteAllResourceAttributes {
+			if _, ok := attributeKeys[keySuffix]; ok != disableResourceAttributes {
 				// Skip the attribute if:
-				// 1. it is in the list of ignore attributes when promoteAllResourceAttributes is true,
-				// 2. it isn't in the list of promote attributes when promoteAllResourceAttributes is false
+				// 1. it is in the list of ignore attributes when disableResourceAttributes is false,
+				// 2. it isn't in the list of promote attributes when disableResourceAttributes is true.
 				continue
 			}
 			key := dctx.fb.formatSubFieldName("", keySuffix)
@@ -504,7 +485,7 @@ func (sm *ScopeMetrics) marshalProtobuf(mm *easyproto.MessageMarshaler) {
 	}
 }
 
-func (dctx *decoderContext) decodeScopeMetrics(src []byte) error {
+func (dctx *decoderContext) decodeScopeMetrics(src []byte, disableScopeMetadata bool) error {
 	// See https://github.com/open-telemetry/opentelemetry-proto/blob/049d4332834935792fd4dbd392ecd31904f99ba2/opentelemetry/proto/metrics/v1/metrics.proto#L86
 	//
 	// message ScopeMetrics {
@@ -512,8 +493,7 @@ func (dctx *decoderContext) decodeScopeMetrics(src []byte) error {
 	//   repeated Metric metrics = 2;
 	// }
 
-	if *promoteScopeMetadata {
-
+	if !disableScopeMetadata {
 		scopeData, ok, err := easyproto.GetMessageData(src, 1)
 		if err != nil {
 			return fmt.Errorf("cannot read InstrumentationScope: %w", err)

--- a/lib/protoparser/opentelemetry/pb/pb.go
+++ b/lib/protoparser/opentelemetry/pb/pb.go
@@ -1,6 +1,7 @@
 package pb
 
 import (
+	"flag"
 	"fmt"
 	"math"
 	"strconv"
@@ -9,10 +10,27 @@ import (
 
 	"github.com/VictoriaMetrics/easyproto"
 
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/flagutil"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/logger"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/prompb"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/promutil"
 )
+
+var (
+	promoteScopeMetadata         = flag.Bool("opentelemetry.promoteScopeMetadata", true, "Whether to promote OTel scope metadata (i.e. name, version, schema URL, and attributes) to metric labels.")
+	promoteAllResourceAttributes = flag.Bool("opentelemetry.promoteAllResourceAttributes", true, "Whether to promote all resource attributes to labels, except for the ones configured with 'opentelemetry.ignoreResourceAttributes'.")
+	promoteResourceAttributes    = flagutil.NewArrayString("opentelemetry.promoteResourceAttributes", "Promote specific list of resource attributes to labels.")
+	ignoreResourceAttributes     = flagutil.NewArrayString("opentelemetry.ignoreResourceAttributes", "Control which resource attributes to ignore, can only be set when 'opentelemetry.promoteAllResourceAttributes' is true.")
+)
+
+func ValidateFlags() {
+	if *promoteAllResourceAttributes && len(*promoteResourceAttributes) > 0 {
+		logger.Fatalf("cannot set both '-opentelemetry.promoteAllResourceAttributes' and '-opentelemetry.promoteResourceAttributes'")
+	}
+	if !*promoteAllResourceAttributes && len(*ignoreResourceAttributes) > 0 {
+		logger.Fatalf("'-opentelemetry.ignoreResourceAttributes' can only be set when '-opentelemetry.promoteAllResourceAttributes' is true.")
+	}
+}
 
 // MetricPusher must push the parsed samples and metric metadata to the underlying storage.
 type MetricPusher interface {
@@ -132,12 +150,20 @@ func (dctx *decoderContext) decodeResourceMetrics(src []byte) error {
 	dctx.ls.Reset()
 	dctx.fb.reset()
 
+	attributes := *ignoreResourceAttributes
+	if !*promoteAllResourceAttributes {
+		attributes = *promoteResourceAttributes
+	}
+	attributeKeys := make(map[string]struct{}, len(attributes))
+	for _, a := range attributes {
+		attributeKeys[a] = struct{}{}
+	}
 	resourceData, ok, err := easyproto.GetMessageData(src, 1)
 	if err != nil {
 		return fmt.Errorf("cannot read Resource data: %w", err)
 	}
 	if ok {
-		if err := dctx.decodeResource(resourceData); err != nil {
+		if err := dctx.decodeResource(resourceData, *promoteAllResourceAttributes, attributeKeys); err != nil {
 			return fmt.Errorf("cannot decode Resource: %w", err)
 		}
 	}
@@ -180,7 +206,7 @@ func (r *Resource) marshalProtobuf(mm *easyproto.MessageMarshaler) {
 	}
 }
 
-func (dctx *decoderContext) decodeResource(src []byte) (err error) {
+func (dctx *decoderContext) decodeResource(src []byte, promoteAllResourceAttributes bool, attributeKeys map[string]struct{}) (err error) {
 	// See https://github.com/open-telemetry/opentelemetry-proto/blob/049d4332834935792fd4dbd392ecd31904f99ba2/opentelemetry/proto/resource/v1/resource.proto#L28
 	//
 	// message Resource {
@@ -199,7 +225,34 @@ func (dctx *decoderContext) decodeResource(src []byte) (err error) {
 			if !ok {
 				return fmt.Errorf("cannot read Attributes")
 			}
-			if err := decodeKeyValue(data, &dctx.ls, &dctx.fb, ""); err != nil {
+			keySuffix, ok, err := easyproto.GetString(data, 1)
+			if err != nil {
+				return fmt.Errorf("cannot find Key in KeyValue: %w", err)
+			}
+			if !ok {
+				// Key is missing, skip it.
+				// See https://github.com/VictoriaMetrics/VictoriaLogs/issues/869#issuecomment-3631307996
+				continue
+			}
+			if _, ok := attributeKeys[keySuffix]; ok == promoteAllResourceAttributes {
+				// Skip the attribute if:
+				// 1. it is in the list of ignore attributes when promoteAllResourceAttributes is true,
+				// 2. it isn't in the list of promote attributes when promoteAllResourceAttributes is false
+				continue
+			}
+			key := dctx.fb.formatSubFieldName("", keySuffix)
+
+			// Decode value
+			value, ok, err := easyproto.GetMessageData(data, 2)
+			if err != nil {
+				return fmt.Errorf("cannot find Value in KeyValue: %w", err)
+			}
+			if !ok {
+				// Value is null, skip it.
+				continue
+			}
+
+			if err := decodeAnyValue(value, &dctx.ls, &dctx.fb, key); err != nil {
 				return fmt.Errorf("cannot unmarshal Attributes: %w", err)
 			}
 		}
@@ -257,7 +310,6 @@ func decodeKeyValue(src []byte, ls *promutil.Labels, fb *fmtBuffer, keyPrefix st
 	if err := decodeAnyValue(valueData, ls, fb, key); err != nil {
 		return fmt.Errorf("cannot decode AnyValue: %w", err)
 	}
-
 	return nil
 }
 
@@ -460,19 +512,23 @@ func (dctx *decoderContext) decodeScopeMetrics(src []byte) error {
 	//   repeated Metric metrics = 2;
 	// }
 
-	scopeData, ok, err := easyproto.GetMessageData(src, 1)
-	if err != nil {
-		return fmt.Errorf("cannot read InstrumentationScope: %w", err)
-	}
-	if ok {
-		if err := dctx.decodeInstrumentationScope(scopeData); err != nil {
-			return fmt.Errorf("cannot decode InstrumentationScope: %w", err)
+	if *promoteScopeMetadata {
+
+		scopeData, ok, err := easyproto.GetMessageData(src, 1)
+		if err != nil {
+			return fmt.Errorf("cannot read InstrumentationScope: %w", err)
+		}
+		if ok {
+			if err := dctx.decodeInstrumentationScope(scopeData); err != nil {
+				return fmt.Errorf("cannot decode InstrumentationScope: %w", err)
+			}
 		}
 	}
 
 	dctxSnapshot := dctx.getSnapshot()
 
 	var fc easyproto.FieldContext
+	var err error
 	for len(src) > 0 {
 		src, err = fc.NextField(src)
 		if err != nil {

--- a/lib/protoparser/opentelemetry/pb/pb_test.go
+++ b/lib/protoparser/opentelemetry/pb/pb_test.go
@@ -1,13 +1,9 @@
 package pb
 
 import (
-	"fmt"
 	"reflect"
-	"sort"
-	"strings"
 	"testing"
 
-	"github.com/VictoriaMetrics/VictoriaMetrics/lib/flagutil"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/prompb"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/promutil"
 )
@@ -42,40 +38,38 @@ func (p *testMetricPusher) PushMetricMetadata(mm *MetricMetadata) {
 }
 
 func TestDecodeScopeMetrics(t *testing.T) {
-	buildMetricsData := func() []byte {
-		scopeName := "my-scope"
-		scopeVersion := "v1.0"
-		envVal := "prod"
-		intVal := int64(1)
-		md := &MetricsData{
-			ResourceMetrics: []*ResourceMetrics{
-				{
-					Resource: &Resource{
-						Attributes: []*KeyValue{
-							{Key: "job", Value: &AnyValue{StringValue: strPtr("vm")}},
-							{Key: "region", Value: &AnyValue{StringValue: strPtr("us-east-1")}},
-						},
+	scopeName := "my-scope"
+	scopeVersion := "v1.0"
+	envVal := "prod"
+	intVal := int64(1)
+	md := &MetricsData{
+		ResourceMetrics: []*ResourceMetrics{
+			{
+				Resource: &Resource{
+					Attributes: []*KeyValue{
+						{Key: "job", Value: &AnyValue{StringValue: new("vm")}},
+						{Key: "region", Value: &AnyValue{StringValue: new("us-east-1")}},
 					},
-					ScopeMetrics: []*ScopeMetrics{
-						{
-							Scope: &InstrumentationScope{
-								Name:    &scopeName,
-								Version: &scopeVersion,
-								Attributes: []*KeyValue{
-									{Key: "env", Value: &AnyValue{StringValue: &envVal}},
-								},
+				},
+				ScopeMetrics: []*ScopeMetrics{
+					{
+						Scope: &InstrumentationScope{
+							Name:    &scopeName,
+							Version: &scopeVersion,
+							Attributes: []*KeyValue{
+								{Key: "env", Value: &AnyValue{StringValue: &envVal}},
 							},
-							Metrics: []*Metric{
-								{
-									Name:        "my-gauge",
-									Description: "a test gauge",
-									Gauge: &Gauge{
-										DataPoints: []*NumberDataPoint{
-											{
-												Attributes:   []*KeyValue{{Key: "label1", Value: &AnyValue{StringValue: strPtr("value1")}}},
-												IntValue:     &intVal,
-												TimeUnixNano: 1000,
-											},
+						},
+						Metrics: []*Metric{
+							{
+								Name:        "my-gauge",
+								Description: "a test gauge",
+								Gauge: &Gauge{
+									DataPoints: []*NumberDataPoint{
+										{
+											Attributes:   []*KeyValue{{Key: "label1", Value: &AnyValue{StringValue: new("value1")}}},
+											IntValue:     &intVal,
+											TimeUnixNano: 1000,
 										},
 									},
 								},
@@ -84,136 +78,89 @@ func TestDecodeScopeMetrics(t *testing.T) {
 					},
 				},
 			},
-		}
-		return md.MarshalProtobuf(nil)
+		},
 	}
+	data := md.MarshalProtobuf(nil)
 
-	decode := func(t *testing.T, data []byte) []prompb.Label {
+	f := func(options DecodeMetricsOptions, wantLabels map[string]string) {
 		t.Helper()
 		mp := &testMetricPusher{}
-		if err := DecodeMetricsData(data, mp); err != nil {
+		if err := DecodeMetricsData(data, mp, options); err != nil {
 			t.Fatalf("DecodeMetricsData error: %v", err)
 		}
 		if len(mp.samples) != 1 {
 			t.Fatalf("expected 1 sample, got %d", len(mp.samples))
 		}
-		return mp.samples[0].labels
-	}
-
-	checkLabels := func(t *testing.T, got []prompb.Label, want map[string]string) {
-		t.Helper()
-		gotMap := make(map[string]string, len(got))
-		for _, l := range got {
-			gotMap[string([]byte(l.Name))] = string([]byte(l.Value))
+		gotMap := make(map[string]string, len(mp.samples[0].labels))
+		for _, l := range mp.samples[0].labels {
+			gotMap[l.Name] = l.Value
 		}
-		if !reflect.DeepEqual(gotMap, want) {
-			t.Errorf("unexpected labels:\n got:  %s\n want: %s", fmtLabelMap(gotMap), fmtLabelMap(want))
+		if !reflect.DeepEqual(gotMap, wantLabels) {
+			t.Errorf("unexpected labels:\n got:  %v\n want: %v", gotMap, wantLabels)
 		}
 	}
 
-	// (default) promoteScopeMetadata=true + promoteAllResourceAttributes=true:
+	// PromoteScopeMetadata=true + PromoteAllResourceAttributes=true:
 	// got all scope labels and resource attrs
-	t.Run("scope_and_all_resource_attrs", func(t *testing.T) {
-		labels := decode(t, buildMetricsData())
-		checkLabels(t, labels, map[string]string{
-			"job":                  "vm",
-			"region":               "us-east-1",
-			"scope.name":           "my-scope",
-			"scope.version":        "v1.0",
-			"scope.attributes.env": "prod",
-			"label1":               "value1",
-		})
+	f(DecodeMetricsOptions{
+		DisableScopeMetadata:      false,
+		DisableResourceAttributes: false,
+	}, map[string]string{
+		"job":                  "vm",
+		"region":               "us-east-1",
+		"scope.name":           "my-scope",
+		"scope.version":        "v1.0",
+		"scope.attributes.env": "prod",
+		"label1":               "value1",
 	})
 
-	// promoteScopeMetadata=false + promoteAllResourceAttributes=true:
-	// got all resource attrs, no scope labels.
-	t.Run("no_scope_all_resource_attrs", func(t *testing.T) {
-		prevScope := *promoteScopeMetadata
-		*promoteScopeMetadata = false
-		defer func() { *promoteScopeMetadata = prevScope }()
-
-		labels := decode(t, buildMetricsData())
-		checkLabels(t, labels, map[string]string{
-			"job":    "vm",
-			"region": "us-east-1",
-			"label1": "value1",
-		})
+	// PromoteScopeMetadata=false + PromoteAllResourceAttributes=true:
+	// got all resource attrs, no scope labels
+	f(DecodeMetricsOptions{
+		DisableScopeMetadata:      true,
+		DisableResourceAttributes: false,
+	}, map[string]string{
+		"job":    "vm",
+		"region": "us-east-1",
+		"label1": "value1",
 	})
 
-	// promoteScopeMetadata=true + promoteAllResourceAttributes=false + promoteResourceAttributes=[region]:
-	// got the `region`` attr
-	t.Run("scope_selected_resource_attrs", func(t *testing.T) {
-		prevAll := *promoteAllResourceAttributes
-		*promoteAllResourceAttributes = false
-		defer func() { *promoteAllResourceAttributes = prevAll }()
-
-		prevPromote := *promoteResourceAttributes
-		*promoteResourceAttributes = flagutil.ArrayString{"region"}
-		defer func() { *promoteResourceAttributes = prevPromote }()
-
-		labels := decode(t, buildMetricsData())
-		checkLabels(t, labels, map[string]string{
-			"region":               "us-east-1",
-			"scope.name":           "my-scope",
-			"scope.version":        "v1.0",
-			"scope.attributes.env": "prod",
-			"label1":               "value1",
-		})
+	// PromoteScopeMetadata=true + PromoteAllResourceAttributes=false + ResourceAttributesList=[region]:
+	// got only the `region` attr from resource
+	f(DecodeMetricsOptions{
+		DisableScopeMetadata:      false,
+		DisableResourceAttributes: true,
+		ResourceAttributesList:    map[string]struct{}{"region": {}},
+	}, map[string]string{
+		"region":               "us-east-1",
+		"scope.name":           "my-scope",
+		"scope.version":        "v1.0",
+		"scope.attributes.env": "prod",
+		"label1":               "value1",
 	})
 
-	// promoteScopeMetadata=true + promoteAllResourceAttributes=true + ignoreResourceAttributes=[region]:
-	// got all resource attrs except `region`
-	t.Run("scope_all_resource_attrs_ignore_region", func(t *testing.T) {
-		prevIgnore := *ignoreResourceAttributes
-		*ignoreResourceAttributes = flagutil.ArrayString{"region"}
-		defer func() { *ignoreResourceAttributes = prevIgnore }()
-
-		labels := decode(t, buildMetricsData())
-		checkLabels(t, labels, map[string]string{
-			"job":                  "vm",
-			"scope.name":           "my-scope",
-			"scope.version":        "v1.0",
-			"scope.attributes.env": "prod",
-			"label1":               "value1",
-		})
+	// PromoteScopeMetadata=true + PromoteAllResourceAttributes=true + ResourceAttributesList=[region]:
+	// got all resource attrs except `region` (ignore list)
+	f(DecodeMetricsOptions{
+		DisableScopeMetadata:      false,
+		DisableResourceAttributes: false,
+		ResourceAttributesList:    map[string]struct{}{"region": {}},
+	}, map[string]string{
+		"job":                  "vm",
+		"scope.name":           "my-scope",
+		"scope.version":        "v1.0",
+		"scope.attributes.env": "prod",
+		"label1":               "value1",
 	})
 
-	// promoteScopeMetadata=false + promoteAllResourceAttributes=false + promoteResourceAttributes=[job]:
+	// PromoteScopeMetadata=false + PromoteAllResourceAttributes=false + ResourceAttributesList=[job]:
 	// got only `job` attr
-	t.Run("no_scope_selected_resource_attrs", func(t *testing.T) {
-		prevScope := *promoteScopeMetadata
-		*promoteScopeMetadata = false
-		defer func() { *promoteScopeMetadata = prevScope }()
-
-		prevAll := *promoteAllResourceAttributes
-		*promoteAllResourceAttributes = false
-		defer func() { *promoteAllResourceAttributes = prevAll }()
-
-		prevPromote := *promoteResourceAttributes
-		*promoteResourceAttributes = flagutil.ArrayString{"job"}
-		defer func() { *promoteResourceAttributes = prevPromote }()
-
-		labels := decode(t, buildMetricsData())
-		checkLabels(t, labels, map[string]string{
-			"job":    "vm",
-			"label1": "value1",
-		})
+	f(DecodeMetricsOptions{
+		DisableScopeMetadata:      true,
+		DisableResourceAttributes: true,
+		ResourceAttributesList:    map[string]struct{}{"job": {}},
+	}, map[string]string{
+		"job":    "vm",
+		"label1": "value1",
 	})
-}
-
-func strPtr(s string) *string {
-	return &s
-}
-
-func fmtLabelMap(m map[string]string) string {
-	keys := make([]string, 0, len(m))
-	for k := range m {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-	parts := make([]string, len(keys))
-	for i, k := range keys {
-		parts[i] = fmt.Sprintf("%s=%q", k, m[k])
-	}
-	return "{" + strings.Join(parts, ", ") + "}"
 }

--- a/lib/protoparser/opentelemetry/pb/pb_test.go
+++ b/lib/protoparser/opentelemetry/pb/pb_test.go
@@ -1,0 +1,219 @@
+package pb
+
+import (
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/flagutil"
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/prompb"
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/promutil"
+)
+
+type testMetricPusher struct {
+	samples  []testSample
+	metadata []MetricMetadata
+}
+
+type testSample struct {
+	mm     MetricMetadata
+	suffix string
+	labels []prompb.Label
+	ts     uint64
+	value  float64
+}
+
+func (p *testMetricPusher) PushSample(mm *MetricMetadata, suffix string, ls *promutil.Labels, timestampNsecs uint64, value float64, _ uint32) {
+	labels := make([]prompb.Label, len(ls.Labels))
+	copy(labels, ls.Labels)
+	p.samples = append(p.samples, testSample{
+		mm:     *mm,
+		suffix: suffix,
+		labels: labels,
+		ts:     timestampNsecs,
+		value:  value,
+	})
+}
+
+func (p *testMetricPusher) PushMetricMetadata(mm *MetricMetadata) {
+	p.metadata = append(p.metadata, *mm)
+}
+
+func TestDecodeScopeMetrics(t *testing.T) {
+	buildMetricsData := func() []byte {
+		scopeName := "my-scope"
+		scopeVersion := "v1.0"
+		envVal := "prod"
+		intVal := int64(1)
+		md := &MetricsData{
+			ResourceMetrics: []*ResourceMetrics{
+				{
+					Resource: &Resource{
+						Attributes: []*KeyValue{
+							{Key: "job", Value: &AnyValue{StringValue: strPtr("vm")}},
+							{Key: "region", Value: &AnyValue{StringValue: strPtr("us-east-1")}},
+						},
+					},
+					ScopeMetrics: []*ScopeMetrics{
+						{
+							Scope: &InstrumentationScope{
+								Name:    &scopeName,
+								Version: &scopeVersion,
+								Attributes: []*KeyValue{
+									{Key: "env", Value: &AnyValue{StringValue: &envVal}},
+								},
+							},
+							Metrics: []*Metric{
+								{
+									Name:        "my-gauge",
+									Description: "a test gauge",
+									Gauge: &Gauge{
+										DataPoints: []*NumberDataPoint{
+											{
+												Attributes:   []*KeyValue{{Key: "label1", Value: &AnyValue{StringValue: strPtr("value1")}}},
+												IntValue:     &intVal,
+												TimeUnixNano: 1000,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		return md.MarshalProtobuf(nil)
+	}
+
+	decode := func(t *testing.T, data []byte) []prompb.Label {
+		t.Helper()
+		mp := &testMetricPusher{}
+		if err := DecodeMetricsData(data, mp); err != nil {
+			t.Fatalf("DecodeMetricsData error: %v", err)
+		}
+		if len(mp.samples) != 1 {
+			t.Fatalf("expected 1 sample, got %d", len(mp.samples))
+		}
+		return mp.samples[0].labels
+	}
+
+	checkLabels := func(t *testing.T, got []prompb.Label, want map[string]string) {
+		t.Helper()
+		gotMap := make(map[string]string, len(got))
+		for _, l := range got {
+			gotMap[string([]byte(l.Name))] = string([]byte(l.Value))
+		}
+		if !reflect.DeepEqual(gotMap, want) {
+			t.Errorf("unexpected labels:\n got:  %s\n want: %s", fmtLabelMap(gotMap), fmtLabelMap(want))
+		}
+	}
+
+	// (default) promoteScopeMetadata=true + promoteAllResourceAttributes=true:
+	// got all scope labels and resource attrs
+	t.Run("scope_and_all_resource_attrs", func(t *testing.T) {
+		labels := decode(t, buildMetricsData())
+		checkLabels(t, labels, map[string]string{
+			"job":                  "vm",
+			"region":               "us-east-1",
+			"scope.name":           "my-scope",
+			"scope.version":        "v1.0",
+			"scope.attributes.env": "prod",
+			"label1":               "value1",
+		})
+	})
+
+	// promoteScopeMetadata=false + promoteAllResourceAttributes=true:
+	// got all resource attrs, no scope labels.
+	t.Run("no_scope_all_resource_attrs", func(t *testing.T) {
+		prevScope := *promoteScopeMetadata
+		*promoteScopeMetadata = false
+		defer func() { *promoteScopeMetadata = prevScope }()
+
+		labels := decode(t, buildMetricsData())
+		checkLabels(t, labels, map[string]string{
+			"job":    "vm",
+			"region": "us-east-1",
+			"label1": "value1",
+		})
+	})
+
+	// promoteScopeMetadata=true + promoteAllResourceAttributes=false + promoteResourceAttributes=[region]:
+	// got the `region`` attr
+	t.Run("scope_selected_resource_attrs", func(t *testing.T) {
+		prevAll := *promoteAllResourceAttributes
+		*promoteAllResourceAttributes = false
+		defer func() { *promoteAllResourceAttributes = prevAll }()
+
+		prevPromote := *promoteResourceAttributes
+		*promoteResourceAttributes = flagutil.ArrayString{"region"}
+		defer func() { *promoteResourceAttributes = prevPromote }()
+
+		labels := decode(t, buildMetricsData())
+		checkLabels(t, labels, map[string]string{
+			"region":               "us-east-1",
+			"scope.name":           "my-scope",
+			"scope.version":        "v1.0",
+			"scope.attributes.env": "prod",
+			"label1":               "value1",
+		})
+	})
+
+	// promoteScopeMetadata=true + promoteAllResourceAttributes=true + ignoreResourceAttributes=[region]:
+	// got all resource attrs except `region`
+	t.Run("scope_all_resource_attrs_ignore_region", func(t *testing.T) {
+		prevIgnore := *ignoreResourceAttributes
+		*ignoreResourceAttributes = flagutil.ArrayString{"region"}
+		defer func() { *ignoreResourceAttributes = prevIgnore }()
+
+		labels := decode(t, buildMetricsData())
+		checkLabels(t, labels, map[string]string{
+			"job":                  "vm",
+			"scope.name":           "my-scope",
+			"scope.version":        "v1.0",
+			"scope.attributes.env": "prod",
+			"label1":               "value1",
+		})
+	})
+
+	// promoteScopeMetadata=false + promoteAllResourceAttributes=false + promoteResourceAttributes=[job]:
+	// got only `job` attr
+	t.Run("no_scope_selected_resource_attrs", func(t *testing.T) {
+		prevScope := *promoteScopeMetadata
+		*promoteScopeMetadata = false
+		defer func() { *promoteScopeMetadata = prevScope }()
+
+		prevAll := *promoteAllResourceAttributes
+		*promoteAllResourceAttributes = false
+		defer func() { *promoteAllResourceAttributes = prevAll }()
+
+		prevPromote := *promoteResourceAttributes
+		*promoteResourceAttributes = flagutil.ArrayString{"job"}
+		defer func() { *promoteResourceAttributes = prevPromote }()
+
+		labels := decode(t, buildMetricsData())
+		checkLabels(t, labels, map[string]string{
+			"job":    "vm",
+			"label1": "value1",
+		})
+	})
+}
+
+func strPtr(s string) *string {
+	return &s
+}
+
+func fmtLabelMap(m map[string]string) string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	parts := make([]string, len(keys))
+	for i, k := range keys {
+		parts[i] = fmt.Sprintf("%s=%q", k, m[k])
+	}
+	return "{" + strings.Join(parts, ", ") + "}"
+}

--- a/lib/protoparser/opentelemetry/stream/streamparser.go
+++ b/lib/protoparser/opentelemetry/stream/streamparser.go
@@ -1,6 +1,7 @@
 package stream
 
 import (
+	"flag"
 	"fmt"
 	"io"
 	"sync"
@@ -10,13 +11,42 @@ import (
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/bytesutil"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/decimal"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/flagutil"
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/logger"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/prompb"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/promutil"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/protoparser/opentelemetry/pb"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/protoparser/protoparserutil"
 )
 
-var maxRequestSize = flagutil.NewBytes("opentelemetry.maxRequestSize", 64*1024*1024, "The maximum size in bytes of a single OpenTelemetry request")
+var (
+	maxRequestSize = flagutil.NewBytes("opentelemetry.maxRequestSize", 64*1024*1024, "The maximum size in bytes of a single OpenTelemetry request")
+
+	promoteScopeMetadata         = flag.Bool("opentelemetry.promoteScopeMetadata", true, "Whether to promote OTel scope metadata (i.e. name, version, schema URL, and attributes) to metric labels.")
+	promoteAllResourceAttributes = flag.Bool("opentelemetry.promoteAllResourceAttributes", true, "Whether to promote all resource attributes to labels, except for the ones configured with 'opentelemetry.ignoreResourceAttributes'.")
+	promoteResourceAttributes    = flagutil.NewArrayString("opentelemetry.promoteResourceAttributes", "Promote specific list of resource attributes to labels.")
+	ignoreResourceAttributes     = flagutil.NewArrayString("opentelemetry.ignoreResourceAttributes", "Control which resource attributes to ignore, can only be set when 'opentelemetry.promoteAllResourceAttributes' is true.")
+)
+
+func InitDecodeOptions() {
+	if *promoteAllResourceAttributes && len(*promoteResourceAttributes) > 0 {
+		logger.Fatalf("cannot set both '-opentelemetry.promoteAllResourceAttributes' and '-opentelemetry.promoteResourceAttributes'")
+	}
+	if !*promoteAllResourceAttributes && len(*ignoreResourceAttributes) > 0 {
+		logger.Fatalf("'-opentelemetry.ignoreResourceAttributes' can only be set when '-opentelemetry.promoteAllResourceAttributes' is true.")
+	}
+	defaultDecodeMetricsOptions.DisableScopeMetadata = !*promoteScopeMetadata
+	defaultDecodeMetricsOptions.DisableResourceAttributes = !*promoteAllResourceAttributes
+	attributes := *ignoreResourceAttributes
+	if !*promoteAllResourceAttributes {
+		attributes = *promoteResourceAttributes
+	}
+	defaultDecodeMetricsOptions.ResourceAttributesList = make(map[string]struct{}, len(attributes))
+	for _, a := range attributes {
+		defaultDecodeMetricsOptions.ResourceAttributesList[a] = struct{}{}
+	}
+}
+
+var defaultDecodeMetricsOptions = pb.DecodeMetricsOptions{}
 
 // ParseStream parses OpenTelemetry protobuf or json data from r and calls callback for the parsed rows.
 //
@@ -47,7 +77,7 @@ func parseData(data []byte, callback func(tss []prompb.TimeSeries, mms []prompb.
 	// the flushFunc will be called multiple time if the request is big, to avoid over allocating memory for such request.
 	wctx.flushFunc = callback
 
-	if err := pb.DecodeMetricsData(data, wctx); err != nil {
+	if err := pb.DecodeMetricsData(data, wctx, defaultDecodeMetricsOptions); err != nil {
 		return fmt.Errorf("cannot unmarshal request from %d bytes: %w", len(data), err)
 	}
 

--- a/lib/protoparser/opentelemetry/stream/streamparser.go
+++ b/lib/protoparser/opentelemetry/stream/streamparser.go
@@ -27,6 +27,7 @@ var (
 	ignoreResourceAttributes     = flagutil.NewArrayString("opentelemetry.ignoreResourceAttributes", "Control which resource attributes to ignore, can only be set when 'opentelemetry.promoteAllResourceAttributes' is true.")
 )
 
+// InitDecodeOptions configures decoding settings for the parser
 func InitDecodeOptions() {
 	if *promoteAllResourceAttributes && len(*promoteResourceAttributes) > 0 {
 		logger.Fatalf("cannot set both '-opentelemetry.promoteAllResourceAttributes' and '-opentelemetry.promoteResourceAttributes'")


### PR DESCRIPTION
fix https://github.com/VictoriaMetrics/VictoriaMetrics/issues/10931.
This change adds four flags to allow managing label promotion for resource attributes and OTel scope metadata, while staying compatible with [Prometheus](https://prometheus.io/docs/prometheus/latest/configuration/configuration/):
- `-opentelemetry.promoteScopeMetadata` - promote OTel scope metadata (i.e. name, version, schema URL, and attributes) to metric labels. 
- `opentelemetry.promoteAllResourceAttributes` - promote all resource attributes to labels, except for the ones configured with `-opentelemetry.ignoreResourceAttributes`.
- `opentelemetry.promoteResourceAttributes` - promote specific list of resource attributes to labels. It cannot be configured simultaneously with `opentelemetry.promoteAllResourceAttributes`. 
- `opentelemetry.ignoreResourceAttributes` - which resource attributes to ignore, can only be set when `opentelemetry.promoteAllResourceAttributes` is true.

`-opentelemetry.promoteScopeMetadata` and `opentelemetry.promoteAllResourceAttributes` are enabled by default in order to preserve the current behavior.