### PR TITLE
lib/prompb: zero bucketSpan before re-using pooled slice memory

### DIFF
--- a/lib/prompb/write_request_unmarshaler.go
+++ b/lib/prompb/write_request_unmarshaler.go
@@ -346,6 +346,7 @@ func appendBucketSpan(spans []bucketSpan, src []byte) ([]bucketSpan, error) {
 	//	}
 	if len(spans) < cap(spans) {
 		spans = spans[:len(spans)+1]
+		spans[len(spans)-1] = bucketSpan{}
 	} else {
 		spans = append(spans, bucketSpan{})
 	}

--- a/lib/prompb/write_request_unmarshaler_test.go
+++ b/lib/prompb/write_request_unmarshaler_test.go
@@ -197,6 +197,38 @@ func TestUnmarshalTimeSeries(t *testing.T) {
 			},
 		})
 	}
+
+}
+
+// TestAppendBucketSpanZeroesReusedSlot is a regression test for the
+// stale-offset bug: a span's offset field is omitted from the wire when its
+// value is the proto3 default 0 (Prometheus's gogo-protobuf encoder does this
+// for prompb.BucketSpan). appendBucketSpan re-uses pooled slice memory for
+// nhctx.positiveSpans/negativeSpans without zeroing the entry, so a
+// subsequent histogram whose first span has offset=0 would inherit a stale
+// non-zero offset from whichever histogram previously occupied that pool
+// slot, producing wildly wrong vmrange labels.
+func TestAppendBucketSpanZeroesReusedSlot(t *testing.T) {
+	// Pre-populate the slot with a stale span that has offset=5.
+	spans := []bucketSpan{{offset: 5, length: 1}}
+	// Reset to len=0 but keep cap=1, as nhctx.reset() does.
+	spans = spans[:0]
+	// Parse a wire-encoded span where offset is omitted (proto3 default 0)
+	// and only length=1 is present. Without the fix, span.offset stays at 5.
+	wire := pbAppendVarint(nil, 2, 1)
+	got, err := appendBucketSpan(spans, wire)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 span, got %d", len(got))
+	}
+	if got[0].offset != 0 {
+		t.Fatalf("expected offset=0 (proto3 default), got offset=%d (stale value bled through from pool)", got[0].offset)
+	}
+	if got[0].length != 1 {
+		t.Fatalf("expected length=1, got length=%d", got[0].length)
+	}
 }
 
 func encodeTimeSeries(labels []Label, samples []Sample, histograms [][]byte) []byte {


### PR DESCRIPTION
Note that this was created using Claude Code, but I am confident the issue is real and the fix works.

## Problem

`appendBucketSpan` in `lib/prompb/write_request_unmarshaler.go` extends
`nhctx.positiveSpans` / `nhctx.negativeSpans` in place when the underlying
array still has capacity from a previous pooled `nativeHistogramContext`:

```go
if len(spans) < cap(spans) {
    spans = spans[:len(spans)+1]   // <-- in-place, not zeroed
} else {
    spans = append(spans, bucketSpan{})
}
span := &spans[len(spans)-1]
```

The new entry was reachable through `&spans[len(spans)-1]` without first
being zeroed. Any field that is absent in the wire then silently inherits
whatever stale value the previously-pooled histogram left in that slot.

This matters in practice because Prometheus's prompb gogo-protobuf encoder
**drops `offset=0`** as a proto3 default (`prompb/types.pb.go`):

```go
if m.Offset != 0 {
    i = encodeVarintTypes(dAtA, i, ...)
}
```

A span with `{offset: 0, length: N}` is therefore serialized as just `length: N`
on the wire. On the receiving side, `appendBucketSpan` enters the
`len(spans) < cap(spans)` branch, re-uses a slot whose `offset` field is whatever
the previous histogram in this pool entry set it to, and only updates `length`
from the wire. The first span of every subsequent native histogram in the same
pool slot then decodes with a leaked offset.

The downstream effect is wildly wrong `vmrange` labels for exponential native
histograms: `appendSpanBuckets` computes `upper := math.Pow(base, float64(bucketIdx))`
where `bucketIdx` starts from the leaked offset, so a bucket that should be
`(0.5, 1.0]` can surface anywhere on the float64 axis. The leak isn't
deterministic — it depends on which histogram last occupied the slot — so two
queries against the same metric on the same server may show different shifts.

## Reproduction

`TestAppendBucketSpanZeroesReusedSlot` in this PR reproduces the bug directly:
it pre-populates the slot with `offset: 5`, resets `len` to 0 (matching what
`nativeHistogramContext.reset()` does), then parses a wire-encoded span
without a field-1 entry (i.e. with `offset` omitted as the proto3 default).
Without the fix the span decodes as `offset=5`; with the fix it decodes as
`offset=0`.

The bug surfaces in production when ingesting Prometheus protobuf native
histograms over remote-write — e.g. via `vmagent` or Grafana Alloy with
`enable_protobuf_negotiation = true` and `send_native_histograms = true`.

## Fix

Explicitly zero the entry when growing the slice in place, so a missing
`offset` field decodes to its proto default 0:

```go
if len(spans) < cap(spans) {
    spans = spans[:len(spans)+1]
    spans[len(spans)-1] = bucketSpan{}     // <-- added
} else {
    spans = append(spans, bucketSpan{})
}
```

## Verification

- New test: `TestAppendBucketSpanZeroesReusedSlot`. Passes with the fix, fails
  without it with `expected offset=0 (proto3 default), got offset=5 (stale
  value bled through from pool)`.
- Existing `TestUnmarshalTimeSeries` still passes (`go test ./lib/prompb/`).
- Verified against a production VictoriaMetrics 1.144.0 instance fed
  exponential native histograms by Grafana Alloy: `vmrange` labels for an
  allocator-size histogram (schema=0, span offset=0, length=21) went from
  garbage like `1.164e-10...2.328e-10` and `3.553e-15...7.105e-15` to the
  expected `5.000e-01...1.000e+00` through `5.243e+05...1.049e+06` after
  rolling out a build with this patch.

## Notes

- Code path was added in 8a6e8a95f for v1.143.0, so all v1.143.x / v1.144.x
  releases are affected.
- NHCB histograms (with `custom_values`) aren't affected: `appendSpanBuckets`
  isn't used on that path.
- The `length` field has the same proto3-default pitfall, but a `length: 0`
  span is already a no-op for `appendSpanBuckets` (its inner loop runs zero
  times), so a stale `length` from the pool can't actually surface — only
  `offset` had observable consequences. The zeroing fix covers both anyway.