### PR TITLE
lib/regexutil: cache simplified prom regexes

### DIFF
--- a/lib/regexutil/regexutil.go
+++ b/lib/regexutil/regexutil.go
@@ -5,6 +5,7 @@ import (
 	"regexp/syntax"
 	"sort"
 	"strings"
+	"sync"
 )
 
 // RemoveStartEndAnchors removes '^' at the start of expr and '$' at the end of the expr.
@@ -184,6 +185,8 @@ func SimplifyRegex(expr string) (string, string) {
 	return prefix, suffix
 }
 
+var promRegexCache sync.Map
+
 // SimplifyPromRegex simplifies the given Prometheus-like expr.
 //
 // It returns plaintext prefix and the remaining regular expression
@@ -193,7 +196,13 @@ func SimplifyRegex(expr string) (string, string) {
 // The function removes capturing parens from the expr,
 // so it cannot be used when capturing parens are necessary.
 func SimplifyPromRegex(expr string) (string, string) {
-	return simplifyRegex(expr, false)
+	if v, ok := promRegexCache.Load(expr); ok {
+		r := v.([2]string)
+		return r[0], r[1]
+	}
+	prefix, regex := simplifyRegex(expr, false)
+	promRegexCache.Store(expr, [2]string{prefix, regex})
+	return prefix, regex
 }
 
 func simplifyRegex(expr string, keepAnchors bool) (string, string) {


### PR DESCRIPTION
While investigating shutdown issues (see #11107), we discovered that our `vmagent` was taking quite a long time to run `loadConfig`. We'd been running it up with the following command-line parameters:

```
...
  -promscrape.config /mnt/vmagent/victoria.yml \
  -promscrape.configCheckInterval 5s \
...
```

And noticed that `loadConfig` was consistently taking 6 seconds to run each time, longer than our configured reload interval.

The [pprof profiles](https://github.com/user-attachments/files/28904987/pprof.vmagent-1.133.0.samples.cpu.001.pb.gz) revealed that the issue was entirely in regex parsing:

<img width="310" height="2444" alt="image" src="https://github.com/user-attachments/assets/4724bd25-5c9f-4a6b-a731-da75c41a7461" />

We use exactly one relabel configuration for all of our jobs:

```go
    relabelConfig{
		SourceLabels: []string{"__address__"},
		Regex:        `([^.]+).+:\d+`,
		TargetLabel:  "instance",
		Replacement:  "$1",
	}
```

`parseRelabelConfig` was parsing the `([^.]+).+:\d+` regex in that config twice for each job, roughly 400 times per `loadConfig`. Within that, the `SimplifyPromRegex`/`simplifyRegex`/`simplifyRegexp` functions were spending all of their time turning simplified regexes back into strings to compare them.

To avoid this, this PR adds a simple cache, ensuring that each regex is simplified at most once.

This is, in principle, a memory leak, since the cache is never cleared. However, it made a night-and-day impact for our use case. Please consider merging this or some equivalent.

Thanks!

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/VictoriaMetrics/VictoriaMetrics/pull/11108?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

