### PR TITLE
stream aggregation: add `sum_sample_total` output function

### DIFF
--- a/docs/victoriametrics/stream-aggregation/configuration.md
+++ b/docs/victoriametrics/stream-aggregation/configuration.md
@@ -506,6 +506,19 @@ See also:
 - [count_samples](#count_samples)
 - [count_series](#count_series)
 
+### `sum_samples_total`
+
+`sum_samples_total` sums input delta values into a cumulative [counter](https://docs.victoriametrics.com/victoriametrics/keyconcepts/index.html#counter) and outputs the result at the given `interval`.
+`sum_samples_total` makes sense only for aggregating delta values from clients such as [StatsD counter](https://github.com/statsd/statsd/blob/master/docs/metric_types.md#counting).
+
+The results of `sum_samples_total` is roughly equal to the following [MetricsQL](https://docs.victoriametrics.com/victoriametrics/metricsql/) query:
+
+```metricsql
+sum(running_sum(some_delta_values))
+```
+
+>Note: The aggregator will forget the cumulative counter if it has not seen input samples for `staleness_interval`(set to `interval` by default) per output result, so the output counter will start from `0` the next time it sees the input again. Increase the `staleness_interval` option if you want to extend the window to tolerate bigger gaps.
+
 ### total
 
 `total` generates output [counter](https://docs.victoriametrics.com/victoriametrics/keyconcepts/#counter) by summing the input counters over the given `interval`.

--- a/lib/streamaggr/streamaggr.go
+++ b/lib/streamaggr/streamaggr.go
@@ -43,6 +43,7 @@ var supportedOutputs = []string{
 	"stddev",
 	"stdvar",
 	"sum_samples",
+	"sum_samples_total",
 	"total",
 	"total_prometheus",
 	"unique_samples",
@@ -770,7 +771,9 @@ func newOutputConfig(ms *metrics.Set, metricLabels, output string, outputsSeen m
 	case "stdvar":
 		return newStdvarAggrConfig(), nil
 	case "sum_samples":
-		return newSumSamplesAggrConfig(), nil
+		return newSumSamplesAggrConfig(true), nil
+	case "sum_samples_total":
+		return newSumSamplesAggrConfig(false), nil
 	case "total":
 		return newTotalAggrConfig(ms, metricLabels, ignoreFirstSampleIntervalSecs, true), nil
 	case "total_prometheus":

--- a/lib/streamaggr/streamaggr_synctest_test.go
+++ b/lib/streamaggr/streamaggr_synctest_test.go
@@ -549,24 +549,53 @@ foo:1m_without_non_existing_label_total_prometheus 12
   outputs: [increase, increase_prometheus, total, total_prometheus]
 `, "111111")
 
-	// multiple aggregate configs
+	// sum_sample and sum_samples_total outputs with different staleness intervals
 	f([]string{`
 foo 1
+foo 2 1
 foo{bar="baz"} 2
-foo 3.3
-`, ``, ``, ``, ``}, time.Minute, `foo:1m_count_series 1
-foo:1m_count_series{bar="baz"} 1
-foo:1m_sum_samples 4.3
+`, `
+foo 4
+`, ``, ``, `
+foo 6
+`, ``, ``}, time.Minute, `foo:1m_sum_samples 3
+foo:1m_sum_samples 4
+foo:1m_sum_samples 6
+foo:1m_sum_samples_total 3
+foo:1m_sum_samples_total 7
+foo:1m_sum_samples_total 6
+foo:1m_sum_samples_total{bar="baz"} 2
 foo:1m_sum_samples{bar="baz"} 2
-foo:5m_by_bar_sum_samples 4.3
+foo:1m_without_non-existing-label_sum_samples 3
+foo:1m_without_non-existing-label_sum_samples 4
+foo:1m_without_non-existing-label_sum_samples 0
+foo:1m_without_non-existing-label_sum_samples 6
+foo:1m_without_non-existing-label_sum_samples 0
+foo:1m_without_non-existing-label_sum_samples_total 3
+foo:1m_without_non-existing-label_sum_samples_total 7
+foo:1m_without_non-existing-label_sum_samples_total 7
+foo:1m_without_non-existing-label_sum_samples_total 6
+foo:1m_without_non-existing-label_sum_samples_total 6
+foo:1m_without_non-existing-label_sum_samples_total{bar="baz"} 2
+foo:1m_without_non-existing-label_sum_samples_total{bar="baz"} 2
+foo:1m_without_non-existing-label_sum_samples{bar="baz"} 2
+foo:1m_without_non-existing-label_sum_samples{bar="baz"} 0
+foo:5m_by_bar_sum_samples 13
+foo:5m_by_bar_sum_samples_total 13
+foo:5m_by_bar_sum_samples_total{bar="baz"} 2
 foo:5m_by_bar_sum_samples{bar="baz"} 2
 `, `
 - interval: 1m
-  outputs: [count_series, sum_samples]
+  staleness_interval: 1m
+  outputs: [ sum_samples, sum_samples_total]
+- interval: 1m
+  staleness_interval: 2m
+  without: [non-existing-label]
+  outputs: [ sum_samples, sum_samples_total]
 - interval: 5m
   by: [bar]
-  outputs: [sum_samples]
-`, "111")
+  outputs: [sum_samples, sum_samples_total]
+`, "11111")
 
 	// min and max outputs
 	f([]string{`

--- a/lib/streamaggr/streamaggr_timing_test.go
+++ b/lib/streamaggr/streamaggr_timing_test.go
@@ -27,6 +27,7 @@ var benchOutputs = []string{
 	"stddev",
 	"stdvar",
 	"sum_samples",
+	"sum_samples_total",
 	"total",
 	"total_prometheus",
 	"unique_samples",

--- a/lib/streamaggr/sum_samples.go
+++ b/lib/streamaggr/sum_samples.go
@@ -1,27 +1,44 @@
 package streamaggr
 
+import (
+	"math"
+)
+
 type sumSamplesAggrValue struct {
 	sum float64
 }
 
 func (av *sumSamplesAggrValue) pushSample(_ aggrConfig, sample *pushSample, _ string, _ int64) {
+	if math.Abs(av.sum) >= (1 << 53) {
+		// It is time to reset the entry, since it starts losing float64 precision
+		av.sum = 0
+	}
 	av.sum += sample.value
 }
 
-func (av *sumSamplesAggrValue) flush(_ aggrConfig, ctx *flushCtx, key string, _ bool) {
-	ctx.appendSeries(key, "sum_samples", av.sum)
-	av.sum = 0
+func (av *sumSamplesAggrValue) flush(c aggrConfig, ctx *flushCtx, key string, _ bool) {
+	ac := c.(*sumSamplesAggrConfig)
+	if ac.resetTotalOnFlush {
+		ctx.appendSeries(key, "sum_samples", av.sum)
+		av.sum = 0
+		return
+	}
+	ctx.appendSeries(key, "sum_samples_total", av.sum)
 }
 
 func (*sumSamplesAggrValue) state() any {
 	return nil
 }
 
-func newSumSamplesAggrConfig() aggrConfig {
-	return &sumSamplesAggrConfig{}
+func newSumSamplesAggrConfig(resetTotalOnFlush bool) aggrConfig {
+	return &sumSamplesAggrConfig{
+		resetTotalOnFlush: resetTotalOnFlush,
+	}
 }
 
-type sumSamplesAggrConfig struct{}
+type sumSamplesAggrConfig struct {
+	resetTotalOnFlush bool
+}
 
 func (*sumSamplesAggrConfig) getValue(_ any) aggrValue {
 	return &sumSamplesAggrValue{}


### PR DESCRIPTION
Fix https://github.com/VictoriaMetrics/VictoriaMetrics/issues/11002, https://github.com/VictoriaMetrics/VictoriaMetrics/issues/4843.

Add `sum_sample_total` aggregation function to sums input delta values into a cumulative [counter](https://docs.victoriametrics.com/victoriametrics/keyconcepts/index.html#counter) and outputs the result at the given `interval`.
`sum_samples_total` makes sense only for aggregating delta values from clients such as [StatsD counter](https://github.com/statsd/statsd/blob/master/docs/metric_types.md#counting).

>Note: The aggregator will forget the cumulative counter if it has not seen input samples for `staleness_interval`(set to `interval` by default) per output result, so the output counter will start from `0` the next time it sees the input again. Increase the `staleness_interval` option if you want to extend the window to tolerate bigger gaps.