### PR TITLE
app/vmctl: fix typo in missing-field influx error

### DIFF
--- a/app/vmctl/influx/influx.go
+++ b/app/vmctl/influx/influx.go
@@ -259,7 +259,7 @@ func (cr *ChunkedResponse) Next() ([]int64, []float64, error) {
 
 	fieldValues, ok := r.values[cr.field]
 	if !ok {
-		return nil, nil, fmt.Errorf("response doesn't contain filed %q", cr.field)
+		return nil, nil, fmt.Errorf("response doesn't contain field %q", cr.field)
 	}
 	values := make([]float64, len(fieldValues))
 	for i, fv := range fieldValues {


### PR DESCRIPTION
Related to #10892

`vmctl influx` returns `response doesn't contain filed "value"` when the response misses the requested field column.
This PR fixes the typo in that error message, adds a regression test, and updates the tip changelog.

How to reproduce
1. Run `go test ./app/vmctl/influx -run TestChunkedResponseNext_MissingField`.
2. Before this change, the expected error text contains `filed`.
3. After this change, it contains `field`.

Checks
`go test ./app/vmctl/influx`
`git diff --check`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/VictoriaMetrics/VictoriaMetrics/pull/11099?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
