### PR TITLE
ci: sign images with cosign

### DIFF
--- a/.github/workflows/sign.yml
+++ b/.github/workflows/sign.yml
@@ -1,0 +1,31 @@
+name: sign
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'PKG_TAG to sign'
+        required: true
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  sign:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Code checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Extract Cosign version
+        id: cosign-version
+        run: echo "version=$(grep 'COSIGN_VERSION ?=' deployment/docker/Makefile | awk '{print $3}')" >> $GITHUB_OUTPUT
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
+        with:
+          cosign-release: ${{ steps.cosign-version.outputs.version }}
+
+      - name: Sign images
+        run: PKG_TAG=${{ inputs.tag }} make sign

--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,16 @@ publish: \
 	publish-vmrestore \
 	publish-vmctl
 
+sign: \
+	sign-victoria-metrics \
+	sign-vmagent \
+	sign-vmalert \
+	sign-vmalert-tool \
+	sign-vmauth \
+	sign-vmbackup \
+	sign-vmrestore \
+	sign-vmctl
+
 package: \
 	package-victoria-metrics \
 	package-vmagent \

--- a/app/victoria-metrics/Makefile
+++ b/app/victoria-metrics/Makefile
@@ -69,6 +69,9 @@ package-victoria-metrics-386:
 publish-victoria-metrics:
 	APP_NAME=victoria-metrics $(MAKE) publish-via-docker
 
+sign-victoria-metrics:
+	APP_NAME=victoria-metrics $(MAKE) sign-via-docker
+
 run-victoria-metrics:
 	mkdir -p victoria-metrics-data
 	DOCKER_OPTS='-v $(shell pwd)/victoria-metrics-data:/victoria-metrics-data' \

--- a/app/vmagent/Makefile
+++ b/app/vmagent/Makefile
@@ -69,6 +69,9 @@ package-vmagent-386:
 publish-vmagent:
 	APP_NAME=vmagent $(MAKE) publish-via-docker
 
+sign-vmagent:
+	APP_NAME=vmagent $(MAKE) sign-via-docker
+
 run-vmagent:
 	mkdir -p vmagent-remotewrite-data
 	DOCKER_OPTS='-v $(shell pwd)/vmagent-remotewrite-data:/vmagent-remotewrite-data' \

--- a/app/vmalert-tool/Makefile
+++ b/app/vmalert-tool/Makefile
@@ -69,6 +69,9 @@ package-vmalert-tool-386:
 publish-vmalert-tool:
 	APP_NAME=vmalert-tool $(MAKE) publish-via-docker
 
+sign-vmalert-tool:
+	APP_NAME=vmalert-tool $(MAKE) sign-via-docker
+
 vmalert-tool-linux-amd64:
 	APP_NAME=vmalert-tool CGO_ENABLED=1 GOOS=linux GOARCH=amd64 $(MAKE) app-local-goos-goarch
 

--- a/app/vmalert/Makefile
+++ b/app/vmalert/Makefile
@@ -69,6 +69,9 @@ package-vmalert-386:
 publish-vmalert:
 	APP_NAME=vmalert $(MAKE) publish-via-docker
 
+sign-vmalert:
+	APP_NAME=vmalert $(MAKE) sign-via-docker
+
 test-vmalert:
 	go test -v -race -cover ./app/vmalert -loggerLevel=ERROR
 	go test -v -race -cover ./app/vmalert/rule

--- a/app/vmauth/Makefile
+++ b/app/vmauth/Makefile
@@ -69,6 +69,9 @@ package-vmauth-386:
 publish-vmauth:
 	APP_NAME=vmauth $(MAKE) publish-via-docker
 
+sign-vmauth:
+	APP_NAME=vmauth $(MAKE) sign-via-docker
+
 run-vmauth:
 	APP_NAME=vmauth \
 	DOCKER_OPTS='-v $(shell pwd)/app/vmauth/:/app/vmauth' \

--- a/app/vmbackup/Makefile
+++ b/app/vmbackup/Makefile
@@ -73,6 +73,9 @@ package-vmbackup-386:
 publish-vmbackup:
 	APP_NAME=vmbackup EXTRA_GO_BUILD_TAGS=$(VMBACKUP_GO_BUILD_TAGS) $(MAKE) publish-via-docker
 
+sign-vmbackup:
+	APP_NAME=vmbackup $(MAKE) sign-via-docker
+
 vmbackup-linux-amd64:
 	APP_NAME=vmbackup EXTRA_GO_BUILD_TAGS=$(VMBACKUP_GO_BUILD_TAGS) CGO_ENABLED=1 GOOS=linux GOARCH=amd64 $(MAKE) app-local-goos-goarch
 

--- a/app/vmctl/Makefile
+++ b/app/vmctl/Makefile
@@ -69,6 +69,9 @@ package-vmctl-386:
 publish-vmctl:
 	APP_NAME=vmctl $(MAKE) publish-via-docker
 
+sign-vmctl:
+	APP_NAME=vmctl $(MAKE) sign-via-docker
+
 vmctl-linux-amd64:
 	APP_NAME=vmctl CGO_ENABLED=1 GOOS=linux GOARCH=amd64 $(MAKE) app-local-goos-goarch
 

--- a/app/vmrestore/Makefile
+++ b/app/vmrestore/Makefile
@@ -73,6 +73,9 @@ package-vmrestore-386:
 publish-vmrestore:
 	APP_NAME=vmrestore EXTRA_GO_BUILD_TAGS=$(VMRESTORE_GO_BUILD_TAGS) $(MAKE) publish-via-docker
 
+sign-vmrestore:
+	APP_NAME=vmrestore $(MAKE) sign-via-docker
+
 vmrestore-linux-amd64:
 	APP_NAME=vmrestore EXTRA_GO_BUILD_TAGS=$(VMRESTORE_GO_BUILD_TAGS) CGO_ENABLED=1 GOOS=linux GOARCH=amd64 $(MAKE) app-local-goos-goarch
 

--- a/deployment/docker/Makefile
+++ b/deployment/docker/Makefile
@@ -3,6 +3,15 @@
 DOCKER_REGISTRIES ?= docker.io quay.io
 DOCKER_NAMESPACE ?= victoriametrics
 
+## Location to install dependencies to
+LOCALBIN ?= $(shell pwd)/bin
+$(LOCALBIN):
+	mkdir -p $(LOCALBIN)
+
+COSIGN_VERSION ?= v3.0.6
+COSIGN_BIN ?= $(LOCALBIN)/cosign-$(COSIGN_VERSION)
+COSIGN ?= $(shell which cosign 2>/dev/null || echo $(COSIGN_BIN))
+
 ROOT_IMAGE ?= alpine:3.23.4
 ROOT_IMAGE_SCRATCH ?= scratch
 CERTS_IMAGE := alpine:3.23.4
@@ -150,6 +159,13 @@ publish-via-docker-latest:
 		docker buildx imagetools create --tag $(registry)/$(DOCKER_NAMESPACE)/$(APP_NAME):latest $(registry)/$(DOCKER_NAMESPACE)/$(APP_NAME):$(PKG_TAG); \
 	)
 
+.PHONY: sign-via-docker
+sign-via-docker: $(COSIGN)
+	for registry in $(DOCKER_REGISTRIES); do \
+		$(COSIGN) sign --yes $${registry}/$(DOCKER_NAMESPACE)/$(APP_NAME)@$(call digest,$(PKG_TAG)$(RACE)$(EXTRA_DOCKER_TAG_SUFFIX)) && \
+		$(COSIGN) sign --yes $${registry}/$(DOCKER_NAMESPACE)/$(APP_NAME)@$(call digest,$(PKG_TAG)$(RACE)$(EXTRA_DOCKER_TAG_SUFFIX)-scratch) ; \
+	done
+
 run-via-docker: package-via-docker
 	$(DOCKER_RUN) -it --rm \
 		--user $(shell id -u):$(shell id -g) \
@@ -252,3 +268,43 @@ docker-single-down: docker-vm-single-down
 
 docker-cluster-up: docker-vm-cluster-up
 docker-cluster-down: docker-vm-cluster-down
+
+UNAME_S=$(shell uname -s 2>/dev/null)
+OS=$(shell echo $(UNAME_S) | tr A-Z a-z)
+ARCH=$(if $(filter x86_64,$(shell uname -m 2>/dev/null)),amd64,arm64)
+
+digest = $(shell $(DOCKER) buildx imagetools inspect docker.io/$(DOCKER_NAMESPACE)/$(APP_NAME):$(1) --format "{{print .Manifest.Digest}}")
+
+.PHONY: cosign
+cosign: $(COSIGN_BIN)
+$(COSIGN_BIN): $(LOCALBIN)
+	$(call download-github-release,$(COSIGN_BIN),sigstore/cosign,$(COSIGN_VERSION),cosign-$(OS)-$(ARCH),cosign-$(OS)-$(ARCH))
+
+# download-github-release will download a binary from github releases
+# $1 - target path with name of binary
+# $2 - repo url
+# $3 - specific version of package
+# $4 - artifact name
+# $5 - binary name
+define download-github-release
+@[ -f $(1) ] || { \
+set -e; \
+url="https://github.com/$(2)/releases/download/$(3)/$(4)"; \
+echo "Downloading $(1) from $${url}" ;\
+if echo "$(4)" | grep -q ".tar.gz$$"; then \
+curl -sL $${url} -o $(LOCALBIN)/$(4); \
+tar -xzf $(LOCALBIN)/$(4) -C $(LOCALBIN); \
+mv $(LOCALBIN)/$(5) $(1); \
+rm $(LOCALBIN)/$(4); \
+elif echo "$(4)" | grep -q ".zip$$"; then \
+curl -sL $${url} -o $(LOCALBIN)/$(4); \
+unzip -o $(LOCALBIN)/$(4) $(5) -d $(LOCALBIN); \
+mv $(LOCALBIN)/$(5) $(1); \
+chmod +x $(1); \
+rm $(LOCALBIN)/$(4); \
+else \
+curl -sL $${url} -o $(1); \
+chmod +x $(1); \
+fi; \
+}
+endef

--- a/docs/victoriametrics/Release-Guide.md
+++ b/docs/victoriametrics/Release-Guide.md
@@ -52,6 +52,7 @@ Key steps:
 
 * Review stability and performance of the RC in the sandbox.
 * Publish final Docker images (without `-rc` suffix) and update `latest` tag.
+* Sign published Docker images using the [sign workflow](.github/workflows/sign.yml).
 * Perform a quick smoke test on final images.
 * Publish the GitHub release.
 * Close issues included in the release.


### PR DESCRIPTION
### Describe Your Changes
Related issue: #9758

Add container signing via cosign, so that users can verify it for enhanced supply chain security.
This aligns with https://github.com/VictoriaMetrics/operator/pull/2125 and https://github.com/VictoriaMetrics/operator/pull/2203.

Unfortunately this repository seems to be releasing manually and updating through dependabot instead of renovatebot. Signing should be run through a github action, not locally, so that the issuer stays stable and trusted. Updating cosign versions should be documented somewhere, I just dont know where.