### PR TITLE
app/vmstorage: fix extra allocations introduced in 18297286

### DIFF
--- a/app/vmstorage/vmstorage.go
+++ b/app/vmstorage/vmstorage.go
@@ -199,10 +199,10 @@ func (bi *blockIterator) NextBlock(dst []byte) ([]byte, bool) {
 	if !bi.sr.NextMetricBlock() {
 		return dst, false
 	}
-	mb := bi.mb
+	mb := &bi.mb
 	mb.MetricName = bi.sr.MetricBlockRef.MetricName
 	bi.sr.MetricBlockRef.BlockRef.MustReadBlock(&mb.Block)
-	dst = bi.marshal(dst[:0], &mb)
+	dst = bi.marshal(dst[:0], mb)
 	return dst, true
 }
 
@@ -256,7 +256,8 @@ func (vms *VMStorage) LabelValues(qt *querytracer.Tracer, sq *storage.SearchQuer
 // https://graphite-api.readthedocs.io/en/latest/api.html#metrics-find or
 // similar APIs.
 func (vms *VMStorage) TagValueSuffixes(qt *querytracer.Tracer, accountID, projectID uint32, tr storage.TimeRange, tagKey, tagValuePrefix string, delimiter byte,
-	maxSuffixes int, deadline uint64) ([]string, error) {
+	maxSuffixes int, deadline uint64,
+) ([]string, error) {
 	if maxSuffixes <= 0 || maxSuffixes > *maxTagValueSuffixesPerSearch {
 		maxSuffixes = *maxTagValueSuffixesPerSearch
 	}

--- a/app/vmstorage/vmstorage.go
+++ b/app/vmstorage/vmstorage.go
@@ -256,8 +256,7 @@ func (vms *VMStorage) LabelValues(qt *querytracer.Tracer, sq *storage.SearchQuer
 // https://graphite-api.readthedocs.io/en/latest/api.html#metrics-find or
 // similar APIs.
 func (vms *VMStorage) TagValueSuffixes(qt *querytracer.Tracer, accountID, projectID uint32, tr storage.TimeRange, tagKey, tagValuePrefix string, delimiter byte,
-	maxSuffixes int, deadline uint64,
-) ([]string, error) {
+	maxSuffixes int, deadline uint64) ([]string, error) {
 	if maxSuffixes <= 0 || maxSuffixes > *maxTagValueSuffixesPerSearch {
 		maxSuffixes = *maxTagValueSuffixesPerSearch
 	}


### PR DESCRIPTION
Follow-up on https://github.com/VictoriaMetrics/VictoriaMetrics/commit/18297286ab902ead73c38cdc2e974786f1b07f1f

```
(pprof) top
Showing nodes accounting for 47162356511, 99.19% of 47547511245 total
Dropped 985 nodes (cum <= 237737556)
      flat  flat%   sum%        cum   cum%
30349327017 63.83% 63.83% 47189015775 99.25%
main.(*blockIterator).NextBlock
16809028759 35.35% 99.18% 16809028759 35.35%
github.com/VictoriaMetrics/VictoriaMetrics/lib/bytesutil.ResizeNoCopyMayOverallocate
(inline)
```

```
(pprof) list \(*blockIterator\).NextBlock
Total: 47547511245
ROUTINE ======================== main.(*blockIterator).NextBlock in
github.com/VictoriaMetrics/VictoriaMetrics/app/vmstorage/vmstorage.go
30349327017 47189015775 (flat, cum) 99.25% of Total
         .          .    198:func (bi *blockIterator) NextBlock(dst
[]byte) ([]byte, bool) {
         .   31647068    199:   if !bi.sr.NextMetricBlock() {
         .          .    200:           return dst, false
         .          .    201:   }
30349327017 30349327017    202: mb := bi.mb
         .          .    203:   mb.MetricName =
bi.sr.MetricBlockRef.MetricName
         . 16808036965    204:
bi.sr.MetricBlockRef.BlockRef.MustReadBlock(&mb.Block)
         .       4725    205:   dst = bi.marshal(dst[:0], &mb)
         .          .    206:   return dst, true
         .          .    207:}
         .          .    208:
         .          .    209:func (bi *blockIterator) Error() error {
         .          .    210:   return bi.sr.Error()
```