### PR TITLE
.github: enforce least privilege permissions for action jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,8 +22,7 @@ on:
       - '!app/vmui/**'
       - '.github/workflows/build.yml'
 
-permissions:
-  contents: read
+permissions: {}
 
 concurrency:
   cancel-in-progress: true
@@ -32,6 +31,8 @@ concurrency:
 jobs:
   build:
     name: ${{ matrix.os }}-${{ matrix.arch }}
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/changelog-linter.yml
+++ b/.github/workflows/changelog-linter.yml
@@ -5,8 +5,12 @@ on:
     paths:
       - "docs/victoriametrics/changelog/CHANGELOG.md"
 
+permissions: {}
+
 jobs:
   tip-lint:
+    permissions:
+      contents: read
     runs-on: 'ubuntu-latest'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2

--- a/.github/workflows/check-commit-signed.yml
+++ b/.github/workflows/check-commit-signed.yml
@@ -3,8 +3,12 @@ name: check-commit-signed
 on:
   pull_request:
 
+permissions: {}
+
 jobs:
   check-commit-signed:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/check-licenses.yml
+++ b/.github/workflows/check-licenses.yml
@@ -6,12 +6,14 @@ on:
   pull_request:
     paths:
       - 'vendor'
-permissions:
-  contents: read
+
+permissions: {}
 
 jobs:
   build:
     name: Build
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - name: Code checkout

--- a/.github/workflows/codeql-analysis-go.yml
+++ b/.github/workflows/codeql-analysis-go.yml
@@ -18,6 +18,8 @@ concurrency:
   cancel-in-progress: true
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
 
+permissions: {}
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -7,12 +7,14 @@ on:
       - 'docs/**'
       - '.github/workflows/docs.yaml'
   workflow_dispatch: {}
-permissions:
-  contents: read  # This is required for actions/checkout and to commit back image update
-  deployments: write
+
+permissions: {}
+
 jobs:
   build:
     name: Build
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - name: Code checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,8 +18,7 @@ on:
       - 'go.*'
       - '.github/workflows/main.yml'
 
-permissions:
-  contents: read
+permissions: {}
 
 concurrency:
   cancel-in-progress: true
@@ -29,6 +28,8 @@ concurrency:
 jobs:
   lint:
     name: lint
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - name: Code checkout
@@ -61,6 +62,8 @@ jobs:
 
   unit:
     name: unit
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
 
     strategy:
@@ -90,6 +93,8 @@ jobs:
 
   apptest:
     name: apptest
+    permissions:
+      contents: read
     runs-on: apptest
 
     steps:

--- a/.github/workflows/vmui.yml
+++ b/.github/workflows/vmui.yml
@@ -16,11 +16,7 @@ on:
       - 'app/vmui/packages/vmui/**'
       - '.github/workflows/vmui.yml'
 
-permissions:
-  contents: read
-  packages: read
-  pull-requests: read
-  checks: write
+permissions: {}
 
 concurrency:
   cancel-in-progress: true
@@ -29,6 +25,10 @@ concurrency:
 jobs:
   vmui-checks:
     name: VMUI Checks (lint, test, typecheck)
+    permissions:
+      checks: write
+      contents: read
+      pull-requests: read
     runs-on: ubuntu-latest
     steps:
       - name: Code checkout


### PR DESCRIPTION
Scope permissions to jobs and set `permissions: {}` at workflow level.

Note: I added and removed permissions in some workflows. The added permissions make previously implicit defaults explicit.