### PR TITLE
fix(vmbackup): retry S3 HTTP 429 and TooManyRequests errors

### DIFF
--- a/docs/victoriametrics/changelog/CHANGELOG.md
+++ b/docs/victoriametrics/changelog/CHANGELOG.md
@@ -26,6 +26,8 @@ See also [LTS releases](https://docs.victoriametrics.com/victoriametrics/lts-rel
 
 ## tip
 
+* BUGFIX: [vmbackup](https://docs.victoriametrics.com/victoriametrics/vmbackup/) and [vmbackupmanager](https://docs.victoriametrics.com/victoriametrics/vmbackupmanager/): retry S3 requests failing with `HTTP 429` status code or `TooManyRequests` error code. Previously such requests were not retried, so a short burst of rate limiting would fail the whole backup. See [#11218](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/11218).
+
 ## [v1.147.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.147.0)
 
 Released at 2026-07-06

--- a/lib/backup/s3remote/s3.go
+++ b/lib/backup/s3remote/s3.go
@@ -164,6 +164,14 @@ func (fs *FS) Init(ctx context.Context) error {
 						// when using EKS Pod Identity or similar.
 						// See: https://github.com/VictoriaMetrics/VictoriaMetrics/issues/9280
 						"ExpiredToken": {},
+						// S3-compatible stores may return TooManyRequests instead of TooManyRequestsException.
+						// See: https://github.com/VictoriaMetrics/VictoriaMetrics/issues/11218
+						"TooManyRequests": {},
+					},
+				}, retry.RetryableHTTPStatusCode{
+					Codes: map[int]struct{}{
+						// S3-compatible stores may return HTTP 429 for rate limiting instead of HTTP 503.
+						429: {},
 					},
 				}, retry.IsErrorRetryableFunc(func(err error) aws.Ternary {
 					if errors.Is(err, io.ErrUnexpectedEOF) {


### PR DESCRIPTION
**What this PR does / why we need it:**
vmbackup fails immediately when S3 returns a 429. The SDK retries TooManyRequestsException but not the short form TooManyRequests, and 429 isn't in the retryable status codes either (only 500/502/503/504 are).
Added both so a rate limit doesn't kill the whole backup.
Note: Followed the same pattern as ExpiredToken and IncompleteBody in the same retryer config.

**Which issue(s) this PR fixes:**
Fixes #11218 