### PR TITLE
vmalert-tool: do not use 1970-01-01 in unit tests

### DIFF
--- a/app/vmalert-tool/unittest/recording.go
+++ b/app/vmalert-tool/unittest/recording.go
@@ -6,7 +6,6 @@ import (
 	"net/url"
 	"reflect"
 	"sort"
-	"time"
 
 	"github.com/VictoriaMetrics/VictoriaMetrics/app/vmalert/datasource"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/prompb"
@@ -93,11 +92,4 @@ Outer:
 
 	}
 	return
-}
-
-func durationToTime(pd *promutil.Duration) time.Time {
-	if pd == nil {
-		return time.Time{}
-	}
-	return time.UnixMilli(pd.Duration().Milliseconds())
 }

--- a/app/vmalert-tool/unittest/unittest.go
+++ b/app/vmalert-tool/unittest/unittest.go
@@ -44,11 +44,18 @@ import (
 var (
 	storagePath    string
 	httpListenAddr string
-	// insert series from 1970-01-01T00:00:00
-	testStartTime          = time.Unix(0, 0).UTC()
+	// Insert series from 2000-01-01T00:00:00.
+	testStartTime          = time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
 	testLogLevel           = "ERROR"
 	disableAlertgroupLabel bool
 )
+
+func durationToTime(pd *promutil.Duration) time.Time {
+	if pd == nil {
+		return testStartTime
+	}
+	return testStartTime.Add(pd.Duration())
+}
 
 const (
 	testStoragePath = "vmalert-unittest"


### PR DESCRIPTION
1970-01-01 is a special date that forces vmstorage to use global index for searching. The unit test will start failing once the global index is disabled by default. See https://github.com/VictoriaMetrics/VictoriaMetrics/pull/11196.

Instead, use some other date, such as 2000-01-01.