### PR TITLE
app/vmctl: fix link to vmctl docs after move into vmctl/ subdir

### DIFF
--- a/app/vmctl/README.md
+++ b/app/vmctl/README.md
@@ -1,3 +1,3 @@
 See vmctl docs [here](https://docs.victoriametrics.com/victoriametrics/vmctl/).
 
-vmctl docs can be edited at [docs/vmctl.md](https://github.com/VictoriaMetrics/VictoriaMetrics/blob/master/docs/victoriametrics/vmctl.md).
+vmctl docs can be edited at [docs/vmctl.md](https://github.com/VictoriaMetrics/VictoriaMetrics/blob/master/docs/victoriametrics/vmctl/vmctl.md).


### PR DESCRIPTION
The "docs can be edited at" link in app/vmctl/README.md points to docs/victoriametrics/vmctl.md, which no longer exists — the file moved to docs/victoriametrics/vmctl/vmctl.md. The sibling app READMEs (vmagent, vmalert, etc.) all resolve correctly; only vmctl's was left behind after the move.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/VictoriaMetrics/VictoriaMetrics/pull/11134?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

