### PR TITLE
lib/fs: retry file deletion on NFS error

### DIFF
--- a/docs/victoriametrics/changelog/CHANGELOG.md
+++ b/docs/victoriametrics/changelog/CHANGELOG.md
@@ -32,6 +32,7 @@ See also [LTS releases](https://docs.victoriametrics.com/victoriametrics/lts-rel
 
 * BUGFIX: [stream aggregation](https://docs.victoriametrics.com/victoriametrics/stream-aggregation/): fix issue with producing aggregated samples with identical timestamps between flushes. See [#10808](https://github.com/VictoriaMetrics/VictoriaMetrics/pull/10808).
 * BUGFIX: [vmbackup](https://docs.victoriametrics.com/vmbackup/), [vmbackupmanager](https://docs.victoriametrics.com/victoriametrics/vmbackupmanager/): do not fail backup list if directory is absent while using `fs://` destination to align with other protocols. See [6c3c548](https://github.com/VictoriaMetrics/VictoriaMetrics/commit/6c3c548ddb0385b749e731f52276f130e2a4e4a8)
+* BUGFIX: [vmsingle](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/) and `vmstorage` in [VictoriaMetrics cluster](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/): prevent more cases of panic during directory deletion on `NFS`-based mounts. See [#11060](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/11060).
 
 ## [v1.145.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.145.0)
 

--- a/lib/fs/dir_remover.go
+++ b/lib/fs/dir_remover.go
@@ -182,6 +182,9 @@ func tryRemoveDir(dirPath string) bool {
 				if !isTemporaryNFSError(err) {
 					logger.Fatalf("FATAL: cannot remove %q: %s", dirEntryPath, err)
 				}
+				if os.IsNotExist(err) {
+					return
+				}
 				mustRetry.Store(true)
 			}
 		}(dirEntryPath)
@@ -203,13 +206,9 @@ func tryRemoveDir(dirPath string) bool {
 
 	deleteFilePath := filepath.Join(dirPath, deleteDirFilename)
 	// Remove the deleteDirFilename file, since there are no other entries left in the directory.
-	if err := os.Remove(deleteFilePath); err != nil {
-		if !isTemporaryNFSError(err) {
-			logger.Fatalf("FATAL: cannot remove %q: %s", deleteFilePath, err)
-		}
+	if !tryRemovePath(deleteFilePath) {
 		return false
 	}
-
 	// Sync the directory after the removing deletDirFilename file in order to make sure
 	// all the metadata files are removed at some exotic filesystems such as OSSFS2.
 	// See https://github.com/VictoriaMetrics/VictoriaLogs/issues/649
@@ -217,16 +216,30 @@ func tryRemoveDir(dirPath string) bool {
 	MustSyncPath(dirPath)
 
 	// Remove the dirPath itself
-	if err := os.Remove(dirPath); err != nil {
-		if !isTemporaryNFSError(err) {
-			logger.Fatalf("FATAL: cannot remove %q: %s", dirPath, err)
-		}
+	if !tryRemovePath(dirPath) {
 		return false
 	}
 
 	// Do not sync the parent directory for the dirPath - the caller can do this if needed.
 	// It is OK if the dirPath will remain undeleted after unclean shutdown - it will be deleted
 	// on the next startup.
+
+	return true
+}
+
+// tryRemovePath removes given path and returns true on success
+// or false if error is temporary NFS error
+func tryRemovePath(path string) bool {
+	if err := os.Remove(path); err != nil {
+		if !isTemporaryNFSError(err) {
+			logger.Fatalf("FATAL: cannot remove %q: %s", path, err)
+		}
+		if os.IsNotExist(err) {
+			return true
+		}
+		nfsDirRemoveFailedAttempts.Inc()
+		return false
+	}
 
 	return true
 }

--- a/lib/fs/dir_remover.go
+++ b/lib/fs/dir_remover.go
@@ -231,11 +231,11 @@ func tryRemoveDir(dirPath string) bool {
 // or false if error is temporary NFS error
 func tryRemovePath(path string) bool {
 	if err := os.Remove(path); err != nil {
-		if !isTemporaryNFSError(err) {
-			logger.Fatalf("FATAL: cannot remove %q: %s", path, err)
-		}
 		if os.IsNotExist(err) {
 			return true
+		}
+		if !isTemporaryNFSError(err) {
+			logger.Fatalf("FATAL: cannot remove %q: %s", path, err)
 		}
 		nfsDirRemoveFailedAttempts.Inc()
 		return false

--- a/lib/fs/dir_remover.go
+++ b/lib/fs/dir_remover.go
@@ -203,7 +203,12 @@ func tryRemoveDir(dirPath string) bool {
 
 	deleteFilePath := filepath.Join(dirPath, deleteDirFilename)
 	// Remove the deleteDirFilename file, since there are no other entries left in the directory.
-	MustRemovePath(deleteFilePath)
+	if err := os.Remove(deleteFilePath); err != nil {
+		if !isTemporaryNFSError(err) {
+			logger.Fatalf("FATAL: cannot remove %q: %s", deleteFilePath, err)
+		}
+		return false
+	}
 
 	// Sync the directory after the removing deletDirFilename file in order to make sure
 	// all the metadata files are removed at some exotic filesystems such as OSSFS2.
@@ -212,7 +217,12 @@ func tryRemoveDir(dirPath string) bool {
 	MustSyncPath(dirPath)
 
 	// Remove the dirPath itself
-	MustRemovePath(dirPath)
+	if err := os.Remove(dirPath); err != nil {
+		if !isTemporaryNFSError(err) {
+			logger.Fatalf("FATAL: cannot remove %q: %s", dirPath, err)
+		}
+		return false
+	}
 
 	// Do not sync the parent directory for the dirPath - the caller can do this if needed.
 	// It is OK if the dirPath will remain undeleted after unclean shutdown - it will be deleted

--- a/lib/fs/dir_remover.go
+++ b/lib/fs/dir_remover.go
@@ -179,11 +179,11 @@ func tryRemoveDir(dirPath string) bool {
 			// times simultaneously and properly close it, fs caching may still
 			// confuse NFS client.
 			if err := os.RemoveAll(dirEntryPath); err != nil {
-				if !isTemporaryNFSError(err) {
-					logger.Fatalf("FATAL: cannot remove %q: %s", dirEntryPath, err)
-				}
 				if os.IsNotExist(err) {
 					return
+				}
+				if !isTemporaryNFSError(err) {
+					logger.Fatalf("FATAL: cannot remove %q: %s", dirEntryPath, err)
 				}
 				mustRetry.Store(true)
 			}


### PR DESCRIPTION
 This commit adds additional file removal retries.
This is follow-up for https://github.com/VictoriaMetrics/VictoriaMetrics/issues/9842.

 According to the stack trace, NFS also could return error for `deleteFilePath`.
This retry is safe, since part already removed from `parts.json` and performs a skips empty directories on restart.

Fixes https://github.com/VictoriaMetrics/VictoriaMetrics/issues/11060

**PLEASE REMOVE LINE BELOW BEFORE SUBMITTING**

Before creating the PR, make sure you have read and followed the [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/VictoriaMetrics/VictoriaMetrics/pull/11111?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

