### PR TITLE
lib/handhashke: narrow down condition for legacy connection fallback

### DIFF
--- a/lib/handshake/handshake.go
+++ b/lib/handshake/handshake.go
@@ -43,7 +43,8 @@ func VMInsertClientWithDialer(dial func() (net.Conn, error), compressionLevel in
 		return bc, nil
 	}
 	_ = c.Close()
-	if !strings.Contains(err.Error(), "cannot read success response after sending hello") {
+	// fallback only if vmstorage closed connection at read success response
+	if !errors.Is(err, io.EOF) && !strings.Contains(err.Error(), "cannot read success response after sending hello") {
 		return nil, err
 	}
 	// try to fallback to the prev non-RPC API version


### PR DESCRIPTION
 vmstorage closes connection if it receives unexpected hello message.
So it makes sense only to perform fall-back into the legacy protocol in this case.

Related to https://github.com/VictoriaMetrics/VictoriaMetrics/issues/11146