### PR TITLE
reduce memory allocations after 35488588437182958c1e2b758f62bbbb3b818690

### DIFF
--- a/app/vmstorage/vmstorage.go
+++ b/app/vmstorage/vmstorage.go
@@ -241,10 +241,10 @@ func (bi *blockIterator) NextBlock(dst []byte) ([]byte, bool) {
 	if !bi.sr.NextMetricBlock() {
 		return dst, false
 	}
-	mb := bi.mb
+	mb := &bi.mb
 	mb.MetricName = bi.sr.MetricBlockRef.MetricName
 	bi.sr.MetricBlockRef.BlockRef.MustReadBlock(&mb.Block)
-	dst = bi.marshal(dst[:0], &mb)
+	dst = bi.marshal(dst[:0], mb)
 	return dst, true
 }
 


### PR DESCRIPTION
 Commit 35488588437182958c1e2b758f62bbbb3b818690 introduced additional
memory allocation because new marshalFunc. Compiler cannot inline `bi.marshal` and have to allocate a copy of `bi.mb` on heap. It made impossible to properly pool `bi.mb`.

 This commit fixes regression by using proper reference to `bi.mb`
 instead of copy.