### PR TITLE
Docs: Update "Multi Retention Setup within VictoriaMetrics Cluster" Guide

### DIFF
--- a/docs/guides/guide-vmcluster-multiple-retention-setup/README.md
+++ b/docs/guides/guide-vmcluster-multiple-retention-setup/README.md
@@ -227,7 +227,7 @@ EOF
 ```
 
 > Two important notes on scraping:
-> - Metrics without a matching `retention` label are silently dropped by the `keep` rules. You must ensure every metric gets the label or use a different routing configuration.
+> - Metrics without a matching `retention` label are silently dropped by the `keep` rules. You must ensure that every metric receives a label, or use a different routing configuration.
 > - The [scrape interval](https://docs.victoriametrics.com/victoriametrics/sd_configs/#scrape_configs) should match the `dedup.minScrapeInterval` defined in the vmstorage nodes.
 `
 
@@ -245,7 +245,7 @@ kubectl rollout status deploy/vmagent-victoria-metrics-agent
 
 ### Step 4: Verification
 
-We can send test data to verify data is flowing to the correct storage group.
+We can send test data to verify that data is flowing to the correct storage group.
 
 First, port-forward vmagent and vmselect:
 
@@ -318,7 +318,7 @@ remoteWrite:
         regex: "infra|sre"
 ```
 
-> Metrics that match none of the `keep` rules are dropped in the configuration above.
+> Metrics that do not match any of the `keep` rules are dropped in the configuration above.
 
 ## Alternative Multi-Tenant Routing
 

--- a/docs/guides/guide-vmcluster-multiple-retention-setup/README.md
+++ b/docs/guides/guide-vmcluster-multiple-retention-setup/README.md
@@ -193,10 +193,10 @@ We'll use `vmagent` to route incoming metrics to the correct retention group. Fo
 
 | `retention` label | Storage Group |
 | ----------------| --------------|
-| "3mo"           | `vmcluster-a`   | 
-| "1yr"           | `vmcluster-b`   | 
-| "3yr"           | `vmcluster-c`   | 
-| (not set)       | `vmcluster-c`   | 
+| `"3mo"`         | `vmcluster-a`   | 
+| `"1yr"`         | `vmcluster-b`   | 
+| `"3yr"`         | `vmcluster-c`   | 
+
 
 Create the values file for vmagent:
 
@@ -205,40 +205,93 @@ cat <<EOF >vmagent.yaml
 service:
   enabled: true
 remoteWrite:
-  # Group A
+  # Group A: receives metrics with retention="3mo"
   - url: http://vmcluster-a-victoria-metrics-cluster-vminsert:8480/insert/0/prometheus/api/v1/write
     urlRelabelConfig:
       - action: keep
         source_labels: [retention]
         regex: "3mo"
-  # Group B
+  # Group B: receives metrics with retention="1yr"
   - url: http://vmcluster-b-victoria-metrics-cluster-vminsert:8480/insert/0/prometheus/api/v1/write
     urlRelabelConfig:
       - action: keep
         source_labels: [retention]
         regex: "1yr"
-  # Group C
+  # Group C: receives metrics with retention="3yr"
   - url: http://vmcluster-c-victoria-metrics-cluster-vminsert:8480/insert/0/prometheus/api/v1/write
     urlRelabelConfig:
       - action: keep
         source_labels: [retention]
         regex: "3yr"
-  # fallback route: catch anything that didn't match so far (send to group C)
-  - url: http://vmcluster-c-victoria-metrics-cluster-vminsert:8480/insert/0/prometheus/api/v1/write
 EOF
 ```
 
-And install the release with:
+> Two important notes on scraping:
+> - Metrics without a matching `retention` label are silently dropped by the `keep` rules. You must ensure every metric gets the label or use a different routing configuration.
+> - The [scrape interval](https://docs.victoriametrics.com/victoriametrics/sd_configs/#scrape_configs) should match the `dedup.minScrapeInterval` defined in the vmstorage nodes.
+`
+
+Now deploy the vmagent release:
 
 ```shell
 helm upgrade --install vmagent vm/victoria-metrics-agent -f vmagent.yaml
 ```
 
+Wait for vmagent to become ready:
+
+```shell
+kubectl rollout status deploy/vmagent-victoria-metrics-agent
+```
+
+### Step 4: Verification
+
+We can send test data to verify data is flowing to the correct storage group.
+
+First, port-forward vmagent and vmselect:
+
+```shell
+VMAGENT_SVC=$(kubectl get svc -l app.kubernetes.io/instance=vmagent -o jsonpath='{.items[0].metadata.name}')
+kubectl port-forward "svc/$VMAGENT_SVC" 8429 &
+
+VMSELECT_SVC=$(kubectl get svc -l app.kubernetes.io/instance=vmselect -o jsonpath='{.items[0].metadata.name}')
+kubectl port-forward "svc/$VMSELECT_SVC" 8481 &
+```
+
+Send test metrics directly to vmagent's HTTP endpoint to exercise all three retention labels:
+
+```shell
+POD=$(kubectl get pod -l app.kubernetes.io/instance=vmagent -o jsonpath='{.items[0].metadata.name}')
+
+for retention in 3mo 1yr 3yr; do
+  kubectl exec "$POD" -- wget -qO- --post-data="test_routing{retention=\"${retention}\"} 1.0" \
+    "http://127.0.0.1:8429/api/v1/import/prometheus"
+done
+```
+
+Query the data back from vmselect (it may take around 30-60 seconds for new data to be available for queries):
+
+```shell
+for retention in 3mo 1yr 3yr; do
+  echo "-> retention=${retention}"
+  curl -s "http://localhost:8481/select/0/prometheus/api/v1/query" \
+    --data-urlencode "query=test_routing{retention=\"${retention}\"}"
+  echo
+done
+```
+
+You can also check that vmagent is forwarding data to all three groups:
+
+```shell
+curl -s http://localhost:8429/metrics | grep vmagent_remotewrite_blocks_sent_total
+```
+
+Each `url="N:secret-url"` corresponds to one `remoteWrite` entry (N=1 for Group A, N=2 for Group B, N=3 for Group C). Non-zero values confirm data is flowing.
+
 ## Alternative Routing by Existing Labels
 
 The example setup above relies on a synthetic `retention` label to exist in every incoming metric.
 
-If having a `retention` label in every metric isn't practical, you can, as an alternative, rely on existing labels to map data to the correct storage group. 
+If having a `retention` label in every metric isn't practical, you can, as an alternative, rely on existing labels to map data to the correct storage group.
 
 The following example configures `vmagent` to route metrics based on the `environment` and `team` labels:
 
@@ -246,26 +299,26 @@ The following example configures `vmagent` to route metrics based on the `enviro
 # vmagent.yaml
 remoteWrite:
   # send dev and staging data to Group A
-  - url: "http://vmcluster-a-vminsert:8480/insert/0/prometheus"
+  - url: "http://vmcluster-a-victoria-metrics-cluster-vminsert:8480/insert/0/prometheus"
     urlRelabelConfig:
       - action: keep
         source_labels: [environment]
         regex: "dev|staging"
   # send prod data to Group B
-  - url: "http://vmcluster-b-vminsert:8480/insert/0/prometheus"
+  - url: "http://vmcluster-b-victoria-metrics-cluster-vminsert:8480/insert/0/prometheus"
     urlRelabelConfig:
       - action: keep
         source_labels: [environment]
         regex: "prod|production"
   # send data from Infra and SRE teams to Group B
-  - url: "http://vmcluster-b-vminsert:8480/insert/0/prometheus"
+  - url: "http://vmcluster-b-victoria-metrics-cluster-vminsert:8480/insert/0/prometheus"
     urlRelabelConfig:
       - action: keep
         source_labels: [team]
         regex: "infra|sre"
-  # fallback route: catch anything that didn't match so far (send to Group C)
-  - url: "http://vmcluster-c-vminsert:8480/insert/0/prometheus"
 ```
+
+> Metrics that match none of the `keep` rules are dropped in the configuration above.
 
 ## Alternative Multi-Tenant Routing
 

--- a/docs/guides/guide-vmcluster-multiple-retention-setup/README.md
+++ b/docs/guides/guide-vmcluster-multiple-retention-setup/README.md
@@ -343,7 +343,7 @@ The tenant path does not affect where data is stored (routing is always determin
 
 You can set up [vmauth](https://docs.victoriametrics.com/victoriametrics/vmauth/) to route data to the specified vminsert group based on the required retention or to restrict which data different users can query.
 
-The following [`-auth.config`](https://docs.victoriametrics.com/vmauth.html#quick-start) example exposes the same vmselect backend via vmauth with two users using basic auth:
++The following [`-auth.config`](https://docs.victoriametrics.com/victoriametrics/vmauth/#quick-start) example exposes the same vmselect backend via vmauth with two users using basic auth:
 
 - `admin`: can query **all** data across all retention groups.
 - `dev`: can query **only** time series that have `team="dev"` label, enforced via the `extra_label` query argument.

--- a/docs/guides/guide-vmcluster-multiple-retention-setup/README.md
+++ b/docs/guides/guide-vmcluster-multiple-retention-setup/README.md
@@ -15,11 +15,13 @@ This guide explains how to set up multiple retentions using an [open-source Vict
 
 VictoriaMetrics retains metrics by default for 1 month. You can change data retention with the [`-retentionPeriod` command-line flag](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#retention), but this value applies to all time series stored on a given `vmstorage` node and cannot be customized per tenant or per metric in the open source version. 
 
+The core idea of multi-tenant architecture is to run separate storage logic groups (or even clusters) with individual `-retentionPeriod` settings, while still providing a single unified write and read path via vmagent and vmselect.
+
 ## Multi-Retention Architecture
 
-To support multiple retentions with the open source version of VictoriaMetrics cluster, you can split the cluster into several logical groups of `vmstorage` nodes, where each group is configured with a different `-retentionPeriod` and receives only the data that must follow that retention. 
+To support multiple retentions with the open source version of VictoriaMetrics cluster, you can split the cluster into several logical groups of storage nodes, where each group is configured with a different `-retentionPeriod` and receives only the data that must follow that retention. 
 
-Each storage group is connected to a separate `vminsert`, while a shared `vmselect` layer queries across all storage groups so that dashboards and alerts continue to see a single logical VictoriaMetrics backend.
+Each storage group is connected to a separate vminsert, while a shared vmselect layer queries across all storage groups so that dashboards and alerts continue to see a single logical VictoriaMetrics backend.
 
 ![Setup](setup.webp)
 
@@ -29,7 +31,7 @@ In the example used throughout this guide, the cluster is divided into three gro
 - Group B: 1-year retention.
 - Group C: 3-year retention. 
 
-Metrics are routed to the appropriate `vminsert` group by [splitting data streams](https://docs.victoriametrics.com/victoriametrics/vmagent/#splitting-data-streams-among-multiple-systems) in `vmagent`. An optional [vmauth](https://docs.victoriametrics.com/victoriametrics/vmauth/) rule can be added on top to enforce per-tenant routing or API access policies.
+Metrics are routed to the appropriate vminsert group by [splitting data streams](https://docs.victoriametrics.com/victoriametrics/vmagent/#splitting-data-streams-among-multiple-systems) in vmagent. An optional [vmauth](https://docs.victoriametrics.com/victoriametrics/vmauth/) rule can be added on top to enforce per-tenant routing or API access policies.
 
 ## Implementing Multi-Retention on Kubernetes
 
@@ -44,13 +46,15 @@ helm repo update
 
 ### Step 1: Deploying storage groups
 
-We'll create three retention groups. Each has a different retention period and disk size. Read [Understand Your Setup Size](https://docs.victoriametrics.com/guides/understand-your-setup-size/) to estimate how much space you will need for each group. The following table is shown as an example.
+We'll create three storage groups. Each has a different retention period and disk size. Read [Understand Your Setup Size](https://docs.victoriametrics.com/guides/understand-your-setup-size/) to estimate how much space you will need for each group. The following table is shown as an example.
 
-| Group       | Retention Period | Disk Size |
-|-------------|------------------|-----------|
-| `vmcluster-a` | 3 months (`3M`)    | 80GB      |
-| `vmcluster-b` | 1 year (`1Y`)      | 300 GB    |
-| `vmcluster-c` | 3 years (`3Y`)     | 900 GB    |
+> Note: disk sizes below are per `vmstorage` replica. The manifests in this guide use 2 replicas per group, so total cluster storage per group = size × 2.
+
+| Group       | Retention Period | Total disk size       |
+|-------------|------------------|-----------------------|
+| `vmcluster-a` | 3 months (`3M`)    | 80 Gi                 |
+| `vmcluster-b` | 1 year (`1Y`)      | 300 Gi                |
+| `vmcluster-c` | 3 years (`3Y`)     | 900 Gi                |
 
 Create a Helm values file for Group A.
 
@@ -58,8 +62,9 @@ Create a Helm values file for Group A.
 cat <<EOF > vmcluster-a.yaml
 vmstorage:
   enabled: true
+  replicaCount: 2
   persistence:
-    size: 80Gi
+    size: 40Gi
   extraArgs:
     retentionPeriod: 3M
     storageDataPath: /vmstorage-data
@@ -78,7 +83,9 @@ vmselect:
 EOF
 ```
 
-The values file above creates `vminsert` and `vmstorage` services while turning off `vmselect`, which we'll deploy separately. It also defines a 30-second [deduplication](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/#deduplication) window to handle possible duplicate metrics. The deduplication window must match the `vmagent` service scrape window (which we'll define later in the guide).
+The values file above creates vminsert and vmstorage services while turning off vmselect, which we'll deploy separately. With `replicaCount: 2`, the storage group runs two vmstorage instances, and vminsert sends incoming data to both of them. The 30-second [deduplication](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/#deduplication) setting tells vmselect how to collapse duplicate samples with identical labels and timestamps into one. This value should match the scrape interval and the `dedup.minScrapeInterval` value configured for vmselect later on.
+
+> The disk size in `values-a.yaml` is per replica, so total storage for Group A is `size * replicaCount` (i.e., 40Gi x 2 = 80Gi).
 
 Create the values files for Group B and Group C:
 
@@ -86,8 +93,9 @@ Create the values files for Group B and Group C:
 cat <<EOF > vmcluster-b.yaml
 vmstorage:
   enabled: true
+  replicaCount: 2
   persistence:
-    size: 300Gi
+    size: 150Gi
   extraArgs:
     retentionPeriod: 1Y
     storageDataPath: /vmstorage-data
@@ -109,8 +117,9 @@ EOF
 cat <<EOF > vmcluster-c.yaml
 vmstorage:
   enabled: true
+  replicaCount: 2
   persistence:
-    size: 900Gi
+    size: 450Gi
   extraArgs:
     retentionPeriod: 3Y
     storageDataPath: /vmstorage-data
@@ -144,7 +153,7 @@ kubectl rollout status statefulset -l app.kubernetes.io/instance=vmcluster-c
 
 ### Step 2: Deploying vmselect
 
-Next, we'll deploy a `vmselect` service to route queries to the storage groups.
+Next, we'll deploy a vmselect service to route queries to the storage groups.
 
 Create a Helm values file with:
 
@@ -176,10 +185,10 @@ EOF
 
 Let's break down the file above:
 
-- Deploys `vmselect` as a separate Helm release 
-- Disables `vminsert` and `vmstorage` as these services were already deployed in Step 1.
-- `supressStorageFQDNsRender: true` turns off automatic FQDN generation for storage nodes. By default, the Helm chart auto-generates `-storageNodes` flags, but since `vmstorage` has been disabled, we need to supply them manually in `extraArgs`.
-- In `extraArgs.storageNode:` we define the list of `vmstorage` services to reach for queries. The `storageNode` flags tell vmselect to query all 6 storage pods, which are organized into three groups: `a`, `b`, and `c`.
+- Deploys vmselect as a separate Helm release 
+- Disables vminsert and vmstorage as these services were already deployed in Step 1.
+- `suppressStorageFQDNsRender: true` turns off automatic FQDN generation for storage nodes. By default, the Helm chart auto-generates `-storageNodes` flags, but since `vmstorage` has been disabled, we need to supply them manually in `extraArgs`.
+- In `extraArgs.storageNode:` we define the vmstorage endpoints for queries. Each entry uses the `<group>/<host>` format. The group prefix tells vmselect which pods are replicas of each other. Groups `a`, `b`, and `c` correspond to the three retention periods. Within each group, the 2 pods are replicas, so vmselect deduplicates within each retention group and unions across groups, providing a unified view of all 6 storage pods.
 
 Deploy the `vmselect` release with:
 
@@ -227,7 +236,7 @@ EOF
 ```
 
 > Two important notes on scraping:
-> - Metrics without a matching `retention` label are silently dropped by the `keep` rules. You must ensure that every metric receives a label, or use a different routing configuration.
+> - Metrics without a matching `retention` label are silently dropped by the `keep` rules. You must ensure that every metric is labeled, or use a different routing configuration.
 > - The [scrape interval](https://docs.victoriametrics.com/victoriametrics/sd_configs/#scrape_configs) should match the `dedup.minScrapeInterval` defined in the vmstorage nodes.
 `
 
@@ -245,7 +254,7 @@ kubectl rollout status deploy/vmagent-victoria-metrics-agent
 
 ### Step 4: Verification
 
-We can send test data to verify that data is flowing to the correct storage group.
+We can send test data to verify that the data is flowing to the correct storage group.
 
 First, port-forward vmagent and vmselect:
 
@@ -293,7 +302,7 @@ The example setup above relies on a synthetic `retention` label to exist in ever
 
 If having a `retention` label in every metric isn't practical, you can, as an alternative, rely on existing labels to map data to the correct storage group.
 
-The following example configures `vmagent` to route metrics based on the `environment` and `team` labels:
+The following example configures vmagent to route metrics based on the `environment` and `team` labels:
 
 ```yaml
 # vmagent.yaml
@@ -324,7 +333,7 @@ remoteWrite:
 
 VictoriaMetrics Cluster supports [multiple isolated tenants](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/#multitenancy) identified by `accountID` (and optionally `projectID`) in the URL path, e.g., `/insert/0/prometheus/...`. 
 
-In a standard deployment, a single `vminsert` handles all tenants and distributes data across a shared pool of `vmstorage` nodes. In our current setup, each retention group deploys its own `vminsert`. This means tenant IDs are not required for routing, since data is already isolated by the URL that receives the write. 
+In a standard deployment, a single vminsert handles all tenants and distributes data across a shared pool of vmstorage nodes. In our current setup, each retention group deploys its own vminsert. This means tenant IDs are not required for routing, since data is already isolated by the URL that receives the write. 
 
 You can safely use a single tenant (`/insert/0/prometheus`) for all groups and rely on the `retention` label or label-based routing to separate data at query time.
 
@@ -336,9 +345,9 @@ If, however, you prefer tenant-level separation for the query layer, you can ass
 | B (1yr) | `/insert/1/prometheus` | `/select/1/prometheus` |
 | C (3yr) | `/insert/2/prometheus` | `/select/2/prometheus` |
 
-This lets you query a single retention group directly, e.g., `/select/1/prometheus/api/v1/query?query=up` returns only data written to group B's `vminsert`. Queries to vmselect without a tenant prefix aggregate across all groups, preserving the unified view for dashboards.
+This lets you query a single retention group directly, e.g., `/select/1/prometheus/api/v1/query?query=up` returns only data written to group B's vminsert. Queries to vmselect without a tenant prefix aggregate across all groups, preserving the unified view for dashboards.
 
-The tenant path does not affect where data is stored (routing is always determined by which `vminsert` receives the data). The tenant ID is purely a query-scoping convenience in this architecture.
+The tenant path does not affect where data is stored (routing is always determined by which vminsert receives the data). The tenant ID is purely a query-scoping convenience in this architecture.
 
 ## Additional Enhancements
 

--- a/docs/guides/guide-vmcluster-multiple-retention-setup/README.md
+++ b/docs/guides/guide-vmcluster-multiple-retention-setup/README.md
@@ -13,6 +13,8 @@ This guide explains how to set up multiple retentions using an [open-source Vict
 
 ## Overview
 
+**Open Source Solution**
+
 VictoriaMetrics retains metrics by default for 1 month. You can change data retention with the [`-retentionPeriod` command-line flag](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#retention), but this value applies to all time series stored on a given `vmstorage` node and cannot be customized per tenant or per metric in the open source version. 
 
 The core idea of multi-tenant architecture is to run separate storage logic groups (or even clusters) with individual `-retentionPeriod` settings, while still providing a single unified write and read path via vmagent and vmselect.

--- a/docs/guides/guide-vmcluster-multiple-retention-setup/README.md
+++ b/docs/guides/guide-vmcluster-multiple-retention-setup/README.md
@@ -9,28 +9,31 @@ sitemap:
 
 [VictoriaMetrics Enterprise](https://docs.victoriametrics.com/victoriametrics/enterprise/) supports specifying multiple retentions for distinct sets of time series and tenants. If you are an Enterprise user, [configure multiple retentions directly through retention filters](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/#retention-filters) instead of following this guide.
 
-This guide explains how to set up multiple retentions using an **open-source VictoriaMetrics Cluster**.
+This guide explains how to set up multiple retentions using an [open-source VictoriaMetrics Cluster](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/).
 
 ## Overview
 
-VictoriaMetrics retains by default 1-month worth of metrics. You can change data retention with the [`-retentionPeriod` command-line flag](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#retention), but this value applies to all time series stored on a given `vmstorage` node and cannot be customized per tenant or per metric in the open source version. 
+VictoriaMetrics retains metrics by default for 1 month. You can change data retention with the [`-retentionPeriod` command-line flag](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#retention), but this value applies to all time series stored on a given `vmstorage` node and cannot be customized per tenant or per metric in the open source version. 
 
 ## Multi-Retention Architecture
 
-To obtain multiple retentions with the open source VictoriaMetrics Cluster, you can split the cluster into several logical groups of `vmstorage` nodes, where each group is configured with a different `-retentionPeriod` and receives only the data that must follow that retention. Each storage group is connected to a separate `vminsert`, while a shared `vmselect` layer queries across all storage groups so that dashboards and alerts continue to see a single logical VictoriaMetrics backend.
+To support multiple retentions with the open source version of VictoriaMetrics cluster, you can split the cluster into several logical groups of `vmstorage` nodes, where each group is configured with a different `-retentionPeriod` and receives only the data that must follow that retention. 
+
+Each storage group is connected to a separate `vminsert`, while a shared `vmselect` layer queries across all storage groups so that dashboards and alerts continue to see a single logical VictoriaMetrics backend.
 
 ![Setup](setup.webp)
 
 In the example used throughout this guide, the cluster is divided into three groups: 
+
 - Group A: 3-month retention.
 - Group B: 1-year retention.
 - Group C: 3-year retention. 
 
-Metrics are routed to the appropiate `vminsert` group by [splitting data streams](https://docs.victoriametrics.com/victoriametrics/vmagent/#splitting-data-streams-among-multiple-systems) with `vmagent`. An optional [vmauth](https://docs.victoriametrics.com/victoriametrics/vmauth/) rules can be added on top to enforce per-tenant routing or API access policies.
+Metrics are routed to the appropriate `vminsert` group by [splitting data streams](https://docs.victoriametrics.com/victoriametrics/vmagent/#splitting-data-streams-among-multiple-systems) in `vmagent`. An optional [vmauth](https://docs.victoriametrics.com/victoriametrics/vmauth/) rule can be added on top to enforce per-tenant routing or API access policies.
 
 ## Implementing Multi-Retention on Kubernetes
 
-In this section, we'll install and configure the components for the VictoriaMetrics cluster. See [Kubernetes monitoring with VictoriaMetrics Cluster](https://docs.victoriametrics.com/guides/k8s-monitoring-via-vm-cluster/) for prerequisites and more details.
+In this section, we'll install and configure the components for a multi-retention deployment of the VictoriaMetrics cluster. See [Kubernetes monitoring with VictoriaMetrics Cluster](https://docs.victoriametrics.com/guides/k8s-monitoring-via-vm-cluster/) for details on running VictoriaMetrics in Kubernetes.
 
 Run the following command to add the VictoriaMetrics Helm repository:
 
@@ -41,7 +44,7 @@ helm repo update
 
 ### Step 1: Deploying storage groups
 
-We'll create three retention groups, groups, each has a different retention period and disk size. Read [Understand Your Setup Size](https://docs.victoriametrics.com/guides/understand-your-setup-size/) to estimate how much space you will need for each retention.
+We'll create three retention groups. Each has a different retention period and disk size. Read [Understand Your Setup Size](https://docs.victoriametrics.com/guides/understand-your-setup-size/) to estimate how much space you will need for each group. The following table is shown as an example.
 
 | Group       | Retention Period | Disk Size |
 |-------------|------------------|-----------|
@@ -49,7 +52,7 @@ We'll create three retention groups, groups, each has a different retention peri
 | `vmcluster-b` | 1 year (`1Y`)      | 300 GB    |
 | `vmcluster-c` | 3 years (`3Y`)     | 900 GB    |
 
-Create a Helm values file for Group A. This creates two `vminsert` and `vmstorage` pods:
+Create a Helm values file for Group A.
 
 ```shell
 cat <<EOF > vmcluster-a.yaml
@@ -75,7 +78,7 @@ vmselect:
 EOF
 ```
 
-The values file creates a `vminsert` and `vmstorage` services while disabling `vmselect`, as we'll deploy it separately. It also defines a 30-second [deduplication](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/#deduplication) window to handle possible duplicate metrics. The deduplication window must match the `vmagent` service scrape window (which we'll define it later in the guide).
+The values file above creates `vminsert` and `vmstorage` services while turning off `vmselect`, which we'll deploy separately. It also defines a 30-second [deduplication](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/#deduplication) window to handle possible duplicate metrics. The deduplication window must match the `vmagent` service scrape window (which we'll define later in the guide).
 
 Create the values files for Group B and Group C:
 
@@ -126,7 +129,7 @@ vmselect:
 EOF
 ```
 
-Create the three logical groups with:
+Deploy the three storage groups with:
 
 ```shell
 helm upgrade --install vmcluster-a vm/victoria-metrics-cluster -f vmcluster-a.yaml
@@ -134,14 +137,14 @@ helm upgrade --install vmcluster-b vm/victoria-metrics-cluster -f vmcluster-b.ya
 helm upgrade --install vmcluster-c vm/victoria-metrics-cluster -f vmcluster-c.yaml
 
 # Wait for all storage pods to be ready
-kubectl rollout status statefulset/vmcluster-a-vmstorage
-kubectl rollout status statefulset/vmcluster-b-vmstorage
-kubectl rollout status statefulset/vmcluster-c-vmstorage
+kubectl rollout status statefulset -l app.kubernetes.io/instance=vmcluster-a
+kubectl rollout status statefulset -l app.kubernetes.io/instance=vmcluster-b
+kubectl rollout status statefulset -l app.kubernetes.io/instance=vmcluster-c
 ```
 
 ### Step 2: Deploying vmselect
 
-Next, we'll deploy a `vmselect` service to route queries to the three storage groups.
+Next, we'll deploy a `vmselect` service to route queries to the storage groups.
 
 Create a Helm values file with:
 
@@ -168,14 +171,14 @@ vmselect:
       - "b/vmcluster-b-victoria-metrics-cluster-vmstorage-0.vmcluster-b-victoria-metrics-cluster-vmstorage.default.svc:8401,b/vmcluster-b-victoria-metrics-cluster-vmstorage-1.vmcluster-b-victoria-metrics-cluster-vmstorage.default.svc:8401"
       - "c/vmcluster-c-victoria-metrics-cluster-vmstorage-0.vmcluster-c-victoria-metrics-cluster-vmstorage.default.svc:8401,c/vmcluster-c-victoria-metrics-cluster-vmstorage-1.vmcluster-c-victoria-metrics-cluster-vmstorage.default.svc:8401"
     dedup.minScrapeInterval: 30s
-  podLabels:
-    component: vmselect-global
+EOF
 ```
 
-Let's break down the values file:
+Let's break down the file above:
 
-- Deploy `vmselect` as a separate Helm release disable `vminsert` and `vmstorage` as the storage groups are already deployed in Step 1.
-- Normally the chart auto-generates `-storageNodes` flags, but since `vmstorage` has been disabled, we need to supply them in as `extraArgs`.
+- Deploys `vmselect` as a separate Helm release 
+- Disables `vminsert` and `vmstorage` as these services were already deployed in Step 1.
+- `supressStorageFQDNsRender: true` turns off automatic FQDN generation for storage nodes. By default, the Helm chart auto-generates `-storageNodes` flags, but since `vmstorage` has been disabled, we need to supply them manually in `extraArgs`.
 - In `extraArgs.storageNode:` we define the list of `vmstorage` services to reach for queries. The `storageNode` flags tell vmselect to query all 6 storage pods, which are organized into three groups: `a`, `b`, and `c`.
 
 Deploy the `vmselect` release with:
@@ -184,15 +187,16 @@ Deploy the `vmselect` release with:
 helm upgrade --install vmselect vm/victoria-metrics-cluster -f vmselect.yaml
 ```
 
-### Step 3: deploy vmagent
+### Step 3: Deploying vmagent
 
-In this setup, `vmagent` routes incoming metrics to the cluster to the right retention group. In the following example, we use a `retention` label to map metrics to storage groups in the following way:
+We'll use `vmagent` to route incoming metrics to the correct retention group. For example, we can use a `retention` label for mapping metrics to storage groups in the following way:
 
 | `retention` label | Storage Group |
 | ----------------| --------------|
 | "3mo"           | `vmcluster-a`   | 
 | "1yr"           | `vmcluster-b`   | 
 | "3yr"           | `vmcluster-c`   | 
+| (not set)       | `vmcluster-c`   | 
 
 Create the values file for vmagent:
 
@@ -201,21 +205,27 @@ cat <<EOF >vmagent.yaml
 service:
   enabled: true
 remoteWrite:
+  # Group A
   - url: http://vmcluster-a-victoria-metrics-cluster-vminsert:8480/insert/0/prometheus/api/v1/write
     urlRelabelConfig:
       - action: keep
         source_labels: [retention]
         regex: "3mo"
+  # Group B
   - url: http://vmcluster-b-victoria-metrics-cluster-vminsert:8480/insert/0/prometheus/api/v1/write
     urlRelabelConfig:
       - action: keep
         source_labels: [retention]
         regex: "1yr"
+  # Group C
   - url: http://vmcluster-c-victoria-metrics-cluster-vminsert:8480/insert/0/prometheus/api/v1/write
     urlRelabelConfig:
       - action: keep
         source_labels: [retention]
         regex: "3yr"
+  # fallback route: catch anything that didn't match so far (send to group C)
+  - url: http://vmcluster-c-victoria-metrics-cluster-vminsert:8480/insert/0/prometheus/api/v1/write
+EOF
 ```
 
 And install the release with:
@@ -226,42 +236,46 @@ helm upgrade --install vmagent vm/victoria-metrics-agent -f vmagent.yaml
 
 ## Alternative Routing by Existing Labels
 
-The example setup above relies on a synthetic `retention` label to be appended to every metric. These labels should be added before pushing the data into the VictoriaMetrics cluster for it to work.
+The example setup above relies on a synthetic `retention` label to exist in every incoming metric.
 
-If appending a `retention` label isn't practical, you can, as an alternative, rely on existing labels to map data to the correct storage group. The following example configures `vmagent` to route metrics based on the `environment` and `team` labels:
+If having a `retention` label in every metric isn't practical, you can, as an alternative, rely on existing labels to map data to the correct storage group. 
+
+The following example configures `vmagent` to route metrics based on the `environment` and `team` labels:
 
 ```yaml
 # vmagent.yaml
 remoteWrite:
-  # send dev and staging data to group a
+  # send dev and staging data to Group A
   - url: "http://vmcluster-a-vminsert:8480/insert/0/prometheus"
     urlRelabelConfig:
       - action: keep
         source_labels: [environment]
         regex: "dev|staging"
-  # send prod data to group b
+  # send prod data to Group B
   - url: "http://vmcluster-b-vminsert:8480/insert/0/prometheus"
     urlRelabelConfig:
       - action: keep
         source_labels: [environment]
         regex: "prod|production"
-  # you can combine rules, for example routing based on a different label ("team")
+  # send data from Infra and SRE teams to Group B
   - url: "http://vmcluster-b-vminsert:8480/insert/0/prometheus"
     urlRelabelConfig:
       - action: keep
         source_labels: [team]
         regex: "infra|sre"
-  # fallback rule: send everything else to group c
+  # fallback route: catch anything that didn't match so far (send to Group C)
   - url: "http://vmcluster-c-vminsert:8480/insert/0/prometheus"
 ```
 
 ## Alternative Multi-Tenant Routing
 
-VictoriaMetrics Cluster supports [multiple isolated tenants](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/#multitenancy) identified by `accountID` (and optionally `projectID`) in the URL path, e.g. `/insert/0/prometheus/...`. 
+VictoriaMetrics Cluster supports [multiple isolated tenants](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/#multitenancy) identified by `accountID` (and optionally `projectID`) in the URL path, e.g., `/insert/0/prometheus/...`. 
 
-In a standard deployment, a single `vminsert` handles all tenants and distributes data across a shared pool of `vmstorage` nodes. In our current setup, each retention group deploys its own `vminsert`. This means tenant IDs are not required for routing as data is already isolated by which URL receives the write. You can safely use a single tenant (`/insert/0/prometheus`) for all groups and rely on the `retention` label or label-based routing to separate data at query time.
+In a standard deployment, a single `vminsert` handles all tenants and distributes data across a shared pool of `vmstorage` nodes. In our current setup, each retention group deploys its own `vminsert`. This means tenant IDs are not required for routing, since data is already isolated by the URL that receives the write. 
 
-If you prefer tenant-level separation at the query layer, you can assign each group a distinct tenant ID, for instance:
+You can safely use a single tenant (`/insert/0/prometheus`) for all groups and rely on the `retention` label or label-based routing to separate data at query time.
+
+If, however, you prefer tenant-level separation for the query layer, you can assign each group a distinct tenant ID, for instance:
 
 | Group | Insert URL | Query URL |
 |-------|------------|-----------|
@@ -269,11 +283,12 @@ If you prefer tenant-level separation at the query layer, you can assign each gr
 | B (1yr) | `/insert/1/prometheus` | `/select/1/prometheus` |
 | C (3yr) | `/insert/2/prometheus` | `/select/2/prometheus` |
 
-This lets you query a single retention group directly, e.g. `/select/1/prometheus/api/v1/query?query=up` returns only data written to group B's `vminsert`. Queries to vmselect without a tenant prefix (or to tenant 0) aggregate across all groups, preserving the unified view for dashboards.
+This lets you query a single retention group directly, e.g., `/select/1/prometheus/api/v1/query?query=up` returns only data written to group B's `vminsert`. Queries to vmselect without a tenant prefix aggregate across all groups, preserving the unified view for dashboards.
 
 The tenant path does not affect where data is stored (routing is always determined by which `vminsert` receives the data). The tenant ID is purely a query-scoping convenience in this architecture.
 
 ## Additional Enhancements
 
-You can set up [vmauth](https://docs.victoriametrics.com/victoriametrics/vmauth/) for routing data to the given vminsert group depending on the needed retention.
+You can set up [vmauth](https://docs.victoriametrics.com/victoriametrics/vmauth/) to route data to the specified vminsert group based on the required retention.
+
 

--- a/docs/guides/guide-vmcluster-multiple-retention-setup/README.md
+++ b/docs/guides/guide-vmcluster-multiple-retention-setup/README.md
@@ -75,7 +75,8 @@ vmstorage:
 
 vminsert:
   enabled: true
-  replicationFactor: 2
+  extraArgs:
+    replicationFactor: 2
   podLabels:
     retention-group: a
 
@@ -84,7 +85,7 @@ vmselect:
 EOF
 ```
 
-The values file above creates vminsert and vmstorage services while turning off vmselect, which we'll deploy separately. With `replicaCount: 2`, the storage group runs two vmstorage instances, and vminsert sends incoming data to both of them. The 30-second [deduplication](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/#deduplication) setting tells vmselect how to collapse duplicate samples with identical labels and timestamps into one. This value should match the scrape interval and the `dedup.minScrapeInterval` value configured for vmselect later on.
+The values file above creates vminsert and vmstorage services while turning off vmselect, which we'll deploy separately. With `replicaCount: 2`, each group runs 2 vmstorage pods. Setting `vminsert.extraArgs.replicationFactor: 2` sets the [replication factor](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/#list-of-command-line-flags-for-vminsert) to vminsert, instructing it to store every ingested sample on 2 distinct vmstorage nodes. Together with the 2 pods, this ensures each sample exists on both pods for high availability. vmselect uses the 30-second [deduplication](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/#deduplication) window to handle duplicate samples at query time. The deduplication value should match `dedup.minScrapeInterval` in vmselect and the [scrape interval](https://docs.victoriametrics.com/victoriametrics/scrape_config_examples/).
 
 > The disk size in `vmcluster-a.yaml` is per replica, so total storage for Group A is `size * replicaCount` (i.e., 40Gi x 2 = 80Gi).
 
@@ -107,7 +108,8 @@ vmstorage:
 
 vminsert:
   enabled: true
-  replicationFactor: 2
+  extraArgs:
+    replicationFactor: 2
   podLabels:
     retention-group: b
 
@@ -132,7 +134,8 @@ vmstorage:
 
 vminsert:
   enabled: true
-  replicationFactor: 2
+  extraArgs:
+    replicationFactor: 2
   podLabels:
     retention-group: c
 

--- a/docs/guides/guide-vmcluster-multiple-retention-setup/README.md
+++ b/docs/guides/guide-vmcluster-multiple-retention-setup/README.md
@@ -7,23 +7,21 @@ sitemap:
   disable: true
 ---
 
-[VictoriaMetrics Enterprise](https://docs.victoriametrics.com/victoriametrics/enterprise/) supports specifying multiple retentions for distinct sets of time series and tenants. If you are an Enterprise user, [configure multiple retentions directly through retention filters](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/#retention-filters) instead of following this guide.
+> [VictoriaMetrics Enterprise](https://docs.victoriametrics.com/victoriametrics/enterprise/) supports specifying multiple retentions for distinct sets of time series and tenants. If you are an Enterprise user, [configure multiple retentions directly through retention filters](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/#retention-filters) instead of following this guide.
 
 This guide explains how to set up multiple retentions using an [open-source VictoriaMetrics Cluster](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/).
 
 ## Overview
 
-**Open Source Solution**
+VictoriaMetrics retains metrics by default for **1 month**. You can change data retention with the [`-retentionPeriod` command-line flag](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#retention), but this value applies to **all time series stored** on a given `vmstorage` node and cannot be customized per tenant or per metric in the open source version. 
 
-VictoriaMetrics retains metrics by default for 1 month. You can change data retention with the [`-retentionPeriod` command-line flag](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#retention), but this value applies to all time series stored on a given `vmstorage` node and cannot be customized per tenant or per metric in the open source version. 
-
-The core idea of multi-tenant architecture is to run separate storage logic groups (or even clusters) with individual `-retentionPeriod` settings, while still providing a single unified write and read path via vmagent and vmselect.
+The core idea of this guide is to run **separate logic groups of storages** (or even clusters) with individual `-retentionPeriod` settings, while still providing a single unified write and read path via vmagent and vmselect.
 
 ## Multi-Retention Architecture
 
-To support multiple retentions with the open source version of VictoriaMetrics cluster, you can split the cluster into several logical groups of storage nodes, where each group is configured with a different `-retentionPeriod` and receives only the data that must follow that retention. 
+To support multiple retentions with the open source version of VictoriaMetrics cluster, you can split the cluster into several logical groups of storage nodes. Each group is configured with a different `-retentionPeriod` and receives only the data that must follow that retention. 
 
-Each storage group is connected to a separate vminsert, while a shared vmselect layer queries across all storage groups so that dashboards and alerts continue to see a single logical VictoriaMetrics backend.
+Each storage group is connected to a separate vminsert, while a shared vmselect layer queries across all storage groups so that dashboards and alerts continue to see a single unified VictoriaMetrics backend.
 
 ![Setup](setup.webp)
 
@@ -48,7 +46,7 @@ helm repo update
 
 ### Step 1: Deploying storage groups {#step1}
 
-We'll create three storage groups. Each has a different retention period and disk size. Read [Understand Your Setup Size](https://docs.victoriametrics.com/guides/understand-your-setup-size/) to estimate how much space you will need for each group. The following table is shown as an example.
+We'll create three storage groups. Each has a different retention period and disk size. Read [Understand Your Setup Size](https://docs.victoriametrics.com/guides/understand-your-setup-size/) to estimate how much space you will need for each group. The following table is shown as an example:
 
 
 | Group        | Retention Period | Total disk size       |
@@ -170,9 +168,9 @@ vmselect:
     # where pod = <release>-victoria-metrics-cluster-vmstorage-<N>
     # and   svc = <release>-victoria-metrics-cluster-vmstorage
     storageNode:
-      - "a/vmcluster-a-victoria-metrics-cluster-vmstorage-0.vmcluster-a-victoria-metrics-cluster-vmstorage.default.svc:8401"
-      - "b/vmcluster-b-victoria-metrics-cluster-vmstorage-0.vmcluster-b-victoria-metrics-cluster-vmstorage.default.svc:8401"
-      - "c/vmcluster-c-victoria-metrics-cluster-vmstorage-0.vmcluster-c-victoria-metrics-cluster-vmstorage.default.svc:8401"
+      - "vmcluster-a-victoria-metrics-cluster-vmstorage-0.vmcluster-a-victoria-metrics-cluster-vmstorage.default.svc:8401"
+      - "vmcluster-b-victoria-metrics-cluster-vmstorage-0.vmcluster-b-victoria-metrics-cluster-vmstorage.default.svc:8401"
+      - "vmcluster-c-victoria-metrics-cluster-vmstorage-0.vmcluster-c-victoria-metrics-cluster-vmstorage.default.svc:8401"
 EOF
 ```
 
@@ -181,7 +179,7 @@ Let's break down the file above:
 - Deploys vmselect as a separate Helm release. 
 - Disables vminsert and vmstorage as these services were already deployed in Step 1.
 - `suppressStorageFQDNsRender: true` turns off automatic FQDN generation for storage nodes. By default, the Helm chart auto-generates `-storageNodes` flags, but since `vmstorage` has been disabled, we need to supply them manually in `extraArgs`.
-- In `extraArgs.storageNode:` we define the vmstorage endpoints for queries. Each entry uses the `<group>/<host>` format, where groups `a`, `b`, and `c` correspond to the three retention periods. Each group has a single `vmstorage` pod in this example, and vmselect unions results across the three groups to provide a unified view of the data.
+- In `extraArgs.storageNode:` we define the vmstorage endpoints for queries. On querying, vmselect merges results across all the specified vmstorages to provide a unified view of the data.
 
 Deploy the `vmselect` release with:
 
@@ -211,20 +209,17 @@ remoteWrite:
   - url: http://vmcluster-a-victoria-metrics-cluster-vminsert:8480/insert/0/prometheus/api/v1/write
     urlRelabelConfig:
       - action: keep
-        source_labels: [retention]
-        regex: "3mo"
+        if: '{retention="3mo"}'
   # Group B: receives metrics with retention="1yr"
   - url: http://vmcluster-b-victoria-metrics-cluster-vminsert:8480/insert/0/prometheus/api/v1/write
     urlRelabelConfig:
       - action: keep
-        source_labels: [retention]
-        regex: "1yr"
+        if: '{retention="1yr"}'
   # Group C: receives metrics with retention="3yr"
   - url: http://vmcluster-c-victoria-metrics-cluster-vminsert:8480/insert/0/prometheus/api/v1/write
     urlRelabelConfig:
       - action: keep
-        source_labels: [retention]
-        regex: "3yr"
+        if: '{retention="3yr"}'
 EOF
 ```
 
@@ -301,49 +296,27 @@ remoteWrite:
   - url: "http://vmcluster-a-victoria-metrics-cluster-vminsert:8480/insert/0/prometheus/api/v1/write"
     urlRelabelConfig:
       - action: keep
-        source_labels: [environment]
-        regex: "dev|staging"
+        if: {environment=~"dev|staging"}
   # send prod data to Group B
   - url: "http://vmcluster-b-victoria-metrics-cluster-vminsert:8480/insert/0/prometheus/api/v1/write"
     urlRelabelConfig:
       - action: keep
-        source_labels: [environment]
+        if: {environment=~"prod|production"}
         regex: "prod|production"
-  # send data from Infra and SRE teams to Group B
-  - url: "http://vmcluster-b-victoria-metrics-cluster-vminsert:8480/insert/0/prometheus/api/v1/write"
+  # send data from Infra and SRE teams to Group C
+  - url: "http://vmcluster-c-victoria-metrics-cluster-vminsert:8480/insert/0/prometheus/api/v1/write"
     urlRelabelConfig:
       - action: keep
-        source_labels: [team]
-        regex: "infra|sre"
+        if: {environment=~"infra|sre"}
 ```
 
 > Metrics that do not match any of the `keep` rules are dropped in the configuration above.
-
-## Alternative Multi-Tenant Routing
-
-VictoriaMetrics Cluster supports [multiple isolated tenants](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/#multitenancy) identified by `accountID` (and optionally `projectID`) in the URL path, e.g., `/insert/0/prometheus/...`. 
-
-In a standard deployment, a single vminsert handles all tenants and distributes data across a shared pool of vmstorage nodes. In our current setup, each retention group deploys its own vminsert. This means tenant IDs are not required for routing, since data is already isolated by the URL that receives the write. 
-
-You can safely use a single tenant (`/insert/0/prometheus`) for all groups and rely on the `retention` label or label-based routing to separate data at query time.
-
-If, however, you prefer tenant-level separation for the query layer, you can assign each group a distinct tenant ID, for instance:
-
-| Group | Insert URL | Query URL |
-|-------|------------|-----------|
-| A (`"3mo"`) | `/insert/0/prometheus` | `/select/0/prometheus` |
-| B (`"1yr"`) | `/insert/1/prometheus` | `/select/1/prometheus` |
-| C (`"3yr"`) | `/insert/2/prometheus` | `/select/2/prometheus` |
-
-This lets you query a single retention group directly, e.g., `/select/1/prometheus/api/v1/query?query=up` returns only data written to group B's vminsert. Queries to vmselect without a tenant prefix aggregate across all groups, preserving the unified view for dashboards.
-
-The tenant path does not affect where data is stored (routing is always determined by which vminsert receives the data). The tenant ID is purely a query-scoping convenience in this architecture.
 
 ## Additional Enhancements
 
 You can set up [vmauth](https://docs.victoriametrics.com/victoriametrics/vmauth/) to route data to the specified vminsert group based on the required retention or to restrict which data different users can query.
 
-+The following [`-auth.config`](https://docs.victoriametrics.com/victoriametrics/vmauth/#quick-start) example exposes the same vmselect backend via vmauth with two users using basic auth:
+The following [`-auth.config`](https://docs.victoriametrics.com/victoriametrics/vmauth/#quick-start) example exposes the same vmselect backend via vmauth with two users using basic auth:
 
 - `admin`: can query **all** data across all retention groups.
 - `dev`: can query **only** time series that have `team="dev"` label, enforced via the `extra_label` query argument.

--- a/docs/guides/guide-vmcluster-multiple-retention-setup/README.md
+++ b/docs/guides/guide-vmcluster-multiple-retention-setup/README.md
@@ -299,19 +299,19 @@ The following example configures `vmagent` to route metrics based on the `enviro
 # vmagent.yaml
 remoteWrite:
   # send dev and staging data to Group A
-  - url: "http://vmcluster-a-victoria-metrics-cluster-vminsert:8480/insert/0/prometheus"
+  - url: "http://vmcluster-a-victoria-metrics-cluster-vminsert:8480/insert/0/prometheus/api/v1/write"
     urlRelabelConfig:
       - action: keep
         source_labels: [environment]
         regex: "dev|staging"
   # send prod data to Group B
-  - url: "http://vmcluster-b-victoria-metrics-cluster-vminsert:8480/insert/0/prometheus"
+  - url: "http://vmcluster-b-victoria-metrics-cluster-vminsert:8480/insert/0/prometheus/api/v1/write"
     urlRelabelConfig:
       - action: keep
         source_labels: [environment]
         regex: "prod|production"
   # send data from Infra and SRE teams to Group B
-  - url: "http://vmcluster-b-victoria-metrics-cluster-vminsert:8480/insert/0/prometheus"
+  - url: "http://vmcluster-b-victoria-metrics-cluster-vminsert:8480/insert/0/prometheus/api/v1/write"
     urlRelabelConfig:
       - action: keep
         source_labels: [team]

--- a/docs/guides/guide-vmcluster-multiple-retention-setup/README.md
+++ b/docs/guides/guide-vmcluster-multiple-retention-setup/README.md
@@ -208,18 +208,18 @@ remoteWrite:
   # Group A: receives metrics with retention="3mo"
   - url: http://vmcluster-a-victoria-metrics-cluster-vminsert:8480/insert/0/prometheus/api/v1/write
     urlRelabelConfig:
-      - action: keep
-        if: '{retention="3mo"}'
+      - if: '{retention="3mo"}'
+        action: keep
   # Group B: receives metrics with retention="1yr"
   - url: http://vmcluster-b-victoria-metrics-cluster-vminsert:8480/insert/0/prometheus/api/v1/write
     urlRelabelConfig:
-      - action: keep
-        if: '{retention="1yr"}'
+      - if: '{retention="1yr"}'
+        action: keep
   # Group C: receives metrics with retention="3yr"
   - url: http://vmcluster-c-victoria-metrics-cluster-vminsert:8480/insert/0/prometheus/api/v1/write
     urlRelabelConfig:
-      - action: keep
-        if: '{retention="3yr"}'
+      - if: '{retention="3yr"}'
+        action: keep
 EOF
 ```
 
@@ -295,19 +295,18 @@ remoteWrite:
   # send dev and staging data to Group A
   - url: "http://vmcluster-a-victoria-metrics-cluster-vminsert:8480/insert/0/prometheus/api/v1/write"
     urlRelabelConfig:
-      - action: keep
-        if: {environment=~"dev|staging"}
+      - if: {environment=~"dev|staging"}
+        action: keep
   # send prod data to Group B
   - url: "http://vmcluster-b-victoria-metrics-cluster-vminsert:8480/insert/0/prometheus/api/v1/write"
     urlRelabelConfig:
-      - action: keep
-        if: {environment=~"prod|production"}
-        regex: "prod|production"
+      - if: {environment=~"prod|production"}
+        action: keep
   # send data from Infra and SRE teams to Group C
   - url: "http://vmcluster-c-victoria-metrics-cluster-vminsert:8480/insert/0/prometheus/api/v1/write"
     urlRelabelConfig:
-      - action: keep
-        if: {environment=~"infra|sre"}
+      - if: {team=~"infra|sre"}
+        action: keep
 ```
 
 > Metrics that do not match any of the `keep` rules are dropped in the configuration above.

--- a/docs/guides/guide-vmcluster-multiple-retention-setup/README.md
+++ b/docs/guides/guide-vmcluster-multiple-retention-setup/README.md
@@ -6,45 +6,274 @@ build:
 sitemap:
   disable: true
 ---
-**Objective**
 
-Setup Victoria Metrics Cluster with support of multiple retention periods within one installation.
+[VictoriaMetrics Enterprise](https://docs.victoriametrics.com/victoriametrics/enterprise/) supports specifying multiple retentions for distinct sets of time series and tenants. If you are an Enterprise user, [configure multiple retentions directly through retention filters](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/#retention-filters) instead of following this guide.
 
-**Enterprise Solution**
+This guide explains how to set up multiple retentions using an **open-source VictoriaMetrics Cluster**.
 
-[VictoriaMetrics Enterprise](https://docs.victoriametrics.com/victoriametrics/enterprise/) supports specifying multiple retentions
-for distinct sets of time series and [tenants](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/#multitenancy)
-via [retention filters](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/#retention-filters).
+## Overview
 
-**Open Source Solution**
+VictoriaMetrics retains by default 1-month worth of metrics. You can change data retention with the [`-retentionPeriod` command-line flag](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#retention), but this value applies to all time series stored on a given `vmstorage` node and cannot be customized per tenant or per metric in the open source version. 
 
-Community version of VictoriaMetrics supports only one retention period per `vmstorage` node via [-retentionPeriod](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#retention) command-line flag.
+## Multi-Retention Architecture
 
-A multi-retention setup can be implemented by dividing a [victoriametrics cluster](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/) into logical groups with different retentions.
-
-Example:
-Setup should handle 3 different retention groups 3months, 1year and 3 years.
-Solution contains 3 groups of vmstorages + vminserts and one group of vmselects. Routing is done by [vmagent](https://docs.victoriametrics.com/victoriametrics/vmagent/)
-by [splitting data streams](https://docs.victoriametrics.com/victoriametrics/vmagent/#splitting-data-streams-among-multiple-systems). 
-The [-retentionPeriod](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#retention) sets how long to keep the metrics.
-
-The diagram below shows a proposed solution
+To obtain multiple retentions with the open source VictoriaMetrics Cluster, you can split the cluster into several logical groups of `vmstorage` nodes, where each group is configured with a different `-retentionPeriod` and receives only the data that must follow that retention. Each storage group is connected to a separate `vminsert`, while a shared `vmselect` layer queries across all storage groups so that dashboards and alerts continue to see a single logical VictoriaMetrics backend.
 
 ![Setup](setup.webp)
 
-**Implementation Details**
+In the example used throughout this guide, the cluster is divided into three groups: 
+- Group A: 3-month retention.
+- Group B: 1-year retention.
+- Group C: 3-year retention. 
 
-1. Groups of vminserts A know about only vmstorages A and this is explicitly specified via `-storageNode` [configuration](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/#cluster-setup). 
-1. Groups of vminserts B know about only vmstorages B and this is explicitly specified via `-storageNode` [configuration](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/#cluster-setup). 
-1. Groups of vminserts C know about only vmstorages C and this is explicitly specified via `-storageNode` [configuration](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/#cluster-setup). 
-1. vmselect reads data from all vmstorage nodes via `-storageNode` [configuration](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/#cluster-setup) 
-   with [deduplication](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/#deduplication) setting equal to vmagent's scrape interval or minimum interval between collected samples. 
-1. vmagent routes incoming metrics to the given set of `vminsert` nodes using relabeling rules specified at `-remoteWrite.urlRelabelConfig` [configuration](https://docs.victoriametrics.com/victoriametrics/relabeling/).
+Metrics are routed to the appropiate `vminsert` group by [splitting data streams](https://docs.victoriametrics.com/victoriametrics/vmagent/#splitting-data-streams-among-multiple-systems) with `vmagent`. An optional [vmauth](https://docs.victoriametrics.com/victoriametrics/vmauth/) rules can be added on top to enforce per-tenant routing or API access policies.
 
-**Multi-Tenant Setup**
+## Implementing Multi-Retention on Kubernetes
 
-Every group of vmstorages can handle one tenant or multiple one. Different groups can have overlapping tenants. As vmselect reads from all vmstorage nodes, the data is aggregated on its level.
+In this section, we'll install and configure the components for the VictoriaMetrics cluster. See [Kubernetes monitoring with VictoriaMetrics Cluster](https://docs.victoriametrics.com/guides/k8s-monitoring-via-vm-cluster/) for prerequisites and more details.
 
-**Additional Enhancements**
+Run the following command to add the VictoriaMetrics Helm repository:
+
+```shell
+helm repo add vm https://victoriametrics.github.io/helm-charts/
+helm repo update
+```
+
+### Step 1: Deploying storage groups
+
+We'll create three retention groups, groups, each has a different retention period and disk size. Read [Understand Your Setup Size](https://docs.victoriametrics.com/guides/understand-your-setup-size/) to estimate how much space you will need for each retention.
+
+| Group       | Retention Period | Disk Size |
+|-------------|------------------|-----------|
+| `vmcluster-a` | 3 months (`3M`)    | 80GB      |
+| `vmcluster-b` | 1 year (`1Y`)      | 300 GB    |
+| `vmcluster-c` | 3 years (`3Y`)     | 900 GB    |
+
+Create a Helm values file for Group A. This creates two `vminsert` and `vmstorage` pods:
+
+```shell
+cat <<EOF > vmcluster-a.yaml
+vmstorage:
+  enabled: true
+  persistence:
+    size: 80Gi
+  extraArgs:
+    retentionPeriod: 3M
+    storageDataPath: /vmstorage-data
+    dedup.minScrapeInterval: 30s
+  podLabels:
+    retention-group: a
+    retention-period: 3M
+
+vminsert:
+  enabled: true
+  podLabels:
+    retention-group: a
+
+vmselect:
+  enabled: false
+EOF
+```
+
+The values file creates a `vminsert` and `vmstorage` services while disabling `vmselect`, as we'll deploy it separately. It also defines a 30-second [deduplication](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/#deduplication) window to handle possible duplicate metrics. The deduplication window must match the `vmagent` service scrape window (which we'll define it later in the guide).
+
+Create the values files for Group B and Group C:
+
+```shell
+cat <<EOF > vmcluster-b.yaml
+vmstorage:
+  enabled: true
+  persistence:
+    size: 300Gi
+  extraArgs:
+    retentionPeriod: 1Y
+    storageDataPath: /vmstorage-data
+    dedup.minScrapeInterval: 30s
+  podLabels:
+    retention-group: b
+    retention-period: 1Y
+
+vminsert:
+  enabled: true
+  podLabels:
+    retention-group: b
+
+vmselect:
+  enabled: false
+EOF
+
+
+cat <<EOF > vmcluster-c.yaml
+vmstorage:
+  enabled: true
+  persistence:
+    size: 900Gi
+  extraArgs:
+    retentionPeriod: 3Y
+    storageDataPath: /vmstorage-data
+    dedup.minScrapeInterval: 30s
+  podLabels:
+    retention-group: c
+    retention-period: 3Y
+
+vminsert:
+  enabled: true
+  podLabels:
+    retention-group: c
+
+vmselect:
+  enabled: false
+EOF
+```
+
+Create the three logical groups with:
+
+```shell
+helm upgrade --install vmcluster-a vm/victoria-metrics-cluster -f vmcluster-a.yaml
+helm upgrade --install vmcluster-b vm/victoria-metrics-cluster -f vmcluster-b.yaml
+helm upgrade --install vmcluster-c vm/victoria-metrics-cluster -f vmcluster-c.yaml
+
+# Wait for all storage pods to be ready
+kubectl rollout status statefulset/vmcluster-a-vmstorage
+kubectl rollout status statefulset/vmcluster-b-vmstorage
+kubectl rollout status statefulset/vmcluster-c-vmstorage
+```
+
+### Step 2: Deploying vmselect
+
+Next, we'll deploy a `vmselect` service to route queries to the three storage groups.
+
+Create a Helm values file with:
+
+```shell
+cat <<EOF >vmselect.yaml
+vmstorage:
+  enabled: false
+
+vminsert:
+  enabled: false
+
+vmselect:
+  enabled: true
+  replicaCount: 2
+  suppressStorageFQDNsRender: true
+  extraArgs:
+    # Each list item is a single -storageNode flag with comma-separated hosts
+    # in the same group. The FQDN format is:
+    #   <pod>.<svc>.default.svc
+    # where pod = <release>-victoria-metrics-cluster-vmstorage-<N>
+    # and   svc  = <release>-victoria-metrics-cluster-vmstorage
+    storageNode:
+      - "a/vmcluster-a-victoria-metrics-cluster-vmstorage-0.vmcluster-a-victoria-metrics-cluster-vmstorage.default.svc:8401,a/vmcluster-a-victoria-metrics-cluster-vmstorage-1.vmcluster-a-victoria-metrics-cluster-vmstorage.default.svc:8401"
+      - "b/vmcluster-b-victoria-metrics-cluster-vmstorage-0.vmcluster-b-victoria-metrics-cluster-vmstorage.default.svc:8401,b/vmcluster-b-victoria-metrics-cluster-vmstorage-1.vmcluster-b-victoria-metrics-cluster-vmstorage.default.svc:8401"
+      - "c/vmcluster-c-victoria-metrics-cluster-vmstorage-0.vmcluster-c-victoria-metrics-cluster-vmstorage.default.svc:8401,c/vmcluster-c-victoria-metrics-cluster-vmstorage-1.vmcluster-c-victoria-metrics-cluster-vmstorage.default.svc:8401"
+    dedup.minScrapeInterval: 30s
+  podLabels:
+    component: vmselect-global
+```
+
+Let's break down the values file:
+
+- Deploy `vmselect` as a separate Helm release disable `vminsert` and `vmstorage` as the storage groups are already deployed in Step 1.
+- Normally the chart auto-generates `-storageNodes` flags, but since `vmstorage` has been disabled, we need to supply them in as `extraArgs`.
+- In `extraArgs.storageNode:` we define the list of `vmstorage` services to reach for queries. The `storageNode` flags tell vmselect to query all 6 storage pods, which are organized into three groups: `a`, `b`, and `c`.
+
+Deploy the `vmselect` release with:
+
+```shell
+helm upgrade --install vmselect vm/victoria-metrics-cluster -f vmselect.yaml
+```
+
+### Step 3: deploy vmagent
+
+In this setup, `vmagent` routes incoming metrics to the cluster to the right retention group. In the following example, we use a `retention` label to map metrics to storage groups in the following way:
+
+| `retention` label | Storage Group |
+| ----------------| --------------|
+| "3mo"           | `vmcluster-a`   | 
+| "1yr"           | `vmcluster-b`   | 
+| "3yr"           | `vmcluster-c`   | 
+
+Create the values file for vmagent:
+
+```shell
+cat <<EOF >vmagent.yaml
+service:
+  enabled: true
+remoteWrite:
+  - url: http://vmcluster-a-victoria-metrics-cluster-vminsert:8480/insert/0/prometheus/api/v1/write
+    urlRelabelConfig:
+      - action: keep
+        source_labels: [retention]
+        regex: "3mo"
+  - url: http://vmcluster-b-victoria-metrics-cluster-vminsert:8480/insert/0/prometheus/api/v1/write
+    urlRelabelConfig:
+      - action: keep
+        source_labels: [retention]
+        regex: "1yr"
+  - url: http://vmcluster-c-victoria-metrics-cluster-vminsert:8480/insert/0/prometheus/api/v1/write
+    urlRelabelConfig:
+      - action: keep
+        source_labels: [retention]
+        regex: "3yr"
+```
+
+And install the release with:
+
+```shell
+helm upgrade --install vmagent vm/victoria-metrics-agent -f vmagent.yaml
+```
+
+## Alternative Routing by Existing Labels
+
+The example setup above relies on a synthetic `retention` label to be appended to every metric. These labels should be added before pushing the data into the VictoriaMetrics cluster for it to work.
+
+If appending a `retention` label isn't practical, you can, as an alternative, rely on existing labels to map data to the correct storage group. The following example configures `vmagent` to route metrics based on the `environment` and `team` labels:
+
+```yaml
+# vmagent.yaml
+remoteWrite:
+  # send dev and staging data to group a
+  - url: "http://vmcluster-a-vminsert:8480/insert/0/prometheus"
+    urlRelabelConfig:
+      - action: keep
+        source_labels: [environment]
+        regex: "dev|staging"
+  # send prod data to group b
+  - url: "http://vmcluster-b-vminsert:8480/insert/0/prometheus"
+    urlRelabelConfig:
+      - action: keep
+        source_labels: [environment]
+        regex: "prod|production"
+  # you can combine rules, for example routing based on a different label ("team")
+  - url: "http://vmcluster-b-vminsert:8480/insert/0/prometheus"
+    urlRelabelConfig:
+      - action: keep
+        source_labels: [team]
+        regex: "infra|sre"
+  # fallback rule: send everything else to group c
+  - url: "http://vmcluster-c-vminsert:8480/insert/0/prometheus"
+```
+
+## Alternative Multi-Tenant Routing
+
+VictoriaMetrics Cluster supports [multiple isolated tenants](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/#multitenancy) identified by `accountID` (and optionally `projectID`) in the URL path, e.g. `/insert/0/prometheus/...`. 
+
+In a standard deployment, a single `vminsert` handles all tenants and distributes data across a shared pool of `vmstorage` nodes. In our current setup, each retention group deploys its own `vminsert`. This means tenant IDs are not required for routing as data is already isolated by which URL receives the write. You can safely use a single tenant (`/insert/0/prometheus`) for all groups and rely on the `retention` label or label-based routing to separate data at query time.
+
+If you prefer tenant-level separation at the query layer, you can assign each group a distinct tenant ID, for instance:
+
+| Group | Insert URL | Query URL |
+|-------|------------|-----------|
+| A (3mo) | `/insert/0/prometheus` | `/select/0/prometheus` |
+| B (1yr) | `/insert/1/prometheus` | `/select/1/prometheus` |
+| C (3yr) | `/insert/2/prometheus` | `/select/2/prometheus` |
+
+This lets you query a single retention group directly, e.g. `/select/1/prometheus/api/v1/query?query=up` returns only data written to group B's `vminsert`. Queries to vmselect without a tenant prefix (or to tenant 0) aggregate across all groups, preserving the unified view for dashboards.
+
+The tenant path does not affect where data is stored (routing is always determined by which `vminsert` receives the data). The tenant ID is purely a query-scoping convenience in this architecture.
+
+## Additional Enhancements
 
 You can set up [vmauth](https://docs.victoriametrics.com/victoriametrics/vmauth/) for routing data to the given vminsert group depending on the needed retention.
+

--- a/docs/guides/guide-vmcluster-multiple-retention-setup/README.md
+++ b/docs/guides/guide-vmcluster-multiple-retention-setup/README.md
@@ -33,7 +33,7 @@ In the example used throughout this guide, the cluster is divided into three gro
 - Group B: 1-year retention.
 - Group C: 3-year retention. 
 
-Metrics are routed to the appropriate vminsert group by [splitting data streams](https://docs.victoriametrics.com/victoriametrics/vmagent/#splitting-data-streams-among-multiple-systems) in vmagent. An optional [vmauth](https://docs.victoriametrics.com/victoriametrics/vmauth/) rule can be added on top to enforce per-tenant routing or API access policies.
+Metrics are routed to the appropriate vminsert group by splitting data streams in vmagent, so each time series is sent to exactly one retention group instead of being replicated to all groups. See [Deploying vmagent](https://docs.victoriametrics.com/guides/guide-vmcluster-multiple-retention-setup/#step3) for an example of label‑based routing that implements this split. An optional [vmauth](https://docs.victoriametrics.com/guides/guide-vmcluster-multiple-retention-setup/#additional-enhancements) layer can be added on top to restrict access to specific sub‑clusters or tenants while still keeping a unified write and read path.
 
 ## Implementing Multi-Retention on Kubernetes
 
@@ -46,17 +46,16 @@ helm repo add vm https://victoriametrics.github.io/helm-charts/
 helm repo update
 ```
 
-### Step 1: Deploying storage groups
+### Step 1: Deploying storage groups {#step1}
 
 We'll create three storage groups. Each has a different retention period and disk size. Read [Understand Your Setup Size](https://docs.victoriametrics.com/guides/understand-your-setup-size/) to estimate how much space you will need for each group. The following table is shown as an example.
 
-> Note: disk sizes below are per `vmstorage` replica. The manifests in this guide use 2 replicas per group, so total cluster storage per group = size × 2.
 
-| Group       | Retention Period | Total disk size       |
-|-------------|------------------|-----------------------|
-| `vmcluster-a` | 3 months (`3M`)    | 80 Gi                 |
-| `vmcluster-b` | 1 year (`1Y`)      | 300 Gi                |
-| `vmcluster-c` | 3 years (`3Y`)     | 900 Gi                |
+| Group        | Retention Period | Total disk size       |
+|--------------|------------------|-----------------------|
+| `vmcluster-a`  | 3 months (`3M`)    | 80 Gi                 |
+| `vmcluster-b`  | 1 year (`1Y`)      | 300 Gi                |
+| `vmcluster-c`  | 3 years (`3Y`)     | 900 Gi                |
 
 Create a Helm values file for Group A.
 
@@ -64,21 +63,16 @@ Create a Helm values file for Group A.
 cat <<EOF > vmcluster-a.yaml
 vmstorage:
   enabled: true
-  replicaCount: 2
+  replicaCount: 1
   persistence:
-    size: 40Gi
+    size: 80Gi
   extraArgs:
     retentionPeriod: 3M
-    storageDataPath: /vmstorage-data
-    dedup.minScrapeInterval: 30s
   podLabels:
     retention-group: a
-    retention-period: 3M
 
 vminsert:
   enabled: true
-  extraArgs:
-    replicationFactor: 2
   podLabels:
     retention-group: a
 
@@ -87,9 +81,7 @@ vmselect:
 EOF
 ```
 
-The values file above creates vminsert and vmstorage services while turning off vmselect, which we'll deploy separately. With `replicaCount: 2`, each group runs 2 vmstorage pods. Setting `vminsert.extraArgs.replicationFactor: 2` sets the [replication factor](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/#list-of-command-line-flags-for-vminsert) to vminsert, instructing it to store every ingested sample on 2 distinct vmstorage nodes. Together with the 2 pods, this ensures each sample exists on both pods for high availability. vmselect uses the 30-second [deduplication](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/#deduplication) window to handle duplicate samples at query time. The deduplication value should match `dedup.minScrapeInterval` in vmselect and the [scrape interval](https://docs.victoriametrics.com/victoriametrics/scrape_config_examples/).
-
-> The disk size in `vmcluster-a.yaml` is per replica, so total storage for Group A is `size * replicaCount` (i.e., 40Gi x 2 = 80Gi).
+The values file above creates vminsert and vmstorage services while turning off vmselect, which we'll deploy separately. The `retentionPeriod` flag configures how long data is kept in this group.
 
 Create the values files for Group B and Group C:
 
@@ -97,21 +89,16 @@ Create the values files for Group B and Group C:
 cat <<EOF > vmcluster-b.yaml
 vmstorage:
   enabled: true
-  replicaCount: 2
+  replicaCount: 1
   persistence:
-    size: 150Gi
+    size: 300Gi
   extraArgs:
-    retentionPeriod: 1Y
-    storageDataPath: /vmstorage-data
-    dedup.minScrapeInterval: 30s
+    retentionPeriod: 1y
   podLabels:
     retention-group: b
-    retention-period: 1Y
 
 vminsert:
   enabled: true
-  extraArgs:
-    replicationFactor: 2
   podLabels:
     retention-group: b
 
@@ -123,21 +110,16 @@ EOF
 cat <<EOF > vmcluster-c.yaml
 vmstorage:
   enabled: true
-  replicaCount: 2
+  replicaCount: 1
   persistence:
-    size: 450Gi
+    size: 900Gi
   extraArgs:
-    retentionPeriod: 3Y
-    storageDataPath: /vmstorage-data
-    dedup.minScrapeInterval: 30s
+    retentionPeriod: 3y
   podLabels:
     retention-group: c
-    retention-period: 3Y
 
 vminsert:
   enabled: true
-  extraArgs:
-    replicationFactor: 2
   podLabels:
     retention-group: c
 
@@ -159,7 +141,7 @@ kubectl rollout status statefulset -l app.kubernetes.io/instance=vmcluster-b
 kubectl rollout status statefulset -l app.kubernetes.io/instance=vmcluster-c
 ```
 
-### Step 2: Deploying vmselect
+### Step 2: Deploying vmselect {#step2}
 
 Next, we'll deploy a vmselect service to route queries to the storage groups.
 
@@ -175,28 +157,31 @@ vminsert:
 
 vmselect:
   enabled: true
-  replicaCount: 2
+  replicaCount: 1
   suppressStorageFQDNsRender: true
   extraArgs:
-    # Each list item is a single -storageNode flag with comma-separated hosts
-    # in the same group. The FQDN format is:
+    # Each list item is a single -storageNode flag. In this example, there is
+    # one vmstorage pod per retention group, so each entry contains a single host.
+    # If you run multiple pods per group, list them as comma-separated hosts
+    # in the same -storageNode value.
+    #
+    # The FQDN format is:
     #   <pod>.<svc>.default.svc
     # where pod = <release>-victoria-metrics-cluster-vmstorage-<N>
-    # and   svc  = <release>-victoria-metrics-cluster-vmstorage
+    # and   svc = <release>-victoria-metrics-cluster-vmstorage
     storageNode:
-      - "a/vmcluster-a-victoria-metrics-cluster-vmstorage-0.vmcluster-a-victoria-metrics-cluster-vmstorage.default.svc:8401,a/vmcluster-a-victoria-metrics-cluster-vmstorage-1.vmcluster-a-victoria-metrics-cluster-vmstorage.default.svc:8401"
-      - "b/vmcluster-b-victoria-metrics-cluster-vmstorage-0.vmcluster-b-victoria-metrics-cluster-vmstorage.default.svc:8401,b/vmcluster-b-victoria-metrics-cluster-vmstorage-1.vmcluster-b-victoria-metrics-cluster-vmstorage.default.svc:8401"
-      - "c/vmcluster-c-victoria-metrics-cluster-vmstorage-0.vmcluster-c-victoria-metrics-cluster-vmstorage.default.svc:8401,c/vmcluster-c-victoria-metrics-cluster-vmstorage-1.vmcluster-c-victoria-metrics-cluster-vmstorage.default.svc:8401"
-    dedup.minScrapeInterval: 30s
+      - "a/vmcluster-a-victoria-metrics-cluster-vmstorage-0.vmcluster-a-victoria-metrics-cluster-vmstorage.default.svc:8401"
+      - "b/vmcluster-b-victoria-metrics-cluster-vmstorage-0.vmcluster-b-victoria-metrics-cluster-vmstorage.default.svc:8401"
+      - "c/vmcluster-c-victoria-metrics-cluster-vmstorage-0.vmcluster-c-victoria-metrics-cluster-vmstorage.default.svc:8401"
 EOF
 ```
 
 Let's break down the file above:
 
-- Deploys vmselect as a separate Helm release 
+- Deploys vmselect as a separate Helm release. 
 - Disables vminsert and vmstorage as these services were already deployed in Step 1.
 - `suppressStorageFQDNsRender: true` turns off automatic FQDN generation for storage nodes. By default, the Helm chart auto-generates `-storageNodes` flags, but since `vmstorage` has been disabled, we need to supply them manually in `extraArgs`.
-- In `extraArgs.storageNode:` we define the vmstorage endpoints for queries. Each entry uses the `<group>/<host>` format. The group prefix tells vmselect which pods are replicas of each other. Groups `a`, `b`, and `c` correspond to the three retention periods. Within each group, the 2 pods are replicas, so vmselect deduplicates within each retention group and unions across groups, providing a unified view of all 6 storage pods.
+- In `extraArgs.storageNode:` we define the vmstorage endpoints for queries. Each entry uses the `<group>/<host>` format, where groups `a`, `b`, and `c` correspond to the three retention periods. Each group has a single `vmstorage` pod in this example, and vmselect unions results across the three groups to provide a unified view of the data.
 
 Deploy the `vmselect` release with:
 
@@ -204,15 +189,15 @@ Deploy the `vmselect` release with:
 helm upgrade --install vmselect vm/victoria-metrics-cluster -f vmselect.yaml
 ```
 
-### Step 3: Deploying vmagent
+### Step 3: Deploying vmagent {#step3}
 
 We'll use `vmagent` to route incoming metrics to the correct retention group. For example, we can use a `retention` label for mapping metrics to storage groups in the following way:
 
 | `retention` label | Storage Group |
-| ----------------| --------------|
-| `"3mo"`         | `vmcluster-a`   | 
-| `"1yr"`         | `vmcluster-b`   | 
-| `"3yr"`         | `vmcluster-c`   | 
+|-------------------|--------------|
+| `"3mo"`           | `vmcluster-a` |
+| `"1yr"`           | `vmcluster-b` |
+| `"3yr"`           | `vmcluster-c` |
 
 
 Create the values file for vmagent:
@@ -243,10 +228,7 @@ remoteWrite:
 EOF
 ```
 
-> Two important notes on scraping:
-> - Metrics without a matching `retention` label are silently dropped by the `keep` rules. You must ensure that every metric is labeled, or use a different routing configuration.
-> - The [scrape interval](https://docs.victoriametrics.com/victoriametrics/sd_configs/#scrape_configs) should match the `dedup.minScrapeInterval` defined in the vmstorage nodes.
-`
+> Metrics without a matching `retention` label are silently dropped by the `keep` rules. You must ensure that every metric is labeled, or use a different routing configuration.
 
 Now deploy the vmagent release:
 
@@ -349,9 +331,9 @@ If, however, you prefer tenant-level separation for the query layer, you can ass
 
 | Group | Insert URL | Query URL |
 |-------|------------|-----------|
-| A (3mo) | `/insert/0/prometheus` | `/select/0/prometheus` |
-| B (1yr) | `/insert/1/prometheus` | `/select/1/prometheus` |
-| C (3yr) | `/insert/2/prometheus` | `/select/2/prometheus` |
+| A (`"3mo"`) | `/insert/0/prometheus` | `/select/0/prometheus` |
+| B (`"1yr"`) | `/insert/1/prometheus` | `/select/1/prometheus` |
+| C (`"3yr"`) | `/insert/2/prometheus` | `/select/2/prometheus` |
 
 This lets you query a single retention group directly, e.g., `/select/1/prometheus/api/v1/query?query=up` returns only data written to group B's vminsert. Queries to vmselect without a tenant prefix aggregate across all groups, preserving the unified view for dashboards.
 
@@ -359,6 +341,41 @@ The tenant path does not affect where data is stored (routing is always determin
 
 ## Additional Enhancements
 
-You can set up [vmauth](https://docs.victoriametrics.com/victoriametrics/vmauth/) to route data to the specified vminsert group based on the required retention.
+You can set up [vmauth](https://docs.victoriametrics.com/victoriametrics/vmauth/) to route data to the specified vminsert group based on the required retention or to restrict which data different users can query.
 
+The following [`-auth.config`](https://docs.victoriametrics.com/vmauth.html#quick-start) example exposes the same vmselect backend via vmauth with two users using basic auth:
 
+- `admin`: can query **all** data across all retention groups.
+- `dev`: can query **only** time series that have `team="dev"` label, enforced via the `extra_label` query argument.
+
+```yaml
+users:
+  # User with access to all data across all retention groups
+  - username: "admin"
+    password: "foo"
+    url_map:
+      - src_paths:
+          - "/api/v1/query"
+          - "/api/v1/query_range"
+          - "/api/v1/series"
+          - "/api/v1/labels"
+          - "/api/v1/label/.+/values"
+        # vmselect service that aggregates all vmstorage groups
+        url_prefix: "http://vmselect-victoria-metrics-cluster-vmselect:8481/select/0/prometheus"
+
+  # User restricted to Dev team data only
+  - username: "dev"
+    password: "bar"
+    url_map:
+      - src_paths:
+          - "/api/v1/query"
+          - "/api/v1/query_range"
+          - "/api/v1/series"
+          - "/api/v1/labels"
+          - "/api/v1/label/.+/values"
+        # Same vmselect backend, but enforce label filter at query time
+        # by adding extra_label=team=dev to every proxied request
+        url_prefix: "http://vmselect-victoria-metrics-cluster-vmselect:8481/select/0/prometheus/?extra_label=team=dev"
+```
+
+This is useful for restricting access by team, environment, or tenant without changing the underlying storage topology.

--- a/docs/guides/guide-vmcluster-multiple-retention-setup/README.md
+++ b/docs/guides/guide-vmcluster-multiple-retention-setup/README.md
@@ -75,6 +75,7 @@ vmstorage:
 
 vminsert:
   enabled: true
+  replicationFactor: 2
   podLabels:
     retention-group: a
 
@@ -85,7 +86,7 @@ EOF
 
 The values file above creates vminsert and vmstorage services while turning off vmselect, which we'll deploy separately. With `replicaCount: 2`, the storage group runs two vmstorage instances, and vminsert sends incoming data to both of them. The 30-second [deduplication](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/#deduplication) setting tells vmselect how to collapse duplicate samples with identical labels and timestamps into one. This value should match the scrape interval and the `dedup.minScrapeInterval` value configured for vmselect later on.
 
-> The disk size in `values-a.yaml` is per replica, so total storage for Group A is `size * replicaCount` (i.e., 40Gi x 2 = 80Gi).
+> The disk size in `vmcluster-a.yaml` is per replica, so total storage for Group A is `size * replicaCount` (i.e., 40Gi x 2 = 80Gi).
 
 Create the values files for Group B and Group C:
 
@@ -106,6 +107,7 @@ vmstorage:
 
 vminsert:
   enabled: true
+  replicationFactor: 2
   podLabels:
     retention-group: b
 
@@ -130,6 +132,7 @@ vmstorage:
 
 vminsert:
   enabled: true
+  replicationFactor: 2
   podLabels:
     retention-group: c
 


### PR DESCRIPTION
This PR updates the [Multi Retention Setup within VictoriaMetrics Cluster](https://docs.victoriametrics.com/guides/guide-vmcluster-multiple-retention-setup/) guide.

Changes:
- Rewrote the introduction and added an overview
- Added step-by-step example setup for Kubernetes
- Expanded on alternative ways to route traffic

I've tested the configuration on a K3s cluster and it works, but I don't know if the way I routed traffic into the retention tiers makes sense, so any feedback is very much appreciated.