### PR TITLE
Docs: Add `docs-check-links` target to docs Makefile

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -32,6 +32,17 @@ docs-image:
 		--platform $(DOCKER_PLATFORM) \
 		vmdocs
 
+docs-check-links: docs-image
+	rm -rf vmdocs/public
+	docker run \
+		--rm \
+		--platform $(DOCKER_PLATFORM) \
+		-v ./vmdocs:/opt/docs \
+		$(shell for d in ./docs/*/; do printf ' -v %s:/opt/docs/content/%s' "$${d}" "$$(basename $${d})"; done) \
+		--entrypoint /bin/sh \
+		vmdocs-docker-package \
+			-c "yarn install && hugo --minify && yarn run check-links"
+
 docs-debug: docs docs-image
 	docker run \
 		--rm \


### PR DESCRIPTION
We have a `check-links` target in the vmdocs repository. This is a good start but it only detects broken links after changes in docs are merged into master in this repository.

It would be nice to have a way to check the documentation in this repository (before creating a PR for instance). This PR introduces a `docs-check-links` target to the docs/Makefile. This lets us see if we have any new broken links in the current branch/PR before merging into main.

Pros:
- We can preview changes in docs before merging to master
- No new tools/big changes required, only add a new target to the Makefile
- Once we fix all links, we could add a GH Actions check

Cons:
- You need access to the vmdocs repo for this target to work
- Running the check in GH Actions could be potentially complex because it needs to clone vmdocs, build the container, etc

If this seems like a good idea, I could add the same check to the other repos (VL, VT, etc).