### PR TITLE
lib/storage: Move rawRowsShards to raw_row.go 

### DIFF
--- a/lib/storage/partition.go
+++ b/lib/storage/partition.go
@@ -465,7 +465,7 @@ func (pt *partition) AddRows(rows []rawRow) {
 		}
 	}
 
-	pt.rawRows.addRows(pt, rows)
+	pt.rawRows.addRows(pt.flushRowssToInmemoryParts, rows)
 }
 
 var isDebug = false
@@ -1008,7 +1008,7 @@ func (pt *partition) pendingRowsFlusher() {
 }
 
 func (pt *partition) flushPendingRows(isFinal bool) {
-	pt.rawRows.flush(pt, isFinal)
+	pt.rawRows.flush(pt.flushRowssToInmemoryParts, isFinal)
 }
 
 func (pt *partition) flushInmemoryRowsToFiles() {

--- a/lib/storage/partition.go
+++ b/lib/storage/partition.go
@@ -11,7 +11,6 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
-	"unsafe"
 
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/cgroup"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/encoding"
@@ -39,14 +38,6 @@ const maxInmemoryParts = 60
 // See appendPartsToMerge tests for details.
 const defaultPartsToMerge = 15
 
-// The number of shards for rawRow entries per partition.
-//
-// Higher number of shards reduces CPU contention and increases the max bandwidth on multi-core systems.
-var rawRowsShardsPerPartition = cgroup.AvailableCPUs()
-
-// The interval for flushing buffered rows into parts, so they become visible to search.
-const pendingRowsFlushInterval = 2 * time.Second
-
 // The interval for guaranteed flush of recently ingested data from memory to on-disk parts, so they survive process crash.
 var dataFlushInterval = 5 * time.Second
 
@@ -64,11 +55,6 @@ func SetDataFlushInterval(d time.Duration) {
 
 	dataFlushInterval = d
 }
-
-// The maximum number of rawRow items in rawRowsShard.
-//
-// Limit the maximum shard size to 8Mb, since this gives the lowest CPU usage under high ingestion rate.
-const maxRawRowsPerShard = (8 << 20) / int(unsafe.Sizeof(rawRow{}))
 
 // partition represents a partition.
 type partition struct {
@@ -1046,66 +1032,6 @@ func (pt *partition) flushInmemoryPartsToFiles(isFinal bool) {
 	if err := pt.mergePartsToFiles(pws, nil, inmemoryPartsConcurrencyCh, false); err != nil {
 		logger.Panicf("FATAL: cannot merge in-memory parts: %s", err)
 	}
-}
-
-func (rrss *rawRowsShards) flush(pt *partition, isFinal bool) {
-	var dst [][]rawRow
-
-	currentTimeMs := time.Now().UnixMilli()
-	flushDeadlineMs := rrss.flushDeadlineMs.Load()
-	if isFinal || currentTimeMs >= flushDeadlineMs {
-		rrss.rowssToFlushLock.Lock()
-		dst = rrss.rowssToFlush
-		rrss.rowssToFlush = nil
-		rrss.rowssToFlushLock.Unlock()
-	}
-
-	for i := range rrss.shards {
-		dst = rrss.shards[i].appendRawRowsToFlush(dst, currentTimeMs, isFinal)
-	}
-
-	pt.flushRowssToInmemoryParts(dst)
-}
-
-func (rrs *rawRowsShard) appendRawRowsToFlush(dst [][]rawRow, currentTimeMs int64, isFinal bool) [][]rawRow {
-	flushDeadlineMs := rrs.flushDeadlineMs.Load()
-	if !isFinal && currentTimeMs < flushDeadlineMs {
-		// Fast path - nothing to flush
-		return dst
-	}
-
-	// Slow path - move rrs.rows to dst.
-	rrs.mu.Lock()
-	dst = appendRawRowss(dst, rrs.rows)
-	rrs.rows = rrs.rows[:0]
-	rrs.mu.Unlock()
-
-	return dst
-}
-
-func (rrs *rawRowsShard) updateFlushDeadline() {
-	rrs.flushDeadlineMs.Store(time.Now().Add(pendingRowsFlushInterval).UnixMilli())
-}
-
-func appendRawRowss(dst [][]rawRow, src []rawRow) [][]rawRow {
-	if len(src) == 0 {
-		return dst
-	}
-	if len(dst) == 0 {
-		dst = append(dst, newRawRows())
-	}
-	prows := &dst[len(dst)-1]
-	n := copy((*prows)[len(*prows):cap(*prows)], src)
-	*prows = (*prows)[:len(*prows)+n]
-	src = src[n:]
-	for len(src) > 0 {
-		rows := newRawRows()
-		n := copy(rows[:cap(rows)], src)
-		rows = rows[:len(rows)+n]
-		src = src[n:]
-		dst = append(dst, rows)
-	}
-	return dst
 }
 
 func (pt *partition) mergePartsToFiles(pws []*partWrapper, stopCh <-chan struct{}, concurrencyCh chan struct{}, useSparseCache bool) error {

--- a/lib/storage/partition.go
+++ b/lib/storage/partition.go
@@ -13,7 +13,6 @@ import (
 	"time"
 	"unsafe"
 
-	"github.com/VictoriaMetrics/VictoriaMetrics/lib/atomicutil"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/cgroup"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/encoding"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/fs"
@@ -484,125 +483,6 @@ func (pt *partition) AddRows(rows []rawRow) {
 }
 
 var isDebug = false
-
-type rawRowsShards struct {
-	flushDeadlineMs atomic.Int64
-
-	shardIdx atomic.Uint32
-
-	// Shards reduce lock contention when adding rows on multi-CPU systems.
-	shards []rawRowsShard
-
-	rowssToFlushLock sync.Mutex
-	rowssToFlush     [][]rawRow
-}
-
-func (rrss *rawRowsShards) init() {
-	rrss.shards = make([]rawRowsShard, rawRowsShardsPerPartition)
-}
-
-func (rrss *rawRowsShards) addRows(pt *partition, rows []rawRow) {
-	shards := rrss.shards
-	shardsLen := uint32(len(shards))
-	for len(rows) > 0 {
-		n := rrss.shardIdx.Add(1)
-		idx := n % shardsLen
-		tailRows, rowsToFlush := shards[idx].addRows(rows)
-		rrss.addRowsToFlush(pt, rowsToFlush)
-		rows = tailRows
-	}
-}
-
-func (rrss *rawRowsShards) addRowsToFlush(pt *partition, rowsToFlush []rawRow) {
-	if len(rowsToFlush) == 0 {
-		return
-	}
-
-	var rowssToMerge [][]rawRow
-
-	rrss.rowssToFlushLock.Lock()
-	if len(rrss.rowssToFlush) == 0 {
-		rrss.updateFlushDeadline()
-	}
-	rrss.rowssToFlush = append(rrss.rowssToFlush, rowsToFlush)
-	if len(rrss.rowssToFlush) >= defaultPartsToMerge {
-		rowssToMerge = rrss.rowssToFlush
-		rrss.rowssToFlush = nil
-	}
-	rrss.rowssToFlushLock.Unlock()
-
-	pt.flushRowssToInmemoryParts(rowssToMerge)
-}
-
-func (rrss *rawRowsShards) Len() int {
-	n := 0
-	for i := range rrss.shards[:] {
-		n += rrss.shards[i].Len()
-	}
-
-	rrss.rowssToFlushLock.Lock()
-	for _, rows := range rrss.rowssToFlush {
-		n += len(rows)
-	}
-	rrss.rowssToFlushLock.Unlock()
-
-	return n
-}
-
-func (rrss *rawRowsShards) updateFlushDeadline() {
-	rrss.flushDeadlineMs.Store(time.Now().Add(pendingRowsFlushInterval).UnixMilli())
-}
-
-type rawRowsShardNopad struct {
-	flushDeadlineMs atomic.Int64
-
-	mu   sync.Mutex
-	rows []rawRow
-}
-
-type rawRowsShard struct {
-	rawRowsShardNopad
-
-	// The padding prevents false sharing
-	_ [atomicutil.CacheLineSize - unsafe.Sizeof(rawRowsShardNopad{})%atomicutil.CacheLineSize]byte
-}
-
-func (rrs *rawRowsShard) Len() int {
-	rrs.mu.Lock()
-	n := len(rrs.rows)
-	rrs.mu.Unlock()
-	return n
-}
-
-func (rrs *rawRowsShard) addRows(rows []rawRow) ([]rawRow, []rawRow) {
-	var rowsToFlush []rawRow
-
-	rrs.mu.Lock()
-	if cap(rrs.rows) == 0 {
-		rrs.rows = newRawRows()
-	}
-	if len(rrs.rows) == 0 {
-		rrs.updateFlushDeadline()
-	}
-	n := copy(rrs.rows[len(rrs.rows):cap(rrs.rows)], rows)
-	rrs.rows = rrs.rows[:len(rrs.rows)+n]
-	rows = rows[n:]
-	if len(rows) > 0 {
-		rowsToFlush = rrs.rows
-		rrs.rows = newRawRows()
-		rrs.updateFlushDeadline()
-		n = copy(rrs.rows[:cap(rrs.rows)], rows)
-		rrs.rows = rrs.rows[:n]
-		rows = rows[n:]
-	}
-	rrs.mu.Unlock()
-
-	return rows, rowsToFlush
-}
-
-func newRawRows() []rawRow {
-	return make([]rawRow, 0, maxRawRowsPerShard)
-}
 
 func (pt *partition) flushRowssToInmemoryParts(rowss [][]rawRow) {
 	if len(rowss) == 0 {

--- a/lib/storage/raw_row.go
+++ b/lib/storage/raw_row.go
@@ -3,7 +3,11 @@ package storage
 import (
 	"sort"
 	"sync"
+	"sync/atomic"
+	"time"
+	"unsafe"
 
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/atomicutil"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/decimal"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/logger"
 )
@@ -149,3 +153,122 @@ func putRawRowsMarshaler(rrm *rawRowsMarshaler) {
 }
 
 var rrmPool sync.Pool
+
+type rawRowsShards struct {
+	flushDeadlineMs atomic.Int64
+
+	shardIdx atomic.Uint32
+
+	// Shards reduce lock contention when adding rows on multi-CPU systems.
+	shards []rawRowsShard
+
+	rowssToFlushLock sync.Mutex
+	rowssToFlush     [][]rawRow
+}
+
+func (rrss *rawRowsShards) init() {
+	rrss.shards = make([]rawRowsShard, rawRowsShardsPerPartition)
+}
+
+func (rrss *rawRowsShards) addRows(pt *partition, rows []rawRow) {
+	shards := rrss.shards
+	shardsLen := uint32(len(shards))
+	for len(rows) > 0 {
+		n := rrss.shardIdx.Add(1)
+		idx := n % shardsLen
+		tailRows, rowsToFlush := shards[idx].addRows(rows)
+		rrss.addRowsToFlush(pt, rowsToFlush)
+		rows = tailRows
+	}
+}
+
+func (rrss *rawRowsShards) addRowsToFlush(pt *partition, rowsToFlush []rawRow) {
+	if len(rowsToFlush) == 0 {
+		return
+	}
+
+	var rowssToMerge [][]rawRow
+
+	rrss.rowssToFlushLock.Lock()
+	if len(rrss.rowssToFlush) == 0 {
+		rrss.updateFlushDeadline()
+	}
+	rrss.rowssToFlush = append(rrss.rowssToFlush, rowsToFlush)
+	if len(rrss.rowssToFlush) >= defaultPartsToMerge {
+		rowssToMerge = rrss.rowssToFlush
+		rrss.rowssToFlush = nil
+	}
+	rrss.rowssToFlushLock.Unlock()
+
+	pt.flushRowssToInmemoryParts(rowssToMerge)
+}
+
+func (rrss *rawRowsShards) Len() int {
+	n := 0
+	for i := range rrss.shards[:] {
+		n += rrss.shards[i].Len()
+	}
+
+	rrss.rowssToFlushLock.Lock()
+	for _, rows := range rrss.rowssToFlush {
+		n += len(rows)
+	}
+	rrss.rowssToFlushLock.Unlock()
+
+	return n
+}
+
+func (rrss *rawRowsShards) updateFlushDeadline() {
+	rrss.flushDeadlineMs.Store(time.Now().Add(pendingRowsFlushInterval).UnixMilli())
+}
+
+type rawRowsShardNopad struct {
+	flushDeadlineMs atomic.Int64
+
+	mu   sync.Mutex
+	rows []rawRow
+}
+
+type rawRowsShard struct {
+	rawRowsShardNopad
+
+	// The padding prevents false sharing
+	_ [atomicutil.CacheLineSize - unsafe.Sizeof(rawRowsShardNopad{})%atomicutil.CacheLineSize]byte
+}
+
+func (rrs *rawRowsShard) Len() int {
+	rrs.mu.Lock()
+	n := len(rrs.rows)
+	rrs.mu.Unlock()
+	return n
+}
+
+func (rrs *rawRowsShard) addRows(rows []rawRow) ([]rawRow, []rawRow) {
+	var rowsToFlush []rawRow
+
+	rrs.mu.Lock()
+	if cap(rrs.rows) == 0 {
+		rrs.rows = newRawRows()
+	}
+	if len(rrs.rows) == 0 {
+		rrs.updateFlushDeadline()
+	}
+	n := copy(rrs.rows[len(rrs.rows):cap(rrs.rows)], rows)
+	rrs.rows = rrs.rows[:len(rrs.rows)+n]
+	rows = rows[n:]
+	if len(rows) > 0 {
+		rowsToFlush = rrs.rows
+		rrs.rows = newRawRows()
+		rrs.updateFlushDeadline()
+		n = copy(rrs.rows[:cap(rrs.rows)], rows)
+		rrs.rows = rrs.rows[:n]
+		rows = rows[n:]
+	}
+	rrs.mu.Unlock()
+
+	return rows, rowsToFlush
+}
+
+func newRawRows() []rawRow {
+	return make([]rawRow, 0, maxRawRowsPerShard)
+}

--- a/lib/storage/raw_row.go
+++ b/lib/storage/raw_row.go
@@ -206,7 +206,7 @@ func (rrss *rawRowsShards) addRows(pt *partition, rows []rawRow) {
 	}
 }
 
-func (rrss *rawRowsShards) addRowsToFlush(pt *partition, rowsToFlush []rawRow) {
+func (rrss *rawRowsShards) addRowsToFlush(rrsf rawRowsFlusher, rowsToFlush []rawRow) {
 	if len(rowsToFlush) == 0 {
 		return
 	}
@@ -224,14 +224,14 @@ func (rrss *rawRowsShards) addRowsToFlush(pt *partition, rowsToFlush []rawRow) {
 	}
 	rrss.rowssToFlushLock.Unlock()
 
-	pt.flushRowssToInmemoryParts(rowssToMerge)
+	rrsf.flushRowssToInmemoryParts(rowssToMerge)
 }
 
 func (rrss *rawRowsShards) updateFlushDeadline() {
 	rrss.flushDeadlineMs.Store(time.Now().Add(pendingRowsFlushInterval).UnixMilli())
 }
 
-func (rrss *rawRowsShards) flush(pt *partition, isFinal bool) {
+func (rrss *rawRowsShards) flush(rrsf rawRowsFlusher, isFinal bool) {
 	var dst [][]rawRow
 
 	currentTimeMs := time.Now().UnixMilli()
@@ -247,7 +247,11 @@ func (rrss *rawRowsShards) flush(pt *partition, isFinal bool) {
 		dst = rrss.shards[i].appendRawRowsToFlush(dst, currentTimeMs, isFinal)
 	}
 
-	pt.flushRowssToInmemoryParts(dst)
+	rrsf.flushRowssToInmemoryParts(dst)
+}
+
+type rawRowsFlusher interface {
+	flushRowssToInmemoryParts(rrs [][]rawRow)
 }
 
 type rawRowsShardNopad struct {

--- a/lib/storage/raw_row.go
+++ b/lib/storage/raw_row.go
@@ -8,6 +8,7 @@ import (
 	"unsafe"
 
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/atomicutil"
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/cgroup"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/decimal"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/logger"
 )
@@ -154,6 +155,14 @@ func putRawRowsMarshaler(rrm *rawRowsMarshaler) {
 
 var rrmPool sync.Pool
 
+// The number of shards for rawRow entries per partition.
+//
+// Higher number of shards reduces CPU contention and increases the max bandwidth on multi-core systems.
+var rawRowsShardsPerPartition = cgroup.AvailableCPUs()
+
+// The interval for flushing buffered rows into parts, so they become visible to search.
+const pendingRowsFlushInterval = 2 * time.Second
+
 type rawRowsShards struct {
 	flushDeadlineMs atomic.Int64
 
@@ -168,6 +177,21 @@ type rawRowsShards struct {
 
 func (rrss *rawRowsShards) init() {
 	rrss.shards = make([]rawRowsShard, rawRowsShardsPerPartition)
+}
+
+func (rrss *rawRowsShards) Len() int {
+	n := 0
+	for i := range rrss.shards[:] {
+		n += rrss.shards[i].Len()
+	}
+
+	rrss.rowssToFlushLock.Lock()
+	for _, rows := range rrss.rowssToFlush {
+		n += len(rows)
+	}
+	rrss.rowssToFlushLock.Unlock()
+
+	return n
 }
 
 func (rrss *rawRowsShards) addRows(pt *partition, rows []rawRow) {
@@ -203,23 +227,27 @@ func (rrss *rawRowsShards) addRowsToFlush(pt *partition, rowsToFlush []rawRow) {
 	pt.flushRowssToInmemoryParts(rowssToMerge)
 }
 
-func (rrss *rawRowsShards) Len() int {
-	n := 0
-	for i := range rrss.shards[:] {
-		n += rrss.shards[i].Len()
-	}
-
-	rrss.rowssToFlushLock.Lock()
-	for _, rows := range rrss.rowssToFlush {
-		n += len(rows)
-	}
-	rrss.rowssToFlushLock.Unlock()
-
-	return n
-}
-
 func (rrss *rawRowsShards) updateFlushDeadline() {
 	rrss.flushDeadlineMs.Store(time.Now().Add(pendingRowsFlushInterval).UnixMilli())
+}
+
+func (rrss *rawRowsShards) flush(pt *partition, isFinal bool) {
+	var dst [][]rawRow
+
+	currentTimeMs := time.Now().UnixMilli()
+	flushDeadlineMs := rrss.flushDeadlineMs.Load()
+	if isFinal || currentTimeMs >= flushDeadlineMs {
+		rrss.rowssToFlushLock.Lock()
+		dst = rrss.rowssToFlush
+		rrss.rowssToFlush = nil
+		rrss.rowssToFlushLock.Unlock()
+	}
+
+	for i := range rrss.shards {
+		dst = rrss.shards[i].appendRawRowsToFlush(dst, currentTimeMs, isFinal)
+	}
+
+	pt.flushRowssToInmemoryParts(dst)
 }
 
 type rawRowsShardNopad struct {
@@ -269,6 +297,52 @@ func (rrs *rawRowsShard) addRows(rows []rawRow) ([]rawRow, []rawRow) {
 	return rows, rowsToFlush
 }
 
+// The maximum number of rawRow items in rawRowsShard.
+//
+// Limit the maximum shard size to 8Mb, since this gives the lowest CPU usage under high ingestion rate.
+const maxRawRowsPerShard = (8 << 20) / int(unsafe.Sizeof(rawRow{}))
+
 func newRawRows() []rawRow {
 	return make([]rawRow, 0, maxRawRowsPerShard)
+}
+
+func (rrs *rawRowsShard) updateFlushDeadline() {
+	rrs.flushDeadlineMs.Store(time.Now().Add(pendingRowsFlushInterval).UnixMilli())
+}
+
+func (rrs *rawRowsShard) appendRawRowsToFlush(dst [][]rawRow, currentTimeMs int64, isFinal bool) [][]rawRow {
+	flushDeadlineMs := rrs.flushDeadlineMs.Load()
+	if !isFinal && currentTimeMs < flushDeadlineMs {
+		// Fast path - nothing to flush
+		return dst
+	}
+
+	// Slow path - move rrs.rows to dst.
+	rrs.mu.Lock()
+	dst = appendRawRowss(dst, rrs.rows)
+	rrs.rows = rrs.rows[:0]
+	rrs.mu.Unlock()
+
+	return dst
+}
+
+func appendRawRowss(dst [][]rawRow, src []rawRow) [][]rawRow {
+	if len(src) == 0 {
+		return dst
+	}
+	if len(dst) == 0 {
+		dst = append(dst, newRawRows())
+	}
+	prows := &dst[len(dst)-1]
+	n := copy((*prows)[len(*prows):cap(*prows)], src)
+	*prows = (*prows)[:len(*prows)+n]
+	src = src[n:]
+	for len(src) > 0 {
+		rows := newRawRows()
+		n := copy(rows[:cap(rows)], src)
+		rows = rows[:len(rows)+n]
+		src = src[n:]
+		dst = append(dst, rows)
+	}
+	return dst
 }

--- a/lib/storage/raw_row.go
+++ b/lib/storage/raw_row.go
@@ -13,6 +13,19 @@ import (
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/logger"
 )
 
+// The number of shards for rawRow entries.
+//
+// Higher number of shards reduces CPU contention and increases the max bandwidth on multi-core systems.
+var numRawRowsShards = cgroup.AvailableCPUs()
+
+// The interval for flushing buffered rows into parts, so they become visible to search.
+const pendingRowsFlushInterval = 2 * time.Second
+
+// The maximum number of rawRow items in rawRowsShard.
+//
+// Limit the maximum shard size to 8Mb, since this gives the lowest CPU usage under high ingestion rate.
+const maxRawRowsPerShard = (8 << 20) / int(unsafe.Sizeof(rawRow{}))
+
 // rawRow represents raw timeseries row.
 type rawRow struct {
 	// TSID is time series id.
@@ -155,14 +168,6 @@ func putRawRowsMarshaler(rrm *rawRowsMarshaler) {
 
 var rrmPool sync.Pool
 
-// The number of shards for rawRow entries per partition.
-//
-// Higher number of shards reduces CPU contention and increases the max bandwidth on multi-core systems.
-var rawRowsShardsPerPartition = cgroup.AvailableCPUs()
-
-// The interval for flushing buffered rows into parts, so they become visible to search.
-const pendingRowsFlushInterval = 2 * time.Second
-
 type rawRowsShards struct {
 	flushDeadlineMs atomic.Int64
 
@@ -176,7 +181,7 @@ type rawRowsShards struct {
 }
 
 func (rrss *rawRowsShards) init() {
-	rrss.shards = make([]rawRowsShard, rawRowsShardsPerPartition)
+	rrss.shards = make([]rawRowsShard, numRawRowsShards)
 }
 
 func (rrss *rawRowsShards) Len() int {
@@ -194,19 +199,19 @@ func (rrss *rawRowsShards) Len() int {
 	return n
 }
 
-func (rrss *rawRowsShards) addRows(pt *partition, rows []rawRow) {
+func (rrss *rawRowsShards) addRows(flush func([][]rawRow), rows []rawRow) {
 	shards := rrss.shards
 	shardsLen := uint32(len(shards))
 	for len(rows) > 0 {
 		n := rrss.shardIdx.Add(1)
 		idx := n % shardsLen
 		tailRows, rowsToFlush := shards[idx].addRows(rows)
-		rrss.addRowsToFlush(pt, rowsToFlush)
+		rrss.addRowsToFlush(flush, rowsToFlush)
 		rows = tailRows
 	}
 }
 
-func (rrss *rawRowsShards) addRowsToFlush(rrsf rawRowsFlusher, rowsToFlush []rawRow) {
+func (rrss *rawRowsShards) addRowsToFlush(flush func([][]rawRow), rowsToFlush []rawRow) {
 	if len(rowsToFlush) == 0 {
 		return
 	}
@@ -224,14 +229,14 @@ func (rrss *rawRowsShards) addRowsToFlush(rrsf rawRowsFlusher, rowsToFlush []raw
 	}
 	rrss.rowssToFlushLock.Unlock()
 
-	rrsf.flushRowssToInmemoryParts(rowssToMerge)
+	flush(rowssToMerge)
 }
 
 func (rrss *rawRowsShards) updateFlushDeadline() {
 	rrss.flushDeadlineMs.Store(time.Now().Add(pendingRowsFlushInterval).UnixMilli())
 }
 
-func (rrss *rawRowsShards) flush(rrsf rawRowsFlusher, isFinal bool) {
+func (rrss *rawRowsShards) flush(flush func(rrs [][]rawRow), isFinal bool) {
 	var dst [][]rawRow
 
 	currentTimeMs := time.Now().UnixMilli()
@@ -247,11 +252,7 @@ func (rrss *rawRowsShards) flush(rrsf rawRowsFlusher, isFinal bool) {
 		dst = rrss.shards[i].appendRawRowsToFlush(dst, currentTimeMs, isFinal)
 	}
 
-	rrsf.flushRowssToInmemoryParts(dst)
-}
-
-type rawRowsFlusher interface {
-	flushRowssToInmemoryParts(rrs [][]rawRow)
+	flush(dst)
 }
 
 type rawRowsShardNopad struct {
@@ -300,11 +301,6 @@ func (rrs *rawRowsShard) addRows(rows []rawRow) ([]rawRow, []rawRow) {
 
 	return rows, rowsToFlush
 }
-
-// The maximum number of rawRow items in rawRowsShard.
-//
-// Limit the maximum shard size to 8Mb, since this gives the lowest CPU usage under high ingestion rate.
-const maxRawRowsPerShard = (8 << 20) / int(unsafe.Sizeof(rawRow{}))
 
 func newRawRows() []rawRow {
 	return make([]rawRow, 0, maxRawRowsPerShard)


### PR DESCRIPTION
Currently, `rawRowsShard` and `rawRowsShards` lives in `lib/partition.go` file. But these types and the `partition` type are only loosely coupled. While the `rawRows` logic is scattered across two files `lib/raw_row.go` and `lib/partition.go`.

This PR moves `rawRowsShard` and `rawRowsShards` and related constants to `raw_row.go`. This allows to keep related funtionality together and view raw row types as functionality that is independent from the `partition` type.

Additionally, the `rawRowsShards` and the `partition` types were decoupled by using the `func([][]rawRow)` callback.