### PR TITLE
vmselect: fix Graphite metrics find response model

### DIFF
--- a/app/vmselect/graphite/metrics_api_test.go
+++ b/app/vmselect/graphite/metrics_api_test.go
@@ -1,6 +1,7 @@
 package graphite
 
 import (
+	"encoding/json"
 	"reflect"
 	"testing"
 )
@@ -64,6 +65,38 @@ func TestFilterLeaves(t *testing.T) {
 	f([]string{"a.", ".", "bc"}, "_", []string{"a.", ".", "bc"})
 	f([]string{"a_", "_", "bc"}, "_", []string{"bc"})
 	f([]string{"foo.", "bar."}, ".", []string{})
+}
+
+func TestMetricsFindResponseDataModel(t *testing.T) {
+	f := func(format string) {
+		t.Helper()
+
+		responseText := MetricsFindResponse([]string{"collectd.db01.", "collectd.foo"}, ".", format, false, "")
+		var response struct {
+			Metrics []map[string]any `json:"metrics"`
+		}
+		if err := json.Unmarshal([]byte(responseText), &response); err != nil {
+			t.Fatalf("cannot unmarshal MetricsFindResponse(format=%q): %s; response: %s", format, err, responseText)
+		}
+		expected := []map[string]any{
+			{
+				"path":    "collectd.db01.",
+				"name":    "db01",
+				"is_leaf": float64(0),
+			},
+			{
+				"path":    "collectd.foo",
+				"name":    "foo",
+				"is_leaf": float64(1),
+			},
+		}
+		if !reflect.DeepEqual(response.Metrics, expected) {
+			t.Fatalf("unexpected MetricsFindResponse(format=%q);\ngot\n%v\nwant\n%v", format, response.Metrics, expected)
+		}
+	}
+
+	f("treejson")
+	f("completer")
 }
 
 func TestAddAutomaticVariants(t *testing.T) {

--- a/app/vmselect/graphite/metrics_find_response.qtpl
+++ b/app/vmselect/graphite/metrics_find_response.qtpl
@@ -1,5 +1,4 @@
 {% import (
-	"sort"
 	"strings"
 
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/logger"
@@ -13,16 +12,16 @@ See https://graphite-api.readthedocs.io/en/latest/api.html#metrics-find
 	{% if jsonp != "" %}{%s= jsonp %}({% endif %}
 	{% switch format %}
 	{% case "completer" %}
-		{%= metricsFindResponseCompleter(paths, delimiter, addWildcards) %}
+		{%= metricsFindResponse(paths, delimiter, addWildcards) %}
 	{% case "treejson" %}
-		{%= metricsFindResponseTreeJSON(paths, delimiter, addWildcards) %}
+		{%= metricsFindResponse(paths, delimiter, addWildcards) %}
 	{% default %}
 		{% code logger.Panicf("BUG: unexpected format=%q", format) %}
 	{% endswitch %}
 	{% if jsonp != "" %}){% endif %}
 {% endfunc %}
 
-{% func metricsFindResponseCompleter(paths []string, delimiter string, addWildcards bool) %}
+{% func metricsFindResponse(paths []string, delimiter string, addWildcards bool) %}
 {
 	"metrics":[
 		{% for i, path := range paths %}
@@ -40,86 +39,6 @@ See https://graphite-api.readthedocs.io/en/latest/api.html#metrics-find
 		{% endif %}
 	]
 }
-{% endfunc %}
-
-{% func metricsFindResponseTreeJSON(paths []string, delimiter string, addWildcards bool) %}
-[
-{% code
-	if len(paths) > 1 {
-		sort.Strings(paths)
-		// Substitute `path` and `path<delimiter>` with `path<delimiter><delimiter>`.
-		// Such path is treated specially during rendering - see code below for details.
-		dst := paths[:1]
-		for _, path := range paths[1:] {
-			prevPath := dst[len(dst)-1]
-			if len(path) == len(prevPath)+1 && strings.HasSuffix(path, delimiter) && strings.HasPrefix(path, prevPath) {
-				// The path is equivalent to <prevPath> + <delimiter>
-				// Overwrite the prevPath with <path> + <delimiter> as carbonapi does.
-				// I.e. the resulting path ends with double delimiter.
-				// Such path is treated specially during rendering - see metrics_find_response.qtpl for details.
-				dst[len(dst)-1] = path + delimiter
-				continue
-			}
-			dst = append(dst, path)
-		}
-		paths = dst
-	}
-%}
-	{% for i, path := range paths %}
-	{
-		{% code
-			id := path
-			allowChildren := "0"
-			isLeaf := "1"
-			if strings.HasSuffix(id, delimiter) {
-				if strings.HasSuffix(id[:len(id)-1], delimiter) {
-					// Special case when id ends with double delimiter.
-					// See the code above for details.
-					id = id[:len(id)-2]
-				}
-				allowChildren = "1"
-				isLeaf = "0"
-			}
-		%}
-		"id": {%q= id %},
-		"text": {%= metricPathName(path, delimiter) %},
-		"allowChildren": {%s= allowChildren %},
-		"expandable": {%s= allowChildren %},
-		"leaf": {%s= isLeaf %}
-	}
-	{% if i+1 < len(paths) %},{% endif %}
-	{% endfor %}
-	{% if addWildcards && len(paths) > 1 %}
-	,{
-		{% code
-			path := paths[0]
-			for strings.HasSuffix(path, delimiter) {
-				path = path[:len(path)-1]
-			}
-			id := ""
-			if n := strings.LastIndexByte(path, delimiter[0]); n >= 0 {
-				id = path[:n+1]
-			}
-			id += "*"
-
-			allowChildren := "0"
-			isLeaf := "1"
-			for _, path := range paths {
-				if strings.HasSuffix(path, delimiter) {
-					allowChildren = "1"
-					isLeaf = "0"
-					break
-				}
-			}
-		%}
-		"id": {%q= id %},
-		"text": "*",
-		"allowChildren": {%s= allowChildren %},
-		"expandable": {%s= allowChildren %},
-		"leaf": {%s= isLeaf %}
-	}
-	{% endif %}
-]
 {% endfunc %}
 
 {% func metricPathName(path, delimiter string) %}

--- a/app/vmselect/graphite/metrics_find_response.qtpl.go
+++ b/app/vmselect/graphite/metrics_find_response.qtpl.go
@@ -6,7 +6,6 @@ package graphite
 
 //line app/vmselect/graphite/metrics_find_response.qtpl:1
 import (
-	"sort"
 	"strings"
 
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/logger"
@@ -14,306 +13,157 @@ import (
 
 // MetricsFindResponse generates response for /metrics/find .See https://graphite-api.readthedocs.io/en/latest/api.html#metrics-find
 
-//line app/vmselect/graphite/metrics_find_response.qtpl:12
+//line app/vmselect/graphite/metrics_find_response.qtpl:11
 import (
 	qtio422016 "io"
 
 	qt422016 "github.com/valyala/quicktemplate"
 )
 
-//line app/vmselect/graphite/metrics_find_response.qtpl:12
+//line app/vmselect/graphite/metrics_find_response.qtpl:11
 var (
 	_ = qtio422016.Copy
 	_ = qt422016.AcquireByteBuffer
 )
 
-//line app/vmselect/graphite/metrics_find_response.qtpl:12
+//line app/vmselect/graphite/metrics_find_response.qtpl:11
 func StreamMetricsFindResponse(qw422016 *qt422016.Writer, paths []string, delimiter, format string, addWildcards bool, jsonp string) {
-//line app/vmselect/graphite/metrics_find_response.qtpl:13
+//line app/vmselect/graphite/metrics_find_response.qtpl:12
 	if jsonp != "" {
-//line app/vmselect/graphite/metrics_find_response.qtpl:13
+//line app/vmselect/graphite/metrics_find_response.qtpl:12
 		qw422016.N().S(jsonp)
-//line app/vmselect/graphite/metrics_find_response.qtpl:13
+//line app/vmselect/graphite/metrics_find_response.qtpl:12
 		qw422016.N().S(`(`)
-//line app/vmselect/graphite/metrics_find_response.qtpl:13
+//line app/vmselect/graphite/metrics_find_response.qtpl:12
 	}
-//line app/vmselect/graphite/metrics_find_response.qtpl:14
+//line app/vmselect/graphite/metrics_find_response.qtpl:13
 	switch format {
-//line app/vmselect/graphite/metrics_find_response.qtpl:15
+//line app/vmselect/graphite/metrics_find_response.qtpl:14
 	case "completer":
+//line app/vmselect/graphite/metrics_find_response.qtpl:15
+		streammetricsFindResponse(qw422016, paths, delimiter, addWildcards)
 //line app/vmselect/graphite/metrics_find_response.qtpl:16
-		streammetricsFindResponseCompleter(qw422016, paths, delimiter, addWildcards)
-//line app/vmselect/graphite/metrics_find_response.qtpl:17
 	case "treejson":
+//line app/vmselect/graphite/metrics_find_response.qtpl:17
+		streammetricsFindResponse(qw422016, paths, delimiter, addWildcards)
 //line app/vmselect/graphite/metrics_find_response.qtpl:18
-		streammetricsFindResponseTreeJSON(qw422016, paths, delimiter, addWildcards)
-//line app/vmselect/graphite/metrics_find_response.qtpl:19
 	default:
-//line app/vmselect/graphite/metrics_find_response.qtpl:20
+//line app/vmselect/graphite/metrics_find_response.qtpl:19
 		logger.Panicf("BUG: unexpected format=%q", format)
 
+//line app/vmselect/graphite/metrics_find_response.qtpl:20
+	}
+//line app/vmselect/graphite/metrics_find_response.qtpl:21
+	if jsonp != "" {
+//line app/vmselect/graphite/metrics_find_response.qtpl:21
+		qw422016.N().S(`)`)
 //line app/vmselect/graphite/metrics_find_response.qtpl:21
 	}
 //line app/vmselect/graphite/metrics_find_response.qtpl:22
-	if jsonp != "" {
-//line app/vmselect/graphite/metrics_find_response.qtpl:22
-		qw422016.N().S(`)`)
-//line app/vmselect/graphite/metrics_find_response.qtpl:22
-	}
-//line app/vmselect/graphite/metrics_find_response.qtpl:23
 }
 
-//line app/vmselect/graphite/metrics_find_response.qtpl:23
+//line app/vmselect/graphite/metrics_find_response.qtpl:22
 func WriteMetricsFindResponse(qq422016 qtio422016.Writer, paths []string, delimiter, format string, addWildcards bool, jsonp string) {
-//line app/vmselect/graphite/metrics_find_response.qtpl:23
+//line app/vmselect/graphite/metrics_find_response.qtpl:22
 	qw422016 := qt422016.AcquireWriter(qq422016)
-//line app/vmselect/graphite/metrics_find_response.qtpl:23
+//line app/vmselect/graphite/metrics_find_response.qtpl:22
 	StreamMetricsFindResponse(qw422016, paths, delimiter, format, addWildcards, jsonp)
-//line app/vmselect/graphite/metrics_find_response.qtpl:23
+//line app/vmselect/graphite/metrics_find_response.qtpl:22
 	qt422016.ReleaseWriter(qw422016)
-//line app/vmselect/graphite/metrics_find_response.qtpl:23
+//line app/vmselect/graphite/metrics_find_response.qtpl:22
 }
 
-//line app/vmselect/graphite/metrics_find_response.qtpl:23
+//line app/vmselect/graphite/metrics_find_response.qtpl:22
 func MetricsFindResponse(paths []string, delimiter, format string, addWildcards bool, jsonp string) string {
-//line app/vmselect/graphite/metrics_find_response.qtpl:23
+//line app/vmselect/graphite/metrics_find_response.qtpl:22
 	qb422016 := qt422016.AcquireByteBuffer()
-//line app/vmselect/graphite/metrics_find_response.qtpl:23
+//line app/vmselect/graphite/metrics_find_response.qtpl:22
 	WriteMetricsFindResponse(qb422016, paths, delimiter, format, addWildcards, jsonp)
-//line app/vmselect/graphite/metrics_find_response.qtpl:23
+//line app/vmselect/graphite/metrics_find_response.qtpl:22
 	qs422016 := string(qb422016.B)
-//line app/vmselect/graphite/metrics_find_response.qtpl:23
+//line app/vmselect/graphite/metrics_find_response.qtpl:22
 	qt422016.ReleaseByteBuffer(qb422016)
-//line app/vmselect/graphite/metrics_find_response.qtpl:23
+//line app/vmselect/graphite/metrics_find_response.qtpl:22
 	return qs422016
-//line app/vmselect/graphite/metrics_find_response.qtpl:23
+//line app/vmselect/graphite/metrics_find_response.qtpl:22
 }
 
-//line app/vmselect/graphite/metrics_find_response.qtpl:25
-func streammetricsFindResponseCompleter(qw422016 *qt422016.Writer, paths []string, delimiter string, addWildcards bool) {
-//line app/vmselect/graphite/metrics_find_response.qtpl:25
+//line app/vmselect/graphite/metrics_find_response.qtpl:24
+func streammetricsFindResponse(qw422016 *qt422016.Writer, paths []string, delimiter string, addWildcards bool) {
+//line app/vmselect/graphite/metrics_find_response.qtpl:24
 	qw422016.N().S(`{"metrics":[`)
-//line app/vmselect/graphite/metrics_find_response.qtpl:28
+//line app/vmselect/graphite/metrics_find_response.qtpl:27
 	for i, path := range paths {
-//line app/vmselect/graphite/metrics_find_response.qtpl:28
+//line app/vmselect/graphite/metrics_find_response.qtpl:27
 		qw422016.N().S(`{"path":`)
-//line app/vmselect/graphite/metrics_find_response.qtpl:30
+//line app/vmselect/graphite/metrics_find_response.qtpl:29
 		qw422016.N().Q(path)
-//line app/vmselect/graphite/metrics_find_response.qtpl:30
+//line app/vmselect/graphite/metrics_find_response.qtpl:29
 		qw422016.N().S(`,"name":`)
-//line app/vmselect/graphite/metrics_find_response.qtpl:31
+//line app/vmselect/graphite/metrics_find_response.qtpl:30
 		streammetricPathName(qw422016, path, delimiter)
-//line app/vmselect/graphite/metrics_find_response.qtpl:31
+//line app/vmselect/graphite/metrics_find_response.qtpl:30
 		qw422016.N().S(`,"is_leaf":`)
-//line app/vmselect/graphite/metrics_find_response.qtpl:32
+//line app/vmselect/graphite/metrics_find_response.qtpl:31
 		if strings.HasSuffix(path, delimiter) {
-//line app/vmselect/graphite/metrics_find_response.qtpl:32
+//line app/vmselect/graphite/metrics_find_response.qtpl:31
 			qw422016.N().S(`0`)
-//line app/vmselect/graphite/metrics_find_response.qtpl:32
+//line app/vmselect/graphite/metrics_find_response.qtpl:31
 		} else {
-//line app/vmselect/graphite/metrics_find_response.qtpl:32
+//line app/vmselect/graphite/metrics_find_response.qtpl:31
 			qw422016.N().S(`1`)
-//line app/vmselect/graphite/metrics_find_response.qtpl:32
+//line app/vmselect/graphite/metrics_find_response.qtpl:31
 		}
-//line app/vmselect/graphite/metrics_find_response.qtpl:32
+//line app/vmselect/graphite/metrics_find_response.qtpl:31
 		qw422016.N().S(`}`)
-//line app/vmselect/graphite/metrics_find_response.qtpl:34
+//line app/vmselect/graphite/metrics_find_response.qtpl:33
 		if i+1 < len(paths) {
-//line app/vmselect/graphite/metrics_find_response.qtpl:34
+//line app/vmselect/graphite/metrics_find_response.qtpl:33
 			qw422016.N().S(`,`)
-//line app/vmselect/graphite/metrics_find_response.qtpl:34
+//line app/vmselect/graphite/metrics_find_response.qtpl:33
 		}
+//line app/vmselect/graphite/metrics_find_response.qtpl:34
+	}
 //line app/vmselect/graphite/metrics_find_response.qtpl:35
-	}
-//line app/vmselect/graphite/metrics_find_response.qtpl:36
 	if addWildcards && len(paths) > 1 {
-//line app/vmselect/graphite/metrics_find_response.qtpl:36
+//line app/vmselect/graphite/metrics_find_response.qtpl:35
 		qw422016.N().S(`,{"name": "*"}`)
-//line app/vmselect/graphite/metrics_find_response.qtpl:40
+//line app/vmselect/graphite/metrics_find_response.qtpl:39
 	}
-//line app/vmselect/graphite/metrics_find_response.qtpl:40
+//line app/vmselect/graphite/metrics_find_response.qtpl:39
 	qw422016.N().S(`]}`)
-//line app/vmselect/graphite/metrics_find_response.qtpl:43
+//line app/vmselect/graphite/metrics_find_response.qtpl:42
 }
 
-//line app/vmselect/graphite/metrics_find_response.qtpl:43
-func writemetricsFindResponseCompleter(qq422016 qtio422016.Writer, paths []string, delimiter string, addWildcards bool) {
-//line app/vmselect/graphite/metrics_find_response.qtpl:43
+//line app/vmselect/graphite/metrics_find_response.qtpl:42
+func writemetricsFindResponse(qq422016 qtio422016.Writer, paths []string, delimiter string, addWildcards bool) {
+//line app/vmselect/graphite/metrics_find_response.qtpl:42
 	qw422016 := qt422016.AcquireWriter(qq422016)
-//line app/vmselect/graphite/metrics_find_response.qtpl:43
-	streammetricsFindResponseCompleter(qw422016, paths, delimiter, addWildcards)
-//line app/vmselect/graphite/metrics_find_response.qtpl:43
+//line app/vmselect/graphite/metrics_find_response.qtpl:42
+	streammetricsFindResponse(qw422016, paths, delimiter, addWildcards)
+//line app/vmselect/graphite/metrics_find_response.qtpl:42
 	qt422016.ReleaseWriter(qw422016)
-//line app/vmselect/graphite/metrics_find_response.qtpl:43
+//line app/vmselect/graphite/metrics_find_response.qtpl:42
 }
 
-//line app/vmselect/graphite/metrics_find_response.qtpl:43
-func metricsFindResponseCompleter(paths []string, delimiter string, addWildcards bool) string {
-//line app/vmselect/graphite/metrics_find_response.qtpl:43
+//line app/vmselect/graphite/metrics_find_response.qtpl:42
+func metricsFindResponse(paths []string, delimiter string, addWildcards bool) string {
+//line app/vmselect/graphite/metrics_find_response.qtpl:42
 	qb422016 := qt422016.AcquireByteBuffer()
-//line app/vmselect/graphite/metrics_find_response.qtpl:43
-	writemetricsFindResponseCompleter(qb422016, paths, delimiter, addWildcards)
-//line app/vmselect/graphite/metrics_find_response.qtpl:43
+//line app/vmselect/graphite/metrics_find_response.qtpl:42
+	writemetricsFindResponse(qb422016, paths, delimiter, addWildcards)
+//line app/vmselect/graphite/metrics_find_response.qtpl:42
 	qs422016 := string(qb422016.B)
-//line app/vmselect/graphite/metrics_find_response.qtpl:43
+//line app/vmselect/graphite/metrics_find_response.qtpl:42
 	qt422016.ReleaseByteBuffer(qb422016)
-//line app/vmselect/graphite/metrics_find_response.qtpl:43
+//line app/vmselect/graphite/metrics_find_response.qtpl:42
 	return qs422016
-//line app/vmselect/graphite/metrics_find_response.qtpl:43
+//line app/vmselect/graphite/metrics_find_response.qtpl:42
 }
 
-//line app/vmselect/graphite/metrics_find_response.qtpl:45
-func streammetricsFindResponseTreeJSON(qw422016 *qt422016.Writer, paths []string, delimiter string, addWildcards bool) {
-//line app/vmselect/graphite/metrics_find_response.qtpl:45
-	qw422016.N().S(`[`)
-//line app/vmselect/graphite/metrics_find_response.qtpl:48
-	if len(paths) > 1 {
-		sort.Strings(paths)
-		// Substitute `path` and `path<delimiter>` with `path<delimiter><delimiter>`.
-		// Such path is treated specially during rendering - see code below for details.
-		dst := paths[:1]
-		for _, path := range paths[1:] {
-			prevPath := dst[len(dst)-1]
-			if len(path) == len(prevPath)+1 && strings.HasSuffix(path, delimiter) && strings.HasPrefix(path, prevPath) {
-				// The path is equivalent to <prevPath> + <delimiter>
-				// Overwrite the prevPath with <path> + <delimiter> as carbonapi does.
-				// I.e. the resulting path ends with double delimiter.
-				// Such path is treated specially during rendering - see metrics_find_response.qtpl for details.
-				dst[len(dst)-1] = path + delimiter
-				continue
-			}
-			dst = append(dst, path)
-		}
-		paths = dst
-	}
-
-//line app/vmselect/graphite/metrics_find_response.qtpl:68
-	for i, path := range paths {
-//line app/vmselect/graphite/metrics_find_response.qtpl:68
-		qw422016.N().S(`{`)
-//line app/vmselect/graphite/metrics_find_response.qtpl:71
-		id := path
-		allowChildren := "0"
-		isLeaf := "1"
-		if strings.HasSuffix(id, delimiter) {
-			if strings.HasSuffix(id[:len(id)-1], delimiter) {
-				// Special case when id ends with double delimiter.
-				// See the code above for details.
-				id = id[:len(id)-2]
-			}
-			allowChildren = "1"
-			isLeaf = "0"
-		}
-
-//line app/vmselect/graphite/metrics_find_response.qtpl:83
-		qw422016.N().S(`"id":`)
-//line app/vmselect/graphite/metrics_find_response.qtpl:84
-		qw422016.N().Q(id)
-//line app/vmselect/graphite/metrics_find_response.qtpl:84
-		qw422016.N().S(`,"text":`)
-//line app/vmselect/graphite/metrics_find_response.qtpl:85
-		streammetricPathName(qw422016, path, delimiter)
-//line app/vmselect/graphite/metrics_find_response.qtpl:85
-		qw422016.N().S(`,"allowChildren":`)
-//line app/vmselect/graphite/metrics_find_response.qtpl:86
-		qw422016.N().S(allowChildren)
-//line app/vmselect/graphite/metrics_find_response.qtpl:86
-		qw422016.N().S(`,"expandable":`)
-//line app/vmselect/graphite/metrics_find_response.qtpl:87
-		qw422016.N().S(allowChildren)
-//line app/vmselect/graphite/metrics_find_response.qtpl:87
-		qw422016.N().S(`,"leaf":`)
-//line app/vmselect/graphite/metrics_find_response.qtpl:88
-		qw422016.N().S(isLeaf)
-//line app/vmselect/graphite/metrics_find_response.qtpl:88
-		qw422016.N().S(`}`)
-//line app/vmselect/graphite/metrics_find_response.qtpl:90
-		if i+1 < len(paths) {
-//line app/vmselect/graphite/metrics_find_response.qtpl:90
-			qw422016.N().S(`,`)
-//line app/vmselect/graphite/metrics_find_response.qtpl:90
-		}
-//line app/vmselect/graphite/metrics_find_response.qtpl:91
-	}
-//line app/vmselect/graphite/metrics_find_response.qtpl:92
-	if addWildcards && len(paths) > 1 {
-//line app/vmselect/graphite/metrics_find_response.qtpl:92
-		qw422016.N().S(`,{`)
-//line app/vmselect/graphite/metrics_find_response.qtpl:95
-		path := paths[0]
-		for strings.HasSuffix(path, delimiter) {
-			path = path[:len(path)-1]
-		}
-		id := ""
-		if n := strings.LastIndexByte(path, delimiter[0]); n >= 0 {
-			id = path[:n+1]
-		}
-		id += "*"
-
-		allowChildren := "0"
-		isLeaf := "1"
-		for _, path := range paths {
-			if strings.HasSuffix(path, delimiter) {
-				allowChildren = "1"
-				isLeaf = "0"
-				break
-			}
-		}
-
-//line app/vmselect/graphite/metrics_find_response.qtpl:114
-		qw422016.N().S(`"id":`)
-//line app/vmselect/graphite/metrics_find_response.qtpl:115
-		qw422016.N().Q(id)
-//line app/vmselect/graphite/metrics_find_response.qtpl:115
-		qw422016.N().S(`,"text": "*","allowChildren":`)
-//line app/vmselect/graphite/metrics_find_response.qtpl:117
-		qw422016.N().S(allowChildren)
-//line app/vmselect/graphite/metrics_find_response.qtpl:117
-		qw422016.N().S(`,"expandable":`)
-//line app/vmselect/graphite/metrics_find_response.qtpl:118
-		qw422016.N().S(allowChildren)
-//line app/vmselect/graphite/metrics_find_response.qtpl:118
-		qw422016.N().S(`,"leaf":`)
-//line app/vmselect/graphite/metrics_find_response.qtpl:119
-		qw422016.N().S(isLeaf)
-//line app/vmselect/graphite/metrics_find_response.qtpl:119
-		qw422016.N().S(`}`)
-//line app/vmselect/graphite/metrics_find_response.qtpl:121
-	}
-//line app/vmselect/graphite/metrics_find_response.qtpl:121
-	qw422016.N().S(`]`)
-//line app/vmselect/graphite/metrics_find_response.qtpl:123
-}
-
-//line app/vmselect/graphite/metrics_find_response.qtpl:123
-func writemetricsFindResponseTreeJSON(qq422016 qtio422016.Writer, paths []string, delimiter string, addWildcards bool) {
-//line app/vmselect/graphite/metrics_find_response.qtpl:123
-	qw422016 := qt422016.AcquireWriter(qq422016)
-//line app/vmselect/graphite/metrics_find_response.qtpl:123
-	streammetricsFindResponseTreeJSON(qw422016, paths, delimiter, addWildcards)
-//line app/vmselect/graphite/metrics_find_response.qtpl:123
-	qt422016.ReleaseWriter(qw422016)
-//line app/vmselect/graphite/metrics_find_response.qtpl:123
-}
-
-//line app/vmselect/graphite/metrics_find_response.qtpl:123
-func metricsFindResponseTreeJSON(paths []string, delimiter string, addWildcards bool) string {
-//line app/vmselect/graphite/metrics_find_response.qtpl:123
-	qb422016 := qt422016.AcquireByteBuffer()
-//line app/vmselect/graphite/metrics_find_response.qtpl:123
-	writemetricsFindResponseTreeJSON(qb422016, paths, delimiter, addWildcards)
-//line app/vmselect/graphite/metrics_find_response.qtpl:123
-	qs422016 := string(qb422016.B)
-//line app/vmselect/graphite/metrics_find_response.qtpl:123
-	qt422016.ReleaseByteBuffer(qb422016)
-//line app/vmselect/graphite/metrics_find_response.qtpl:123
-	return qs422016
-//line app/vmselect/graphite/metrics_find_response.qtpl:123
-}
-
-//line app/vmselect/graphite/metrics_find_response.qtpl:125
+//line app/vmselect/graphite/metrics_find_response.qtpl:44
 func streammetricPathName(qw422016 *qt422016.Writer, path, delimiter string) {
-//line app/vmselect/graphite/metrics_find_response.qtpl:127
+//line app/vmselect/graphite/metrics_find_response.qtpl:46
 	name := path
 	for strings.HasSuffix(name, delimiter) {
 		name = name[:len(name)-1]
@@ -322,33 +172,33 @@ func streammetricPathName(qw422016 *qt422016.Writer, path, delimiter string) {
 		name = name[n+1:]
 	}
 
-//line app/vmselect/graphite/metrics_find_response.qtpl:135
+//line app/vmselect/graphite/metrics_find_response.qtpl:54
 	qw422016.N().Q(name)
-//line app/vmselect/graphite/metrics_find_response.qtpl:136
+//line app/vmselect/graphite/metrics_find_response.qtpl:55
 }
 
-//line app/vmselect/graphite/metrics_find_response.qtpl:136
+//line app/vmselect/graphite/metrics_find_response.qtpl:55
 func writemetricPathName(qq422016 qtio422016.Writer, path, delimiter string) {
-//line app/vmselect/graphite/metrics_find_response.qtpl:136
+//line app/vmselect/graphite/metrics_find_response.qtpl:55
 	qw422016 := qt422016.AcquireWriter(qq422016)
-//line app/vmselect/graphite/metrics_find_response.qtpl:136
+//line app/vmselect/graphite/metrics_find_response.qtpl:55
 	streammetricPathName(qw422016, path, delimiter)
-//line app/vmselect/graphite/metrics_find_response.qtpl:136
+//line app/vmselect/graphite/metrics_find_response.qtpl:55
 	qt422016.ReleaseWriter(qw422016)
-//line app/vmselect/graphite/metrics_find_response.qtpl:136
+//line app/vmselect/graphite/metrics_find_response.qtpl:55
 }
 
-//line app/vmselect/graphite/metrics_find_response.qtpl:136
+//line app/vmselect/graphite/metrics_find_response.qtpl:55
 func metricPathName(path, delimiter string) string {
-//line app/vmselect/graphite/metrics_find_response.qtpl:136
+//line app/vmselect/graphite/metrics_find_response.qtpl:55
 	qb422016 := qt422016.AcquireByteBuffer()
-//line app/vmselect/graphite/metrics_find_response.qtpl:136
+//line app/vmselect/graphite/metrics_find_response.qtpl:55
 	writemetricPathName(qb422016, path, delimiter)
-//line app/vmselect/graphite/metrics_find_response.qtpl:136
+//line app/vmselect/graphite/metrics_find_response.qtpl:55
 	qs422016 := string(qb422016.B)
-//line app/vmselect/graphite/metrics_find_response.qtpl:136
+//line app/vmselect/graphite/metrics_find_response.qtpl:55
 	qt422016.ReleaseByteBuffer(qb422016)
-//line app/vmselect/graphite/metrics_find_response.qtpl:136
+//line app/vmselect/graphite/metrics_find_response.qtpl:55
 	return qs422016
-//line app/vmselect/graphite/metrics_find_response.qtpl:136
+//line app/vmselect/graphite/metrics_find_response.qtpl:55
 }

--- a/apptest/model.go
+++ b/apptest/model.go
@@ -546,16 +546,16 @@ func sortTSDBStatusResponseEntries(entries []TSDBStatusResponseEntry) {
 type GraphiteMetricsIndexResponse = []string
 
 type GraphiteMetric struct {
-	Id            string
-	Text          string
-	AllowChildren int
-	Expandable    int
-	Leaf          int
+	Path   string `json:"path"`
+	Name   string `json:"name"`
+	IsLeaf int    `json:"is_leaf"`
 }
 
-// GraphiteMetricsIndexResponse is an in-memory representation of the json response
+// GraphiteMetricsFindResponse is an in-memory representation of the json response
 // returned by the /graphite/metrics/find endpoint.
-type GraphiteMetricsFindResponse = []GraphiteMetric
+type GraphiteMetricsFindResponse struct {
+	Metrics []GraphiteMetric `json:"metrics"`
+}
 
 // GraphiteMetricsExpandResponse is an in-memory representation of the json response
 // returned by the /graphite/metrics/expand endpoint.

--- a/docs/victoriametrics/changelog/CHANGELOG.md
+++ b/docs/victoriametrics/changelog/CHANGELOG.md
@@ -33,6 +33,7 @@ See also [LTS releases](https://docs.victoriametrics.com/victoriametrics/lts-rel
 
 * BUGFIX: [stream aggregation](https://docs.victoriametrics.com/victoriametrics/stream-aggregation/): fix issue with producing aggregated samples with identical timestamps between flushes. See [#10808](https://github.com/VictoriaMetrics/VictoriaMetrics/pull/10808).
 * BUGFIX: `vmselect` in [VictoriaMetrics cluster](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/): fix corrupted metrics metadata when a response contains multiple rows.
+* BUGFIX: [vmsingle](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/) and `vmselect` in [VictoriaMetrics cluster](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/): properly format response for [graphite](https://docs.victoriametrics.com/victoriametrics/integrations/graphite/#graphite-api-usage) `/metrics/find` API response. See [#10945](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/10945). Thanks to @zasdaym for contribution.
 * BUGFIX: [vmbackup](https://docs.victoriametrics.com/vmbackup/), [vmbackupmanager](https://docs.victoriametrics.com/victoriametrics/vmbackupmanager/): do not fail backup list if directory is absent while using `fs://` destination to align with other protocols. See [6c3c548](https://github.com/VictoriaMetrics/VictoriaMetrics/commit/6c3c548ddb0385b749e731f52276f130e2a4e4a8)
 
 ## [v1.145.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.145.0)


### PR DESCRIPTION
Fixes #10945.

### Changes
- Return the documented Graphite `/metrics/find` data model with `metrics[].path`, `metrics[].name`, and `metrics[].is_leaf` for both supported response formats.
- Update app test helpers to decode the `metrics` response wrapper.
- Add a regression test for the response data model.

### Tests
- `go test ./app/vmselect/graphite`
- `go test ./apptest`
- `go test ./apptest/tests -run '^$'`