### PR TITLE
docs/victoriametrics: clarify storage/tsid cache eviction and label filter selectivity in Troubleshooting

### DIFF
--- a/docs/victoriametrics/Troubleshooting.md
+++ b/docs/victoriametrics/Troubleshooting.md
@@ -202,6 +202,17 @@ These are the most common reasons for slow data ingestion in VictoriaMetrics:
    then it is likely that the current number of [active time series](https://docs.victoriametrics.com/victoriametrics/faq/#what-is-an-active-time-series)
    cannot fit the `storage/tsid` cache.
 
+   The `storage/tsid` cache has a fixed maximum size — 37% of the memory available to VictoriaMetrics (or `vmstorage`)
+   by default. It can be overridden with the `-storage.cacheSizeStorageTSID` command-line flag. Entries are evicted from the cache
+   when they aren't accessed during the `-cacheExpireDuration` (30 minutes by default) or when the cache overflows.
+   The eviction isn't tied to the configured retention. So, after a temporary spike in the number of active time series
+   (for example, during a rolling restart of monitored workloads in Kubernetes, which changes pod names),
+   the elevated `slow inserts` percentage usually recovers within hours after the spike ends,
+   as the cache gets re-populated with the entries for the currently active series.
+   If the `slow inserts` percentage stays high, then the number of active time series permanently exceeds the cache capacity.
+   In this case the eviction of entries for active series continues until the available memory is increased
+   or the number of active time series is reduced.
+
    These are the solutions that exist for this issue:
 
    - Increase the available memory on the host where VictoriaMetrics runs until the `slow inserts` percentage
@@ -351,6 +362,24 @@ These are the solutions that exist for improving the performance of slow queries
 
   See also [this article](https://valyala.medium.com/how-to-optimize-promql-and-metricsql-queries-85a1b75bf986),
   which explains how to identify and optimize slow queries.
+
+- Improving the selectivity of label filters.
+
+  VictoriaMetrics locates the requested time series via the first non-negative label filter with the smallest cost,
+  e.g. the smallest number of matching time series. Negative label filters (`!=` and `!~`) cannot be used
+  for locating time series — they only filter out the series located via non-negative filters.
+  If the query contains only negative label filters, then VictoriaMetrics has to locate all the time series
+  for the selected time range before applying these filters.
+
+  This means negative label filters reduce the size of the query response, but not the amounts of CPU, RAM
+  and disk read I/O needed for executing the query. For example, `node_filesystem_files{fstype!~"tmpfs|overlay"}`
+  locates all the `node_filesystem_files` series via the `__name__` filter and only then drops the series
+  with `tmpfs` and `overlay` filesystems, so it executes as slowly as `node_filesystem_files` without filters.
+  Rewriting the filter in the equivalent positive form, such as `node_filesystem_files{fstype=~"ext4|xfs"}`,
+  allows locating only the needed series and reduces both the query duration and memory usage.
+
+  [Query tracing](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#query-tracing)
+  shows which label filters are used for locating the time series.
 
 ## Out of memory errors
 

--- a/docs/victoriametrics/Troubleshooting.md
+++ b/docs/victoriametrics/Troubleshooting.md
@@ -375,8 +375,9 @@ These are the solutions that exist for improving the performance of slow queries
   and disk read I/O needed for executing the query. For example, `node_filesystem_files{fstype!~"tmpfs|overlay"}`
   locates all the `node_filesystem_files` series via the `__name__` filter and only then drops the series
   with `tmpfs` and `overlay` filesystems, so it executes as slowly as `node_filesystem_files` without filters.
-  Rewriting the filter in the equivalent positive form, such as `node_filesystem_files{fstype=~"ext4|xfs"}`,
+  Rewriting the filter as an allow-list of the filesystem types you actually need, such as `node_filesystem_files{fstype=~"ext4|xfs"}`,
   allows locating only the needed series and reduces both the query duration and memory usage.
+  Note the allow-list must enumerate all the needed values - it selects a different set of series than the negative filter unless the enumeration is complete.
 
   [Query tracing](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#query-tracing)
   shows which label filters are used for locating the time series.

--- a/docs/victoriametrics/Troubleshooting.md
+++ b/docs/victoriametrics/Troubleshooting.md
@@ -378,7 +378,8 @@ These are the solutions that exist for improving the performance of slow queries
   Rewriting the filter as an allow-list of the filesystem types you actually need, such as `node_filesystem_files{fstype=~"ext4|xfs"}`,
   allows locating only the needed series and reduces both the query duration and memory usage.
   Note the allow-list selects a different set of series than the negative filter: it only matches series that have the label
-  with one of the enumerated values, while the negative filter also matches series without the label.
+  with one of the enumerated values, while the negative filter also matches series without the label
+  (this applies to regexes that don't match an empty string, like the ones above).
   Make sure the allow-list covers all the needed values and that all the needed series have the label.
 
   [Query tracing](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#query-tracing)

--- a/docs/victoriametrics/Troubleshooting.md
+++ b/docs/victoriametrics/Troubleshooting.md
@@ -377,7 +377,9 @@ These are the solutions that exist for improving the performance of slow queries
   with `tmpfs` and `overlay` filesystems, so it executes as slowly as `node_filesystem_files` without filters.
   Rewriting the filter as an allow-list of the filesystem types you actually need, such as `node_filesystem_files{fstype=~"ext4|xfs"}`,
   allows locating only the needed series and reduces both the query duration and memory usage.
-  Note the allow-list must enumerate all the needed values - it selects a different set of series than the negative filter unless the enumeration is complete.
+  Note the allow-list selects a different set of series than the negative filter: it only matches series that have the label
+  with one of the enumerated values, while the negative filter also matches series without the label.
+  Make sure the allow-list covers all the needed values and that all the needed series have the label.
 
   [Query tracing](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#query-tracing)
   shows which label filters are used for locating the time series.


### PR DESCRIPTION
### Describe Your Changes

Adds two clarifications to the Troubleshooting docs, based on what we had to learn from source while operating a 13-shard cluster (~480M active series) through a cardinality incident:

**Slow data ingestion / `storage/tsid` cache:** the current text explains cache misses but not the eviction model, and we initially assumed elevated slow inserts would persist for the whole retention period. Documented that the cache has a fixed maximum size (37% of allowed memory by default, `-storage.cacheSizeStorageTSID` to override), entries are evicted on inactivity (`-cacheExpireDuration`) or overflow, and recovery after a churn spike (e.g. Kubernetes rolling restarts changing pod names) takes hours, not the retention period. Also documented the symptom of the cache being permanently over capacity.

**Slow queries / label filter selectivity:** documented that negative label filters (`!=`, `!~`) cannot be used for locating series in the index and only reduce the response, not the query cost. Matches the behavior in `lib/storage/index_db.go` (`getMetricIDsForDateAndFilters`: "Populate metricIDs for the first non-negative filter with the smallest cost", with fallback to all metric ids when all filters are negative). We confirmed this in production: adding `fstype!~` exclusions to an expensive alert expression left per-evaluation duration unchanged (~36s) until we rewrote it with a positive `fstype=~` filter. Currently this behavior is only described in an external blog post, not in the docs.

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/).
