### PR TITLE
lib/storage: unit tests for searching label names with just one tag filter

### DIFF
--- a/lib/storage/index_db.go
+++ b/lib/storage/index_db.go
@@ -729,9 +729,7 @@ func (db *indexDB) SearchLabelValues(qt *querytracer.Tracer, labelName string, t
 		needSlowSearch := len(lvs) == maxMetrics
 
 		lvsLen := len(lvs)
-
 		filterLabelValues(lvs, &tfss[0].tfs[0], key)
-
 		qt.Printf("found %d out of %d values for the label %q after filtering", len(lvs), lvsLen, labelName)
 		if len(lvs) >= maxLabelValues {
 			qt.Printf("leave %d out of %d values for the label %q because of the limit", maxLabelValues, len(lvs), labelName)

--- a/lib/storage/index_db.go
+++ b/lib/storage/index_db.go
@@ -729,7 +729,9 @@ func (db *indexDB) SearchLabelValues(qt *querytracer.Tracer, labelName string, t
 		needSlowSearch := len(lvs) == maxMetrics
 
 		lvsLen := len(lvs)
+
 		filterLabelValues(lvs, &tfss[0].tfs[0], key)
+
 		qt.Printf("found %d out of %d values for the label %q after filtering", len(lvs), lvsLen, labelName)
 		if len(lvs) >= maxLabelValues {
 			qt.Printf("leave %d out of %d values for the label %q because of the limit", maxLabelValues, len(lvs), labelName)

--- a/lib/storage/index_db_test.go
+++ b/lib/storage/index_db_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/mergeset"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/uint64set"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/workingsetcache"
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestTagFiltersToMetricIDsCache(t *testing.T) {
@@ -2140,4 +2141,47 @@ func TestSearchLabelValues(t *testing.T) {
 	s.tb.PutPartition(ptw)
 	s.MustClose()
 	fs.MustRemoveDir(path)
+}
+
+func TestFilterLabelValues(t *testing.T) {
+	const n = 1000
+	key := "key"
+	var all []string
+	for i := range n {
+		all = append(all, fmt.Sprintf("value_%03d", i))
+	}
+
+	var got, want map[string]struct{}
+
+	tfsAll := NewTagFilters()
+	if err := tfsAll.Add([]byte("key"), []byte("value_.*"), false, true); err != nil {
+		t.Fatalf("unexpected error in TagFilters.Add: %v", err)
+	}
+	got = make(map[string]struct{})
+	want = make(map[string]struct{})
+	for _, v := range all {
+		got[v] = struct{}{}
+		want[v] = struct{}{}
+	}
+	filterLabelValues(got, &tfsAll.tfs[0], key)
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("unexpected label values (-want, +got):\n%s", diff)
+	}
+
+	tfsEvery10th := NewTagFilters()
+	if err := tfsEvery10th.Add([]byte("key"), []byte("value_[0-9]{2}0"), false, true); err != nil {
+		t.Fatalf("unexpected error in TagFilters.Add: %v", err)
+	}
+	got = make(map[string]struct{})
+	want = make(map[string]struct{})
+	for i, v := range all {
+		got[v] = struct{}{}
+		if i%10 == 0 {
+			want[v] = struct{}{}
+		}
+	}
+	filterLabelValues(got, &tfsEvery10th.tfs[0], key)
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("unexpected label values (-want, +got):\n%s", diff)
+	}
 }

--- a/lib/storage/storage_test.go
+++ b/lib/storage/storage_test.go
@@ -2506,6 +2506,79 @@ func testStorageOpOnVariousTimeRanges(t *testing.T, op func(t *testing.T, tr Tim
 	})
 }
 
+func TestStorageSearchLabelValues_SingleFilterOnLabelName(t *testing.T) {
+	defer testRemoveAll(t)
+
+	const N = 1000
+
+	tr := TimeRange{
+		MinTimestamp: time.Date(2024, 1, 15, 0, 0, 0, 0, time.UTC).UnixMilli(),
+		MaxTimestamp: time.Date(2024, 12, 15, 23, 59, 59, 999_999_999, time.UTC).UnixMilli(),
+	}
+	step := (tr.MaxTimestamp - tr.MinTimestamp) / N
+	mrs := make([]MetricRow, N)
+	allMetricNames := make([]string, N)
+	allLabelValues := make([]string, N)
+
+	for i := range int64(N) {
+		metricName := fmt.Sprintf("metric_%03d", i)
+		labelValue := fmt.Sprintf("value_%03d", i)
+		mn := MetricName{
+			MetricGroup: []byte(metricName),
+			Tags: []Tag{
+				{
+					Key:   []byte("label"),
+					Value: []byte(labelValue),
+				},
+			},
+		}
+
+		mrs[i].MetricNameRaw = mn.marshalRaw(nil)
+		mrs[i].Timestamp = tr.MinTimestamp + i*step
+		mrs[i].Value = float64(i)
+		allMetricNames[i] = metricName
+		allLabelValues[i] = labelValue
+	}
+
+	s := MustOpenStorage(t.Name(), OpenOptions{})
+	defer s.MustClose()
+	s.AddRows(mrs, defaultPrecisionBits)
+	s.DebugFlush()
+
+	f := func(label, k, v string, isNegative, isRegex bool, tr TimeRange, maxLabelValues, maxMetrics int, want []string) {
+		tfs := NewTagFilters()
+		if err := tfs.Add([]byte(k), []byte(v), isNegative, isRegex); err != nil {
+			t.Fatalf("unexpected error in TagFilters.Add: %v", err)
+		}
+		got, err := s.SearchLabelValues(nil, label, []*TagFilters{tfs}, tr, maxLabelValues, maxMetrics, noDeadline)
+		if err != nil {
+			t.Fatalf("SearchLabelValues() failed unexpectedly: %v", err)
+		}
+		slices.Sort(got)
+		if diff := cmp.Diff(want, got); diff != "" {
+			t.Fatalf("unexpected label values (-want, +got):\n%s", diff)
+		}
+	}
+
+	wantAllMetricNames := allMetricNames
+	wantAllLabelValues := allLabelValues
+	f("", "", "metric_.*", false, true, tr, N+1, N+1, wantAllMetricNames)
+	f("__name__", "", "metric_.*", false, true, tr, N+1, N+1, wantAllMetricNames)
+	f("label", "label", "value_.*", false, true, tr, N+1, N+1, wantAllLabelValues)
+
+	var wantEvery10thMetricName []string
+	var wantEvery10thLabelValue []string
+	for i := range N {
+		if i%10 == 0 {
+			wantEvery10thMetricName = append(wantEvery10thMetricName, allMetricNames[i])
+			wantEvery10thLabelValue = append(wantEvery10thLabelValue, allLabelValues[i])
+		}
+	}
+	f("", "", "metric_[0-9]{2}0", false, true, tr, N+1, N+1, wantEvery10thMetricName)
+	f("__name__", "", "metric_[0-9]{2}0", false, true, tr, N+1, N+1, wantEvery10thMetricName)
+	f("label", "label", "value_[0-9]{2}0", false, true, tr, N+1, N+1, wantEvery10thLabelValue)
+}
+
 func TestStorageSearchLabelValues_EmptyValuesAreNotReturned(t *testing.T) {
 	defer testRemoveAll(t)
 

--- a/lib/storage/storage_test.go
+++ b/lib/storage/storage_test.go
@@ -2546,6 +2546,7 @@ func TestStorageSearchLabelValues_SingleFilterOnLabelName(t *testing.T) {
 	s.DebugFlush()
 
 	f := func(label, k, v string, isNegative, isRegex bool, tr TimeRange, maxLabelValues, maxMetrics int, want []string) {
+		t.Helper()
 		tfs := NewTagFilters()
 		if err := tfs.Add([]byte(k), []byte(v), isNegative, isRegex); err != nil {
 			t.Fatalf("unexpected error in TagFilters.Add: %v", err)

--- a/lib/storage/tag_filters_test.go
+++ b/lib/storage/tag_filters_test.go
@@ -1406,3 +1406,38 @@ func TestTagFilterLess(t *testing.T) {
 	f(prefixA, prefixB, true)
 	f(prefixB, prefixA, false)
 }
+
+func TestTagFilters_Add(t *testing.T) {
+	tfs := NewTagFilters()
+	f := func(k, v string, isNegative, isRegexp bool, want int) {
+		t.Helper()
+		if err := tfs.Add([]byte(k), []byte(v), isNegative, isRegexp); err != nil {
+			t.Fatalf("unexpected error in TagFilters.Add: %v", err)
+		}
+		if got := len(tfs.tfs); got != want {
+			t.Fatalf("unexpected tfs count: got %d, want %d", got, want)
+		}
+	}
+
+	// .* filter matches anything and therefore is not added to tfs.
+	f("key0", ".*", false, true, 0)
+
+	// empty filter matches only empty label values and is added to tfs.
+	f("key1", "", false, false, 1)
+
+	f("key2", "value", false, false, 2)
+	f("key3", "value.*", false, true, 3)
+	f("key4", "value", true, false, 4)
+	f("key5", "value.*", true, true, 5)
+
+	// .* filter matches anything and therefore is not added to tfs.
+	f("", ".*", false, true, 5)
+
+	// empty filter matches only empty label values and is added to tfs.
+	f("", "", false, false, 6)
+
+	f("", "value", false, false, 7)
+	f("", "value.*", false, true, 8)
+	f("", "value", true, false, 9)
+	f("", "value.*", true, true, 10)
+}


### PR DESCRIPTION
Related to https://github.com/VictoriaMetrics/VictoriaMetrics/pull/11196 since searching with one tag filter involves filtering which involves using of `nsPrefixTagToMetricIDs` global index prefix (see `filterLabelValues()` in `lib/storage/index_db.go`)