### PR TITLE
lib/httpserver: allow disabling server hostname header

### DIFF
--- a/docs/victoriametrics/changelog/CHANGELOG.md
+++ b/docs/victoriametrics/changelog/CHANGELOG.md
@@ -26,6 +26,8 @@ See also [LTS releases](https://docs.victoriametrics.com/victoriametrics/lts-rel
 
 ## tip
 
+* FEATURE: all VictoriaMetrics components: add `-http.header.disableServerHostname` command-line flag for disabling the `X-Server-Hostname` HTTP response header. See [#11067](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/11067). Thanks to @zasdaym for contribution.
+
 * BUGFIX: [stream aggregation](https://docs.victoriametrics.com/victoriametrics/stream-aggregation/): fix issue with producing aggregated samples with identical timestamps between flushes. See PR [#10808](https://github.com/VictoriaMetrics/VictoriaMetrics/pull/10808) for details.
 
 ## [v1.145.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.145.0)

--- a/docs/victoriametrics/victoria_metrics_common_flags.md
+++ b/docs/victoriametrics/victoria_metrics_common_flags.md
@@ -95,6 +95,8 @@ See the docs at https://docs.victoriametrics.com/victoriametrics/
      Disable compression of HTTP responses to save CPU resources. By default, compression is enabled to save network bandwidth
   -http.header.csp string
      Value for 'Content-Security-Policy' header, recommended: "default-src 'self'"
+  -http.header.disableServerHostname
+     Whether to disable 'X-Server-Hostname' header in HTTP responses
   -http.header.frameOptions string
      Value for 'X-Frame-Options' header
   -http.header.hsts string

--- a/docs/victoriametrics/vmagent_common_flags.md
+++ b/docs/victoriametrics/vmagent_common_flags.md
@@ -74,6 +74,8 @@ See the docs at https://docs.victoriametrics.com/victoriametrics/vmagent/ .
      Disable compression of HTTP responses to save CPU resources. By default, compression is enabled to save network bandwidth
   -http.header.csp string
      Value for 'Content-Security-Policy' header, recommended: "default-src 'self'"
+  -http.header.disableServerHostname
+     Whether to disable 'X-Server-Hostname' header in HTTP responses
   -http.header.frameOptions string
      Value for 'X-Frame-Options' header
   -http.header.hsts string

--- a/docs/victoriametrics/vmalert_common_flags.md
+++ b/docs/victoriametrics/vmalert_common_flags.md
@@ -115,6 +115,8 @@ See the docs at https://docs.victoriametrics.com/victoriametrics/vmalert/ .
      Disable compression of HTTP responses to save CPU resources. By default, compression is enabled to save network bandwidth
   -http.header.csp string
      Value for 'Content-Security-Policy' header, recommended: "default-src 'self'"
+  -http.header.disableServerHostname
+     Whether to disable 'X-Server-Hostname' header in HTTP responses
   -http.header.frameOptions string
      Value for 'X-Frame-Options' header
   -http.header.hsts string

--- a/docs/victoriametrics/vmauth_common_flags.md
+++ b/docs/victoriametrics/vmauth_common_flags.md
@@ -59,6 +59,8 @@ See the docs at https://docs.victoriametrics.com/victoriametrics/vmauth/ .
      Disable compression of HTTP responses to save CPU resources. By default, compression is enabled to save network bandwidth
   -http.header.csp string
      Value for 'Content-Security-Policy' header, recommended: "default-src 'self'"
+  -http.header.disableServerHostname
+     Whether to disable 'X-Server-Hostname' header in HTTP responses
   -http.header.frameOptions string
      Value for 'X-Frame-Options' header
   -http.header.hsts string

--- a/docs/victoriametrics/vmbackup.md
+++ b/docs/victoriametrics/vmbackup.md
@@ -400,6 +400,8 @@ Run `vmbackup -help` in order to see all the available options:
      Disable compression of HTTP responses to save CPU resources. By default, compression is enabled to save network bandwidth
   -http.header.csp string
      Value for 'Content-Security-Policy' header, recommended: "default-src 'self'"
+  -http.header.disableServerHostname
+     Whether to disable 'X-Server-Hostname' header in HTTP responses
   -http.header.frameOptions string
      Value for 'X-Frame-Options' header
   -http.header.hsts string

--- a/docs/victoriametrics/vmbackupmanager.md
+++ b/docs/victoriametrics/vmbackupmanager.md
@@ -575,6 +575,8 @@ command-line flags:
      Disable compression of HTTP responses to save CPU resources. By default, compression is enabled to save network bandwidth
   -http.header.csp string
      Value for 'Content-Security-Policy' header, recommended: "default-src 'self'"
+  -http.header.disableServerHostname
+     Whether to disable 'X-Server-Hostname' header in HTTP responses
   -http.header.frameOptions string
      Value for 'X-Frame-Options' header
   -http.header.hsts string

--- a/docs/victoriametrics/vmgateway.md
+++ b/docs/victoriametrics/vmgateway.md
@@ -496,6 +496,8 @@ Below is the list of configuration flags (it can be viewed by running `./vmgatew
      Disable compression of HTTP responses to save CPU resources. By default, compression is enabled to save network bandwidth
   -http.header.csp string
      Value for 'Content-Security-Policy' header, recommended: "default-src 'self'"
+  -http.header.disableServerHostname
+     Whether to disable 'X-Server-Hostname' header in HTTP responses
   -http.header.frameOptions string
      Value for 'X-Frame-Options' header
   -http.header.hsts string

--- a/docs/victoriametrics/vminsert_common_flags.md
+++ b/docs/victoriametrics/vminsert_common_flags.md
@@ -76,6 +76,8 @@ See the docs at https://docs.victoriametrics.com/victoriametrics/cluster-victori
      Disable compression of HTTP responses to save CPU resources. By default, compression is enabled to save network bandwidth
   -http.header.csp string
      Value for 'Content-Security-Policy' header, recommended: "default-src 'self'"
+  -http.header.disableServerHostname
+     Whether to disable 'X-Server-Hostname' header in HTTP responses
   -http.header.frameOptions string
      Value for 'X-Frame-Options' header
   -http.header.hsts string

--- a/docs/victoriametrics/vmrestore.md
+++ b/docs/victoriametrics/vmrestore.md
@@ -102,6 +102,8 @@ Run `vmrestore -help` in order to see all the available options:
      Disable compression of HTTP responses to save CPU resources. By default, compression is enabled to save network bandwidth
   -http.header.csp string
      Value for 'Content-Security-Policy' header, recommended: "default-src 'self'"
+  -http.header.disableServerHostname
+     Whether to disable 'X-Server-Hostname' header in HTTP responses
   -http.header.frameOptions string
      Value for 'X-Frame-Options' header
   -http.header.hsts string

--- a/docs/victoriametrics/vmselect_common_flags.md
+++ b/docs/victoriametrics/vmselect_common_flags.md
@@ -75,6 +75,8 @@ See the docs at https://docs.victoriametrics.com/victoriametrics/cluster-victori
      Disable compression of HTTP responses to save CPU resources. By default, compression is enabled to save network bandwidth
   -http.header.csp string
      Value for 'Content-Security-Policy' header, recommended: "default-src 'self'"
+  -http.header.disableServerHostname
+     Whether to disable 'X-Server-Hostname' header in HTTP responses
   -http.header.frameOptions string
      Value for 'X-Frame-Options' header
   -http.header.hsts string

--- a/docs/victoriametrics/vmstorage_common_flags.md
+++ b/docs/victoriametrics/vmstorage_common_flags.md
@@ -68,6 +68,8 @@ See the docs at https://docs.victoriametrics.com/victoriametrics/cluster-victori
      Disable compression of HTTP responses to save CPU resources. By default, compression is enabled to save network bandwidth
   -http.header.csp string
      Value for 'Content-Security-Policy' header, recommended: "default-src 'self'"
+  -http.header.disableServerHostname
+     Whether to disable 'X-Server-Hostname' header in HTTP responses
   -http.header.frameOptions string
      Value for 'X-Frame-Options' header
   -http.header.hsts string

--- a/lib/httpserver/httpserver.go
+++ b/lib/httpserver/httpserver.go
@@ -64,9 +64,10 @@ var (
 	connTimeout                 = flag.Duration("http.connTimeout", 2*time.Minute, "Incoming connections to -httpListenAddr are closed after the configured timeout. "+
 		"This may help evenly spreading load among a cluster of services behind TCP-level load balancer. Zero value disables closing of incoming connections")
 
-	headerHSTS         = flag.String("http.header.hsts", "", "Value for 'Strict-Transport-Security' header, recommended: 'max-age=31536000; includeSubDomains'")
-	headerFrameOptions = flag.String("http.header.frameOptions", "", "Value for 'X-Frame-Options' header")
-	headerCSP          = flag.String("http.header.csp", "", `Value for 'Content-Security-Policy' header, recommended: "default-src 'self'"`)
+	headerHSTS                  = flag.String("http.header.hsts", "", "Value for 'Strict-Transport-Security' header, recommended: 'max-age=31536000; includeSubDomains'")
+	headerFrameOptions          = flag.String("http.header.frameOptions", "", "Value for 'X-Frame-Options' header")
+	headerCSP                   = flag.String("http.header.csp", "", `Value for 'Content-Security-Policy' header, recommended: "default-src 'self'"`)
+	headerDisableServerHostname = flag.Bool("http.header.disableServerHostname", false, "Whether to disable 'X-Server-Hostname' header in HTTP responses")
 
 	disableCORS = flag.Bool("http.disableCORS", false, `Disable CORS for all origins (*)`)
 )
@@ -329,7 +330,9 @@ func handlerWrapper(w http.ResponseWriter, r *http.Request, rh RequestHandler) {
 	if *headerCSP != "" {
 		h.Add("Content-Security-Policy", *headerCSP)
 	}
-	h.Add("X-Server-Hostname", hostname)
+	if !*headerDisableServerHostname {
+		h.Add("X-Server-Hostname", hostname)
+	}
 	requestsTotal.Inc()
 	if whetherToCloseConn(r) {
 		connTimeoutClosedConns.Inc()

--- a/lib/httpserver/httpserver_test.go
+++ b/lib/httpserver/httpserver_test.go
@@ -228,4 +228,30 @@ func TestHandlerWrapper(t *testing.T) {
 	if got := h.Get("Content-Security-Policy"); got != cspHeader {
 		t.Fatalf("unexpected CSP header; got %q; want %q", got, cspHeader)
 	}
+	if got := h.Get("X-Server-Hostname"); got != hostname {
+		t.Fatalf("unexpected X-Server-Hostname header; got %q; want %q", got, hostname)
+	}
+}
+
+func TestHandlerWrapperDisableServerHostnameHeader(t *testing.T) {
+	origDisableServerHostname := *headerDisableServerHostname
+	*headerDisableServerHostname = true
+	defer func() {
+		*headerDisableServerHostname = origDisableServerHostname
+	}()
+
+	req, _ := http.NewRequest("GET", "/health", nil)
+
+	srv := &server{s: &http.Server{}}
+	w := &httptest.ResponseRecorder{}
+
+	handlerWrapper(w, req, func(w http.ResponseWriter, r *http.Request) bool {
+		return builtinRoutesHandler(srv, r, w, func(_ http.ResponseWriter, _ *http.Request) bool {
+			return true
+		})
+	})
+
+	if got := w.Header().Get("X-Server-Hostname"); got != "" {
+		t.Fatalf("unexpected X-Server-Hostname header; got %q; want empty value", got)
+	}
 }


### PR DESCRIPTION
## Summary

- add `-http.header.disableServerHostname` for disabling the `X-Server-Hostname` HTTP response header
- keep the existing default behavior unchanged
- document the new flag and add a changelog entry

## Testing

- `go test ./lib/httpserver`
- `go run ./app/victoria-metrics -help 2>&1 | rg -A1 "http.header.disableServerHostname"`

Fixes https://github.com/VictoriaMetrics/VictoriaMetrics/issues/11067
