### PR TITLE
docs: vmsingle multitenancy

### DIFF
--- a/docs/victoriametrics/FAQ.md
+++ b/docs/victoriametrics/FAQ.md
@@ -339,7 +339,7 @@ File bugs and feature requests in our [GitHub Issues](https://github.com/Victori
 
 See [these docs](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/#multitenancy).
 Multitenancy is fully supported only by the [cluster version](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/) of VictoriaMetrics.
-Single-node provides limited [multitenancy](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#multitenancy) support to facilitate
+Single-node provides limited [multitenancy](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#multi-tenancy) support to facilitate
 the migration [from single-node to cluster](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#from-single-node-to-cluster).
 
 ## How to set a memory limit for VictoriaMetrics components?

--- a/docs/victoriametrics/FAQ.md
+++ b/docs/victoriametrics/FAQ.md
@@ -467,7 +467,11 @@ Cluster version of VictoriaMetrics may be preferred over single-node VictoriaMet
 
 The single-node version of VictoriaMetrics stores data on disk in slightly different format compared to the cluster version of VictoriaMetrics.
 This makes it impossible to just copy the on-disk data from `-storageDataPath` directory from single-node VictoriaMetrics to a `vmstorage` node in VictoriaMetrics cluster.
-If you need to migrate data from a single-node VictoriaMetrics to the cluster version, then [follow these instructions](https://docs.victoriametrics.com/victoriametrics/vmctl/victoriametrics/).
+
+There are two options, however:
+
+1. Deploy an new cluster next to the existing single-node and let them co-exist until the cluster is filled with new data and the old data in vmsingle becomes outside of the retention period. This option requires no data migration nor downtime. See instructions [here](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#from-single-node-to-cluster)
+2. If you need to actually migrate data from a single-node VictoriaMetrics to the cluster version (and/or possibly modify it), then [follow these vmctl instructions](https://docs.victoriametrics.com/victoriametrics/vmctl/victoriametrics/).
 
 ## Why isn't MetricsQL 100% compatible with PromQL?
 

--- a/docs/victoriametrics/FAQ.md
+++ b/docs/victoriametrics/FAQ.md
@@ -339,7 +339,7 @@ File bugs and feature requests in our [GitHub Issues](https://github.com/Victori
 
 See [these docs](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/#multitenancy).
 Multitenancy is fully supported only by the [cluster version](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/) of VictoriaMetrics.
-Single node provides limited [multitenancy](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#multitenancy) support to facilitate
+Single-node provides limited [multitenancy](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#multitenancy) support to facilitate
 the migration [from single-node to cluster](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#from-single-node-to-cluster).
 
 ## How to set a memory limit for VictoriaMetrics components?
@@ -472,8 +472,8 @@ This makes it impossible to just copy the on-disk data from `-storageDataPath` d
 
 There are two options, however:
 
-1. Deploy a new cluster next to the existing single-node and let them co-exist until the cluster is filled with new data and the old data in vmsingle becomes outside of the retention period. This option requires no data migration nor downtime. See instructions [here](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#from-single-node-to-cluster)
-2. If you need to actually migrate data from a single-node VictoriaMetrics to the cluster version (and/or possibly modify it), then [follow these vmctl instructions](https://docs.victoriametrics.com/victoriametrics/vmctl/victoriametrics/).
+1. Deploy a new cluster next to the existing single-node and let them co-exist until the cluster is filled with new data and the old data in vmsingle becomes outside of the retention period. This option requires no data migration nor downtime. See instructions [here](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#from-single-node-to-cluster).
+2. If you need to actually migrate data from a single-node VictoriaMetrics to the cluster version (and/or possibly modify it), then follow [these vmctl instructions](https://docs.victoriametrics.com/victoriametrics/vmctl/victoriametrics/).
 
 ## Why isn't MetricsQL 100% compatible with PromQL?
 

--- a/docs/victoriametrics/FAQ.md
+++ b/docs/victoriametrics/FAQ.md
@@ -472,7 +472,7 @@ This makes it impossible to just copy the on-disk data from `-storageDataPath` d
 
 There are two options, however:
 
-1. Deploy an new cluster next to the existing single-node and let them co-exist until the cluster is filled with new data and the old data in vmsingle becomes outside of the retention period. This option requires no data migration nor downtime. See instructions [here](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#from-single-node-to-cluster)
+1. Deploy a new cluster next to the existing single-node and let them co-exist until the cluster is filled with new data and the old data in vmsingle becomes outside of the retention period. This option requires no data migration nor downtime. See instructions [here](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#from-single-node-to-cluster)
 2. If you need to actually migrate data from a single-node VictoriaMetrics to the cluster version (and/or possibly modify it), then [follow these vmctl instructions](https://docs.victoriametrics.com/victoriametrics/vmctl/victoriametrics/).
 
 ## Why isn't MetricsQL 100% compatible with PromQL?

--- a/docs/victoriametrics/FAQ.md
+++ b/docs/victoriametrics/FAQ.md
@@ -338,7 +338,9 @@ File bugs and feature requests in our [GitHub Issues](https://github.com/Victori
 ## Where can I find information about multi-tenancy?
 
 See [these docs](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/#multitenancy).
-Multitenancy is supported only by the [cluster version](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/) of VictoriaMetrics.
+Multitenancy is fully supported only by the [cluster version](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/) of VictoriaMetrics.
+Single node provides limited [multitenancy](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#multitenancy) support to facilitate
+the migration [from single-node to cluster](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#from-single-node-to-cluster).
 
 ## How to set a memory limit for VictoriaMetrics components?
 

--- a/docs/victoriametrics/FAQ.md
+++ b/docs/victoriametrics/FAQ.md
@@ -346,7 +346,7 @@ the migration [from single-node to cluster](https://docs.victoriametrics.com/vic
 
 All VictoriaMetrics components provide command-line flags to control the size of internal buffers and caches:
 `-memory.allowedPercent` and `-memory.allowedBytes` (pass `-help` to any VictoriaMetrics component in order to see the description for these flags).
-These limits don't take into account additional memory, which may be needed for processing incoming queries.
+These limits don't account for additional memory that may be needed to process incoming queries.
 Hard limits may be enforced only by the OS via [cgroups](https://en.wikipedia.org/wiki/Cgroups),
 Docker (see [these docs](https://docs.docker.com/config/containers/resource_constraints)) or
 Kubernetes (see [these docs](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers)).
@@ -467,12 +467,12 @@ Cluster version of VictoriaMetrics may be preferred over single-node VictoriaMet
 
 ## How to migrate data from single-node VictoriaMetrics to cluster version?
 
-The single-node version of VictoriaMetrics stores data on disk in slightly different format compared to the cluster version of VictoriaMetrics.
-This makes it impossible to just copy the on-disk data from `-storageDataPath` directory from single-node VictoriaMetrics to a `vmstorage` node in VictoriaMetrics cluster.
+The single-node version of VictoriaMetrics stores data on disk in a slightly different format compared to the cluster version of VictoriaMetrics.
+This makes it impossible to just copy the on-disk data from the `-storageDataPath` directory from single-node VictoriaMetrics to a `vmstorage` node in a VictoriaMetrics cluster.
 
 There are two options, however:
 
-1. Deploy a new cluster next to the existing single-node and let them co-exist until the cluster is filled with new data and the old data in vmsingle becomes outside of the retention period. This option requires no data migration nor downtime. See instructions [here](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#from-single-node-to-cluster).
+1. Deploy a new cluster next to the existing single-node and let them co-exist until the cluster is filled with new data and the old data in vmsingle becomes outside of the retention period. This option requires no data migration or downtime. See instructions [here](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#from-single-node-to-cluster).
 2. If you need to actually migrate data from a single-node VictoriaMetrics to the cluster version (and/or possibly modify it), then follow [these vmctl instructions](https://docs.victoriametrics.com/victoriametrics/vmctl/victoriametrics/).
 
 ## Why isn't MetricsQL 100% compatible with PromQL?

--- a/docs/victoriametrics/README.md
+++ b/docs/victoriametrics/README.md
@@ -1719,7 +1719,7 @@ operate in VictoriaMetrics cluster setups. I.e., one or more single-nodes that
 contain data for different tenants can be a part of a cluster, and the entire
 non-homogeneous deployment can be queried with a higher-level `vmselect`.
 
-This, in turn, enables easy [migrations from single-node to cluster](#from-single-node-to-cluster).
+This, in turn, enables easy [migrations from single-node to cluster](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#from-single-node-to-cluster).
 Previously, the only option was the use of
 [vmctl](https://docs.victoriametrics.com/victoriametrics/vmctl/victoriametrics/).
 

--- a/docs/victoriametrics/README.md
+++ b/docs/victoriametrics/README.md
@@ -2340,14 +2340,14 @@ multitenancy becomes a requirement, etc.) the migration can be as simple as:
 1. Restart the existing single-node with multitenancy support enabled as
    described in [Multitenancy](#multitenancy) section.
 1. Deploy an empty cluster next to the existing single-node.
-1. Deploy higher-level vmselect and configure it to query both the existing
+1. Deploy higher-level `vmselect` and configure it to query both the existing
    single-node and the new cluster.
-1. Start writing data to the cluster
-1. Stop writing data to the single-node
+1. Start writing data to the cluster.
+1. Stop writing data to the single-node.
 
-This requires no data migration nor downtime (apart from restarting the
+This approach requires no data migration nor downtime (apart from restarting the
 single-node at step 1). And once the single-node data becomes outside the
-retention period, the single-node deployment can be removed.
+retention period, the single-node can be removed from the deployment.
 
 Note that if you need to actually migrate data to cluster and/or modify it, you
 will need to use

--- a/docs/victoriametrics/README.md
+++ b/docs/victoriametrics/README.md
@@ -2338,7 +2338,7 @@ cluster (such as the single-node can't be scaled vertically anymore, or
 multitenancy becomes a requirement, etc.) the migration can be as simple as:
 
 1. Restart the existing single-node with multitenancy support enabled as
-   described in [Multitenancy](#multi-tenancy) section.
+   described in [Multitenancy](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#multi-tenancy) section.
 1. Deploy an empty cluster next to the existing single-node.
 1. Deploy higher-level `vmselect` and configure it to query both the existing
    single-node and the new cluster.

--- a/docs/victoriametrics/README.md
+++ b/docs/victoriametrics/README.md
@@ -1693,16 +1693,16 @@ The functionality is disabled by default and can be enabled by setting the
 `-vmselectAddr` flag. This will start the `vmselect RPC server` that accepts
 requests and serves responses in cluster format.
 
-Cluster data format assumes the presense of a `tenantID`. Single-node data
+Cluster data format assumes the presence of a `tenantID`. Single-node data
 format still does not support multitenancy but it is possible to configure the
-single-node which `tenantID` its data corresponds to with `-accountID` and
-`-projectID` flags. Both are `0` by default, which means that `"0:0"` `tenantID`
-is used by default.
+single-node which `tenantID` the single-node's data corresponds to with
+`-accountID` and `-projectID` flags. Both are `0` by default, which means that
+`"0:0"` `tenantID` is used by default.
 
-For example, the following command will start a single-node with that listens
-for vmselect RPC requests on `8401` port. The requests must be either
-`multinenant`(i.e. want data for all tenants) or for `"12:34"` tenant.
-Otherwise, single node will return empty result:
+For example, the following command will start a single-node that listens for
+vmselect RPC requests on `8401` port. The requests must be either `multitenant`
+(i.e. want data for all tenants) or for `"12:34"` tenant. Otherwise, the
+single-node will return an empty result:
 
 ```shell
 ./victoria-metrics -storageDataPath=/data -vmselectAddr=:8401 -accountID=12 -projectID=34
@@ -2349,7 +2349,7 @@ This requires no data migration nor downtime (apart from restarting the
 single-node at step 1). And once the single-node data becomes outside the
 retention period, the single-node deployment can be removed.
 
-Note that if you need the actually migrate data to cluster and/or modify it, you
+Note that if you need to actually migrate data to cluster and/or modify it, you
 will need to use
 [vmctl](https://docs.victoriametrics.com/victoriametrics/vmctl/victoriametrics/)
 instead.

--- a/docs/victoriametrics/README.md
+++ b/docs/victoriametrics/README.md
@@ -1682,9 +1682,46 @@ See also [retention filters](#retention-filters).
 The downsampling can be evaluated for free by downloading and using enterprise binaries from [the releases page](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/latest).
 See how to request a [free trial license](https://victoriametrics.com/products/enterprise/trial/).
 
-## Multi-tenancy
+## Multitenancy
 
-Single-node VictoriaMetrics doesn't support multi-tenancy. Use the [cluster version](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/#multitenancy) instead.
+Starting from `v1.147.0` single-node VictoriaMetrics has limited
+[multitenancy](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/#multitenancy)
+support. Specifically, single-node can serve multitenant queries as if it were a
+`vmstorage`. Write path is not supported.
+
+The functionality is disabled by default and can be enabled by setting the
+`-vmselectAddr` flag. This will start the `vmselect RPC server` that accepts
+requests and serves responses in cluster format.
+
+Cluster data format assumes the presense of a `tenantID`. Single-node data
+format still does not support multitenancy but it is possible to configure the
+single-node which `tenantID` its data corresponds to with `-accountID` and
+`-projectID` flags. Both are `0` by default, which means that `"0:0"` `tenantID`
+is used by default.
+
+For example, the following command will start a single-node with that listens
+for vmselect RPC requests on `8401` port. The requests must be either
+`multinenant`(i.e. want data for all tenants) or for `"12:34"` tenant.
+Otherwise, single node will return empty result:
+
+```shell
+./victoria-metrics -storageDataPath=/data -vmselectAddr=:8401 -accountID=12 -projectID=34
+```
+
+The `tenantID` configuration is not persisted in any way and is enforced only at
+runtime. Thus, it is safe to change the `-accountID` and `-projectID` flag
+values at any time.
+
+Note that the single-node's HTTP handlers still do not support multitenancy.
+
+The purpose of this limited multitenancy support is enabling the single-node to
+operate in VictoriaMetrics cluster setups. I.e. one or more single-nodes that
+contain data for different tenants can be a part of a cluster, and the entire
+non-homogenous deployment can be queried with a higher-level `vmselect`.
+
+This, in turn, enables easy [migrations from single-node to cluster](#from-single-node-to-cluster).
+Previously, the only option was the use of
+[vmctl](https://docs.victoriametrics.com/victoriametrics/vmctl/victoriametrics/).
 
 ## Scalability and cluster version
 
@@ -2293,6 +2330,30 @@ Things to consider when copying data:
 
 For scenarios like single-to-cluster, cluster-to-single, re-sharding or migrating only a fraction of data: 
 [see how to migrate data from VictoriaMetrics via vmctl](https://docs.victoriametrics.com/victoriametrics/vmctl/victoriametrics/).
+
+### From Single-node to Cluster
+
+When, for some reason, the deployment needs to be switched from single-node to
+cluster (such as the single-node can't be scaled vertically anymore, or
+multitenancy becomes a requirement, etc.) the migration can be as simple as:
+
+1. Restart the existing single-node with multitenancy support enabled as
+   described in [Multitenancy](#multitenancy) section.
+1. Deploy an empty cluster next to the existing single-node.
+1. Deploy higher-level vmselect and configure it to query both the existing
+   single-node and the new cluster.
+1. Start writing data to the cluster
+1. Stop writing data to the single-node
+
+This requires no data migration nor downtime (apart from restarting the
+single-node at step 1). And once the single-node data becomes outside the
+retention period, the single-node deployment can be removed.
+
+Note that if you need the actually migrate data to cluster and/or modify it, you
+will need to use
+[vmctl](https://docs.victoriametrics.com/victoriametrics/vmctl/victoriametrics/)
+instead.
+
 
 ### From other systems
 

--- a/docs/victoriametrics/README.md
+++ b/docs/victoriametrics/README.md
@@ -1686,22 +1686,22 @@ See how to request a [free trial license](https://victoriametrics.com/products/e
 
 Starting from `v1.147.0` single-node VictoriaMetrics has limited
 [multitenancy](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/#multitenancy)
-support. Specifically, single-node can serve multitenant queries as if it were a
-`vmstorage`. Write path is not supported.
+support. Specifically, a single-node can serve multitenant queries as if it were a
+`vmstorage`. The write path is not supported.
 
 The functionality is disabled by default and can be enabled by setting the
 `-vmselectAddr` flag. This will start the `vmselect RPC server` that accepts
 requests and serves responses in cluster format.
 
 Cluster data format assumes the presence of a `tenantID`. Single-node data
-format still does not support multitenancy but it is possible to configure the
-single-node which `tenantID` the single-node's data corresponds to with
+format still does not support multitenancy, but it is possible to configure the
+single-node to specify which `tenantID` the single-node's data corresponds to with the
 `-accountID` and `-projectID` flags. Both are `0` by default, which means that
 `"0:0"` `tenantID` is used by default.
 
 For example, the following command will start a single-node that listens for
-vmselect RPC requests on `8401` port. The requests must be either `multitenant`
-(i.e. want data for all tenants) or for `"12:34"` tenant. Otherwise, the
+vmselect RPC requests on the `8401` port. The requests must be either `multitenant`
+(i.e., want data for all tenants) or for `"12:34"` tenant. Otherwise, the
 single-node will return an empty result:
 
 ```shell
@@ -1715,9 +1715,9 @@ values at any time.
 Note that the single-node's HTTP handlers still do not support multitenancy.
 
 The purpose of this limited multitenancy support is enabling the single-node to
-operate in VictoriaMetrics cluster setups. I.e. one or more single-nodes that
+operate in VictoriaMetrics cluster setups. I.e., one or more single-nodes that
 contain data for different tenants can be a part of a cluster, and the entire
-non-homogenous deployment can be queried with a higher-level `vmselect`.
+non-homogeneous deployment can be queried with a higher-level `vmselect`.
 
 This, in turn, enables easy [migrations from single-node to cluster](#from-single-node-to-cluster).
 Previously, the only option was the use of

--- a/docs/victoriametrics/README.md
+++ b/docs/victoriametrics/README.md
@@ -1682,7 +1682,7 @@ See also [retention filters](#retention-filters).
 The downsampling can be evaluated for free by downloading and using enterprise binaries from [the releases page](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/latest).
 See how to request a [free trial license](https://victoriametrics.com/products/enterprise/trial/).
 
-## Multitenancy
+## Multitenancy {#multi-tenancy}
 
 Starting from `v1.147.0` single-node VictoriaMetrics has limited
 [multitenancy](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/#multitenancy)
@@ -2338,7 +2338,7 @@ cluster (such as the single-node can't be scaled vertically anymore, or
 multitenancy becomes a requirement, etc.) the migration can be as simple as:
 
 1. Restart the existing single-node with multitenancy support enabled as
-   described in [Multitenancy](#multitenancy) section.
+   described in [Multitenancy](#multi-tenancy) section.
 1. Deploy an empty cluster next to the existing single-node.
 1. Deploy higher-level `vmselect` and configure it to query both the existing
    single-node and the new cluster.

--- a/docs/victoriametrics/README.md
+++ b/docs/victoriametrics/README.md
@@ -1684,7 +1684,7 @@ See how to request a [free trial license](https://victoriametrics.com/products/e
 
 ## Multitenancy {#multi-tenancy}
 
-Starting from `v1.147.0` single-node VictoriaMetrics has limited
+Starting from{{% available_from "v1.147.0" %}} single-node VictoriaMetrics has limited
 [multitenancy](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/#multitenancy)
 support. Specifically, a single-node can serve multitenant queries as if it were a
 `vmstorage`. The write path is not supported.

--- a/docs/victoriametrics/vmctl/victoriametrics.md
+++ b/docs/victoriametrics/vmctl/victoriametrics.md
@@ -9,8 +9,8 @@ menu:
 ---
 
 The simplest way to migrate data between VictoriaMetrics installations is [to copy data between instances](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#data-migration) or [to run single-node and cluster together](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#from-single-node-to-cluster).
-But when simple copy isn't possible (migration between single-node and cluster, or re-sharding) or when data need to be
-modified - use `vmctl vm-native` to migrate data.
+But when simple copy isn't possible (migration between single-node and cluster, or re-sharding) or when data needs to be
+modified, use `vmctl vm-native` to migrate data.
 
 See `./vmctl vm-native --help` for details and full list of flags.
 

--- a/docs/victoriametrics/vmctl/victoriametrics.md
+++ b/docs/victoriametrics/vmctl/victoriametrics.md
@@ -8,7 +8,7 @@ menu:
     weight: 9
 ---
 
-The simplest way to migrate data between VictoriaMetrics installations is [to copy data between instances](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#data-migration).
+The simplest way to migrate data between VictoriaMetrics installations is [to copy data between instances](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#data-migration) or [to run single-node and cluster together](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#from-single-node-to-cluster).
 But when simple copy isn't possible (migration between single-node and cluster, or re-sharding) or when data need to be
 modified - use `vmctl vm-native` to migrate data.
 


### PR DESCRIPTION
Document the limited multitenancy support in vmsingle and how this enables easy migrations from vmsingle to vmcluster.

Follow-up for #4328, #10926.