### PR TITLE
docs: add retention related content to quick start guide #Productionization section

### DIFF
--- a/docs/victoriametrics/Quick-Start.md
+++ b/docs/victoriametrics/Quick-Start.md
@@ -440,7 +440,7 @@ VictoriaMetrics Single-node and `vmstorage` in VictoriaMetrics Cluster retain da
 Data older than the retention period will be automatically deleted. To change the retention period, use the `-retentionPeriod` flag (e.g. `-retentionPeriod=90d`).
 See the [retention](https://docs.victoriametrics.com/victoriametrics/#retention) documentation for more details. 
 
-If free disk space falls below `-storage.minFreeDiskSpaceBytes` (default `100000000` bytes), VictoriaMetrics Single-node or `vmstorage` switches to read-only mode and stops accepting new data. To prevent this, ensure proper [capacity planning](#capacity-planning) and set up monitoring and alerting for disk usage.
+If free disk space falls below `-storage.minFreeDiskSpaceBytes`, VictoriaMetrics Single-node or `vmstorage` switches to read-only mode and stops accepting new data. To prevent this, ensure proper [capacity planning](#capacity-planning) and set up monitoring and alerting for disk usage.
 
 ### Capacity planning
 

--- a/docs/victoriametrics/Quick-Start.md
+++ b/docs/victoriametrics/Quick-Start.md
@@ -441,8 +441,8 @@ See the [Retention](https://docs.victoriametrics.com/victoriametrics/#retention)
 
 This flag's value affects [capacity planning](#capacity-planning).
 
-If `vmstorage` nodes in a VictoriaMetrics cluster run out of disk space (via `-minFreeDiskSpaceBytes`) before data retention expires, they will enter [read-only mode](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/#readonly-mode).
-`vminsert` nodes stop sending data to such nodes and start re-routing the data to the remaining `vmstorage` nodes.
+If VictoriaMetrics single-node or `vmstorage` run out of disk space (defined by `-minFreeDiskSpaceBytes`) before data retention expires, they will stop accepting new data.
+`vmstorage` will enter [read-only mode](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/#readonly-mode). `vminsert` nodes cease sending data to these nodes and reroute traffic to other available `vmstorage` nodes instead.
 
 ### Capacity planning
 

--- a/docs/victoriametrics/Quick-Start.md
+++ b/docs/victoriametrics/Quick-Start.md
@@ -436,13 +436,11 @@ See more details in the article [VictoriaMetrics Monitoring](https://victoriamet
 
 ### Retention
 
-VictoriaMetrics Single-node and `vmstorage` in VictoriaMetrics Cluster retain data for 1 month (`1M`) by default via the `--retentionPeriod` flag.
-See the [Retention](https://docs.victoriametrics.com/victoriametrics/#retention) section in the documentation for more details.
+VictoriaMetrics Single-node and `vmstorage` in VictoriaMetrics Cluster retain data for 1 month by default.
+Data older than the retention period will be automatically deleted. To change the retention period, use the `-retentionPeriod` flag (e.g. `-retentionPeriod=90d`).
+See the [retention](https://docs.victoriametrics.com/victoriametrics/#retention) documentation for more details. 
 
-This flag's value affects [capacity planning](#capacity-planning).
-
-If VictoriaMetrics Single-node or `vmstorage` run out of disk space (defined by `-storage.minFreeDiskSpaceBytes`) before data retention expires, they will stop accepting new data.
-`vmstorage` will enter [read-only mode](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/#readonly-mode). `vminsert` nodes cease sending data to these nodes and reroute traffic to other available `vmstorage` nodes instead.
+If free disk space falls below `-storage.minFreeDiskSpaceBytes` (default `100000000` bytes), VictoriaMetrics Single-node or `vmstorage` switches to read-only mode and stops accepting new data. To prevent this, ensure proper [capacity planning](#capacity-planning) and set up monitoring and alerting for disk usage.
 
 ### Capacity planning
 

--- a/docs/victoriametrics/Quick-Start.md
+++ b/docs/victoriametrics/Quick-Start.md
@@ -436,10 +436,13 @@ See more details in the article [VictoriaMetrics Monitoring](https://victoriamet
 
 ### Retention
 
-VictoriaMetrics single-node and vmstorage in VictoriaMetrics Cluster retain data for 1 month (`1M`) by default via the `--retentionPeriod` flag.
+VictoriaMetrics single-node and `vmstorage` in VictoriaMetrics Cluster retain data for 1 month (`1M`) by default via the `--retentionPeriod` flag.
 See the [Retention](https://docs.victoriametrics.com/victoriametrics/#retention) section in the documentation for more details.
 
 This flag's value affects [capacity planning](#capacity-planning).
+
+If `vmstorage` nodes in a VictoriaMetrics cluster run out of disk space (via `-minFreeDiskSpaceBytes`) before data retention expires, they will enter [read-only mode](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/#readonly-mode).
+`vminsert` nodes stop sending data to such nodes and start re-routing the data to the remaining `vmstorage` nodes.
 
 ### Capacity planning
 

--- a/docs/victoriametrics/Quick-Start.md
+++ b/docs/victoriametrics/Quick-Start.md
@@ -147,7 +147,7 @@ After=network.target
 Type=simple
 User=victoriametrics
 Group=victoriametrics
-ExecStart=/usr/local/bin/victoria-metrics-prod -storageDataPath=/var/lib/victoria-metrics -retentionPeriod=90d -selfScrapeInterval=10s
+ExecStart=/usr/local/bin/victoria-metrics-prod -storageDataPath=/var/lib/victoria-metrics -selfScrapeInterval=10s
 SyslogIdentifier=victoriametrics
 Restart=always
 
@@ -231,7 +231,7 @@ Type=simple
 User=victoriametrics
 Group=victoriametrics
 Restart=always
-ExecStart=/usr/local/bin/vmstorage-prod -retentionPeriod=90d -storageDataPath=/var/lib/vmstorage
+ExecStart=/usr/local/bin/vmstorage-prod -storageDataPath=/var/lib/vmstorage
 
 PrivateTmp=yes
 NoNewPrivileges=yes
@@ -435,6 +435,10 @@ the main monitoring installation.
 See more details in the article [VictoriaMetrics Monitoring](https://victoriametrics.com/blog/victoriametrics-monitoring/).
 
 ### Capacity planning
+
+It should be noted that VictoriaMetrics Single-node and vmstorage in VictoriaMetrics Cluster retain data for one month (`1M`) by default via the `--retentionPeriod` flag.
+Refer to the [Retention](https://docs.victoriametrics.com/victoriametrics/#retention) section for further details.
+You may adjust this value based on your actual needs after completing reasonable capacity planning.
 
 See capacity planning sections in [docs](https://docs.victoriametrics.com) for
 [Single-server-VictoriaMetrics](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#capacity-planning)

--- a/docs/victoriametrics/Quick-Start.md
+++ b/docs/victoriametrics/Quick-Start.md
@@ -441,7 +441,7 @@ See the [Retention](https://docs.victoriametrics.com/victoriametrics/#retention)
 
 This flag's value affects [capacity planning](#capacity-planning).
 
-If VictoriaMetrics Single-node or `vmstorage` run out of disk space (defined by `-minFreeDiskSpaceBytes`) before data retention expires, they will stop accepting new data.
+If VictoriaMetrics Single-node or `vmstorage` run out of disk space (defined by `-storage.minFreeDiskSpaceBytes`) before data retention expires, they will stop accepting new data.
 `vmstorage` will enter [read-only mode](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/#readonly-mode). `vminsert` nodes cease sending data to these nodes and reroute traffic to other available `vmstorage` nodes instead.
 
 ### Capacity planning

--- a/docs/victoriametrics/Quick-Start.md
+++ b/docs/victoriametrics/Quick-Start.md
@@ -434,11 +434,14 @@ the main monitoring installation.
 
 See more details in the article [VictoriaMetrics Monitoring](https://victoriametrics.com/blog/victoriametrics-monitoring/).
 
-### Capacity planning
+### Retention
 
-It should be noted that VictoriaMetrics Single-node and vmstorage in VictoriaMetrics Cluster retain data for one month (`1M`) by default via the `--retentionPeriod` flag.
-Refer to the [Retention](https://docs.victoriametrics.com/victoriametrics/#retention) section for further details.
-You may adjust this value based on your actual needs after completing reasonable capacity planning.
+VictoriaMetrics single-node and vmstorage in VictoriaMetrics Cluster retain data for 1 month (`1M`) by default via the `--retentionPeriod` flag.
+See the [Retention](https://docs.victoriametrics.com/victoriametrics/#retention) section in the documentation for more details.
+
+This flag's value affects [capacity planning](#capacity-planning).
+
+### Capacity planning
 
 See capacity planning sections in [docs](https://docs.victoriametrics.com) for
 [Single-server-VictoriaMetrics](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#capacity-planning)

--- a/docs/victoriametrics/Quick-Start.md
+++ b/docs/victoriametrics/Quick-Start.md
@@ -436,12 +436,12 @@ See more details in the article [VictoriaMetrics Monitoring](https://victoriamet
 
 ### Retention
 
-VictoriaMetrics single-node and `vmstorage` in VictoriaMetrics Cluster retain data for 1 month (`1M`) by default via the `--retentionPeriod` flag.
+VictoriaMetrics Single-node and `vmstorage` in VictoriaMetrics Cluster retain data for 1 month (`1M`) by default via the `--retentionPeriod` flag.
 See the [Retention](https://docs.victoriametrics.com/victoriametrics/#retention) section in the documentation for more details.
 
 This flag's value affects [capacity planning](#capacity-planning).
 
-If VictoriaMetrics single-node or `vmstorage` run out of disk space (defined by `-minFreeDiskSpaceBytes`) before data retention expires, they will stop accepting new data.
+If VictoriaMetrics Single-node or `vmstorage` run out of disk space (defined by `-minFreeDiskSpaceBytes`) before data retention expires, they will stop accepting new data.
 `vmstorage` will enter [read-only mode](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/#readonly-mode). `vminsert` nodes cease sending data to these nodes and reroute traffic to other available `vmstorage` nodes instead.
 
 ### Capacity planning


### PR DESCRIPTION
The `--retentionPeriod` flag is missing in several quick start guide examples. This may cause users to overlook the parameter and incorrectly believe data will be stored permanently until manually deleted.

But the quick start guide is not intended for production deployment, and we have dedicated section `#Productionization` there already. We should mention `--retentionPeriod` flag in this section.

This change could be helpful to https://github.com/VictoriaMetrics/VictoriaMetrics/issues/249#issuecomment-4468637250