### PR TITLE
lib/storage: prune per-day index entries outside the retention period

### DIFF
--- a/lib/mergeset/table.go
+++ b/lib/mergeset/table.go
@@ -743,6 +743,61 @@ func (tb *Table) DebugFlush() {
 	tb.flushPendingItemsWG.Wait()
 }
 
+// ForceMerge merges all the file parts in the table into a minimal number of parts.
+//
+// It first converts pending items to searchable parts and flushes all in-memory
+// parts to disk, then merges the resulting file parts. Unlike background merges,
+// it merges even a single file part, so the prepareBlock callback (see
+// MustOpenTable) is guaranteed to run over every block. This is needed for
+// transformations applied only during merge, such as retention-based pruning of
+// per-day index entries in the storage layer.
+//
+// Merging is stopped prematurely if stopCh is closed.
+func (tb *Table) ForceMerge(stopCh <-chan struct{}) error {
+	if tb.isReadOnly.Load() {
+		return nil
+	}
+
+	// Move all the data into file parts, so the merge below covers everything.
+	tb.DebugFlush()
+	tb.flushInmemoryPartsToFiles(true)
+
+	// Grab all the file parts which aren't currently being merged by background mergers.
+	tb.partsLock.Lock()
+	var pws []*partWrapper
+	for _, pw := range tb.fileParts {
+		if !pw.isInMerge {
+			pw.isInMerge = true
+			pws = append(pws, pw)
+		}
+	}
+	tb.partsLock.Unlock()
+
+	if len(pws) == 0 {
+		// Nothing to merge.
+		return nil
+	}
+
+	// Check whether there is enough disk space for merging pws.
+	newPartSize := getPartsSize(pws)
+	maxOutBytes := fs.MustGetFreeSpace(tb.path)
+	if newPartSize > maxOutBytes {
+		tb.releasePartsToMerge(pws)
+		return fmt.Errorf("cannot force merge %d parts in %q; additional %d bytes of disk space needed", len(pws), tb.path, newPartSize-maxOutBytes)
+	}
+
+	// Merge all the file parts into a single part. mergeParts() runs the
+	// prepareBlock callback over all blocks, even when len(pws) == 1, and
+	// releases the isInMerge flag on the parts before returning.
+	if err := tb.mergeParts(pws, stopCh, false); err != nil {
+		if errors.Is(err, errForciblyStopped) {
+			return nil
+		}
+		return fmt.Errorf("cannot force merge %d file parts in %q: %w", len(pws), tb.path, err)
+	}
+	return nil
+}
+
 func (tb *Table) pendingItemsFlusher() {
 	// do not add jitter in order to guarantee flush interval
 	d := pendingItemsFlushInterval

--- a/lib/storage/index_db.go
+++ b/lib/storage/index_db.go
@@ -172,13 +172,11 @@ func mustOpenIndexDB(id uint64, tr TimeRange, name, path string, s *Storage, isR
 	}
 
 	tfssCache := lrucache.NewCache(getTagFiltersCacheSize)
-	tb := mergeset.MustOpenTable(path, dataFlushInterval, tfssCache.Reset, 0, mergeTagToMetricIDsRows, isReadOnly)
 	db := &indexDB{
 		legacyMinMissingTimestampByKey: make(map[string]int64),
 		id:                             id,
 		tr:                             tr,
 		name:                           name,
-		tb:                             tb,
 		s:                              s,
 		tagFiltersToMetricIDsCache:     tfssCache,
 		loopsPerDateTagFilterCache:     workingsetcache.New(memory.Allowed() / 128),
@@ -186,6 +184,10 @@ func mustOpenIndexDB(id uint64, tr TimeRange, name, path string, s *Storage, isR
 		dateMetricIDCache:              newDateMetricIDCache(),
 	}
 	db.noRegisterNewSeries.Store(noRegisterNewSeries)
+
+	// The prepareBlock callback is bound to db, so it can prune per-day index
+	// entries outside the retention period during merges. See db.prepareBlock.
+	db.tb = mergeset.MustOpenTable(path, dataFlushInterval, tfssCache.Reset, 0, db.prepareBlock, isReadOnly)
 	db.mustLoadDeletedMetricIDs()
 	return db
 }
@@ -3245,6 +3247,95 @@ func (mp *tagToMetricIDsRowParser) GetMatchingSeriesCount(filter, negativeFilter
 		}
 	}
 	return n
+}
+
+// prepareBlock is the mergeset.PrepareBlockCallback for the partition indexDB.
+//
+// In addition to merging tag->metricIDs rows (see mergeTagToMetricIDsRows), it
+// prunes per-day index entries that fall outside the retention period.
+//
+// Each partition has its own indexDB which accumulates per-day index entries
+// for every day of the partition's month. Without pruning, indexDBs of
+// partitions with retention periods shorter than one month would keep per-day
+// entries for days already outside the retention, wasting disk space. The
+// pruning here is the index-side counterpart of the per-block retention filter
+// applied to the data parts during merge (see blockStreamMerger in merge.go).
+func (db *indexDB) prepareBlock(data []byte, items []mergeset.Item) ([]byte, []mergeset.Item) {
+	data, items = db.pruneExpiredPerDayIndexItems(data, items)
+	return mergeTagToMetricIDsRows(data, items)
+}
+
+// pruneExpiredPerDayIndexItems drops per-day index items (nsPrefixDateToMetricID,
+// nsPrefixDateTagToMetricIDs and nsPrefixDateMetricNameToTSID) whose date is
+// fully outside the retention period.
+//
+// The first and the last items are always preserved unchanged in order to
+// satisfy the mergeset.PrepareBlockCallback contract (the returned first item
+// must be >= the original first item and the last item must be <= the original
+// last item, so the sort order of adjacent blocks is preserved). As a result
+// pruning is best-effort: an expired item which happens to be the first or the
+// last item of a block is removed during a later merge once it is no longer at
+// the block boundary.
+func (db *indexDB) pruneExpiredPerDayIndexItems(data []byte, items []mergeset.Item) ([]byte, []mergeset.Item) {
+	if db.s.disablePerDayIndex {
+		// There are no per-day index entries to prune.
+		return data, items
+	}
+	if len(items) <= 2 {
+		// The first and the last items must remain unchanged, so there is
+		// nothing to prune in between.
+		return data, items
+	}
+
+	// Fast path: items are sorted by nsPrefix, so if the last item has a prefix
+	// smaller than the smallest per-day prefix, there are no per-day items.
+	lastItem := items[len(items)-1].Bytes(data)
+	if len(lastItem) == 0 || lastItem[0] < nsPrefixDateToMetricID {
+		return data, items
+	}
+
+	retentionDeadline := int64(fasttime.UnixTimestamp()*1000) - db.s.retentionMsecs
+	if retentionDeadline <= 0 {
+		// Nothing can be outside the retention yet.
+		return data, items
+	}
+	// minDate is the earliest date which still has retained samples. Every date
+	// strictly smaller than minDate is fully outside the retention period, so
+	// its per-day index entries can be safely dropped.
+	minDate := uint64(retentionDeadline) / msecPerDay
+
+	dstData := data[:0]
+	dstItems := items[:0]
+	for i, it := range items {
+		item := it.Bytes(data)
+		// Always keep the first and the last items unchanged, see the func comment.
+		if i != 0 && i != len(items)-1 && isExpiredPerDayIndexItem(item, minDate) {
+			continue
+		}
+		dstData = append(dstData, item...)
+		dstItems = append(dstItems, mergeset.Item{
+			Start: uint32(len(dstData) - len(item)),
+			End:   uint32(len(dstData)),
+		})
+	}
+	return dstData, dstItems
+}
+
+// isExpiredPerDayIndexItem returns true if item is a per-day index entry whose
+// date is strictly smaller than minDate, i.e. fully outside the retention.
+func isExpiredPerDayIndexItem(item []byte, minDate uint64) bool {
+	// Per-day index items are encoded as [1-byte nsPrefix][8-byte big-endian date][...].
+	// See indexDB.createPerDayIndexes.
+	if len(item) < 9 {
+		return false
+	}
+	switch item[0] {
+	case nsPrefixDateToMetricID, nsPrefixDateTagToMetricIDs, nsPrefixDateMetricNameToTSID:
+	default:
+		return false
+	}
+	date := encoding.UnmarshalUint64(item[1:9])
+	return date < minDate
 }
 
 func mergeTagToMetricIDsRows(data []byte, items []mergeset.Item) ([]byte, []mergeset.Item) {

--- a/lib/storage/index_db_prune_test.go
+++ b/lib/storage/index_db_prune_test.go
@@ -1,0 +1,137 @@
+package storage
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/encoding"
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/fasttime"
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/mergeset"
+)
+
+func TestPruneExpiredPerDayIndexItems(t *testing.T) {
+	// minDate equals nowDate-2 for a 2-day retention, since 2*msecPerDay is a
+	// multiple of msecPerDay. Every date < nowDate-2 is fully outside retention.
+	nowDate := uint64(fasttime.UnixTimestamp()*1000) / msecPerDay
+
+	// perDay builds a per-day index item: [nsPrefix][date][metricID].
+	perDay := func(nsPrefix byte, date, metricID uint64) string {
+		dst := marshalCommonPrefix(nil, nsPrefix)
+		dst = encoding.MarshalUint64(dst, date)
+		dst = encoding.MarshalUint64(dst, metricID)
+		return string(dst)
+	}
+	// global builds a non per-day item that must never be pruned by date.
+	global := func(nsPrefix byte, metricID uint64) string {
+		dst := marshalCommonPrefix(nil, nsPrefix)
+		dst = encoding.MarshalUint64(dst, metricID)
+		return string(dst)
+	}
+
+	f := func(db *indexDB, items, expectedItems []string) {
+		t.Helper()
+		var data []byte
+		var itemsB []mergeset.Item
+		for _, item := range items {
+			data = append(data, item...)
+			itemsB = append(itemsB, mergeset.Item{
+				Start: uint32(len(data) - len(item)),
+				End:   uint32(len(data)),
+			})
+		}
+		if !checkItemsSorted(data, itemsB) {
+			t.Fatalf("source items aren't sorted; items:\n%v", itemsB)
+		}
+		resultData, resultItemsB := db.pruneExpiredPerDayIndexItems(data, itemsB)
+		if !checkItemsSorted(resultData, resultItemsB) {
+			t.Fatalf("result items aren't sorted; items:\n%v", resultItemsB)
+		}
+		var resultItems []string
+		for _, it := range resultItemsB {
+			resultItems = append(resultItems, string(it.Bytes(resultData)))
+		}
+		if len(resultItems) == 0 {
+			resultItems = nil
+		}
+		if !reflect.DeepEqual(expectedItems, resultItems) {
+			t.Fatalf("unexpected items;\ngot\n%X\nwant\n%X", resultItems, expectedItems)
+		}
+	}
+
+	// 2-day retention.
+	db := &indexDB{s: &Storage{retentionMsecs: 2 * msecPerDay}}
+
+	expired := nowDate - 3 // fully outside retention
+	retained := nowDate    // within retention
+
+	// Expired per-day item in the middle is pruned for every per-day prefix.
+	// A global item is placed first so the expired item is not at a boundary
+	// (items must stay sorted, and within a per-day prefix they sort by date).
+	for _, ns := range []byte{nsPrefixDateToMetricID, nsPrefixDateTagToMetricIDs, nsPrefixDateMetricNameToTSID} {
+		f(db, []string{
+			global(nsPrefixMetricIDToTSID, 1),
+			perDay(ns, expired, 2),
+			perDay(ns, retained, 3),
+		}, []string{
+			global(nsPrefixMetricIDToTSID, 1),
+			perDay(ns, retained, 3),
+		})
+	}
+
+	// First and last items must be preserved even when expired.
+	f(db, []string{
+		perDay(nsPrefixDateToMetricID, expired, 1),
+		perDay(nsPrefixDateToMetricID, expired, 2),
+		perDay(nsPrefixDateToMetricID, expired, 3),
+	}, []string{
+		perDay(nsPrefixDateToMetricID, expired, 1),
+		perDay(nsPrefixDateToMetricID, expired, 3),
+	})
+
+	// Global (non per-day) items are never pruned by date.
+	f(db, []string{
+		global(nsPrefixMetricIDToTSID, 1),
+		global(nsPrefixMetricIDToTSID, 2),
+		global(nsPrefixMetricIDToTSID, 3),
+	}, []string{
+		global(nsPrefixMetricIDToTSID, 1),
+		global(nsPrefixMetricIDToTSID, 2),
+		global(nsPrefixMetricIDToTSID, 3),
+	})
+
+	// Mixed block: global items kept, expired per-day pruned, retained per-day kept.
+	f(db, []string{
+		global(nsPrefixMetricIDToTSID, 1),
+		global(nsPrefixMetricIDToTSID, 2),
+		perDay(nsPrefixDateToMetricID, expired, 1),
+		perDay(nsPrefixDateToMetricID, retained, 2),
+		perDay(nsPrefixDateMetricNameToTSID, expired, 3),
+		perDay(nsPrefixDateMetricNameToTSID, retained, 4),
+	}, []string{
+		global(nsPrefixMetricIDToTSID, 1),
+		global(nsPrefixMetricIDToTSID, 2),
+		perDay(nsPrefixDateToMetricID, retained, 2),
+		perDay(nsPrefixDateMetricNameToTSID, retained, 4),
+	})
+
+	// disablePerDayIndex: nothing is pruned.
+	dbDisabled := &indexDB{s: &Storage{retentionMsecs: 2 * msecPerDay, disablePerDayIndex: true}}
+	f(dbDisabled, []string{
+		global(nsPrefixMetricIDToTSID, 1),
+		perDay(nsPrefixDateToMetricID, expired, 2),
+		perDay(nsPrefixDateToMetricID, retained, 3),
+	}, []string{
+		global(nsPrefixMetricIDToTSID, 1),
+		perDay(nsPrefixDateToMetricID, expired, 2),
+		perDay(nsPrefixDateToMetricID, retained, 3),
+	})
+
+	// Two-item blocks are returned unchanged (both are boundaries).
+	f(db, []string{
+		perDay(nsPrefixDateToMetricID, expired, 1),
+		perDay(nsPrefixDateToMetricID, expired, 2),
+	}, []string{
+		perDay(nsPrefixDateToMetricID, expired, 1),
+		perDay(nsPrefixDateToMetricID, expired, 2),
+	})
+}

--- a/lib/storage/partition.go
+++ b/lib/storage/partition.go
@@ -1258,6 +1258,24 @@ func (pt *partition) mergePartsToFiles(pws []*partWrapper, stopCh <-chan struct{
 
 // ForceMergeAllParts runs merge for all the parts in pt.
 func (pt *partition) ForceMergeAllParts(stopCh <-chan struct{}) error {
+	if err := pt.forceMergeAllDataParts(stopCh); err != nil {
+		return err
+	}
+
+	// Force-merge the per-partition indexdb as well, so the prepareBlock callback
+	// runs over all the index parts. This applies retention-based pruning of
+	// per-day index entries (see indexDB.prepareBlock), which background index
+	// merges otherwise apply only opportunistically. Without this, indexdbs of
+	// partitions with retention shorter than one month keep per-day index entries
+	// for days already outside the retention.
+	if err := pt.idb.tb.ForceMerge(stopCh); err != nil {
+		return fmt.Errorf("cannot force merge indexdb for partition %q: %w", pt.name, err)
+	}
+
+	return nil
+}
+
+func (pt *partition) forceMergeAllDataParts(stopCh <-chan struct{}) error {
 	pws := pt.getAllPartsForMerge()
 	if len(pws) == 0 {
 		// Nothing to merge.


### PR DESCRIPTION
### Problem

With the per-partition index (#7599, #8134, shipped in v1.133.0), each **monthly** partition owns its own indexdb, stored under `data/indexdb/<YYYY_MM>/`. During ingestion `createPerDayIndexes` writes a fresh set of per-day index entries (`date→metricID`, `(date,tag)→metricID`, `(date,metricName)→TSID`) for every active series, every day.

A partition (and its indexdb) is only dropped once the **entire month** falls out of retention (`table.retentionWatcher`). So with a retention period **shorter than one month**, samples older than the retention are trimmed continuously during merges, but the current month's indexdb keeps stacking up to ~30 days of per-day entries — roughly **30× the expected size** by month-end. This regressed disk usage for short-retention deployments.

### Change

1. **Prune per-day index entries during indexdb merges.** `indexDB.prepareBlock` (the mergeset `PrepareBlockCallback`) now drops per-day items whose `date` is fully outside the retention period before the existing tag-row compaction. This mirrors the per-block retention filter already applied to the data parts in `blockStreamMerger`. The cutoff is computed at merge time from `retentionMsecs`. Pruning is best-effort within a block — the first and last items are preserved to satisfy the callback contract (sorted output, unchanged boundaries) — and converges across merges. Global (non per-day) index entries are never touched.

2. **Make pruning deterministically triggerable.** `/internal/force_merge` previously merged only the data parts, not the indexdb mergeset, so a settled single index part was never re-merged and never pruned. This adds `mergeset.Table.ForceMerge` (merges all file parts into one, even a single part, so `prepareBlock` runs over every block) and invokes it from `partition.ForceMergeAllParts`. Background index merges still apply the same pruning opportunistically.

### Test plan

- New unit test `TestPruneExpiredPerDayIndexItems` covers per-prefix pruning, boundary preservation, global-item immunity, mixed blocks, `-disablePerDayIndex`, and small blocks.
- `go test ./lib/storage/ ./lib/mergeset/` pass.
- End-to-end: load a month of per-day index under a large retention into a single partition, restart with `1d` retention, then `force_merge`. Measured (2000 series × 24 days):

  | build | indexdb after restart @1d | |
  |---|---|---|
  | master | 1.5 MB (100%) | bug |
  | this branch | 222 KB (15%) | pruned to ~1 day + global index |

### Notes / open questions

- Draft: no CHANGELOG entry yet — happy to add one under the agreed section.
- `ForceMerge` merges all file parts into one (like the data-side `ForceMergeAllParts`); for very large indexes this is a heavy one-shot merge guarded by a free-space check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)