### PR TITLE
vmstorage: Minor fixes in vmselect server

### DIFF
--- a/app/vmstorage/servers/vmselect_test.go
+++ b/app/vmstorage/servers/vmselect_test.go
@@ -2,7 +2,7 @@ package servers
 
 import (
 	"math"
-	"runtime"
+	"strconv"
 	"testing"
 )
 
@@ -15,8 +15,8 @@ func TestCalculateMaxMetricsLimitByResource(t *testing.T) {
 		}
 	}
 
-	// Skip when GOARCH=386
-	if runtime.GOARCH != "386" {
+	// 64-bit architectures support memory sizes > 4GB.
+	if strconv.IntSize == 64 {
 		// 8 CPU & 32 GiB
 		f(16, int(math.Round(32*1024*1024*1024*0.4)), 4294967)
 		// 4 CPU & 32 GiB

--- a/lib/vmselectapi/server.go
+++ b/lib/vmselectapi/server.go
@@ -134,7 +134,7 @@ func NewServer(addr string, api API, limits Limits, disableResponseCompression b
 		labelNamesRequests:          metrics.NewCounter(fmt.Sprintf(`vm_vmselect_rpc_requests_total{action="labelNames",addr=%q}`, addr)),
 		labelValuesRequests:         metrics.NewCounter(fmt.Sprintf(`vm_vmselect_rpc_requests_total{action="labelValues",addr=%q}`, addr)),
 		tagValueSuffixesRequests:    metrics.NewCounter(fmt.Sprintf(`vm_vmselect_rpc_requests_total{action="tagValueSuffixes",addr=%q}`, addr)),
-		seriesCountRequests:         metrics.NewCounter(fmt.Sprintf(`vm_vmselect_rpc_requests_total{action="seriesSount",addr=%q}`, addr)),
+		seriesCountRequests:         metrics.NewCounter(fmt.Sprintf(`vm_vmselect_rpc_requests_total{action="seriesCount",addr=%q}`, addr)),
 		tsdbStatusRequests:          metrics.NewCounter(fmt.Sprintf(`vm_vmselect_rpc_requests_total{action="tsdbStatus",addr=%q}`, addr)),
 		searchMetricNamesRequests:   metrics.NewCounter(fmt.Sprintf(`vm_vmselect_rpc_requests_total{action="searchMetricNames",addr=%q}`, addr)),
 		searchRequests:              metrics.NewCounter(fmt.Sprintf(`vm_vmselect_rpc_requests_total{action="search",addr=%q}`, addr)),
@@ -800,7 +800,7 @@ func (s *Server) processTagValueSuffixes(ctx *vmselectRequestCtx) error {
 	}
 	maxSuffixes, err := ctx.readLimit()
 	if err != nil {
-		return fmt.Errorf("cannot read maxTagValueSuffixes: %d", err)
+		return fmt.Errorf("cannot read maxTagValueSuffixes: %w", err)
 	}
 	if maxSuffixes <= 0 || maxSuffixes > s.limits.MaxTagValueSuffixes {
 		maxSuffixes = s.limits.MaxTagValueSuffixes


### PR DESCRIPTION
Fix remarks found by ai in #10926. Fixing them separately in cluster branch, because these files were copied from cluster branch to single-node branch.