### PR TITLE
Makefile: add govulncheck-docker target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,6 @@ GO_BUILDINFO = -X '$(PKG_PREFIX)/lib/buildinfo.Version=$(APP_NAME)-$(DATEINFO_TA
 TAR_OWNERSHIP ?= --owner=1000 --group=1000
 
 GOLANGCI_LINT_VERSION := 2.9.0
-# keep in sync with GO_BUILDER_IMAGE from deployment/docker/Makefile
-GOVULNCHECK_IMAGE := golang:1.26.3
 
 .PHONY: $(MAKECMDGOALS)
 
@@ -538,7 +536,7 @@ govulncheck: install-govulncheck
 	govulncheck ./...
 
 govulncheck-docker:
-	docker run -w $(PWD) -v $(PWD):$(PWD) "$(GOVULNCHECK_IMAGE)" /bin/sh -c "go install golang.org/x/vuln/cmd/govulncheck@latest && govulncheck ./..."
+	docker run -w $(PWD) -v $(PWD):$(PWD) "$(GO_BUILDER_IMAGE)" /bin/sh -c "go install golang.org/x/vuln/cmd/govulncheck@latest && govulncheck ./..."
 
 install-govulncheck:
 	which govulncheck || go install golang.org/x/vuln/cmd/govulncheck@latest

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,8 @@ GO_BUILDINFO = -X '$(PKG_PREFIX)/lib/buildinfo.Version=$(APP_NAME)-$(DATEINFO_TA
 TAR_OWNERSHIP ?= --owner=1000 --group=1000
 
 GOLANGCI_LINT_VERSION := 2.9.0
+# keep in sync with GO_BUILDER_IMAGE from deployment/docker/Makefile
+GOVULNCHECK_IMAGE := golang:1.26.3
 
 .PHONY: $(MAKECMDGOALS)
 
@@ -534,6 +536,9 @@ remove-golangci-lint:
 
 govulncheck: install-govulncheck
 	govulncheck ./...
+
+govulncheck-docker:
+	docker run -w $(PWD) -v $(PWD):$(PWD) "$(GOVULNCHECK_IMAGE)" /bin/sh -c "go install golang.org/x/vuln/cmd/govulncheck@latest && govulncheck ./..."
 
 install-govulncheck:
 	which govulncheck || go install golang.org/x/vuln/cmd/govulncheck@latest


### PR DESCRIPTION
govulncheck run locally uses the local Go version, which may differ from the one used to build production binaries.

For example, local go1.26.2 may report vulnerabilities already fixed in go1.26.3 used by the builder.
In this case the command would report issues which has to be manually triaged by a developer.

Add govulncheck-docker target that runs govulncheck inside a Docker container using the same version used to build production binaries.

The command will be used in release scripts and could be used manually. 