### PR TITLE
chore(vmui): removed unused tab item color property

### DIFF
--- a/app/vmui/packages/vmui/src/components/Main/Tabs/TabItem.tsx
+++ b/app/vmui/packages/vmui/src/components/Main/Tabs/TabItem.tsx
@@ -1,6 +1,5 @@
 import { Component, FC, Ref } from "preact/compat";
 import classNames from "classnames";
-import { getCssVariable } from "../../../utils/theme";
 import { TabItemType } from "./Tabs";
 import TabItemWrapper from "./TabItemWrapper";
 import "./style.scss";
@@ -8,7 +7,6 @@ import "./style.scss";
 interface TabItemProps {
   activeItem: string
   item: TabItemType
-  color?: string
   onChange?: (value: string) => void
   activeNavRef: Ref<Component>
   isNavLink?: boolean
@@ -17,7 +15,6 @@ interface TabItemProps {
 const TabItem: FC<TabItemProps> = ({
   activeItem,
   item,
-  color = getCssVariable("color-primary"),
   activeNavRef,
   onChange,
   isNavLink
@@ -35,7 +32,6 @@ const TabItem: FC<TabItemProps> = ({
       })}
       isNavLink={isNavLink}
       to={item.value}
-      style={{ color: color }}
       onClick={createHandlerClickTab(item.value)}
       ref={activeItem === item.value ? activeNavRef : undefined}
     >

--- a/app/vmui/packages/vmui/src/components/Main/Tabs/TabItemWrapper.tsx
+++ b/app/vmui/packages/vmui/src/components/Main/Tabs/TabItemWrapper.tsx
@@ -6,7 +6,6 @@ interface TabItemWrapperProps {
   to: string
   isNavLink?: boolean
   className: string
-  style: { color: string }
   children: ReactNode
   onClick: () => void
 }

--- a/app/vmui/packages/vmui/src/components/Main/Tabs/Tabs.tsx
+++ b/app/vmui/packages/vmui/src/components/Main/Tabs/Tabs.tsx
@@ -1,6 +1,5 @@
 import { Component, FC, useRef, useState } from "preact/compat";
 import { ReactNode, useEffect } from "react";
-import { getCssVariable } from "../../../utils/theme";
 import TabItem from "./TabItem";
 import "./style.scss";
 import useWindowSize from "../../../hooks/useWindowSize";
@@ -15,7 +14,6 @@ export interface TabItemType {
 interface TabsProps {
   activeItem: string
   items: TabItemType[]
-  color?: string
   onChange?: (value: string) => void
   indicatorPlacement?: "bottom" | "top"
   isNavLink?: boolean
@@ -24,7 +22,6 @@ interface TabsProps {
 const Tabs: FC<TabsProps> = ({
   activeItem,
   items,
-  color = getCssVariable("color-primary"),
   onChange,
   indicatorPlacement = "bottom",
   isNavLink,
@@ -48,14 +45,13 @@ const Tabs: FC<TabsProps> = ({
         activeItem={activeItem}
         item={item}
         onChange={onChange}
-        color={color}
         activeNavRef={activeNavRef}
         isNavLink={isNavLink}
       />
     ))}
     <div
       className="vm-tabs__indicator"
-      style={{ ...indicatorPosition, borderColor: color }}
+      style={{ ...indicatorPosition }}
     />
   </div>;
 };

--- a/app/vmui/packages/vmui/src/components/Main/Tabs/style.scss
+++ b/app/vmui/packages/vmui/src/components/Main/Tabs/style.scss
@@ -14,7 +14,7 @@
     align-items: center;
     justify-content: center;
     padding: $padding-global $padding-small;
-    color: inherit;
+    color: $color-primary;
     text-decoration: none;
     text-transform: capitalize;
     font-size: inherit;
@@ -46,5 +46,6 @@
     position: absolute;
     border-bottom: 2px solid;
     transition: width 200ms ease, left 300ms cubic-bezier(0.280, 0.840, 0.420, 1);
+    border-color: $color-primary;
   }
 }


### PR DESCRIPTION
consistently use $color-primary for tabs and removed unused tab item style customization.
also this allows to override primary color for all page items at once (using it in cloud)