### PR TITLE
lib/persistentqueue: skip zero-length blocks as corrupt data in readBlock

### DIFF
--- a/app/vmagent/remotewrite/client.go
+++ b/app/vmagent/remotewrite/client.go
@@ -311,11 +311,6 @@ func (c *client) runWorker() {
 		if !ok {
 			return
 		}
-		if len(block) == 0 {
-			// skip empty data blocks from sending
-			// see https://github.com/VictoriaMetrics/VictoriaMetrics/pull/6241
-			continue
-		}
 		go func() {
 			startTime := time.Now()
 			ch <- c.sendBlock(block)
@@ -529,10 +524,6 @@ func (c *client) drainInMemoryQueue(stopCtx context.Context, block []byte) {
 			// or persisted queue is being used.
 			// In this case it is guaranteed that fq will be empty
 			return
-		}
-		if len(block) == 0 {
-			// skip empty data blocks from sending
-			continue
 		}
 
 		// at this stage c.stopCh should be closed

--- a/lib/persistentqueue/persistentqueue.go
+++ b/lib/persistentqueue/persistentqueue.go
@@ -485,6 +485,14 @@ again:
 		}
 		goto again
 	}
+	// see https://github.com/VictoriaMetrics/VictoriaMetrics/pull/6241
+	if blockLen == 0 {
+		logger.Errorf("skipping corrupted %q, since zero block size is read from it", q.readerPath)
+		if err := q.skipBrokenChunkFile(); err != nil {
+			return dst, err
+		}
+		goto again
+	}
 	if blockLen > q.maxBlockSize {
 		logger.Errorf("skipping corrupted %q, since too big block size is read from it: %d bytes; cannot exceed %d bytes", q.readerPath, blockLen, q.maxBlockSize)
 		if err := q.skipBrokenChunkFile(); err != nil {


### PR DESCRIPTION
Zero-length blocks indicate file corruption. Valid blocks should always have a non-zero length. Previously, PR
https://github.com/VictoriaMetrics/VictoriaMetrics/pull/6241 worked around this at the client level by [silently skipping such blocks](https://github.com/VictoriaMetrics/VictoriaMetrics/blob/b1dea965aa4785757a934bf6835088c753d699be/app/vmagent/remotewrite/client.go#L314). 

Move the check into readBlock, consistent with how other corrupted headers are handled there, and remove the now-redundant empty-block guards from the client.

Follow-up on discussion https://github.com/VictoriaMetrics/VictoriaMetrics/pull/10932#discussion_r3264924234