### PR TITLE
Docs: Object Storage References Credentials File With No Example

### DIFF
--- a/docs/guides/connecting-vm-components-to-cloud-storage/README.md
+++ b/docs/guides/connecting-vm-components-to-cloud-storage/README.md
@@ -1,11 +1,11 @@
 Several VictoriaMetrics components can connect to cloud storage to read or write object data.
 
-| Component | S3 | Google Cloud Storage | Azure Blob Storage |
+| Component | AWS S3 and S3-compatible | Google Cloud Storage | Azure Blob Storage |
 |-----------|----|----------------------|--------------------|
 | [vmbackup](https://docs.victoriametrics.com/victoriametrics/vmbackup/) | ✅ | ✅ | ✅ |
 | [vmrestore](https://docs.victoriametrics.com/victoriametrics/vmrestore/) | ✅ | ✅ | ✅ |
-| [vmbackupmanager](https://docs.victoriametrics.com/victoriametrics/vmbackupmanager/) (Enterprise only) | ✅ | ✅ | ✅ |
-| [vmalert](https://docs.victoriametrics.com/victoriametrics/vmalert/) (Enterprise only) |  ✅ | ✅ | ❌ |
+| [vmbackupmanager](https://docs.victoriametrics.com/victoriametrics/vmbackupmanager/) | ✅ | ✅ | ✅ |
+| [vmalert](https://docs.victoriametrics.com/victoriametrics/vmalert/) |  ✅ | ✅ | ❌ |
 
 All these components use the same underlying libraries, so the authentication setup is largely the same. The main difference is in flag names: 
 
@@ -16,7 +16,7 @@ See the [component reference](#per-component-flag-reference) for details.
 
 ## Obtaining credentials
 
-You need to supply credentials so the component can connect to the cloud storage. The steps depend on the cloud provider.
+You need to supply credentials so the component can connect to the cloud storage. The setup differs by provider; the sections below cover AWS S3, S3‑compatible systems, GCS, and Azure Blob Storage.
 
 ### AWS S3
 
@@ -38,7 +38,7 @@ Generate access keys using your storage system's admin interface or CLI. The cre
 
 ### Azure Blob Storage
 
-> Azure does not use a credential files.
+> Azure does not use credential files.
 
 1. Log in to the Azure Portal.
 1. Search for and select **Storage accounts**.
@@ -49,7 +49,7 @@ Generate access keys using your storage system's admin interface or CLI. The cre
 
 ## Authenticating with the cloud provider
 
-Provide the credential file or environment variables and the path to the cloud storage bucket. The syntax for the bucket name depends on the cloud provider:
+Provide the credentials as a file or with environment variables, along with the path to the cloud storage bucket. The syntax for the bucket name depends on the cloud provider:
 
 - `s3://`: for AWS S3 and S3-compatible storage (MinIO, Ceph)
 - `gs://`: Google Cloud Storage
@@ -57,20 +57,20 @@ Provide the credential file or environment variables and the path to the cloud s
 
 ### vmbackup and vmrestore
 
-The following example backs up to an S3 bucket using a credentials file:
+The following example backs up to an AWS S3 bucket using a credentials file:
 
 ```sh
 vmbackup \
-  -storageDataPath=/data \ ok
+  -storageDataPath=/data \
   -snapshot.createURL=http://localhost:8428/snapshot/create \
   -dst=s3://victoriametrics-backup/backup01 \
   -credsFilePath=/etc/credentials
 ```
 
-In order to restore from the same S3 backup:
+In order to restore from the same backup from AWS S3:
 
 ```sh
-vmrestore \ ok
+vmrestore \
   -src=s3://victoriametrics-backup/backup01 \
   -storageDataPath=/data \
   -credsFilePath=/etc/credentials
@@ -83,12 +83,12 @@ Alternatively, you can set the access keys as environment variables instead of u
 export AWS_ACCESS_KEY_ID=YOUR_AWS_ACCESS_KEY
 export AWS_SECRET_ACCESS_KEY=YOUR_SECRET_AWS_ACCESS_KEY
 
-vmbackup \ ok
+vmbackup \
   -storageDataPath=/data \
   -snapshot.createURL=http://localhost:8428/snapshot/create \
   -dst=s3://victoriametrics-backup/backup01
 
-vmrestore \ ok
+vmrestore \
   -src=s3://victoriametrics-backup/backup01 \
   -storageDataPath=/data
 ```
@@ -98,7 +98,7 @@ vmrestore \ ok
 Backups on Google Cloud Storage use the `gs://` prefix in the destination:
 
 ```sh
-vmbackup \ ok
+vmbackup \
   -storageDataPath=/data \
   -snapshot.createURL=http://localhost:8428/snapshot/create \
   -dst=gs://victoriametrics-backup/backup01 \
@@ -108,7 +108,7 @@ vmbackup \ ok
 You can restore this backup with:
 
 ```sh
-vmrestore \ ok
+vmrestore \
   -src=gs://victoriametrics-backup/backup01 \
   -storageDataPath=/data \
   -credsFilePath=/etc/credentials
@@ -119,43 +119,37 @@ On Google Cloud, you can define the path to the JSON credential file with `GOOGL
 ```sh
 export GOOGLE_APPLICATION_CREDENTIALS=/etc/credentials
 
-vmbackup \ ok
+vmbackup \
   -storageDataPath=/data \
   -snapshot.createURL=http://localhost:8428/snapshot/create \
   -dst=gs://victoriametrics-backup/backup01
-```
 
-You can restore this backup with:
-
-```sh
-export GOOGLE_APPLICATION_CREDENTIALS=/etc/credentials
-
-vmrestore \ ok
+vmrestore \
   -src=gs://victoriametrics-backup/backup01 \
   -storageDataPath=/data
 ```
 
-For Azure Blog Storage uses `azblob://` prefix and relies on environment variables instead of `-credsFilePath`.
+For Azure Blob Storage, use the `azblob://` prefix and rely on environment variables instead of `-credsFilePath`.
 
 ```sh
 export AZURE_STORAGE_ACCOUNT_NAME=myaccount
 export AZURE_STORAGE_ACCOUNT_KEY=mykey
 
-vmbackup \ ok
+vmbackup \
   -storageDataPath=/data \
   -snapshot.createURL=http://localhost:8428/snapshot/create \
   -dst=azblob://victoriametrics-backup/backup01
 
-vmrestore \ ok
+vmrestore \
   -src=azblob://victoriametrics-backup/backup01 \
   -storageDataPath=/data
 ```
 
 ### vmbackupmanager 
 
-> Cloud storage only works in the [Enterprise](https://docs.victoriametrics.com/victoriametrics/enterprise/) edition
+> vmbackupmanager only works in the [Enterprise](https://docs.victoriametrics.com/victoriametrics/enterprise/) edition.
 
-To manage backups with vmbackupmanager on AWS S3, add the credential with the `-credsFilePath` flag:
+To manage backups with vmbackupmanager on AWS S3, add the credentials with the `-credsFilePath` flag:
 
 ```sh
 vmbackupmanager \
@@ -204,14 +198,14 @@ vmbackupmanager \
   -licenseFile=/etc/vm-license
 ```
 
-vmbackupmanager can also use the Azure Blob Storage by defining environment variables:
+vmbackupmanager can also use Azure Blob Storage by defining environment variables:
 
 ```sh
 export AZURE_STORAGE_ACCOUNT_NAME=mystorageaccount
 export AZURE_STORAGE_ACCOUNT_KEY=myaccountkey
 
 vmbackupmanager \
-  -dst=gs://vmstorage-data/backups \
+  -dst=azblob://vmstorage-data/backups \
   -storageDataPath=/vmstorage-data \
   -snapshot.createURL=http://vmstorage:8482/snapshot/create \
   -licenseFile=/etc/vm-license
@@ -244,7 +238,7 @@ vmalert \
   -notifier.url=http://alertmanager:9093
 ```
 
-> To use non-AWS S3 buckets, you must [supply the `-s3.customS3Endpoint` argument](#s3-compatible-endpoints).
+> To use non-AWS S3 buckets, you must [supply the `-s3.customEndpoint` argument](#s3-compatible-endpoints).
 
 To read rules from Google Cloud Storage:
 
@@ -362,7 +356,7 @@ vmbackup \
   -customS3Endpoint=http://minio.example.local:9000
 ```
 
-On vmalert use the `-s3.customEndpoint` flag instead:
+On vmalert, use the `-s3.customEndpoint` flag instead:
 
 ```sh
 vmalert \
@@ -373,42 +367,35 @@ vmalert \
   -notifier.url=http://alertmanager:9093
 ```
 
-### Addressing objects
+### Addressing S3-compatible buckets
 
-S3-compatible storage supports two ways of addressing objects in a bucket.
+When connecting to non-AWS S3-compatible buckets, there is an additional flag you might need to configure:
 
-| Style | `-s3ForcePathStyle` | Example URL | Use with |
-|---|---|---|---|
-| Path-style | `true` (default) | `https://endpoint/bucket/key` | MinIO, Ceph, most S3-compatible storages |
-| Virtual hosted-style | `false` | `https://bucket.endpoint/key` | [Aliyun OSS](https://www.aliyun.com/product/oss) and other endpoints that require it |
+- `-s3ForcePathStyle`: on vmbackupmanager, vmbackup, and vmrestore.
+- `-s3.forcePathStyle`: on vmalert.
 
-The flag only takes effect when you use a custom endpoint (`-customS3Endpoint` or `-s3.customEndpoint` on vmalert). When connecting to real AWS S3, the SDK handles addressing automatically.
+The flag changes the expected URL pattern for a bucket.
+
+| Flag value | Address-style | Example | Use with |
+|------------|---------------|---------|----------|
+| `true` (default) | Path-style | `https://endpoint/bucket/key` |  MinIO, Ceph, most S3-compatible storages |
+| `false`        | Virtual host-style | `https://endpoint/bucket/key` | [Aliyun OSS](https://www.aliyun.com/product/oss) and other endpoints that require it |
+
+> The flag only takes effect when you use a custom endpoint (`-customS3Endpoint` or `-s3.customEndpoint` on vmalert). When connecting to real AWS S3, the SDK handles addressing automatically.
 
 ## Per-component flag reference
 
 The table below shows how the same concept maps to different flag names across components.
 
-| Concept | vmalert (Enterprise) | vmbackup | vmrestore | vmbackupmanager (Enterprise) |
+| Concept | vmalert | vmbackup, vmrestore, and vmbackupmanager |
 |---|---|---|---|---|
-| Credentials file | `-s3.credsFilePath` | `-credsFilePath` | `-credsFilePath` | `-credsFilePath` |
-| Config file | `-s3.configFilePath` | `-configFilePath` | `-configFilePath` | `-configFilePath` |
-| Profile selection | `-s3.configProfile` | `-configProfile` | `-configProfile` | `-configProfile` |
-| Custom endpoint | `-s3.customEndpoint` | `-customS3Endpoint` | `-customS3Endpoint` | `-customS3Endpoint` |
-| Force path style | `-s3.forcePathStyle` | `-s3ForcePathStyle` | `-s3ForcePathStyle` | `-s3ForcePathStyle` |
-| TLS insecure | — | `-s3TLSInsecureSkipVerify` | `-s3TLSInsecureSkipVerify` | `-s3TLSInsecureSkipVerify` |
-| Storage class | — | `-s3StorageClass` | `-s3StorageClass` | `-s3StorageClass` |
-| ACL | — | `-s3ACL` | — | `-s3ACL` |
-| SSE KMS key | — | `-s3SSEKMSKeyId` | `-s3SSEKMSKeyId` | `-s3SSEKMSKeyId` |
-| Object tags | — | `-s3ObjectTags` | — | — |
-| Delete versions | — | `-deleteAllObjectVersions` | `-deleteAllObjectVersions` | `-deleteAllObjectVersions` |
+| Credentials file | `-s3.credsFilePath`  `-credsFilePath` |
+| Config file | `-s3.configFilePath` | `-configFilePath` |
+| Profile selection | `-s3.configProfile` | `-configProfile` |
+| Custom endpoint | `-s3.customEndpoint` | `-customS3Endpoint` |
+| Force path style | `-s3.forcePathStyle` | `-s3ForcePathStyle` |
+| TLS insecure | N/A | `-s3TLSInsecureSkipVerify` |
+| Storage class | N/A | `-s3StorageClass` |
 
-## Advanced S3 flags
 
-The following flags are only available in `vmbackup`, `vmrestore`, and `vmbackupmanager`:
 
-- `-s3StorageClass` — set the storage class for uploaded objects (for example, `GLACIER`, `STANDARD_IA`).
-- `-s3ACL` — set a canned ACL (for example, `private`, `public-read`).
-- `-s3SSEKMSKeyId` — specify a KMS key ID for server-side encryption.
-- `-s3TLSInsecureSkipVerify` — skip TLS certificate verification for the S3 endpoint.
-- `-s3ObjectTags` — set tags on uploaded objects in JSON format.
-- `-deleteAllObjectVersions` — remove all versions of an object on delete (useful when versioning is enabled).

--- a/docs/guides/connecting-vm-components-to-cloud-storage/README.md
+++ b/docs/guides/connecting-vm-components-to-cloud-storage/README.md
@@ -383,7 +383,7 @@ The flag changes the expected URL pattern for a bucket.
 | Flag value | Address-style | Example | Use with |
 |------------|---------------|---------|----------|
 | `true` (default) | Path-style | `https://endpoint/bucket/key` |  MinIO, Ceph, most S3-compatible storages |
-| `false`        | Virtual host-style | `https://endpoint/bucket/key` | [Aliyun OSS](https://www.aliyun.com/product/oss) and other endpoints that require it |
+| `false`        | Virtual host-style | `https://bucket.endpoint/key` | [Aliyun OSS](https://www.aliyun.com/product/oss) and other endpoints that require it |
 
 > The flag only takes effect when you use a custom endpoint (`-customS3Endpoint` or `-s3.customEndpoint` on vmalert). When connecting to real AWS S3, the SDK handles addressing automatically.
 

--- a/docs/guides/connecting-vm-components-to-cloud-storage/README.md
+++ b/docs/guides/connecting-vm-components-to-cloud-storage/README.md
@@ -393,7 +393,7 @@ The table below shows how the same concept maps to different flag names across c
 
 | Concept | vmalert | vmbackup, vmrestore, and vmbackupmanager |
 |---|---|---|---|---|
-| Credentials file | `-s3.credsFilePath`  `-credsFilePath` |
+| Credentials file | `-s3.credsFilePath` | `-credsFilePath` |
 | Config file | `-s3.configFilePath` | `-configFilePath` |
 | Profile selection | `-s3.configProfile` | `-configProfile` |
 | Custom endpoint | `-s3.customEndpoint` | `-customS3Endpoint` |

--- a/docs/guides/connecting-vm-components-to-cloud-storage/README.md
+++ b/docs/guides/connecting-vm-components-to-cloud-storage/README.md
@@ -1,0 +1,414 @@
+Several VictoriaMetrics components can connect to cloud storage to read or write object data.
+
+| Component | S3 | Google Cloud Storage | Azure Blob Storage |
+|-----------|----|----------------------|--------------------|
+| [vmbackup](https://docs.victoriametrics.com/victoriametrics/vmbackup/) | ✅ | ✅ | ✅ |
+| [vmrestore](https://docs.victoriametrics.com/victoriametrics/vmrestore/) | ✅ | ✅ | ✅ |
+| [vmbackupmanager](https://docs.victoriametrics.com/victoriametrics/vmbackupmanager/) (Enterprise only) | ✅ | ✅ | ✅ |
+| [vmalert](https://docs.victoriametrics.com/victoriametrics/vmalert/) (Enterprise only) |  ✅ | ✅ | ❌ |
+
+All these components use the same underlying libraries, so the authentication setup is largely the same. The main difference is in flag names: 
+
+- vmalert uses `-s3.*` prefixed flags (e.g., `-s3.credsFilePath`)
+- backup and restore tools use unprefixed flags (e.g., `-credsFilePath`)
+
+See the [component reference](#per-component-flag-reference) for details.
+
+## Obtaining credentials
+
+You need to supply credentials so the component can connect to the cloud storage. The steps depend on the cloud provider.
+
+### AWS S3
+
+1. In AWS, [create an IAM user](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_users_create.html) or role with permissions to read and write the target bucket.
+2. [Create an access key](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html) for that IAM identity.
+3. Copy the **Access key ID** and **Secret access key** values. You will use them in the credentials file or environment variables.
+
+### S3-compatible storage (MinIO, Ceph)
+
+Generate access keys using your storage system's admin interface or CLI. The credentials follow the same format as AWS S3.
+
+### Google Cloud Storage
+
+1. Open the Google Cloud Console and go to **IAM & Admin > Service Accounts**.
+2. Click **Create service account**, enter a name, and assign a Storage role (for example, Storage Object Admin).
+3. Open the service account, go to **Keys**, then click **Add key > Create new key**.
+4. Choose **JSON** as the key type and click **Create**.
+5. Store the JSON file on the machine running the VictoriaMetrics component.
+
+### Azure Blob Storage
+
+> Azure does not use a credential files.
+
+1. Log in to the Azure Portal.
+1. Search for and select **Storage accounts**.
+1. Click on your specific storage account name. (This is your `AZURE_STORAGE_ACCOUNT_NAME`).
+1. In the left menu under **Security + networking**, click **Access keys**.
+1. Copy the key value from either **key1** or **key2** (this is your `AZURE_STORAGE_ACCOUNT_KEY`).
+1. Define the access keys [as environment variables](#authentication-via-environment-variables).
+
+## Authenticating with the cloud provider
+
+Provide the credential file or environment variables and the path to the cloud storage bucket. The syntax for the bucket name depends on the cloud provider:
+
+- `s3://`: for AWS S3 and S3-compatible storage (MinIO, Ceph)
+- `gs://`: Google Cloud Storage
+- `azblob://`: Azure Blob Storage
+
+### vmbackup and vmrestore
+
+The following example backs up to an S3 bucket using a credentials file:
+
+```sh
+vmbackup \
+  -storageDataPath=/data \ ok
+  -snapshot.createURL=http://localhost:8428/snapshot/create \
+  -dst=s3://victoriametrics-backup/backup01 \
+  -credsFilePath=/etc/credentials
+```
+
+In order to restore from the same S3 backup:
+
+```sh
+vmrestore \ ok
+  -src=s3://victoriametrics-backup/backup01 \
+  -storageDataPath=/data \
+  -credsFilePath=/etc/credentials
+
+```
+
+Alternatively, you can set the access keys as environment variables instead of using a credential file:
+
+```sh
+export AWS_ACCESS_KEY_ID=YOUR_AWS_ACCESS_KEY
+export AWS_SECRET_ACCESS_KEY=YOUR_SECRET_AWS_ACCESS_KEY
+
+vmbackup \ ok
+  -storageDataPath=/data \
+  -snapshot.createURL=http://localhost:8428/snapshot/create \
+  -dst=s3://victoriametrics-backup/backup01
+
+vmrestore \ ok
+  -src=s3://victoriametrics-backup/backup01 \
+  -storageDataPath=/data
+```
+
+> To use non-AWS S3 buckets, you must [supply the `-customS3Endpoint` argument](#s3-compatible-endpoints).
+
+Backups on Google Cloud Storage use the `gs://` prefix in the destination:
+
+```sh
+vmbackup \ ok
+  -storageDataPath=/data \
+  -snapshot.createURL=http://localhost:8428/snapshot/create \
+  -dst=gs://victoriametrics-backup/backup01 \
+  -credsFilePath=/etc/credentials
+```
+
+You can restore this backup with:
+
+```sh
+vmrestore \ ok
+  -src=gs://victoriametrics-backup/backup01 \
+  -storageDataPath=/data \
+  -credsFilePath=/etc/credentials
+```
+
+On Google Cloud, you can define the path to the JSON credential file with `GOOGLE_APPLICATION_CREDENTIALS`. For example:
+
+```sh
+export GOOGLE_APPLICATION_CREDENTIALS=/etc/credentials
+
+vmbackup \ ok
+  -storageDataPath=/data \
+  -snapshot.createURL=http://localhost:8428/snapshot/create \
+  -dst=gs://victoriametrics-backup/backup01
+```
+
+You can restore this backup with:
+
+```sh
+export GOOGLE_APPLICATION_CREDENTIALS=/etc/credentials
+
+vmrestore \ ok
+  -src=gs://victoriametrics-backup/backup01 \
+  -storageDataPath=/data
+```
+
+For Azure Blog Storage uses `azblob://` prefix and relies on environment variables instead of `-credsFilePath`.
+
+```sh
+export AZURE_STORAGE_ACCOUNT_NAME=myaccount
+export AZURE_STORAGE_ACCOUNT_KEY=mykey
+
+vmbackup \ ok
+  -storageDataPath=/data \
+  -snapshot.createURL=http://localhost:8428/snapshot/create \
+  -dst=azblob://victoriametrics-backup/backup01
+
+vmrestore \ ok
+  -src=azblob://victoriametrics-backup/backup01 \
+  -storageDataPath=/data
+```
+
+### vmbackupmanager 
+
+> Cloud storage only works in the [Enterprise](https://docs.victoriametrics.com/victoriametrics/enterprise/) edition
+
+To manage backups with vmbackupmanager on AWS S3, add the credential with the `-credsFilePath` flag:
+
+```sh
+vmbackupmanager \
+  -dst=s3://vmstorage-data/backups \
+  -credsFilePath=/etc/credentials \
+  -storageDataPath=/vmstorage-data \
+  -snapshot.createURL=http://vmstorage:8482/snapshot/create \
+  -licenseFile=/etc/vm-license
+```
+
+Or define the access keys using environment variables:
+
+```sh
+export AWS_ACCESS_KEY_ID=YOUR_AWS_ACCESS_KEY
+export AWS_SECRET_ACCESS_KEY=YOUR_SECRET_AWS_ACCESS_KEY
+
+vmbackupmanager \
+  -dst=s3://vmstorage-data/backups \
+  -storageDataPath=/vmstorage-data \
+  -snapshot.createURL=http://vmstorage:8482/snapshot/create \
+  -licenseFile=/etc/vm-license
+```
+
+> To use non-AWS S3 buckets, you must [supply the `-customS3Endpoint` argument](#s3-compatible-endpoints).
+
+Automated backups on Google Cloud Storage take the following form:
+
+```sh
+vmbackupmanager \
+  -dst=gs://vmstorage-data/backups \
+  -credsFilePath=/etc/credentials \
+  -storageDataPath=/vmstorage-data \
+  -snapshot.createURL=http://vmstorage:8482/snapshot/create \
+  -licenseFile=/etc/vm-license
+```
+
+As with vmbackup and vmrestore, you can also define the path to the JSON credential file with `GOOGLE_APPLICATION_CREDENTIALS`:
+
+```sh
+export GOOGLE_APPLICATION_CREDENTIALS=/etc/credentials
+
+vmbackupmanager \
+  -dst=gs://vmstorage-data/backups \
+  -storageDataPath=/vmstorage-data \
+  -snapshot.createURL=http://vmstorage:8482/snapshot/create \
+  -licenseFile=/etc/vm-license
+```
+
+vmbackupmanager can also use the Azure Blob Storage by defining environment variables:
+
+```sh
+export AZURE_STORAGE_ACCOUNT_NAME=mystorageaccount
+export AZURE_STORAGE_ACCOUNT_KEY=myaccountkey
+
+vmbackupmanager \
+  -dst=gs://vmstorage-data/backups \
+  -storageDataPath=/vmstorage-data \
+  -snapshot.createURL=http://vmstorage:8482/snapshot/create \
+  -licenseFile=/etc/vm-license
+```
+
+### vmalert
+
+> - vmalert cloud storage command line flags are prefixed with `-s3.` for S3 buckets *and* Google Cloud Storage.
+> - Cloud storage only works in the [Enterprise](https://docs.victoriametrics.com/victoriametrics/enterprise/) edition.
+
+Read alerting rules from an S3 bucket. The `-rule` flag accepts a prefix, so it matches all files starting with `alerts_` in the `rules` folder:
+
+```sh
+vmalert \
+  -rule=s3://my-alert-bucket/rules/alerts_ \
+  -s3.credsFilePath=/etc/vmalert/aws-credentials \
+  -datasource.url=http://vmselect:8481/select/0/prometheus \
+  -notifier.url=http://alertmanager:9093
+```
+
+Instead of a credential file, you can supply the access keys using environment variables:
+
+```sh
+export AWS_ACCESS_KEY_ID=YOUR_AWS_ACCESS_KEY
+export AWS_SECRET_ACCESS_KEY=YOUR_SECRET_AWS_ACCESS_KEY
+
+vmalert \
+  -rule=s3://my-alert-bucket/rules/alerts_ \
+  -datasource.url=http://vmselect:8481/select/0/prometheus \
+  -notifier.url=http://alertmanager:9093
+```
+
+> To use non-AWS S3 buckets, you must [supply the `-s3.customS3Endpoint` argument](#s3-compatible-endpoints).
+
+To read rules from Google Cloud Storage:
+
+```sh
+vmalert \
+  -rule=gs://my-alert-bucket/rules/alerts_ \
+  -s3.credsFilePath=/etc/vmalert/gcp-service-account.json \
+  -datasource.url=http://vmselect:8481/select/0/prometheus \
+  -notifier.url=http://alertmanager:9093
+```
+
+If you prefer, you can supply the path to the JSON credential file with the `GOOGLE_APPLICATION_CREDENTIALS` environment variable:
+
+```sh
+export GOOGLE_APPLICATION_CREDENTIALS=/etc/credentials
+
+vmalert \
+  -rule=gs://my-alert-bucket/rules/alerts_ \
+  -datasource.url=http://vmselect:8481/select/0/prometheus \
+  -notifier.url=http://alertmanager:9093
+```
+
+## Credentials files format
+
+The file format depends on the storage provider.
+
+### S3 credentials
+
+The file uses the standard AWS shared credentials format used by the [AWS CLI](https://docs.aws.amazon.com/cli/v1/userguide/cli-configure-files.html) and [AWS SDKs](https://docs.aws.amazon.com/sdkref/latest/guide/file-format.html):
+
+```ini
+[default]
+aws_access_key_id=YOUR_AWS_ACCESS_KEY
+aws_secret_access_key=YOUR_AWS_SECRET_ACCESS_KEY
+```
+
+You can define multiple profiles in a single file:
+
+```ini
+[default]
+aws_access_key_id=DEFAULT_ACCESS_KEY
+aws_secret_access_key=DEFAULT_SECRET_KEY
+
+[monitoring]
+aws_access_key_id=MONITORING_ACCESS_KEY
+aws_secret_access_key=MONITORING_SECRET_KEY
+
+[alerts]
+aws_access_key_id=ALERTS_ACCESS_KEY
+aws_secret_access_key=ALERTS_SECRET_KEY
+```
+
+Use the `-configProfile` flag (or `-s3.configProfile` in vmalert) to select a non-default profile:
+
+```sh
+-configProfile=alerts
+```
+
+You can separate credentials from other configuration settings. Put credentials in one file:
+
+```ini
+[default]
+aws_access_key_id=DEFAULT_ACCESS_KEY
+aws_secret_access_key=DEFAULT_SECRET_KEY
+```
+
+And non-sensitive settings in another:
+
+```ini
+[default]
+region=us-east-1
+```
+
+Then pass both files:
+
+```sh
+-configFilePath=/etc/aws-config \
+-credsFilePath=/etc/credentials
+```
+
+### GCS credentials file format
+
+The file is the JSON key downloaded from Google Cloud Console. Its content looks like this:
+
+```json
+{
+  "type": "service_account",
+  "project_id": "project-id",
+  "private_key_id": "key-id",
+  "private_key": "-----BEGIN PRIVATE KEY-----\nprivate-key\n-----END PRIVATE KEY-----\n",
+  "client_email": "service-account-email",
+  "client_id": "client-id",
+  "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+  "token_uri": "https://accounts.google.com/o/oauth2/token",
+  "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+  "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/service-account-email"
+}
+```
+
+This is the standard service account key format defined by [Google Cloud IAM](https://developers.google.com/workspace/guides/create-credentials).
+
+### Azure Blob Storage
+
+Azure does not support credentials via file. Use environment variables instead.
+
+## S3-compatible endpoints
+
+For S3-compatible storage such as MinIO or Ceph, set a custom endpoint with the `-customS3Endpoint` flag  for vmbackup, vmrestore, and vmbackupmanager. For example:
+
+```sh
+vmbackup \
+  -storageDataPath=/data \
+  -snapshot.createURL=http://localhost:8428/snapshot/create \
+  -dst=s3://victoriametrics-backup/backup01 \
+  -customS3Endpoint=http://minio.example.local:9000
+```
+
+On vmalert use the `-s3.customEndpoint` flag instead:
+
+```sh
+vmalert \
+  -rule=s3://my-alert-bucket/rules/alerts_ \
+  -s3.customEndpoint=http://minio.example.local:9000 \
+  -s3.credsFilePath=/etc/vmalert/aws-credentials \
+  -datasource.url=http://vmselect:8481/select/0/prometheus \
+  -notifier.url=http://alertmanager:9093
+```
+
+### Addressing objects
+
+S3-compatible storage supports two ways of addressing objects in a bucket.
+
+| Style | `-s3ForcePathStyle` | Example URL | Use with |
+|---|---|---|---|
+| Path-style | `true` (default) | `https://endpoint/bucket/key` | MinIO, Ceph, most S3-compatible storages |
+| Virtual hosted-style | `false` | `https://bucket.endpoint/key` | [Aliyun OSS](https://www.aliyun.com/product/oss) and other endpoints that require it |
+
+The flag only takes effect when you use a custom endpoint (`-customS3Endpoint` or `-s3.customEndpoint` on vmalert). When connecting to real AWS S3, the SDK handles addressing automatically.
+
+## Per-component flag reference
+
+The table below shows how the same concept maps to different flag names across components.
+
+| Concept | vmalert (Enterprise) | vmbackup | vmrestore | vmbackupmanager (Enterprise) |
+|---|---|---|---|---|
+| Credentials file | `-s3.credsFilePath` | `-credsFilePath` | `-credsFilePath` | `-credsFilePath` |
+| Config file | `-s3.configFilePath` | `-configFilePath` | `-configFilePath` | `-configFilePath` |
+| Profile selection | `-s3.configProfile` | `-configProfile` | `-configProfile` | `-configProfile` |
+| Custom endpoint | `-s3.customEndpoint` | `-customS3Endpoint` | `-customS3Endpoint` | `-customS3Endpoint` |
+| Force path style | `-s3.forcePathStyle` | `-s3ForcePathStyle` | `-s3ForcePathStyle` | `-s3ForcePathStyle` |
+| TLS insecure | — | `-s3TLSInsecureSkipVerify` | `-s3TLSInsecureSkipVerify` | `-s3TLSInsecureSkipVerify` |
+| Storage class | — | `-s3StorageClass` | `-s3StorageClass` | `-s3StorageClass` |
+| ACL | — | `-s3ACL` | — | `-s3ACL` |
+| SSE KMS key | — | `-s3SSEKMSKeyId` | `-s3SSEKMSKeyId` | `-s3SSEKMSKeyId` |
+| Object tags | — | `-s3ObjectTags` | — | — |
+| Delete versions | — | `-deleteAllObjectVersions` | `-deleteAllObjectVersions` | `-deleteAllObjectVersions` |
+
+## Advanced S3 flags
+
+The following flags are only available in `vmbackup`, `vmrestore`, and `vmbackupmanager`:
+
+- `-s3StorageClass` — set the storage class for uploaded objects (for example, `GLACIER`, `STANDARD_IA`).
+- `-s3ACL` — set a canned ACL (for example, `private`, `public-read`).
+- `-s3SSEKMSKeyId` — specify a KMS key ID for server-side encryption.
+- `-s3TLSInsecureSkipVerify` — skip TLS certificate verification for the S3 endpoint.
+- `-s3ObjectTags` — set tags on uploaded objects in JSON format.
+- `-deleteAllObjectVersions` — remove all versions of an object on delete (useful when versioning is enabled).

--- a/docs/guides/connecting-vm-components-to-cloud-storage/README.md
+++ b/docs/guides/connecting-vm-components-to-cloud-storage/README.md
@@ -21,8 +21,8 @@ You need to supply credentials so the component can connect to the cloud storage
 ### AWS S3
 
 1. In AWS, [create an IAM user](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_users_create.html) or role with permissions to read and write the target bucket.
-2. [Create an access key](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html) for that IAM identity.
-3. Copy the **Access key ID** and **Secret access key** values. You will use them in the credentials file or environment variables.
+1. [Create an access key](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html) for that IAM identity.
+1. Copy the **Access key ID** and **Secret access key** values. You will use them in the credentials file or environment variables.
 
 ### S3-compatible storage (MinIO, Ceph)
 
@@ -31,10 +31,10 @@ Generate access keys using your storage system's admin interface or CLI. The cre
 ### Google Cloud Storage
 
 1. Open the Google Cloud Console and go to **IAM & Admin > Service Accounts**.
-2. Click **Create service account**, enter a name, and assign a Storage role (for example, Storage Object Admin).
-3. Open the service account, go to **Keys**, then click **Add key > Create new key**.
-4. Choose **JSON** as the key type and click **Create**.
-5. Store the JSON file on the machine running the VictoriaMetrics component.
+1. Click **Create service account**, enter a name, and assign a Storage role (for example, Storage Object Admin).
+1. Open the service account, go to **Keys**, then click **Add key > Create new key**.
+1. Choose **JSON** as the key type and click **Create**.
+1. Store the JSON file on the machine running the VictoriaMetrics component.
 
 ### Azure Blob Storage
 
@@ -45,7 +45,11 @@ Generate access keys using your storage system's admin interface or CLI. The cre
 1. Click on your specific storage account name. (This is your `AZURE_STORAGE_ACCOUNT_NAME`).
 1. In the left menu under **Security + networking**, click **Access keys**.
 1. Copy the key value from either **key1** or **key2** (this is your `AZURE_STORAGE_ACCOUNT_KEY`).
-1. Define the access keys [as environment variables](#authentication-via-environment-variables).
+1. Define the access keys as environment variables.
+    ```sh
+    export AZURE_STORAGE_ACCOUNT_NAME=mystorageaccount
+    export AZURE_STORAGE_ACCOUNT_KEY=myaccountkey
+    ```
 
 ## Authenticating with the cloud provider
 

--- a/docs/guides/connecting-vm-components-to-cloud-storage/README.md
+++ b/docs/guides/connecting-vm-components-to-cloud-storage/README.md
@@ -1,5 +1,7 @@
 Several VictoriaMetrics components can connect to cloud storage to read or write object data.
 
+The following table shows the supported types of storage for each component:
+
 | Component | AWS S3 and S3-compatible | Google Cloud Storage | Azure Blob Storage |
 |-----------|----|----------------------|--------------------|
 | [vmbackup](https://docs.victoriametrics.com/victoriametrics/vmbackup/) | ✅ | ✅ | ✅ |
@@ -7,12 +9,12 @@ Several VictoriaMetrics components can connect to cloud storage to read or write
 | [vmbackupmanager](https://docs.victoriametrics.com/victoriametrics/vmbackupmanager/) | ✅ | ✅ | ✅ |
 | [vmalert](https://docs.victoriametrics.com/victoriametrics/vmalert/) |  ✅ | ✅ | ❌ |
 
-All these components use the same underlying libraries, so the authentication setup is largely the same. The main difference is in flag names: 
+All these components use the same underlying libraries, so the authentication setup is largely the same. The main difference is in the command-line flags: 
 
 - vmalert uses `-s3.*` prefixed flags (e.g., `-s3.credsFilePath`)
 - backup and restore tools use unprefixed flags (e.g., `-credsFilePath`)
 
-See the [component reference](#per-component-flag-reference) for details.
+See the [component reference](https://docs.victoriametrics.com/guides/connecting-vm-components-to-cloud-storage/#per-component-flag-reference) for details.
 
 ## Obtaining credentials
 
@@ -20,9 +22,17 @@ You need to supply credentials so the component can connect to the cloud storage
 
 ### AWS S3
 
-1. In AWS, [create an IAM user](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_users_create.html) or role with permissions to read and write the target bucket.
+1. In AWS, [create an IAM user](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_users_create.html) or role with the minimum permissions for the target bucket (see table below).
 1. [Create an access key](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html) for that IAM identity.
 1. Copy the **Access key ID** and **Secret access key** values. You will use them in the credentials file or environment variables.
+
+| Component       | S3 usage                                                    | Minimum S3 permissions |
+|-----------------|-------------------------------------------------------------|------------------------|
+| vmalert (Enterprise) | Reads alerting/recording rules from bucket.    | `s3:GetObject`, `s3:ListBucket` on the rules bucket/prefix.|
+| vmrestore       | Restores backups from S3 buckets                            | `s3:GetObject`, `s3:ListBucket` on the backup bucket/prefix.|
+| vmbackup        | Uploads backups to S3 and may delete old backup objects during maintenance.| `s3:PutObject`, `s3:GetObject`, `s3:ListBucket`, `s3:DeleteObject` on the backup bucket/prefix.|
+| vmbackupmanager (Enterprise) | Automates backups using vmbackup behavior.                  | Same as vmbackup. |
+
 
 ### S3-compatible storage (MinIO, Ceph)
 
@@ -55,13 +65,13 @@ Generate access keys using your storage system's admin interface or CLI. The cre
 
 Provide the credentials as a file or with environment variables, along with the path to the cloud storage bucket. The syntax for the bucket name depends on the cloud provider:
 
-- `s3://`: for AWS S3 and S3-compatible storage (MinIO, Ceph)
+- `s3://`: for AWS S3 and self-hosted S3-compatible storage (MinIO, Ceph)
 - `gs://`: Google Cloud Storage
 - `azblob://`: Azure Blob Storage
 
 ### vmbackup and vmrestore
 
-The following example backs up to an AWS S3 bucket using a credentials file:
+The following example backups to an AWS S3 bucket using a credentials file:
 
 ```sh
 vmbackup \
@@ -81,6 +91,8 @@ vmrestore \
 
 ```
 
+> To use non-AWS S3 buckets such as MinIO or Ceph, you must [supply the `-customS3Endpoint` argument](https://docs.victoriametrics.com/guides/connecting-vm-components-to-cloud-storage/#s3-compatible).
+
 Alternatively, you can set the access keys as environment variables instead of using a credential file:
 
 ```sh
@@ -97,7 +109,6 @@ vmrestore \
   -storageDataPath=/data
 ```
 
-> To use non-AWS S3 buckets, you must [supply the `-customS3Endpoint` argument](#s3-compatible-endpoints).
 
 Backups on Google Cloud Storage use the `gs://` prefix in the destination:
 
@@ -227,7 +238,8 @@ vmalert \
   -rule=s3://my-alert-bucket/rules/alerts_ \
   -s3.credsFilePath=/etc/vmalert/aws-credentials \
   -datasource.url=http://vmselect:8481/select/0/prometheus \
-  -notifier.url=http://alertmanager:9093
+  -notifier.url=http://alertmanager:9093 \
+  -licenseFile=/etc/vm-license
 ```
 
 Instead of a credential file, you can supply the access keys using environment variables:
@@ -348,7 +360,12 @@ This is the standard service account key format defined by [Google Cloud IAM](ht
 
 Azure does not support credentials via file. Use environment variables instead.
 
-## S3-compatible endpoints
+```sh
+export AZURE_STORAGE_ACCOUNT_NAME=mystorageaccount
+export AZURE_STORAGE_ACCOUNT_KEY=myaccountkey
+```
+
+## Self-hosted S3-compatible endpoints {#s3-compatible}
 
 For S3-compatible storage such as MinIO or Ceph, set a custom endpoint with the `-customS3Endpoint` flag  for vmbackup, vmrestore, and vmbackupmanager. For example:
 

--- a/docs/guides/connecting-vm-components-to-cloud-storage/README.md
+++ b/docs/guides/connecting-vm-components-to-cloud-storage/README.md
@@ -188,7 +188,7 @@ vmbackupmanager \
   -licenseFile=/etc/vm-license
 ```
 
-> To use non-AWS S3 buckets, you must [supply the `-customS3Endpoint` argument](#s3-compatible-endpoints).
+> To use non-AWS S3 buckets, you must [supply the `-customS3Endpoint` argument](#s3-compatible).
 
 Automated backups on Google Cloud Storage take the following form:
 
@@ -255,7 +255,7 @@ vmalert \
   -licenseFile=/etc/vm-license
 ```
 
-> To use non-AWS S3 buckets, you must [supply the `-s3.customEndpoint` argument](#s3-compatible-endpoints).
+> To use non-AWS S3 buckets, you must [supply the `-s3.customEndpoint` argument](#s3-compatible).
 
 To read rules from Google Cloud Storage:
 
@@ -368,7 +368,7 @@ export AZURE_STORAGE_ACCOUNT_NAME=mystorageaccount
 export AZURE_STORAGE_ACCOUNT_KEY=myaccountkey
 ```
 
-## Self-hosted and S3-compatible endpoints {#s3-compatible}
+## Self-hosted and S3-compatible endpoints
 
 For S3-compatible storage such as MinIO or Ceph, set a custom endpoint with the `-customS3Endpoint` flag  for vmbackup, vmrestore, and vmbackupmanager. For example:
 
@@ -392,7 +392,7 @@ vmalert \
   -licenseFile=/etc/vm-license
 ```
 
-### Addressing S3-compatible buckets
+### Addressing S3-compatible buckets {#s3-compatible}
 
 When connecting to non-AWS S3-compatible buckets, there is an additional flag you might need to configure:
 

--- a/docs/guides/connecting-vm-components-to-cloud-storage/README.md
+++ b/docs/guides/connecting-vm-components-to-cloud-storage/README.md
@@ -251,7 +251,8 @@ export AWS_SECRET_ACCESS_KEY=YOUR_SECRET_AWS_ACCESS_KEY
 vmalert \
   -rule=s3://my-alert-bucket/rules/alerts_ \
   -datasource.url=http://vmselect:8481/select/0/prometheus \
-  -notifier.url=http://alertmanager:9093
+  -notifier.url=http://alertmanager:9093 \
+  -licenseFile=/etc/vm-license
 ```
 
 > To use non-AWS S3 buckets, you must [supply the `-s3.customEndpoint` argument](#s3-compatible-endpoints).
@@ -263,7 +264,8 @@ vmalert \
   -rule=gs://my-alert-bucket/rules/alerts_ \
   -s3.credsFilePath=/etc/vmalert/gcp-service-account.json \
   -datasource.url=http://vmselect:8481/select/0/prometheus \
-  -notifier.url=http://alertmanager:9093
+  -notifier.url=http://alertmanager:9093 \
+  -licenseFile=/etc/vm-license
 ```
 
 If you prefer, you can supply the path to the JSON credential file with the `GOOGLE_APPLICATION_CREDENTIALS` environment variable:
@@ -274,7 +276,8 @@ export GOOGLE_APPLICATION_CREDENTIALS=/etc/credentials
 vmalert \
   -rule=gs://my-alert-bucket/rules/alerts_ \
   -datasource.url=http://vmselect:8481/select/0/prometheus \
-  -notifier.url=http://alertmanager:9093
+  -notifier.url=http://alertmanager:9093 \
+  -licenseFile=/etc/vm-license
 ```
 
 ## Credentials files format
@@ -365,7 +368,7 @@ export AZURE_STORAGE_ACCOUNT_NAME=mystorageaccount
 export AZURE_STORAGE_ACCOUNT_KEY=myaccountkey
 ```
 
-## Self-hosted S3-compatible endpoints {#s3-compatible}
+## Self-hosted and S3-compatible endpoints {#s3-compatible}
 
 For S3-compatible storage such as MinIO or Ceph, set a custom endpoint with the `-customS3Endpoint` flag  for vmbackup, vmrestore, and vmbackupmanager. For example:
 
@@ -385,7 +388,8 @@ vmalert \
   -s3.customEndpoint=http://minio.example.local:9000 \
   -s3.credsFilePath=/etc/vmalert/aws-credentials \
   -datasource.url=http://vmselect:8481/select/0/prometheus \
-  -notifier.url=http://alertmanager:9093
+  -notifier.url=http://alertmanager:9093 \
+  -licenseFile=/etc/vm-license
 ```
 
 ### Addressing S3-compatible buckets

--- a/docs/guides/connecting-vm-components-to-cloud-storage/_index.md
+++ b/docs/guides/connecting-vm-components-to-cloud-storage/_index.md
@@ -1,6 +1,6 @@
 ---
 weight: 5
-title: Connecting VM components to cloud storage
+title: Connecting VictoriaMetrics components to cloud storage
 menu:
   docs:
     parent: guides

--- a/docs/guides/connecting-vm-components-to-cloud-storage/_index.md
+++ b/docs/guides/connecting-vm-components-to-cloud-storage/_index.md
@@ -1,0 +1,12 @@
+---
+weight: 5
+title: Connecting VM components to cloud storage
+menu:
+  docs:
+    parent: guides
+    weight: 5
+tags:
+  - metrics
+  - guide
+---
+{{% content "README.md" %}}

--- a/docs/victoriametrics/vmalert.md
+++ b/docs/victoriametrics/vmalert.md
@@ -546,7 +546,7 @@ tags at [Docker Hub](https://hub.docker.com/r/victoriametrics/vmalert/tags) and 
 
 ## Reading rules from object storage
 
-[Enterprise version](https://docs.victoriametrics.com/victoriametrics/enterprise/) of `vmalert` may read alerting and recording rules
+The [Enterprise version](https://docs.victoriametrics.com/victoriametrics/enterprise/) of `vmalert` may read alerting and recording rules
 from object storage:
 
 * `./bin/vmalert -rule=s3://bucket/dir/alert.rules` would read rules from the given path at S3 bucket
@@ -562,6 +562,8 @@ The following [command-line flags](#flags) can be used for fine-tuning access to
 * `-s3.configProfile` - profile name for S3 configs. If no set, the value of the environment variable will be loaded (`AWS_PROFILE` or `AWS_DEFAULT_PROFILE`).
 * `-s3.customEndpoint` - custom S3 endpoint for use with S3-compatible storages (e.g. MinIO). S3 is used if not set.
 * `-s3.forcePathStyle` - prefixing endpoint with bucket name when set false, true by default.
+
+See [providing credentials as a file](https://docs.victoriametrics.com/victoriametrics/vmbackup/#providing-credentials-as-a-file) for details on how to create and use credentials to access S3-compatible buckets and Google Cloud Storage.
 
 ## Topology examples
 

--- a/docs/victoriametrics/vmalert.md
+++ b/docs/victoriametrics/vmalert.md
@@ -563,7 +563,132 @@ The following [command-line flags](#flags) can be used for fine-tuning access to
 * `-s3.customEndpoint` - custom S3 endpoint for use with S3-compatible storages (e.g. MinIO). S3 is used if not set.
 * `-s3.forcePathStyle` - prefixing endpoint with bucket name when set false, true by default.
 
-See [providing credentials as a file](https://docs.victoriametrics.com/victoriametrics/vmbackup/#providing-credentials-as-a-file) for details on how to create and use credentials to access S3-compatible buckets and Google Cloud Storage.
+### S3 (AWS and S3-compatible)
+
+1. In AWS, [create an IAM user](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_users_create.html) or role with read-only permissions on the target bucket.
+2. [Create an access key](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html) for that IAM identity and copy the **Access key** and **Secret access key** values
+3. On the machine running vmalert, create a credentials file with the following content and point `-s3.credsFilePath` to it:
+
+   ```ini
+   [default]
+   aws_access_key_id=YOUR_AWS_ACCESS_KEY
+   aws_secret_access_key=YOUR_AWS_SECRET_ACCESS_KEY
+   ```
+
+   This format matches the standard shared AWS credentials file used by the [AWS CLI](https://docs.aws.amazon.com/cli/v1/userguide/cli-configure-files.html) and [AWS SDKs](https://docs.aws.amazon.com/sdkref/latest/guide/file-format.html).
+
+The following example reads the rules from the S3 bucket called `my-alert-bucket`. If our bucket contains `rules/alerts_cpu.yml` and `rules/alerts_memory.yml`, then `-rule=s3://my-alert-bucket/rules/alerts_` matches both files because both keys start with that exact prefix
+
+```sh
+./bin/vmalert \
+  -rule=s3://my-alert-bucket/rules/alerts_ \
+  -s3.credsFilePath=/etc/vmalert/aws-credentials \
+  -datasource.url=http://vmselect:8481/select/0/prometheus \
+  -notifier.url=http://alertmanager:9093
+```
+
+You define multiple profiles in a single credentials file with different access keys:
+
+```ini
+[default]
+aws_access_key_id=DEFAULT_ACCESS_KEY
+aws_secret_access_key=DEFAULT_SECRET_KEY
+
+[monitoring]
+aws_access_key_id=MONITORING_ACCESS_KEY
+aws_secret_access_key=MONITORING_SECRET_KEY
+
+[alerts]
+aws_access_key_id=ALERTS_ACCESS_KEY
+aws_secret_access_key=ALERTS_SECRET_KEY
+```
+
+Then you can start vmalert with `-s3.configProfile` to use a non-default profile:
+
+```sh
+./bin/vmalert \
+  -rule=s3://my-alert-bucket/rules/alerts_ \
+  -s3.credsFilePath=/etc/vmalert/aws-credentials \
+  -s3.configProfile=alerts
+```
+
+Additionally, you can separate the credentials file from other configuration files. For example, one file can have credentials:
+
+
+```ini
+[default]
+aws_access_key_id=DEFAULT_ACCESS_KEY
+aws_secret_access_key=DEFAULT_SECRET_KEY
+```
+
+And leave the rest of the non-sensitive settings in a separate configuration file:
+
+```ini
+[default]
+region=us-east-1
+```
+
+Then pass both files to vmalert:
+
+```sh
+./bin/vmalert \
+  -rule=s3://my-alert-bucket/rules/alerts_ \
+  -s3.credsFilePath=/etc/vmalert/aws-credentials \
+  -s3.configFilePath=/etc/vmalert/aws-config
+```
+
+For S3-compatible backends such as [MinIO](https://www.min.io/) or [Ceph](https://ceph.io/), create access keys in the respective
+system and use the same file format and set a custom endpoint with `-s3.customS3Endpoint`.
+
+For example:
+
+```sh
+./bin/vmalert \
+  -rule=s3://victoriametrics-alert-rules/rules_ \
+  -s3.credsFilePath=/etc/vmalert/aws-credentials \
+  -s3.customEndpoint=http://minio.example.local:9000 \
+  -datasource.url=http://vmselect:8481/select/0/prometheus \
+  -notifier.url=http://alertmanager:9093
+```
+
+### Google Cloud Storage (GCS)
+
+To create a service account and download the credential file, follow these steps:
+
+1. Open the Google Cloud Console and go to **IAM & Admin → Service Accounts**.
+2. Click **Create service account**.
+3. Enter a service account name.
+4. Assign the role the account needs to access Google Cloud Storage. See [IAM permissions for JSON methods](https://docs.cloud.google.com/storage/docs/access-control/iam-json) for more details.
+5. Open the service account, go to **Keys**, then click **Add key → Create new key**.
+6. Choose **JSON** as the key type
+7. Save the downloaded JSON file on the machine running vmalert and point `-s3.credsFilePath` to it. The file contents look similar to:
+
+   ```json
+   {
+     "type": "service_account",
+     "project_id": "project-id",
+     "private_key_id": "key-id",
+     "private_key": "-----BEGIN PRIVATE KEY-----\nprivate-key\n-----END PRIVATE KEY-----\n",
+     "client_email": "service-account-email",
+     "client_id": "client-id",
+     "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+     "token_uri": "https://accounts.google.com/o/oauth2/token",
+     "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+     "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/service-account-email"
+   }
+   ```
+
+  This JSON is the standard service account key format defined by [Google Cloud IAM](https://developers.google.com/workspace/guides/create-credentials) and is used by Google client libraries and tools.
+
+The following example shows how to load rules from Google Cloud Storage in vmalert:
+
+```sh
+./bin/vmalert \
+  -rule=gs://my-alert-bucket/rules/alerts_ \
+  -s3.credsFilePath=/etc/vmalert/gcp-service-account.json \
+  -datasource.url=http://vmselect:8481/select/0/prometheus \
+  -notifier.url=http://alertmanager:9093
+```
 
 ## Topology examples
 

--- a/docs/victoriametrics/vmalert.md
+++ b/docs/victoriametrics/vmalert.md
@@ -565,82 +565,18 @@ The following [command-line flags](#flags) can be used for fine-tuning access to
 
 ### S3 (AWS and S3-compatible)
 
-1. In AWS, [create an IAM user](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_users_create.html) or role with read-only permissions on the target bucket.
-2. [Create an access key](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html) for that IAM identity and copy the **Access key** and **Secret access key** values
-3. On the machine running vmalert, create a credentials file with the following content and point `-s3.credsFilePath` to it:
-
-   ```ini
-   [default]
-   aws_access_key_id=YOUR_AWS_ACCESS_KEY
-   aws_secret_access_key=YOUR_AWS_SECRET_ACCESS_KEY
-   ```
-
-   This format matches the standard shared AWS credentials file used by the [AWS CLI](https://docs.aws.amazon.com/cli/v1/userguide/cli-configure-files.html) and [AWS SDKs](https://docs.aws.amazon.com/sdkref/latest/guide/file-format.html).
-
-The following example reads the rules from the S3 bucket called `my-alert-bucket`. If our bucket contains `rules/alerts_cpu.yml` and `rules/alerts_memory.yml`, then `-rule=s3://my-alert-bucket/rules/alerts_` matches both files because both keys start with that exact prefix
+The following example reads rules from an S3 bucket:
 
 ```sh
 ./bin/vmalert \
   -rule=s3://my-alert-bucket/rules/alerts_ \
   -s3.credsFilePath=/etc/vmalert/aws-credentials \
   -datasource.url=http://vmselect:8481/select/0/prometheus \
-  -notifier.url=http://alertmanager:9093
+  -notifier.url=http://alertmanager:9093 \
+  -licenseFile=/etc/vm-license
 ```
 
-You define multiple profiles in a single credentials file with different access keys:
-
-```ini
-[default]
-aws_access_key_id=DEFAULT_ACCESS_KEY
-aws_secret_access_key=DEFAULT_SECRET_KEY
-
-[monitoring]
-aws_access_key_id=MONITORING_ACCESS_KEY
-aws_secret_access_key=MONITORING_SECRET_KEY
-
-[alerts]
-aws_access_key_id=ALERTS_ACCESS_KEY
-aws_secret_access_key=ALERTS_SECRET_KEY
-```
-
-Then you can start vmalert with `-s3.configProfile` to use a non-default profile:
-
-```sh
-./bin/vmalert \
-  -rule=s3://my-alert-bucket/rules/alerts_ \
-  -s3.credsFilePath=/etc/vmalert/aws-credentials \
-  -s3.configProfile=alerts
-```
-
-Additionally, you can separate the credentials file from other configuration files. For example, one file can have credentials:
-
-
-```ini
-[default]
-aws_access_key_id=DEFAULT_ACCESS_KEY
-aws_secret_access_key=DEFAULT_SECRET_KEY
-```
-
-And leave the rest of the non-sensitive settings in a separate configuration file:
-
-```ini
-[default]
-region=us-east-1
-```
-
-Then pass both files to vmalert:
-
-```sh
-./bin/vmalert \
-  -rule=s3://my-alert-bucket/rules/alerts_ \
-  -s3.credsFilePath=/etc/vmalert/aws-credentials \
-  -s3.configFilePath=/etc/vmalert/aws-config
-```
-
-For S3-compatible backends such as [MinIO](https://www.min.io/) or [Ceph](https://ceph.io/), create access keys in the respective
-system and use the same file format and set a custom endpoint with `-s3.customS3Endpoint`.
-
-For example:
+For S3-compatible backends such as [MinIO](https://www.min.io/) or [Ceph](https://ceph.io/), add `-s3.customEndpoint`:
 
 ```sh
 ./bin/vmalert \
@@ -648,47 +584,26 @@ For example:
   -s3.credsFilePath=/etc/vmalert/aws-credentials \
   -s3.customEndpoint=http://minio.example.local:9000 \
   -datasource.url=http://vmselect:8481/select/0/prometheus \
-  -notifier.url=http://alertmanager:9093
+  -notifier.url=http://alertmanager:9093 \
+  -licenseFile=/etc/vm-license
 ```
+
+See [Connecting VM components to cloud storage](https://docs.victoriametrics.com/guides/connecting-vm-components-to-cloud-storage/) for details on creating IAM users, credentials file format, environment variables, and IAM roles.
 
 ### Google Cloud Storage (GCS)
 
-To create a service account and download the credential file, follow these steps:
-
-1. Open the Google Cloud Console and go to **IAM & Admin → Service Accounts**.
-2. Click **Create service account**.
-3. Enter a service account name.
-4. Assign the role the account needs to access Google Cloud Storage. See [IAM permissions for JSON methods](https://docs.cloud.google.com/storage/docs/access-control/iam-json) for more details.
-5. Open the service account, go to **Keys**, then click **Add key → Create new key**.
-6. Choose **JSON** as the key type
-7. Save the downloaded JSON file on the machine running vmalert and point `-s3.credsFilePath` to it. The file contents look similar to:
-
-   ```json
-   {
-     "type": "service_account",
-     "project_id": "project-id",
-     "private_key_id": "key-id",
-     "private_key": "-----BEGIN PRIVATE KEY-----\nprivate-key\n-----END PRIVATE KEY-----\n",
-     "client_email": "service-account-email",
-     "client_id": "client-id",
-     "auth_uri": "https://accounts.google.com/o/oauth2/auth",
-     "token_uri": "https://accounts.google.com/o/oauth2/token",
-     "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
-     "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/service-account-email"
-   }
-   ```
-
-  This JSON is the standard service account key format defined by [Google Cloud IAM](https://developers.google.com/workspace/guides/create-credentials) and is used by Google client libraries and tools.
-
-The following example shows how to load rules from Google Cloud Storage in vmalert:
+The following example reads rules from a GCS bucket:
 
 ```sh
 ./bin/vmalert \
   -rule=gs://my-alert-bucket/rules/alerts_ \
   -s3.credsFilePath=/etc/vmalert/gcp-service-account.json \
   -datasource.url=http://vmselect:8481/select/0/prometheus \
-  -notifier.url=http://alertmanager:9093
+  -notifier.url=http://alertmanager:9093 \
+  -licenseFile=/etc/vm-license
 ```
+
+See [Connecting VM components to cloud storage](https://docs.victoriametrics.com/guides/connecting-vm-components-to-cloud-storage/) for details on creating service accounts and downloading JSON keys.
 
 ## Topology examples
 

--- a/docs/victoriametrics/vmbackup.md
+++ b/docs/victoriametrics/vmbackup.md
@@ -204,7 +204,7 @@ See [this article](https://medium.com/@valyala/speeding-up-backups-for-big-time-
 
 ### Providing credentials as a file
 
-`vmbackup`, `vmbackupmanager`, and [`vmalert`](https://docs.victoriametrics.com/victoriametrics/vmalert/) can load credentials from a file via the `-credsFilePath` flag to access remote S3-compatible buckets and Google Cloud Storage.
+`vmbackup` and `vmbackupmanager` can load credentials from a file via the `-credsFilePath` flag to access remote S3-compatible buckets and Google Cloud Storage.
 
 To use a credential file, add the flag:
 

--- a/docs/victoriametrics/vmbackup.md
+++ b/docs/victoriametrics/vmbackup.md
@@ -204,38 +204,80 @@ See [this article](https://medium.com/@valyala/speeding-up-backups-for-big-time-
 
 ### Providing credentials as a file
 
-Obtaining credentials from a file.
+`vmbackup`, `vmbackupmanager`, and [`vmalert`](https://docs.victoriametrics.com/victoriametrics/vmalert/) can load credentials from a file via the `-credsFilePath` flag to access remote S3-compatible buckets and Google Cloud Storage.
 
-Add flag `-credsFilePath=/etc/credentials` with the following content:
+To use a credential file, add the flag:
 
-* for S3 (AWS, MinIO or other S3 compatible storages):
+```sh
+-credsFilePath=/etc/credentials
+```
 
-     ```sh
-     [default]
-     aws_access_key_id=theaccesskey
-     aws_secret_access_key=thesecretaccesskeyvalue
-    ```
+The argument should point to a file with one of the formats below, depending on the storage provider.
 
-* for GCP cloud storage:
+#### S3 (AWS and S3-compatible)
 
-    ```json
-    {
-           "type": "service_account",
-           "project_id": "project-id",
-           "private_key_id": "key-id",
-           "private_key": "-----BEGIN PRIVATE KEY-----\nprivate-key\n-----END PRIVATE KEY-----\n",
-           "client_email": "service-account-email",
-           "client_id": "client-id",
-           "auth_uri": "https://accounts.google.com/o/oauth2/auth",
-           "token_uri": "https://accounts.google.com/o/oauth2/token",
-           "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
-           "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/service-account-email"
-    }
-    ```
+1. In AWS, [create an IAM user](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_users_create.html) or role with permissions to read and write the target bucket.
+2. [Create an access key](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html) for that IAM identity and copy the **Access key** and **Secret access key** values
+3. On the machine running `vmbackup`, create a credentials file with the following content and point `-credsFilePath` to it:
+
+   ```ini
+   [default]
+   aws_access_key_id=YOUR_AWS_ACCESS_KEY
+   aws_secret_access_key=YOUR_AWS_SECRET_ACCESS_KEY
+   ```
+
+This format matches the standard shared AWS credentials file used by the [AWS CLI](https://docs.aws.amazon.com/cli/v1/userguide/cli-configure-files.html) and [AWS SDKs](https://docs.aws.amazon.com/sdkref/latest/guide/file-format.html).
+
+For S3-compatible backends such as [MinIO](https://www.min.io/) or [Ceph](https://ceph.io/), create access keys in the respective
+system and use the same file format and set a custom endpoint with `-customS3Endpoint`. 
+
+For example:
+
+```sh
+vmbackup \
+  -storageDataPath=/data \
+  -snapshot.createURL=http://localhost:8428/snapshot/create \
+  -dst=s3://victoriametrics-backup/backup01 \
+  -customS3Endpoint=http://minio.example.local:9000 \
+  -credsFilePath=/etc/credentials
+```
+
+#### Google Cloud Storage (GCS)
+
+To create an IAM user and download the credential file, follow these steps:
+
+1. Open the Google Cloud Console and go to **IAM & Admin → Service Accounts**.
+2. Click **Create service account**.
+3. Enter a service account name.
+4. Assign the role the account needs to access Google Cloud Storage. See [IAM permissions for JSON methods](https://docs.cloud.google.com/storage/docs/access-control/iam-json) for more details.
+5. Open the service account, go to **Keys**, then click **Add key → Create new key**.
+6. Choose **JSON** as the key type
+7. Save the downloaded JSON file on the machine running `vmbackup` and point `-credsFilePath` to it. The file contents look similar to:
+
+   ```json
+   {
+     "type": "service_account",
+     "project_id": "project-id",
+     "private_key_id": "key-id",
+     "private_key": "-----BEGIN PRIVATE KEY-----\nprivate-key\n-----END PRIVATE KEY-----\n",
+     "client_email": "service-account-email",
+     "client_id": "client-id",
+     "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+     "token_uri": "https://accounts.google.com/o/oauth2/token",
+     "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+     "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/service-account-email"
+   }
+   ```
+
+This JSON is the standard service account key format defined by [Google Cloud IAM](https://developers.google.com/workspace/guides/create-credentials) and is used by Google client libraries and tools.
+
+#### Azure Blob Storage
+
+Azure Blob Storage uses environment variables rather than `-credsFilePath` in `vmbackup`. See [providing credentials via env variables](https://docs.victoriametrics.com/victoriametrics/vmbackup/#providing-credentials-via-env-variables) for details.
 
 ### Providing credentials via env variables
 
-Obtaining credentials from env variables.
+Obtaining credentials from environment variables.
 
 * For AWS S3 compatible storages set env variable `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`.
   Also you can set env variable `AWS_SHARED_CREDENTIALS_FILE` with path to credentials file.

--- a/docs/victoriametrics/vmbackup.md
+++ b/docs/victoriametrics/vmbackup.md
@@ -204,103 +204,45 @@ See [this article](https://medium.com/@valyala/speeding-up-backups-for-big-time-
 
 ### Providing credentials as a file
 
-`vmbackup` and `vmbackupmanager` can load credentials from a file via the `-credsFilePath` flag to access remote S3-compatible buckets and Google Cloud Storage.
+See [Connecting VM components to cloud storage](https://docs.victoriametrics.com/guides/connecting-vm-components-to-cloud-storage/) for instructions on obtaining credentials and providing them via credential files, environment variables, cloud provider metadata service, or Kubernetes secrets and IAM roles.
 
-To use a credential file, add the flag:
-
-```sh
--credsFilePath=/etc/credentials
-```
-
-The argument should point to a file with one of the formats below, depending on the storage provider.
+The following examples show the most common authentication patterns for each storage provider.
 
 #### S3 (AWS and S3-compatible)
-
-1. In AWS, [create an IAM user](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_users_create.html) or role with permissions to read and write the target bucket.
-2. [Create an access key](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html) for that IAM identity and copy the **Access key** and **Secret access key** values
-3. On the machine running `vmbackup`, create a credentials file with the following content and point `-credsFilePath` to it:
-
-   ```ini
-   [default]
-   aws_access_key_id=YOUR_AWS_ACCESS_KEY
-   aws_secret_access_key=YOUR_AWS_SECRET_ACCESS_KEY
-   ```
-
-This format matches the standard shared AWS credentials file used by the [AWS CLI](https://docs.aws.amazon.com/cli/v1/userguide/cli-configure-files.html) and [AWS SDKs](https://docs.aws.amazon.com/sdkref/latest/guide/file-format.html).
-
-For S3-compatible backends such as [MinIO](https://www.min.io/) or [Ceph](https://ceph.io/), create access keys in the respective
-system and use the same file format and set a custom endpoint with `-customS3Endpoint`. 
-
-For example:
 
 ```sh
 vmbackup \
   -storageDataPath=/data \
   -snapshot.createURL=http://localhost:8428/snapshot/create \
   -dst=s3://victoriametrics-backup/backup01 \
-  -customS3Endpoint=http://minio.example.local:9000 \
   -credsFilePath=/etc/credentials
 ```
 
 #### Google Cloud Storage (GCS)
 
-To create an IAM user and download the credential file, follow these steps:
-
-1. Open the Google Cloud Console and go to **IAM & Admin → Service Accounts**.
-2. Click **Create service account**.
-3. Enter a service account name.
-4. Assign the role the account needs to access Google Cloud Storage. See [IAM permissions for JSON methods](https://docs.cloud.google.com/storage/docs/access-control/iam-json) for more details.
-5. Open the service account, go to **Keys**, then click **Add key → Create new key**.
-6. Choose **JSON** as the key type
-7. Save the downloaded JSON file on the machine running `vmbackup` and point `-credsFilePath` to it. The file contents look similar to:
-
-   ```json
-   {
-     "type": "service_account",
-     "project_id": "project-id",
-     "private_key_id": "key-id",
-     "private_key": "-----BEGIN PRIVATE KEY-----\nprivate-key\n-----END PRIVATE KEY-----\n",
-     "client_email": "service-account-email",
-     "client_id": "client-id",
-     "auth_uri": "https://accounts.google.com/o/oauth2/auth",
-     "token_uri": "https://accounts.google.com/o/oauth2/token",
-     "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
-     "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/service-account-email"
-   }
-   ```
-
-This JSON is the standard service account key format defined by [Google Cloud IAM](https://developers.google.com/workspace/guides/create-credentials) and is used by Google client libraries and tools.
+```sh
+vmbackup \
+  -storageDataPath=/data \
+  -snapshot.createURL=http://localhost:8428/snapshot/create \
+  -dst=gs://victoriametrics-backup/backup01 \
+  -credsFilePath=/etc/credentials
+```
 
 #### Azure Blob Storage
 
-Azure Blob Storage uses environment variables rather than `-credsFilePath` in `vmbackup`. See [providing credentials via env variables](https://docs.victoriametrics.com/victoriametrics/vmbackup/#providing-credentials-via-env-variables) for details.
+```sh
+export AZURE_STORAGE_ACCOUNT_NAME=mystorageaccount
+export AZURE_STORAGE_ACCOUNT_KEY=myaccountkey
 
-### Providing credentials via env variables
-
-Obtaining credentials from environment variables.
-
-* For AWS S3 compatible storages set env variable `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`.
-  Also you can set env variable `AWS_SHARED_CREDENTIALS_FILE` with path to credentials file.
-* For GCE cloud storage set env variable `GOOGLE_APPLICATION_CREDENTIALS` with path to credentials file.
-* For Azure storage use one of these env variables:
-  * `AZURE_STORAGE_ACCOUNT_CONNECTION_STRING`: use a connection string (must be either SAS Token or Account/Key)
-  * `AZURE_STORAGE_ACCOUNT_NAME` and `AZURE_STORAGE_ACCOUNT_KEY`: use a specific account name and key (either primary or secondary)
-  * `AZURE_USE_DEFAULT_CREDENTIAL` and `AZURE_STORAGE_ACCOUNT_NAME`: use the `DefaultAzureCredential` to allow the Azure library
-     to search for multiple options (for example, managed identity related variables). Note that if multiple credentials are available,
-     it is required to specify the `AZURE_CLIENT_ID` to select specific credentials.
-
-  The `AZURE_STORAGE_DOMAIN` can be used for optionally overriding the default domain for the Azure storage service.
-
-Please, note that `vmbackup` will use credentials provided by cloud providers metadata service [when applicable](https://docs.victoriametrics.com/victoriametrics/vmbackup/#using-cloud-providers-metadata-service).
-
-### Using cloud providers metadata service
-
-`vmbackup` and `vmbackupmanager` will automatically use cloud providers metadata service in order to obtain credentials if they are running in cloud environment and credentials are not explicitly provided via flags or env variables.
+vmbackup \
+  -storageDataPath=/data \
+  -snapshot.createURL=http://localhost:8428/snapshot/create \
+  -dst=azblob://victoriametrics-backup/backup01
+```
 
 ### Providing credentials in Kubernetes
 
-The simplest way to provide credentials in Kubernetes is to use [Secrets](https://kubernetes.io/docs/concepts/configuration/secret/)
-and inject them into the pod as environment variables. For example, the following secret can be used for AWS S3 credentials:
+The simplest way to provide credentials in Kubernetes is to use [Secrets](https://kubernetes.io/docs/concepts/configuration/secret/) and inject them into the pod as environment variables. For example, the following secret can be used for AWS S3 credentials:
 
 ```yaml
 apiVersion: v1
@@ -308,14 +250,13 @@ kind: Secret
 metadata:
   name: vmbackup-credentials
 data:
-  access_key: key
-  secret_key: secret
+  access_key: <base64-encoded-key>
+  secret_key: <base64-encoded-secret>
 ```
 
 And then it can be injected into the pod as environment variables:
 
 ```yaml
-...
 env:
 - name: AWS_ACCESS_KEY_ID
   valueFrom:
@@ -327,7 +268,6 @@ env:
     secretKeyRef:
       key: secret_key
       name: vmbackup-credentials
-...
 ```
 
 A more secure way is to use IAM roles to provide tokens for pods instead of managing credentials manually.

--- a/docs/victoriametrics/vmbackupmanager.md
+++ b/docs/victoriametrics/vmbackupmanager.md
@@ -88,33 +88,20 @@ There are two flags which could help with performance tuning:
 
 ### Example of Usage
 
-GCS and cluster version. You need to have a credentials file in json format with following structure:
-
-credentials.json
-
-```json
-{
-  "type": "service_account",
-  "project_id": "<project>",
-  "private_key_id": "",
-  "private_key": "-----BEGIN PRIVATE KEY-----\-----END PRIVATE KEY-----\n",
-  "client_email": "test@<project>.iam.gserviceaccount.com",
-  "client_id": "",
-  "auth_uri": "https://accounts.google.com/o/oauth2/auth",
-  "token_uri": "https://oauth2.googleapis.com/token",
-  "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
-  "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/test%40<project>.iam.gserviceaccount.com"
-}
-
-```
-
-Backup manager launched with the following configuration:
+The following command backs up data to a GCS bucket:
 
 ```sh
 export NODE_IP=192.168.0.10
 export VMSTORAGE_ENDPOINT=http://127.0.0.1:8428
-./vmbackupmanager -dst=gs://vmstorage-data/$NODE_IP -credsFilePath=credentials.json -storageDataPath=/vmstorage-data -snapshot.createURL=$VMSTORAGE_ENDPOINT/snapshot/create -licenseFile=/path/to/vm-license
+./vmbackupmanager \
+  -dst=gs://vmstorage-data/$NODE_IP \
+  -credsFilePath=credentials.json \
+  -storageDataPath=/vmstorage-data \
+  -snapshot.createURL=$VMSTORAGE_ENDPOINT/snapshot/create \
+  -licenseFile=/path/to/vm-license
 ```
+
+See [Connecting VM components to cloud storage](https://docs.victoriametrics.com/guides/connecting-vm-components-to-cloud-storage/) for instructions on obtaining credentials and configuring access to S3, GCS, and Azure Blob Storage.
 
 Expected logs in vmbackupmanager:
 
@@ -147,8 +134,7 @@ objects. Typical object storage systems implement server-side copy by creating n
 This is very fast and efficient. Unfortunately there are systems such as [S3 Glacier](https://aws.amazon.com/s3/storage-classes/glacier/),
 which perform full object copy during server-side copying. This may be slow and expensive.
 
-Please, see [vmbackup docs](https://docs.victoriametrics.com/victoriametrics/vmbackup/#advanced-usage) for more examples of authentication with different
-storage types.
+See [Connecting VM components to cloud storage](https://docs.victoriametrics.com/guides/connecting-vm-components-to-cloud-storage/) for more examples of authentication with different storage types.
 
 ### Backup Retention Policy
 

--- a/docs/victoriametrics/vmrestore.md
+++ b/docs/victoriametrics/vmrestore.md
@@ -47,13 +47,13 @@ i.e. the end result would be similar to [rsync --delete](https://askubuntu.com/q
 
 ## Troubleshooting
 
-* See [how to setup credentials via environment variables](https://docs.victoriametrics.com/victoriametrics/vmbackup/#providing-credentials-via-env-variables).
+* See [Connecting VM components to cloud storage](https://docs.victoriametrics.com/guides/connecting-vm-components-to-cloud-storage/) for instructions on configuring credentials.
 * If `vmrestore` consumes all the network bandwidth, then set `-maxBytesPerSecond` to the desired value.
 * If `vmrestore` has been interrupted due to temporary error, then just restart it with the same args. It will resume the restore process.
 
 ## Advanced usage
 
-Please, see [vmbackup docs](https://docs.victoriametrics.com/victoriametrics/vmbackup/#advanced-usage) for examples of authentication
+See [Connecting VM components to cloud storage](https://docs.victoriametrics.com/guides/connecting-vm-components-to-cloud-storage/) for examples of authentication
 with different storage types.
 
 Run `vmrestore -help` in order to see all the available options:


### PR DESCRIPTION
This PR expands the credentials section of vmbackup and adds a link on the vmalert page

Addresses: https://github.com/VictoriaMetrics/VictoriaMetrics/issues/11073

