### PR TITLE
lib/mergeset: make the flushCallback interval configurable

### DIFF
--- a/lib/mergeset/table.go
+++ b/lib/mergeset/table.go
@@ -48,6 +48,12 @@ const maxPartSize = 400e9
 // The interval for flushing buffered data to parts, so it becomes visible to search.
 const pendingItemsFlushInterval = time.Second
 
+// The default interval for calling flushCallback when there is pending data to flush.
+//
+// It is set relatively high in order to improve the effectiveness of caches reset by flushCallback.
+// It is used when the flushCallbackInterval arg at MustOpenTable is set to zero.
+const defaultFlushCallbackInterval = 10 * time.Second
+
 // maxItemsPerCachedPart is the maximum items per created part by the merge,
 // which must be cached in the OS page cache.
 //
@@ -88,6 +94,7 @@ type Table struct {
 	flushInterval time.Duration
 
 	flushCallback         func()
+	flushCallbackInterval time.Duration
 	needFlushCallbackCall atomic.Bool
 
 	prepareBlock PrepareBlockCallback
@@ -332,17 +339,24 @@ func (pw *partWrapper) decRef() {
 // Optional flushCallback is called every time new data batch is flushed
 // to the underlying storage and becomes visible to search.
 //
+// The flushCallbackInterval is how often flushCallback is invoked when there is
+// pending data to flush. If it is set to zero, then defaultFlushCallbackInterval is used.
+//
 // Optional prepareBlock is called during merge before flushing the prepared block
 // to persistent storage.
 //
 // The table is created if it doesn't exist yet.
-func MustOpenTable(path string, flushInterval time.Duration, flushCallback func(), prepareBlock PrepareBlockCallback, isReadOnly *atomic.Bool) *Table {
+func MustOpenTable(path string, flushInterval time.Duration, flushCallback func(), flushCallbackInterval time.Duration, prepareBlock PrepareBlockCallback, isReadOnly *atomic.Bool) *Table {
 	path = filepath.Clean(path)
 
 	if flushInterval < pendingItemsFlushInterval {
 		// There is no sense in setting flushInterval to values smaller than pendingItemsFlushInterval,
 		// since pending rows unconditionally remain in memory for up to pendingItemsFlushInterval.
 		flushInterval = pendingItemsFlushInterval
+	}
+
+	if flushCallbackInterval <= 0 {
+		flushCallbackInterval = defaultFlushCallbackInterval
 	}
 
 	// Create a directory at the path if it doesn't exist yet.
@@ -355,14 +369,15 @@ func MustOpenTable(path string, flushInterval time.Duration, flushCallback func(
 	fs.MustSyncPathAndParentDir(path)
 
 	tb := &Table{
-		path:                 path,
-		flushInterval:        flushInterval,
-		flushCallback:        flushCallback,
-		prepareBlock:         prepareBlock,
-		isReadOnly:           isReadOnly,
-		fileParts:            pws,
-		inmemoryPartsLimitCh: make(chan struct{}, maxInmemoryParts),
-		stopCh:               make(chan struct{}),
+		path:                  path,
+		flushInterval:         flushInterval,
+		flushCallback:         flushCallback,
+		flushCallbackInterval: flushCallbackInterval,
+		prepareBlock:          prepareBlock,
+		isReadOnly:            isReadOnly,
+		fileParts:             pws,
+		inmemoryPartsLimitCh:  make(chan struct{}, maxInmemoryParts),
+		stopCh:                make(chan struct{}),
 	}
 	tb.mergeIdx.Store(uint64(time.Now().UnixNano()))
 	tb.rawItems.init()
@@ -429,9 +444,9 @@ func (tb *Table) startFlushCallbackWorker() {
 	}
 
 	tb.wg.Go(func() {
-		// call flushCallback once per 10 seconds in order to improve the effectiveness of caches,
-		// which are reset by the flushCallback.
-		d := timeutil.AddJitterToDuration(time.Second * 10)
+		// call flushCallback at flushCallbackInterval in order to improve the effectiveness
+		// of caches, which are reset by the flushCallback.
+		d := timeutil.AddJitterToDuration(tb.flushCallbackInterval)
 		tc := time.NewTicker(d)
 		for {
 			select {

--- a/lib/mergeset/table_search_test.go
+++ b/lib/mergeset/table_search_test.go
@@ -40,7 +40,7 @@ func TestTableSearchSerial(t *testing.T) {
 	func() {
 		// Re-open the table and verify the search works.
 		var isReadOnly atomic.Bool
-		tb := MustOpenTable(path, 0, nil, nil, &isReadOnly)
+		tb := MustOpenTable(path, 0, nil, 0, nil, &isReadOnly)
 		defer tb.MustClose()
 		if err := testTableSearchSerial(tb, items); err != nil {
 			t.Fatalf("unexpected error: %s", err)
@@ -70,7 +70,7 @@ func TestTableSearchConcurrent(t *testing.T) {
 	// Re-open the table and verify the search works.
 	func() {
 		var isReadOnly atomic.Bool
-		tb := MustOpenTable(path, 0, nil, nil, &isReadOnly)
+		tb := MustOpenTable(path, 0, nil, 0, nil, &isReadOnly)
 		defer tb.MustClose()
 		if err := testTableSearchConcurrent(tb, items); err != nil {
 			t.Fatalf("unexpected error: %s", err)
@@ -144,7 +144,7 @@ func newTestTable(r *rand.Rand, path string, itemsCount int) (*Table, []string, 
 		flushes.Add(1)
 	}
 	var isReadOnly atomic.Bool
-	tb := MustOpenTable(path, 0, flushCallback, nil, &isReadOnly)
+	tb := MustOpenTable(path, 0, flushCallback, 0, nil, &isReadOnly)
 	items := make([]string, itemsCount)
 	for i := range itemsCount {
 		item := fmt.Sprintf("%d:%d", r.Intn(1e9), i)

--- a/lib/mergeset/table_search_timing_test.go
+++ b/lib/mergeset/table_search_timing_test.go
@@ -33,7 +33,7 @@ func benchmarkTableSearch(b *testing.B, itemsCount int) {
 	// Force finishing pending merges
 	tb.MustClose()
 	var isReadOnly atomic.Bool
-	tb = MustOpenTable(path, 0, nil, nil, &isReadOnly)
+	tb = MustOpenTable(path, 0, nil, 0, nil, &isReadOnly)
 	defer tb.MustClose()
 
 	keys := make([][]byte, len(items))

--- a/lib/mergeset/table_test.go
+++ b/lib/mergeset/table_test.go
@@ -18,14 +18,14 @@ func TestTableOpenClose(t *testing.T) {
 
 	// Create a new table
 	var isReadOnly atomic.Bool
-	tb := MustOpenTable(path, 0, nil, nil, &isReadOnly)
+	tb := MustOpenTable(path, 0, nil, 0, nil, &isReadOnly)
 
 	// Close it
 	tb.MustClose()
 
 	// Re-open created table multiple times.
 	for range 4 {
-		tb := MustOpenTable(path, 0, nil, nil, &isReadOnly)
+		tb := MustOpenTable(path, 0, nil, 0, nil, &isReadOnly)
 		tb.MustClose()
 	}
 }
@@ -35,7 +35,7 @@ func TestTableAddItemsTooLongItem(t *testing.T) {
 	fs.MustRemoveDir(path)
 
 	var isReadOnly atomic.Bool
-	tb := MustOpenTable(path, 0, nil, nil, &isReadOnly)
+	tb := MustOpenTable(path, 0, nil, 0, nil, &isReadOnly)
 	tb.AddItems([][]byte{make([]byte, maxInmemoryBlockSize+1)})
 	tb.MustClose()
 	fs.MustRemoveDir(path)
@@ -52,7 +52,7 @@ func TestTableAddItemsSerial(t *testing.T) {
 		flushes.Add(1)
 	}
 	var isReadOnly atomic.Bool
-	tb := MustOpenTable(path, 0, flushCallback, nil, &isReadOnly)
+	tb := MustOpenTable(path, 0, flushCallback, 0, nil, &isReadOnly)
 
 	const itemsCount = 10e3
 	testAddItemsSerial(r, tb, itemsCount)
@@ -75,7 +75,7 @@ func TestTableAddItemsSerial(t *testing.T) {
 	testReopenTable(t, path, itemsCount)
 
 	// Add more items in order to verify merge between inmemory parts and file-based parts.
-	tb = MustOpenTable(path, 0, nil, nil, &isReadOnly)
+	tb = MustOpenTable(path, 0, nil, 0, nil, &isReadOnly)
 	const moreItemsCount = itemsCount * 3
 	testAddItemsSerial(r, tb, moreItemsCount)
 	tb.MustClose()
@@ -99,7 +99,7 @@ func TestTableCreateSnapshotAt(t *testing.T) {
 	fs.MustRemoveDir(path)
 
 	var isReadOnly atomic.Bool
-	tb := MustOpenTable(path, 0, nil, nil, &isReadOnly)
+	tb := MustOpenTable(path, 0, nil, 0, nil, &isReadOnly)
 
 	// Write a lot of items into the table, so background merges would start.
 	const itemsCount = 3e5
@@ -111,7 +111,7 @@ func TestTableCreateSnapshotAt(t *testing.T) {
 	// Close and open the table in order to flush all the data to disk before creating snapshots.
 	// See https://github.com/VictoriaMetrics/VictoriaMetrics/issues/4272#issuecomment-1550221840
 	tb.MustClose()
-	tb = MustOpenTable(path, 0, nil, nil, &isReadOnly)
+	tb = MustOpenTable(path, 0, nil, 0, nil, &isReadOnly)
 
 	// Create multiple snapshots.
 	snapshot1 := path + "-test-snapshot1"
@@ -121,8 +121,8 @@ func TestTableCreateSnapshotAt(t *testing.T) {
 	tb.MustCreateSnapshotAt(snapshot2)
 
 	// Verify snapshots contain all the data.
-	tb1 := MustOpenTable(snapshot1, 0, nil, nil, &isReadOnly)
-	tb2 := MustOpenTable(snapshot2, 0, nil, nil, &isReadOnly)
+	tb1 := MustOpenTable(snapshot1, 0, nil, 0, nil, &isReadOnly)
+	tb2 := MustOpenTable(snapshot2, 0, nil, 0, nil, &isReadOnly)
 
 	var ts, ts1, ts2 TableSearch
 	ts.Init(tb, false)
@@ -197,7 +197,7 @@ func TestTableAddItemsConcurrentStress(t *testing.T) {
 	}
 
 	var isReadOnly atomic.Bool
-	tb := MustOpenTable(path, 0, flushCallback, prepareBlock, &isReadOnly)
+	tb := MustOpenTable(path, 0, flushCallback, 0, prepareBlock, &isReadOnly)
 
 	testAddItems(tb)
 
@@ -232,7 +232,7 @@ func TestTableAddItemsConcurrent(t *testing.T) {
 		return data, items
 	}
 	var isReadOnly atomic.Bool
-	tb := MustOpenTable(path, 0, flushCallback, prepareBlock, &isReadOnly)
+	tb := MustOpenTable(path, 0, flushCallback, 0, prepareBlock, &isReadOnly)
 
 	const itemsCount = 10e3
 	testAddItemsConcurrent(tb, itemsCount)
@@ -255,7 +255,7 @@ func TestTableAddItemsConcurrent(t *testing.T) {
 	testReopenTable(t, path, itemsCount)
 
 	// Add more items in order to verify merge between inmemory parts and file-based parts.
-	tb = MustOpenTable(path, 0, nil, nil, &isReadOnly)
+	tb = MustOpenTable(path, 0, nil, 0, nil, &isReadOnly)
 	const moreItemsCount = itemsCount * 3
 	testAddItemsConcurrent(tb, moreItemsCount)
 	tb.MustClose()
@@ -292,7 +292,7 @@ func testReopenTable(t *testing.T, path string, itemsCount int) {
 
 	for range 10 {
 		var isReadOnly atomic.Bool
-		tb := MustOpenTable(path, 0, nil, nil, &isReadOnly)
+		tb := MustOpenTable(path, 0, nil, 0, nil, &isReadOnly)
 		var m TableMetrics
 		tb.UpdateMetrics(&m)
 		if n := m.TotalItemsCount(); n != uint64(itemsCount) {
@@ -308,7 +308,7 @@ func TestTableMustMergeInmemoryPartsFinal_pwsRefCount(t *testing.T) {
 	defer fs.MustRemoveDir(path)
 
 	var isReadOnly atomic.Bool
-	tb := MustOpenTable(path, 0, nil, nil, &isReadOnly)
+	tb := MustOpenTable(path, 0, nil, 0, nil, &isReadOnly)
 	defer tb.MustClose()
 
 	generatePartWrappers := func(n int) []*partWrapper {

--- a/lib/storage/index_db.go
+++ b/lib/storage/index_db.go
@@ -172,7 +172,7 @@ func mustOpenIndexDB(id uint64, tr TimeRange, name, path string, s *Storage, isR
 	}
 
 	tfssCache := lrucache.NewCache(getTagFiltersCacheSize)
-	tb := mergeset.MustOpenTable(path, dataFlushInterval, tfssCache.Reset, mergeTagToMetricIDsRows, isReadOnly)
+	tb := mergeset.MustOpenTable(path, dataFlushInterval, tfssCache.Reset, 0, mergeTagToMetricIDsRows, isReadOnly)
 	db := &indexDB{
 		legacyMinMissingTimestampByKey: make(map[string]int64),
 		id:                             id,


### PR DESCRIPTION
Add a configurable `flushCallbackInterval` to `mergeset.MustOpenTable` instead of the hardcoded 10s flushCallback ticker. This lets VictoriaLogs lower it to 1s so filter-cache invalidation keeps up with live tailing, 

See https://github.com/VictoriaMetrics/VictoriaLogs/issues/1477.