### PR TITLE
docs/vmauth: add security recommendations for vmselect multitenant reads

### DIFF
--- a/app/vmauth/main_test.go
+++ b/app/vmauth/main_test.go
@@ -545,6 +545,31 @@ requested_url={BACKEND}/path2/foo/?de=fg`
 	if n := retries.Load(); n != 2 {
 		t.Fatalf("unexpected number of retries; got %d; want 2", n)
 	}
+
+	// make sure that empty config value erases client extra filters and extra labels
+	cfgStr = `
+unauthorized_user:
+  url_prefix: {BACKEND}/foo?bar=baz&extra_filters[]=&extra_label=`
+	requestURL = "http://some-host.com/abc/def?some_arg=some_value&extra_filters[]=baz&extra_label=tenant=admin"
+	backendHandler = func(w http.ResponseWriter, r *http.Request) {
+		h := w.Header()
+		h.Set("Connection", "close")
+		h.Set("Foo", "bar")
+
+		var bb bytes.Buffer
+		if err := r.Header.Write(&bb); err != nil {
+			panic(fmt.Errorf("unexpected error when marshaling headers: %w", err))
+		}
+		fmt.Fprintf(w, "requested_url=http://%s%s\n%s", r.Host, r.URL, bb.String())
+	}
+	responseExpected = `
+statusCode=200
+Foo: bar
+requested_url={BACKEND}/foo/abc/def?bar=baz&extra_filters%5B%5D=&extra_label=&some_arg=some_value
+Pass-Header: abc
+User-Agent: vmauth
+X-Forwarded-For: 12.34.56.78, 42.2.3.84`
+	f(cfgStr, requestURL, backendHandler, responseExpected)
 }
 
 func TestJWTRequestHandler(t *testing.T) {

--- a/app/vmauth/main_test.go
+++ b/app/vmauth/main_test.go
@@ -549,8 +549,8 @@ requested_url={BACKEND}/path2/foo/?de=fg`
 	// make sure that empty config value erases client extra filters and extra labels
 	cfgStr = `
 unauthorized_user:
-  url_prefix: {BACKEND}/foo?bar=baz&extra_filters[]=&extra_label=`
-	requestURL = "http://some-host.com/abc/def?some_arg=some_value&extra_filters[]=baz&extra_label=tenant=admin"
+  url_prefix: {BACKEND}/foo?bar=baz&extra_filters[]=&extra_label=&extra_filters=`
+	requestURL = "http://some-host.com/abc/def?some_arg=some_value&extra_filters[]=baz&extra_label=tenant=admin&extra_filters=bar"
 	backendHandler = func(w http.ResponseWriter, r *http.Request) {
 		h := w.Header()
 		h.Set("Connection", "close")
@@ -565,7 +565,7 @@ unauthorized_user:
 	responseExpected = `
 statusCode=200
 Foo: bar
-requested_url={BACKEND}/foo/abc/def?bar=baz&extra_filters%5B%5D=&extra_label=&some_arg=some_value
+requested_url={BACKEND}/foo/abc/def?bar=baz&extra_filters=&extra_filters%5B%5D=&extra_label=&some_arg=some_value
 Pass-Header: abc
 User-Agent: vmauth
 X-Forwarded-For: 12.34.56.78, 42.2.3.84`

--- a/docs/victoriametrics/Cluster-VictoriaMetrics.md
+++ b/docs/victoriametrics/Cluster-VictoriaMetrics.md
@@ -205,13 +205,15 @@ curl 'http://vmselect:8481/select/multitenant/prometheus/api/v1/query' \
 
 The precedence for applying filters for tenants follows this order:
 
-1. Filter tenants by `extra_label` and `extra_filters` filters.
+1. Filter tenants by `extra_label`, `extra_filters` and `extra_filters[]` filters.
  These filters have the highest priority and are applied first when provided through the query arguments.
+ Filters use `OR` logic - a tenant is selected if it matches any of the filters.
 2. Filter tenants from labels selectors defined at metricsQL query expression.
 
 > **Security considerations**
 It is recommended restricting access to `multitenant` endpoints only to trusted sources,
 since untrusted source may break per-tenant data by writing unwanted samples or get access to data of arbitrary tenants.
+See also [vmauth security doc](https://docs.victoriametrics.com/victoriametrics/vmauth/#security).
 
 ## Binaries
 

--- a/docs/victoriametrics/vmauth.md
+++ b/docs/victoriametrics/vmauth.md
@@ -1541,7 +1541,7 @@ When `vmauth` performs tenant routing for [multitenant](https://docs.victoriamet
 
 ```yaml
 unauthorized_user:
-    url_prefix: http://vmselect/select/multitenant/extra_filters[]=&extra_filters=&extra_label=vm_account_id=10&vm_project_id=100
+    url_prefix: http://vmselect/select/multitenant?extra_filters[]=&extra_filters=&extra_label=vm_account_id=10&vm_project_id=100
 ```
 
 This is required because `vmselect` uses `OR` logic for tenant filtering. If a client sets `extra_filters[]` or `extra_filters`, it could bypass the tenant restriction configured via `extra_label`.

--- a/docs/victoriametrics/vmauth.md
+++ b/docs/victoriametrics/vmauth.md
@@ -1537,7 +1537,7 @@ To enable TLS on the public listener while keeping the internal listener non-TLS
 `vmauth` also supports restricting access by IP - see [these docs](#ip-filters). See also [concurrency limiting docs](#concurrency-limiting).
 
 
-When `vmauth` performs tenant routing for [multitenant](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/#multitenant-reads) requests, it is crucial to explicitly set `extra_label`, `extra_filters` and `extra_filters[]` params in the configuration file:
+When `vmauth` performs tenant routing for [multitenant](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/#multitenant-reads) requests, it is crucial to explicitly set `extra_label`, `extra_filters` and `extra_filters[]` in the url_prefix configuration:
 
 ```yaml
 unauthorized_user:

--- a/docs/victoriametrics/vmauth.md
+++ b/docs/victoriametrics/vmauth.md
@@ -1541,7 +1541,7 @@ When `vmauth` performs tenant routing for [multitenant](https://docs.victoriamet
 
 ```yaml
 unauthorized_user:
-    url_prefix: http://vmselect/select/multitenant?extra_filters[]=&extra_filters=&extra_label=vm_account_id=10&vm_project_id=100
+    url_prefix: http://vmselect/select/multitenant?extra_filters[]=&extra_filters=&extra_label=vm_account_id=10&extra_label=vm_project_id=100
 ```
 
 This is required because `vmselect` uses `OR` logic for tenant filtering. If a client sets `extra_filters[]` or `extra_filters`, it could bypass the tenant restriction configured via `extra_label`.

--- a/docs/victoriametrics/vmauth.md
+++ b/docs/victoriametrics/vmauth.md
@@ -1536,6 +1536,16 @@ To enable TLS on the public listener while keeping the internal listener non-TLS
 
 `vmauth` also supports restricting access by IP - see [these docs](#ip-filters). See also [concurrency limiting docs](#concurrency-limiting).
 
+
+When `vmauth` performs tenant routing for [multitenant](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/#multitenant-reads) requests, it is crucial to explicitly set `extra_label`, `extra_filters` and `extra_filters[]` params in the configuration file:
+
+```yaml
+unauthorized_user:
+    url_prefix: http://vmselect/select/multitenant/extra_filters[]=&extra_filters=&extra_label=vm_account_id=10&vm_project_id=100
+```
+
+This is required because `vmselect` uses `OR` logic for tenant filtering. If a client sets `extra_filters[]` or `extra_filters`, it could bypass the tenant restriction configured via `extra_label`.
+
 ## Automatic issuing of TLS certificates
 
 `vmauth` [Enterprise](https://docs.victoriametrics.com/victoriametrics/enterprise/) supports automatic issuing of TLS certificates via [Let's Encrypt service](https://letsencrypt.org/).


### PR DESCRIPTION
 Currently, vmselect uses `OR` logic to filter out tenants for
 `multitenant` requests. And if vmauth is used to enforce tenant
 requests with `extra_label` or `extra_filters`. It's required to set
 `extra_label`, `extra_filters` and `extra_filters[]` explicitly at
 configuration file to prevent possible enforcement bypass.
