### PR TITLE
Makefile: fix apptest-mixed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -494,7 +494,7 @@ apptest-legacy: victoria-metrics-race vmbackup-race vmrestore-race
 apptest-mixed: victoria-metrics-race
 	OS=$$(uname | tr '[:upper:]' '[:lower:]'); \
 	ARCH=$$(uname -m | tr '[:upper:]' '[:lower:]' | sed 's/x86_64/amd64/'); \
-	VERSION=v1.145.0; \
+	VERSION=v1.147.0; \
 	VMCLUSTER=victoria-metrics-$${OS}-$${ARCH}-$${VERSION}-cluster.tar.gz; \
 	URL=https://github.com/VictoriaMetrics/VictoriaMetrics/releases/download/$${VERSION}; \
 	DIR=/tmp/$${VERSION}; \


### PR DESCRIPTION
Change the external binary version to v1.147.0 since this is the first version that supports vmselect RPC in vmsingle. This change is only important for cluster branches. Single-node apptests pass just fine.

Follow-up for https://github.com/VictoriaMetrics/VictoriaMetrics/pull/10926.