### PR TITLE
chore: improve VictoriaMetrics maintenance path

### DIFF
--- a/apptest/app.go
+++ b/apptest/app.go
@@ -113,15 +113,23 @@ func startApp(instance string, binary string, flags []string, opts *appOptions) 
 // setDefaultFlags adds flags with default values to `flags` if it does not
 // initially contain them.
 func setDefaultFlags(flags []string, defaultFlags map[string]string) []string {
+	// Make a copy to avoid mutating the caller's map, which could cause
+	// unexpected side effects when the same appOptions are reused across
+	// multiple test apps (e.g. in CI pipelines).
+	remaining := make(map[string]string, len(defaultFlags))
+	for k, v := range defaultFlags {
+		remaining[k] = v
+	}
+
 	for _, flag := range flags {
-		for name := range defaultFlags {
+		for name := range remaining {
 			if strings.HasPrefix(flag, name) {
-				delete(defaultFlags, name)
+				delete(remaining, name)
 				continue
 			}
 		}
 	}
-	for name, value := range defaultFlags {
+	for name, value := range remaining {
 		flags = append(flags, name+"="+value)
 	}
 	return flags

--- a/apptest/app_test.go
+++ b/apptest/app_test.go
@@ -1,0 +1,49 @@
+package apptest
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestSetDefaultFlags(t *testing.T) {
+	t.Run("does-not-mutate-input-map", func(t *testing.T) {
+		original := map[string]string{
+			"-foo": "1",
+			"-bar": "2",
+		}
+		want := map[string]string{
+			"-foo": "1",
+			"-bar": "2",
+		}
+
+		flags := setDefaultFlags([]string{"-foo=3"}, original)
+
+		if !reflect.DeepEqual(original, want) {
+			t.Fatalf("setDefaultFlags mutated the input map: got %v, want %v", original, want)
+		}
+
+		wantFlags := []string{"-foo=3", "-bar=2"}
+		if !reflect.DeepEqual(flags, wantFlags) {
+			t.Fatalf("unexpected flags: got %v, want %v", flags, wantFlags)
+		}
+	})
+
+	t.Run("nil-default-flags", func(t *testing.T) {
+		flags := setDefaultFlags([]string{"-foo=1"}, nil)
+		want := []string{"-foo=1"}
+		if !reflect.DeepEqual(flags, want) {
+			t.Fatalf("unexpected flags: got %v, want %v", flags, want)
+		}
+	})
+
+	t.Run("all-defaults-already-present", func(t *testing.T) {
+		original := map[string]string{
+			"-foo": "1",
+		}
+		flags := setDefaultFlags([]string{"-foo=1"}, original)
+		want := []string{"-foo=1"}
+		if !reflect.DeepEqual(flags, want) {
+			t.Fatalf("unexpected flags: got %v, want %v", flags, want)
+		}
+	})
+}


### PR DESCRIPTION
Summary:
- Add or tighten focused edge-case tests or type assertions in apptest/app.go, apptest/model.go related to CI, Docker, Kubernetes, build tooling, release automation; avoid docs-only changes and broad refactors.
- Keep the change narrow so it is straightforward to review.

Notes:
- I kept this scoped to the relevant implementation and tests.