### PR TITLE
apptest: refactor apps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -485,8 +485,8 @@ apptest-legacy: victoria-metrics-race vmbackup-race vmrestore-race
 		curl --output-dir /tmp -LO $${URL}/$${VMSINGLE} && tar xzf /tmp/$${VMSINGLE} -C $${DIR} && \
 		curl --output-dir /tmp -LO $${URL}/$${VMCLUSTER} && tar xzf /tmp/$${VMCLUSTER} -C $${DIR} \
 	); \
-	VM_LEGACY_VMSINGLE_PATH=$${DIR}/victoria-metrics-prod \
-	VM_LEGACY_VMSTORAGE_PATH=$${DIR}/vmstorage-prod \
+	VMSINGLE_V1_132_0_PATH=$${DIR}/victoria-metrics-prod \
+	VMSTORAGE_V1_132_0_PATH=$${DIR}/vmstorage-prod \
 	go test ./apptest/tests -run="^TestLegacySingle.*"
 
 benchmark:

--- a/apptest/app.go
+++ b/apptest/app.go
@@ -22,6 +22,7 @@ var (
 	vminsertAddrRE              = regexp.MustCompile(`accepting vminsert conns at (.*:\d{1,5})$`)
 	vminsertClusterNativeAddrRE = regexp.MustCompile(`started TCP clusternative server at "(.*:\d{1,5})"`)
 	vmselectAddrRE              = regexp.MustCompile(`accepting vmselect conns at (.*:\d{1,5})$`)
+	vmauthHttpListenAddrRE      = regexp.MustCompile(`pprof handlers are exposed at http://(.*:\d{1,5})/debug/pprof/`)
 )
 
 // app represents an instance of some VictoriaMetrics server (such as vmstorage,

--- a/apptest/testcase.go
+++ b/apptest/testcase.go
@@ -88,19 +88,11 @@ func (tc *TestCase) MustStartDefaultVmsingle() *Vmsingle {
 }
 
 // MustStartVmsingle is a test helper function that starts an instance of
-// vmsingle located at ../../bin/victoria-metrics-race and fails the test if the app
-// fails to start.
+// vmsingle (latest version) and fails the test if the app fails to start.
 func (tc *TestCase) MustStartVmsingle(instance string, flags []string) *Vmsingle {
 	tc.t.Helper()
-	return tc.MustStartVmsingleAt(instance, "../../bin/victoria-metrics-race", flags)
-}
 
-// MustStartVmsingleAt is a test helper function that starts an instance of
-// vmsingle and fails the test if the app fails to start.
-func (tc *TestCase) MustStartVmsingleAt(instance, binary string, flags []string) *Vmsingle {
-	tc.t.Helper()
-
-	app, err := StartVmsingleAt(instance, binary, flags, tc.cli, tc.output)
+	app, err := StartVmsingle(instance, flags, tc.cli, tc.output)
 	if err != nil {
 		tc.t.Fatalf("Could not start %s: %v", instance, err)
 	}
@@ -109,19 +101,11 @@ func (tc *TestCase) MustStartVmsingleAt(instance, binary string, flags []string)
 }
 
 // MustStartVmstorage is a test helper function that starts an instance of
-// vmstorage located at ../../bin/vmstorage-race and fails the test if the app fails
-// to start.
+// vmstorage (latest version) and fails the test if the app fails to start.
 func (tc *TestCase) MustStartVmstorage(instance string, flags []string) *Vmstorage {
 	tc.t.Helper()
-	return tc.MustStartVmstorageAt(instance, "../../bin/vmstorage-race", flags)
-}
 
-// MustStartVmstorageAt is a test helper function that starts an instance of
-// vmstorage and fails the test if the app fails to start.
-func (tc *TestCase) MustStartVmstorageAt(instance string, binary string, flags []string) *Vmstorage {
-	tc.t.Helper()
-
-	app, err := StartVmstorageAt(instance, binary, flags, tc.cli, tc.output)
+	app, err := StartVmstorage(instance, flags, tc.cli, tc.output)
 	if err != nil {
 		tc.t.Fatalf("Could not start %s: %v", instance, err)
 	}
@@ -130,7 +114,7 @@ func (tc *TestCase) MustStartVmstorageAt(instance string, binary string, flags [
 }
 
 // MustStartVmselect is a test helper function that starts an instance of
-// vmselect and fails the test if the app fails to start.
+// vmselect (latest version) and fails the test if the app fails to start.
 func (tc *TestCase) MustStartVmselect(instance string, flags []string) *Vmselect {
 	tc.t.Helper()
 
@@ -290,10 +274,8 @@ func (tc *TestCase) MustStartDefaultCluster() *Vmcluster {
 // tests usually come paired with corresponding vmsingle tests.
 type ClusterOptions struct {
 	Vmstorage1Instance string
-	Vmstorage1Binary   string
 	Vmstorage1Flags    []string
 	Vmstorage2Instance string
-	Vmstorage2Binary   string
 	Vmstorage2Flags    []string
 	VminsertInstance   string
 	VminsertFlags      []string
@@ -305,15 +287,8 @@ type ClusterOptions struct {
 func (tc *TestCase) MustStartCluster(opts *ClusterOptions) *Vmcluster {
 	tc.t.Helper()
 
-	if opts.Vmstorage1Binary == "" {
-		opts.Vmstorage1Binary = "../../bin/vmstorage-race"
-	}
-	vmstorage1 := tc.MustStartVmstorageAt(opts.Vmstorage1Instance, opts.Vmstorage1Binary, opts.Vmstorage1Flags)
-
-	if opts.Vmstorage2Binary == "" {
-		opts.Vmstorage2Binary = "../../bin/vmstorage-race"
-	}
-	vmstorage2 := tc.MustStartVmstorageAt(opts.Vmstorage2Instance, opts.Vmstorage2Binary, opts.Vmstorage2Flags)
+	vmstorage1 := tc.MustStartVmstorage(opts.Vmstorage1Instance, opts.Vmstorage1Flags)
+	vmstorage2 := tc.MustStartVmstorage(opts.Vmstorage2Instance, opts.Vmstorage2Flags)
 
 	opts.VminsertFlags = append(opts.VminsertFlags, []string{
 		"-storageNode=" + vmstorage1.VminsertAddr() + "," + vmstorage2.VminsertAddr(),

--- a/apptest/testcase_legacy.go
+++ b/apptest/testcase_legacy.go
@@ -1,0 +1,50 @@
+package apptest
+
+// MustStartVmsingle_v1_132_0 is a test helper function that starts an instance
+// of vmsingle-v1.132.0 (last version that uses legacy index) and fails the test
+// if the app fails to start.
+func (tc *TestCase) MustStartVmsingle_v1_132_0(instance string, flags []string) *Vmsingle {
+	tc.t.Helper()
+
+	app, err := StartVmsingle_v1_132_0(instance, flags, tc.cli, tc.output)
+	if err != nil {
+		tc.t.Fatalf("Could not start %s: %v", instance, err)
+	}
+	tc.addApp(instance, app)
+	return app
+}
+
+// MustStartVmstorage_v1_132_0 is a test helper function that starts an instance
+// of vmstorage-v1.132.0 (last version that uses legacy index)  and fails the
+// test if the app fails to start.
+func (tc *TestCase) MustStartVmstorage_v1_132_0(instance string, flags []string) *Vmstorage {
+	tc.t.Helper()
+
+	app, err := StartVmstorage_v1_132_0(instance, flags, tc.cli, tc.output)
+	if err != nil {
+		tc.t.Fatalf("Could not start %s: %v", instance, err)
+	}
+	tc.addApp(instance, app)
+	return app
+}
+
+// MustStartCluster_v1_132_0 starts a cluster with vmstorage-v1.132.0 with
+// custom flags.
+func (tc *TestCase) MustStartCluster_v1_132_0(opts *ClusterOptions) *Vmcluster {
+	tc.t.Helper()
+
+	vmstorage1 := tc.MustStartVmstorage_v1_132_0(opts.Vmstorage1Instance, opts.Vmstorage1Flags)
+	vmstorage2 := tc.MustStartVmstorage_v1_132_0(opts.Vmstorage2Instance, opts.Vmstorage2Flags)
+
+	opts.VminsertFlags = append(opts.VminsertFlags, []string{
+		"-storageNode=" + vmstorage1.VminsertAddr() + "," + vmstorage2.VminsertAddr(),
+	}...)
+	vminsert := tc.MustStartVminsert(opts.VminsertInstance, opts.VminsertFlags)
+
+	opts.VmselectFlags = append(opts.VmselectFlags, []string{
+		"-storageNode=" + vmstorage1.VmselectAddr() + "," + vmstorage2.VmselectAddr(),
+	}...)
+	vmselect := tc.MustStartVmselect(opts.VmselectInstance, opts.VmselectFlags)
+
+	return &Vmcluster{vminsert, vmselect, []*Vmstorage{vmstorage1, vmstorage2}}
+}

--- a/apptest/tests/legacy_indexdb_test.go
+++ b/apptest/tests/legacy_indexdb_test.go
@@ -2,18 +2,12 @@ package tests
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 	"slices"
 	"testing"
 	"time"
 
 	at "github.com/VictoriaMetrics/VictoriaMetrics/apptest"
-)
-
-var (
-	legacyVmsinglePath  = os.Getenv("VM_LEGACY_VMSINGLE_PATH")
-	legacyVmstoragePath = os.Getenv("VM_LEGACY_VMSTORAGE_PATH")
 )
 
 type testLegacyDeleteSeriesOpts struct {
@@ -31,7 +25,7 @@ func TestLegacySingleDeleteSeries(t *testing.T) {
 
 	opts := testLegacyDeleteSeriesOpts{
 		startLegacySUT: func() at.PrometheusWriteQuerier {
-			return tc.MustStartVmsingleAt("vmsingle-legacy", legacyVmsinglePath, []string{
+			return tc.MustStartVmsingle_v1_132_0("vmsingle-legacy", []string{
 				"-storageDataPath=" + storageDataPath,
 				"-retentionPeriod=100y",
 				"-search.maxStalenessInterval=1m",
@@ -64,15 +58,13 @@ func TestLegacyClusterDeleteSeries(t *testing.T) {
 
 	opts := testLegacyDeleteSeriesOpts{
 		startLegacySUT: func() at.PrometheusWriteQuerier {
-			return tc.MustStartCluster(&at.ClusterOptions{
+			return tc.MustStartCluster_v1_132_0(&at.ClusterOptions{
 				Vmstorage1Instance: "vmstorage1-legacy",
-				Vmstorage1Binary:   legacyVmstoragePath,
 				Vmstorage1Flags: []string{
 					"-storageDataPath=" + storage1DataPath,
 					"-retentionPeriod=100y",
 				},
 				Vmstorage2Instance: "vmstorage2-legacy",
-				Vmstorage2Binary:   legacyVmstoragePath,
 				Vmstorage2Flags: []string{
 					"-storageDataPath=" + storage2DataPath,
 					"-retentionPeriod=100y",
@@ -255,7 +247,7 @@ func TestLegacySingleBackupRestore(t *testing.T) {
 
 	opts := testLegacyBackupRestoreOpts{
 		startLegacySUT: func() at.PrometheusWriteQuerier {
-			return tc.MustStartVmsingleAt("vmsingle-legacy", legacyVmsinglePath, []string{
+			return tc.MustStartVmsingle_v1_132_0("vmsingle-legacy", []string{
 				"-storageDataPath=" + storageDataPath,
 				"-retentionPeriod=100y",
 				"-search.disableCache=true",
@@ -298,15 +290,13 @@ func TestLegacyClusterBackupRestore(t *testing.T) {
 
 	opts := testLegacyBackupRestoreOpts{
 		startLegacySUT: func() at.PrometheusWriteQuerier {
-			return tc.MustStartCluster(&at.ClusterOptions{
+			return tc.MustStartCluster_v1_132_0(&at.ClusterOptions{
 				Vmstorage1Instance: "vmstorage1-legacy",
-				Vmstorage1Binary:   legacyVmstoragePath,
 				Vmstorage1Flags: []string{
 					"-storageDataPath=" + storage1DataPath,
 					"-retentionPeriod=100y",
 				},
 				Vmstorage2Instance: "vmstorage2-legacy",
-				Vmstorage2Binary:   legacyVmstoragePath,
 				Vmstorage2Flags: []string{
 					"-storageDataPath=" + storage2DataPath,
 					"-retentionPeriod=100y",
@@ -583,7 +573,7 @@ func TestLegacySingleDowngrade(t *testing.T) {
 
 	opts := testLegacyDowngradeOpts{
 		startLegacySUT: func() at.PrometheusWriteQuerier {
-			return tc.MustStartVmsingleAt("vmsingle-legacy", legacyVmsinglePath, []string{
+			return tc.MustStartVmsingle_v1_132_0("vmsingle-legacy", []string{
 				"-storageDataPath=" + storageDataPath,
 				"-retentionPeriod=100y",
 				"-search.disableCache=true",
@@ -618,15 +608,13 @@ func TestLegacyClusterDowngrade(t *testing.T) {
 
 	opts := testLegacyDowngradeOpts{
 		startLegacySUT: func() at.PrometheusWriteQuerier {
-			return tc.MustStartCluster(&at.ClusterOptions{
+			return tc.MustStartCluster_v1_132_0(&at.ClusterOptions{
 				Vmstorage1Instance: "vmstorage1-legacy",
-				Vmstorage1Binary:   legacyVmstoragePath,
 				Vmstorage1Flags: []string{
 					"-storageDataPath=" + storage1DataPath,
 					"-retentionPeriod=100y",
 				},
 				Vmstorage2Instance: "vmstorage2-legacy",
-				Vmstorage2Binary:   legacyVmstoragePath,
 				Vmstorage2Flags: []string{
 					"-storageDataPath=" + storage2DataPath,
 					"-retentionPeriod=100y",

--- a/apptest/vmagent.go
+++ b/apptest/vmagent.go
@@ -16,43 +16,63 @@ import (
 	"github.com/golang/snappy"
 )
 
-// Vmagent holds the state of a vmagent app and provides vmagent-specific functions
-type Vmagent struct {
-	*app
-	*metricsClient
-
-	httpListenAddr string
-
-	cli *Client
-}
-
-// StartVmagent starts an instance of vmagent with the given flags. It also
-// sets the default flags and populates the app instance state with runtime
-// values extracted from the application log (such as httpListenAddr)
+// StartVmagent starts the latest version of vmagent.
+//
+// The path to the binary can be provided via VMAGENT_PATH environment
+// variable. If the variable is not set, ../../bin/vmagent-race will be
+// used.
 func StartVmagent(instance string, flags []string, cli *Client, promScrapeConfigFilePath string, output io.Writer) (*Vmagent, error) {
-	extractREs := []*regexp.Regexp{
-		httpListenAddrRE,
+	binary := os.Getenv("VMAGENT_PATH")
+	if binary == "" {
+		binary = "../../bin/vmagent-race"
 	}
-
-	app, stderrExtracts, err := startApp(instance, "../../bin/vmagent-race", flags, &appOptions{
+	app, stderrExtracts, err := startApp(instance, binary, flags, &appOptions{
 		defaultFlags: map[string]string{
 			"-httpListenAddr":          "127.0.0.1:0",
 			"-promscrape.config":       promScrapeConfigFilePath,
 			"-remoteWrite.tmpDataPath": fmt.Sprintf("%s/%s-%d", os.TempDir(), instance, time.Now().UnixNano()),
 		},
-		extractREs: extractREs,
-		output:     output,
+		extractREs: []*regexp.Regexp{
+			httpListenAddrRE,
+		},
+		output: output,
 	})
 	if err != nil {
 		return nil, err
 	}
 
+	return newVmagent(app, cli, vmagentRuntimeValues{
+		httpListenAddr: stderrExtracts[0],
+	}), nil
+}
+
+type vmagentRuntimeValues struct {
+	httpListenAddr string
+}
+
+func newVmagent(app *app, cli *Client, rt vmagentRuntimeValues) *Vmagent {
 	return &Vmagent{
 		app:            app,
-		metricsClient:  newMetricsClient(cli, stderrExtracts[0]),
-		httpListenAddr: stderrExtracts[0],
 		cli:            cli,
-	}, nil
+		metricsClient:  newMetricsClient(cli, rt.httpListenAddr),
+		httpListenAddr: rt.httpListenAddr,
+	}
+}
+
+// Vmagent holds the state of a vmagent app and provides vmagent-specific
+// functions.
+type Vmagent struct {
+	*app
+	*metricsClient
+
+	cli            *Client
+	httpListenAddr string
+}
+
+// HTTPAddr returns the address at which the vmagent process is listening
+// for http connections.
+func (app *Vmagent) HTTPAddr() string {
+	return app.httpListenAddr
 }
 
 // APIV1ImportPrometheus is a test helper function that inserts a
@@ -201,12 +221,6 @@ func (app *Vmagent) PrometheusAPIV1Write(t *testing.T, wr prompb.WriteRequest, o
 			t.Fatalf("unexpected status code: got %d, want %d", statusCode, http.StatusNoContent)
 		}
 	})
-}
-
-// HTTPAddr returns the address at which the vmagent process is listening
-// for http connections.
-func (app *Vmagent) HTTPAddr() string {
-	return app.httpListenAddr
 }
 
 // sendBlocking sends the data to vmstorage by executing `send` function and

--- a/apptest/vmauth.go
+++ b/apptest/vmauth.go
@@ -2,6 +2,7 @@ package apptest
 
 import (
 	"io"
+	"os"
 	"regexp"
 	"syscall"
 	"testing"
@@ -10,7 +11,48 @@ import (
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/fs"
 )
 
-var httpBuilitinListenAddrRE = regexp.MustCompile(`pprof handlers are exposed at http://(.*:\d{1,5})/debug/pprof/`)
+// StartVmauth starts the latest version of vmauth.
+//
+// The path to the binary can be provided via VMAUTH_PATH environment
+// variable. If the variable is not set, ../../bin/vmauth-race will be
+// used.
+func StartVmauth(instance string, flags []string, cli *Client, configFilePath string, output io.Writer) (*Vmauth, error) {
+	binary := os.Getenv("VMAUTH_PATH")
+	if binary == "" {
+		binary = "../../bin/vmauth-race"
+	}
+	app, stderrExtracts, err := startApp(instance, binary, flags, &appOptions{
+		defaultFlags: map[string]string{
+			"-httpListenAddr": "127.0.0.1:0",
+			"-auth.config":    configFilePath,
+		},
+		extractREs: []*regexp.Regexp{
+			vmauthHttpListenAddrRE,
+		},
+		output: output,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return newVmauth(app, cli, configFilePath, vmauthRuntimeValues{
+		httpListenAddr: stderrExtracts[0],
+	}), nil
+}
+
+type vmauthRuntimeValues struct {
+	httpListenAddr string
+}
+
+func newVmauth(app *app, cli *Client, configFilePath string, rt vmauthRuntimeValues) *Vmauth {
+	return &Vmauth{
+		app:            app,
+		metricsClient:  newMetricsClient(cli, rt.httpListenAddr),
+		httpListenAddr: rt.httpListenAddr,
+		configFilePath: configFilePath,
+		cli:            cli,
+	}
+}
 
 // Vmauth holds the state of a vmauth app and provides vmauth-specific
 // functions.
@@ -18,38 +60,14 @@ type Vmauth struct {
 	*app
 	*metricsClient
 
+	cli            *Client
 	httpListenAddr string
 	configFilePath string
-	cli            *Client
 }
 
-// StartVmauth starts an instance of vmauth with the given flags. It also
-// sets the default flags and populates the app instance state with runtime
-// values extracted from the application log (such as httpListenAddr)
-func StartVmauth(instance string, flags []string, cli *Client, configFilePath string, output io.Writer) (*Vmauth, error) {
-	extractREs := []*regexp.Regexp{
-		httpBuilitinListenAddrRE,
-	}
-
-	app, stderrExtracts, err := startApp(instance, "../../bin/vmauth-race", flags, &appOptions{
-		defaultFlags: map[string]string{
-			"-httpListenAddr": "127.0.0.1:0",
-			"-auth.config":    configFilePath,
-		},
-		extractREs: extractREs,
-		output:     output,
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	return &Vmauth{
-		app:            app,
-		metricsClient:  newMetricsClient(cli, stderrExtracts[0]),
-		httpListenAddr: stderrExtracts[0],
-		configFilePath: configFilePath,
-		cli:            cli,
-	}, nil
+// GetHTTPListenAddr returns listen http addr
+func (app *Vmauth) GetHTTPListenAddr() string {
+	return app.httpListenAddr
 }
 
 // UpdateConfiguration updates the vmauth configuration file with the provided YAML content,
@@ -78,9 +96,4 @@ func (app *Vmauth) UpdateConfiguration(t *testing.T, configFileYAML string) {
 	}
 
 	t.Fatalf("config were not reloaded after SIGHUP signal; previous total: %d, current total: %d", prevTotal, currTotal)
-}
-
-// GetHTTPListenAddr returns listen http addr
-func (app *Vmauth) GetHTTPListenAddr() string {
-	return app.httpListenAddr
 }

--- a/apptest/vmbackup.go
+++ b/apptest/vmbackup.go
@@ -1,15 +1,26 @@
 package apptest
 
-import "io"
+import (
+	"io"
+	"os"
+)
 
-// StartVmbackup starts an instance of vmbackup with the given flags and waits
-// until it exits.
+// StartVmbackup starts the latest version of vmbackup with the given flags and
+// waits until it exits.
+//
+// The path to the binary can be provided via VMBACKUP_PATH environment
+// variable. If the variable is not set, ../../bin/vmbackup-race will be
+// used.
 func StartVmbackup(instance, storageDataPath, snapshotCreateURL, dst string, output io.Writer) error {
+	binary := os.Getenv("VMBACKUP_PATH")
+	if binary == "" {
+		binary = "../../bin/vmbackup-race"
+	}
 	flags := []string{
 		"-storageDataPath=" + storageDataPath,
 		"-snapshot.createURL=" + snapshotCreateURL,
 		"-dst=" + dst,
 	}
-	_, _, err := startApp(instance, "../../bin/vmbackup-race", flags, &appOptions{wait: true, output: output})
+	_, _, err := startApp(instance, binary, flags, &appOptions{wait: true, output: output})
 	return err
 }

--- a/apptest/vmctl.go
+++ b/apptest/vmctl.go
@@ -1,9 +1,23 @@
 package apptest
 
-import "io"
+import (
+	"io"
+	"os"
+)
 
 // StartVmctl starts an instance of vmctl cli with the given flags
+
+// StartVmctl starts the latest version of vmctl with the given flags and
+// waits until it exits.
+//
+// The path to the binary can be provided via VMCTL_PATH environment
+// variable. If the variable is not set, ../../bin/vmctl-race will be
+// used.
 func StartVmctl(instance string, flags []string, output io.Writer) error {
-	_, _, err := startApp(instance, "../../bin/vmctl-race", flags, &appOptions{wait: true, output: output})
+	binary := os.Getenv("VMCTL_PATH")
+	if binary == "" {
+		binary = "../../bin/vmctl-race"
+	}
+	_, _, err := startApp(instance, binary, flags, &appOptions{wait: true, output: output})
 	return err
 }

--- a/apptest/vminsert.go
+++ b/apptest/vminsert.go
@@ -40,7 +40,7 @@ func StartVminsert(instance string, flags []string, cli *Client, output io.Write
 		extractREs = append(extractREs, regexp.MustCompile(logRecord))
 	}
 
-	binary := os.Getenv("VMSINSERT_PATH")
+	binary := os.Getenv("VMINSERT_PATH")
 	if binary == "" {
 		binary = "../../bin/vminsert-race"
 	}

--- a/apptest/vminsert.go
+++ b/apptest/vminsert.go
@@ -3,22 +3,12 @@ package apptest
 import (
 	"fmt"
 	"io"
+	"os"
 	"regexp"
 	"strings"
 	"testing"
 	"time"
 )
-
-// Vminsert holds the state of a vminsert app and provides vminsert-specific
-// functions.
-type Vminsert struct {
-	*app
-	*metricsClient
-	*vminsertClient
-
-	httpListenAddr          string
-	clusternativeListenAddr string
-}
 
 // storageNodes returns the storage node addresses passed to vminsert via
 // -storageNode command line flag.
@@ -31,9 +21,11 @@ func storageNodes(flags []string) []string {
 	return nil
 }
 
-// StartVminsert starts an instance of vminsert with the given flags. It also
-// sets the default flags and populates the app instance state with runtime
-// values extracted from the application log (such as httpListenAddr)
+// StartVminsert starts the latest version of vminsert.
+//
+// The path to the binary can be provided via VMINSERT_PATH environment
+// variable. If the variable is not set, ../../bin/vminsert-race will be
+// used.
 func StartVminsert(instance string, flags []string, cli *Client, output io.Writer) (*Vminsert, error) {
 	extractREs := []*regexp.Regexp{
 		httpListenAddrRE,
@@ -48,11 +40,15 @@ func StartVminsert(instance string, flags []string, cli *Client, output io.Write
 		extractREs = append(extractREs, regexp.MustCompile(logRecord))
 	}
 
-	app, stderrExtracts, err := startApp(instance, "../../bin/vminsert-race", flags, &appOptions{
+	binary := os.Getenv("VMSINSERT_PATH")
+	if binary == "" {
+		binary = "../../bin/vminsert-race"
+	}
+	app, stderrExtracts, err := startApp(instance, binary, flags, &appOptions{
 		defaultFlags: map[string]string{
 			"-httpListenAddr":                              "127.0.0.1:0",
 			"-clusternativeListenAddr":                     "127.0.0.1:0",
-			"-graphiteListenAddr":                          ":0",
+			"-graphiteListenAddr":                          "127.0.0.1:0",
 			"-opentsdbListenAddr":                          "127.0.0.1:0",
 			"-clusternative.vminsertConnsShutdownDuration": "1ms",
 		},
@@ -63,27 +59,56 @@ func StartVminsert(instance string, flags []string, cli *Client, output io.Write
 		return nil, err
 	}
 
-	metricsClient := newMetricsClient(cli, stderrExtracts[0])
-	return &Vminsert{
-		app:           app,
-		metricsClient: metricsClient,
-		vminsertClient: &vminsertClient{
-			vminsertCli: cli,
-			url: func(op, path string, opts QueryOpts) string {
-				return getClusterPath(stderrExtracts[0], op, path, opts)
-			},
-			openTSDBURL: func(op, path string, opts QueryOpts) string {
-				return getClusterPath(stderrExtracts[3], op, path, opts)
-			},
-			graphiteListenAddr: stderrExtracts[2],
-			sendBlocking: func(t *testing.T, numRecordsToSend int, send func()) {
-				t.Helper()
-				sendBlocking(t, metricsClient, numRecordsToSend, send)
-			},
-		},
+	return newVminsert(app, cli, vminsertRuntimeValues{
 		httpListenAddr:          stderrExtracts[0],
 		clusternativeListenAddr: stderrExtracts[1],
-	}, nil
+		graphiteListenAddr:      stderrExtracts[2],
+		openTSDBListenAddr:      stderrExtracts[3],
+	}), nil
+}
+
+type vminsertRuntimeValues struct {
+	httpListenAddr          string
+	clusternativeListenAddr string
+	graphiteListenAddr      string
+	openTSDBListenAddr      string
+}
+
+func newVminsert(app *app, cli *Client, rt vminsertRuntimeValues) *Vminsert {
+	metricsClient := newMetricsClient(cli, rt.httpListenAddr)
+	vminsertClient := &vminsertClient{
+		vminsertCli: cli,
+		url: func(op, path string, opts QueryOpts) string {
+			return getClusterPath(rt.httpListenAddr, op, path, opts)
+		},
+		openTSDBURL: func(op, path string, opts QueryOpts) string {
+			return getClusterPath(rt.openTSDBListenAddr, op, path, opts)
+		},
+		graphiteListenAddr: rt.graphiteListenAddr,
+		sendBlocking: func(t *testing.T, numRecordsToSend int, send func()) {
+			t.Helper()
+			sendBlocking(t, metricsClient, numRecordsToSend, send)
+		},
+	}
+
+	return &Vminsert{
+		app:                     app,
+		metricsClient:           metricsClient,
+		vminsertClient:          vminsertClient,
+		httpListenAddr:          rt.httpListenAddr,
+		clusternativeListenAddr: rt.clusternativeListenAddr,
+	}
+}
+
+// Vminsert holds the state of a vminsert app and provides vminsert-specific
+// functions.
+type Vminsert struct {
+	*app
+	*metricsClient
+	*vminsertClient
+
+	httpListenAddr          string
+	clusternativeListenAddr string
 }
 
 // ClusternativeListenAddr returns the address at which the vminsert process is

--- a/apptest/vmrestore.go
+++ b/apptest/vmrestore.go
@@ -1,14 +1,25 @@
 package apptest
 
-import "io"
+import (
+	"io"
+	"os"
+)
 
-// StartVmrestore starts an instance of vmrestore with the given flags and waits
-// until it exits.
+// StartVmrestore starts the latest version of vmrestore with the given flags
+// and waits until it exits.
+//
+// The path to the binary can be provided via VMRESTORE_PATH environment
+// variable. If the variable is not set, ../../bin/vmrestore-race will be
+// used.
 func StartVmrestore(instance, src, storageDataPath string, output io.Writer) error {
+	binary := os.Getenv("VMRESTORE_PATH")
+	if binary == "" {
+		binary = "../../bin/vmrestore-race"
+	}
 	flags := []string{
 		"-src=" + src,
 		"-storageDataPath=" + storageDataPath,
 	}
-	_, _, err := startApp(instance, "../../bin/vmrestore-race", flags, &appOptions{wait: true, output: output})
+	_, _, err := startApp(instance, binary, flags, &appOptions{wait: true, output: output})
 	return err
 }

--- a/apptest/vmselect.go
+++ b/apptest/vmselect.go
@@ -3,26 +3,21 @@ package apptest
 import (
 	"fmt"
 	"io"
+	"os"
 	"regexp"
 )
 
-// Vmselect holds the state of a vmselect app and provides vmselect-specific
-// functions.
-type Vmselect struct {
-	*app
-	*metricsClient
-	*vmselectClient
-
-	httpListenAddr          string
-	clusternativeListenAddr string
-	cli                     *Client
-}
-
-// StartVmselect starts an instance of vmselect with the given flags. It also
-// sets the default flags and populates the app instance state with runtime
-// values extracted from the application log (such as httpListenAddr)
+// StartVmselect starts the latest version of vmselect.
+//
+// The path to the binary can be provided via VMSELECT_PATH environment
+// variable. If the variable is not set, ../../bin/vmselect-race will be
+// used.
 func StartVmselect(instance string, flags []string, cli *Client, output io.Writer) (*Vmselect, error) {
-	app, stderrExtracts, err := startApp(instance, "../../bin/vmselect-race", flags, &appOptions{
+	binary := os.Getenv("VMSELECT_PATH")
+	if binary == "" {
+		binary = "../../bin/vmselect-race"
+	}
+	app, stderrExtracts, err := startApp(instance, binary, flags, &appOptions{
 		defaultFlags: map[string]string{
 			"-httpListenAddr":          "127.0.0.1:0",
 			"-clusternativeListenAddr": "127.0.0.1:0",
@@ -37,21 +32,43 @@ func StartVmselect(instance string, flags []string, cli *Client, output io.Write
 		return nil, err
 	}
 
+	return newVmselect(app, cli, vmselectRuntimeValues{
+		httpListenAddr:          stderrExtracts[0],
+		clusternativeListenAddr: stderrExtracts[1],
+	}), nil
+}
+
+type vmselectRuntimeValues struct {
+	httpListenAddr          string
+	clusternativeListenAddr string
+}
+
+func newVmselect(app *app, cli *Client, rt vmselectRuntimeValues) *Vmselect {
 	return &Vmselect{
 		app:           app,
-		metricsClient: newMetricsClient(cli, stderrExtracts[0]),
+		metricsClient: newMetricsClient(cli, rt.httpListenAddr),
 		vmselectClient: &vmselectClient{
 			vmselectCli: cli,
 			url: func(op, path string, opts QueryOpts) string {
-				return getClusterPath(stderrExtracts[0], op, path, opts)
+				return getClusterPath(rt.httpListenAddr, op, path, opts)
 			},
-			metricNamesStatsResetURL: fmt.Sprintf("http://%s/admin/api/v1/admin/status/metric_names_stats/reset", stderrExtracts[0]),
-			tenantsURL:               fmt.Sprintf("http://%s/admin/tenants", stderrExtracts[0]),
+			metricNamesStatsResetURL: fmt.Sprintf("http://%s/admin/api/v1/admin/status/metric_names_stats/reset", rt.httpListenAddr),
+			tenantsURL:               fmt.Sprintf("http://%s/admin/tenants", rt.httpListenAddr),
 		},
-		httpListenAddr:          stderrExtracts[0],
-		clusternativeListenAddr: stderrExtracts[1],
-		cli:                     cli,
-	}, nil
+		httpListenAddr:          rt.httpListenAddr,
+		clusternativeListenAddr: rt.clusternativeListenAddr,
+	}
+}
+
+// Vmselect holds the state of a vmselect app and provides vmselect-specific
+// functions.
+type Vmselect struct {
+	*app
+	*metricsClient
+	*vmselectClient
+
+	httpListenAddr          string
+	clusternativeListenAddr string
 }
 
 // ClusternativeListenAddr returns the address at which the vmselect process is

--- a/apptest/vmsingle.go
+++ b/apptest/vmsingle.go
@@ -9,28 +9,21 @@ import (
 	"time"
 )
 
-// Vmsingle holds the state of a vmsingle app and provides vmsingle-specific
-// functions.
-type Vmsingle struct {
-	*app
-	*metricsClient
-	*vmstorageClient
-	*vmselectClient
-	*vminsertClient
-
-	storageDataPath string
-	httpListenAddr  string
-}
-
-// StartVmsingleAt starts an instance of vmsingle with the given flags. It also
-// sets the default flags and populates the app instance state with runtime
-// values extracted from the application log (such as httpListenAddr).
-func StartVmsingleAt(instance, binary string, flags []string, cli *Client, output io.Writer) (*Vmsingle, error) {
+// StartVmsingle starts the latest version of vmsingle.
+//
+// The path to the binary can be provided via VMSINGLE_PATH environment
+// variable. If the variable is not set, ../../bin/victoria-metrics-race will be
+// used.
+func StartVmsingle(instance string, flags []string, cli *Client, output io.Writer) (*Vmsingle, error) {
+	binary := os.Getenv("VMSINGLE_PATH")
+	if binary == "" {
+		binary = "../../bin/victoria-metrics-race"
+	}
 	app, stderrExtracts, err := startApp(instance, binary, flags, &appOptions{
 		defaultFlags: map[string]string{
 			"-storageDataPath":    fmt.Sprintf("%s/%s-%d", os.TempDir(), instance, time.Now().UnixNano()),
 			"-httpListenAddr":     "127.0.0.1:0",
-			"-graphiteListenAddr": ":0",
+			"-graphiteListenAddr": "127.0.0.1:0",
 			"-opentsdbListenAddr": "127.0.0.1:0",
 		},
 		extractREs: []*regexp.Regexp{
@@ -45,38 +38,67 @@ func StartVmsingleAt(instance, binary string, flags []string, cli *Client, outpu
 		return nil, err
 	}
 
+	return newVmsingle(app, cli, vmsingleRuntimeValues{
+		storageDataPath:    stderrExtracts[0],
+		httpListenAddr:     stderrExtracts[1],
+		graphiteListenAddr: stderrExtracts[2],
+		openTSDBListenAddr: stderrExtracts[3],
+	}), nil
+}
+
+type vmsingleRuntimeValues struct {
+	storageDataPath    string
+	httpListenAddr     string
+	graphiteListenAddr string
+	openTSDBListenAddr string
+}
+
+func newVmsingle(app *app, cli *Client, rt vmsingleRuntimeValues) *Vmsingle {
 	return &Vmsingle{
 		app:           app,
-		metricsClient: newMetricsClient(cli, stderrExtracts[1]),
+		metricsClient: newMetricsClient(cli, rt.httpListenAddr),
 		vmstorageClient: &vmstorageClient{
 			vmstorageCli:   cli,
-			httpListenAddr: stderrExtracts[1],
+			httpListenAddr: rt.httpListenAddr,
 		},
 		vmselectClient: &vmselectClient{
 			vmselectCli: cli,
 			url: func(op, path string, opts QueryOpts) string {
-				return fmt.Sprintf("http://%s/%s", stderrExtracts[1], path)
+				return fmt.Sprintf("http://%s/%s", rt.httpListenAddr, path)
 			},
-			metricNamesStatsResetURL: fmt.Sprintf("http://%s/api/v1/admin/status/metric_names_stats/reset", stderrExtracts[1]),
+			metricNamesStatsResetURL: fmt.Sprintf("http://%s/api/v1/admin/status/metric_names_stats/reset", rt.httpListenAddr),
 			tenantsURL:               "vmsingle-does-not-serve-tenants",
 		},
 		vminsertClient: &vminsertClient{
 			vminsertCli: cli,
 			url: func(_, path string, _ QueryOpts) string {
-				return fmt.Sprintf("http://%s/%s", stderrExtracts[1], path)
+				return fmt.Sprintf("http://%s/%s", rt.httpListenAddr, path)
 			},
 			openTSDBURL: func(_, path string, _ QueryOpts) string {
-				return fmt.Sprintf("http://%s/%s", stderrExtracts[3], path)
+				return fmt.Sprintf("http://%s/%s", rt.openTSDBListenAddr, path)
 			},
-			graphiteListenAddr: stderrExtracts[2],
+			graphiteListenAddr: rt.graphiteListenAddr,
 			sendBlocking: func(t *testing.T, _ int, send func()) {
 				t.Helper()
 				send()
 			},
 		},
-		storageDataPath: stderrExtracts[0],
-		httpListenAddr:  stderrExtracts[1],
-	}, nil
+		storageDataPath: rt.storageDataPath,
+		httpListenAddr:  rt.httpListenAddr,
+	}
+}
+
+// Vmsingle holds the state of a vmsingle app and provides vmsingle-specific
+// functions.
+type Vmsingle struct {
+	*app
+	*metricsClient
+	*vmstorageClient
+	*vmselectClient
+	*vminsertClient
+
+	storageDataPath string
+	httpListenAddr  string
 }
 
 // HTTPAddr returns the address at which the vminsert process is

--- a/apptest/vmsingle_legacy.go
+++ b/apptest/vmsingle_legacy.go
@@ -1,0 +1,43 @@
+package apptest
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"regexp"
+	"time"
+)
+
+// StartVmsingle_v1_132_0 starts vmsingle-v1.132.0 (the last version that uses
+// legacy index).
+//
+// The path to the binary must be provided via VMSINGLE_V1_132_0_PATH
+// environment variable.
+func StartVmsingle_v1_132_0(instance string, flags []string, cli *Client, output io.Writer) (*Vmsingle, error) {
+	binary := os.Getenv("VMSINGLE_V1_132_0_PATH")
+	app, stderrExtracts, err := startApp(instance, binary, flags, &appOptions{
+		defaultFlags: map[string]string{
+			"-storageDataPath":    fmt.Sprintf("%s/%s-%d", os.TempDir(), instance, time.Now().UnixNano()),
+			"-httpListenAddr":     "127.0.0.1:0",
+			"-graphiteListenAddr": "127.0.0.1:0",
+			"-opentsdbListenAddr": "127.0.0.1:0",
+		},
+		extractREs: []*regexp.Regexp{
+			storageDataPathRE,
+			httpListenAddrRE,
+			graphiteListenAddrRE,
+			openTSDBListenAddrRE,
+		},
+		output: output,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return newVmsingle(app, cli, vmsingleRuntimeValues{
+		storageDataPath:    stderrExtracts[0],
+		httpListenAddr:     stderrExtracts[1],
+		graphiteListenAddr: stderrExtracts[2],
+		openTSDBListenAddr: stderrExtracts[3],
+	}), nil
+}

--- a/apptest/vmstorage.go
+++ b/apptest/vmstorage.go
@@ -8,23 +8,22 @@ import (
 	"time"
 )
 
-// Vmstorage holds the state of a vmstorage app and provides vmstorage-specific
-// functions.
-type Vmstorage struct {
-	*app
-	*metricsClient
-	*vmstorageClient
-
-	storageDataPath string
-	httpListenAddr  string
-	vminsertAddr    string
-	vmselectAddr    string
+// StartVmstorage starts the latest version of vmstorage.
+//
+// The path to the binary can be provided via VMSTORAGE_PATH environment
+// variable. If the variable is not set, ../../bin/vmstorage-race will be used.
+func StartVmstorage(instance string, flags []string, cli *Client, output io.Writer) (*Vmstorage, error) {
+	binary := os.Getenv("VMSTORAGE_PATH")
+	if binary == "" {
+		binary = "../../bin/vmstorage-race"
+	}
+	return startVmstorage(instance, binary, flags, cli, output)
 }
 
-// StartVmstorageAt starts an instance of vmstorage with the given flags. It also
+// startVmstorage starts an instance of vmstorage with the given flags. It also
 // sets the default flags and populates the app instance state with runtime
 // values extracted from the application log (such as httpListenAddr)
-func StartVmstorageAt(instance, binary string, flags []string, cli *Client, output io.Writer) (*Vmstorage, error) {
+func startVmstorage(instance, binary string, flags []string, cli *Client, output io.Writer) (*Vmstorage, error) {
 	app, stderrExtracts, err := startApp(instance, binary, flags, &appOptions{
 		defaultFlags: map[string]string{
 			"-storageDataPath": fmt.Sprintf("%s/%s-%d", os.TempDir(), instance, time.Now().UnixNano()),
@@ -44,18 +43,47 @@ func StartVmstorageAt(instance, binary string, flags []string, cli *Client, outp
 		return nil, err
 	}
 
-	return &Vmstorage{
-		app:           app,
-		metricsClient: newMetricsClient(cli, stderrExtracts[1]),
-		vmstorageClient: &vmstorageClient{
-			vmstorageCli:   cli,
-			httpListenAddr: stderrExtracts[1],
-		},
+	return newVmstorage(app, cli, vmstorageRuntimeValues{
 		storageDataPath: stderrExtracts[0],
 		httpListenAddr:  stderrExtracts[1],
 		vminsertAddr:    stderrExtracts[2],
 		vmselectAddr:    stderrExtracts[3],
-	}, nil
+	}), nil
+}
+
+type vmstorageRuntimeValues struct {
+	storageDataPath string
+	httpListenAddr  string
+	vminsertAddr    string
+	vmselectAddr    string
+}
+
+func newVmstorage(app *app, cli *Client, rt vmstorageRuntimeValues) *Vmstorage {
+	return &Vmstorage{
+		app:           app,
+		metricsClient: newMetricsClient(cli, rt.httpListenAddr),
+		vmstorageClient: &vmstorageClient{
+			vmstorageCli:   cli,
+			httpListenAddr: rt.httpListenAddr,
+		},
+		storageDataPath: rt.storageDataPath,
+		httpListenAddr:  rt.httpListenAddr,
+		vminsertAddr:    rt.vminsertAddr,
+		vmselectAddr:    rt.vmselectAddr,
+	}
+}
+
+// Vmstorage holds the state of a vmstorage app and provides vmstorage-specific
+// functions.
+type Vmstorage struct {
+	*app
+	*metricsClient
+	*vmstorageClient
+
+	storageDataPath string
+	httpListenAddr  string
+	vminsertAddr    string
+	vmselectAddr    string
 }
 
 // VminsertAddr returns the address at which the vmstorage process is listening

--- a/apptest/vmstorage_legacy.go
+++ b/apptest/vmstorage_legacy.go
@@ -1,0 +1,16 @@
+package apptest
+
+import (
+	"io"
+	"os"
+)
+
+// StartVmstorage_v1_132_0 starts vmstorage-v1.132.0 (the last version that uses
+// legacy index).
+//
+// The path to the binary must be provided via VMSTORAGE_V1_132_0_PATH
+// environment variable.
+func StartVmstorage_v1_132_0(instance string, flags []string, cli *Client, output io.Writer) (*Vmstorage, error) {
+	binary := os.Getenv("VMSTORAGE_V1_132_0_PATH")
+	return startVmstorage(instance, binary, flags, cli, output)
+}


### PR DESCRIPTION
- Separate process creation and type instantiation
- Get the binary path either from an env var or use default path
- move apps that use legacy indexdb to a separate *_legacy.go files

Related to https://github.com/VictoriaMetrics/VictoriaMetrics/pull/10926