### PR TITLE
docs: add "Graceful Shutdown" section to the quickstart

### DIFF
--- a/docs/victoriametrics/Quick-Start.md
+++ b/docs/victoriametrics/Quick-Start.md
@@ -470,7 +470,7 @@ For backup configuration, please refer to [vmbackup documentation](https://docs.
 To gracefully shut down VictoriaMetrics (or any other) process - send `SIGTERM` or `SIGINT` signals and wait until shutdown finishes.
 See [how to send signals to processes](https://stackoverflow.com/questions/33239959/send-signal-to-process-from-command-line).
 
-Graceful shutdown guarantees data safety and graceful handling of the ongoing connections.
+Graceful shutdown is required for data safety. A successful graceful shutdown guarantees that pending in-memory data is flushed before the process exits. It stops accepting new HTTP connections, waits for in-flight requests, and cancels the remaining requests shortly before `-http.maxGracefulShutdownDuration` expires.
 
 ### Configuring limits
 

--- a/docs/victoriametrics/Quick-Start.md
+++ b/docs/victoriametrics/Quick-Start.md
@@ -467,10 +467,12 @@ For backup configuration, please refer to [vmbackup documentation](https://docs.
 
 ### Graceful shutdown
 
-To gracefully shut down a VictoriaMetrics process, send SIGTERM or SIGINT and wait until the process exits.
+To gracefully shut down a VictoriaMetrics process, send SIGTERM or SIGINT signal and wait until the process exits.
 See [how to send signals to processes](https://stackoverflow.com/questions/33239959/send-signal-to-process-from-command-line).
 
-Graceful shutdown is required for data safety. A successful graceful shutdown guarantees that pending in-memory data is flushed before the process exits. It stops accepting new HTTP connections, waits for in-flight requests, and cancels the remaining requests shortly before `-http.maxGracefulShutdownDuration` expires.
+Graceful shutdown is required for data safety. A successful graceful shutdown guarantees that pending in-memory data and 
+ongoing writes are flushed on disk before the process exits. During graceful shutdown, VictoriaMetrics stops accepting
+new HTTP connections and waits for in-flight requests to finish until `-http.maxGracefulShutdownDuration` expires.
 
 ### Configuring limits
 

--- a/docs/victoriametrics/Quick-Start.md
+++ b/docs/victoriametrics/Quick-Start.md
@@ -467,7 +467,7 @@ For backup configuration, please refer to [vmbackup documentation](https://docs.
 
 ### Graceful shutdown
 
-To gracefully shut down VictoriaMetrics (or any other) process - send `SIGTERM` or `SIGINT` signals and wait until shutdown finishes.
+To gracefully shut down a VictoriaMetrics process, send SIGTERM or SIGINT and wait until the process exits.
 See [how to send signals to processes](https://stackoverflow.com/questions/33239959/send-signal-to-process-from-command-line).
 
 Graceful shutdown is required for data safety. A successful graceful shutdown guarantees that pending in-memory data is flushed before the process exits. It stops accepting new HTTP connections, waits for in-flight requests, and cancels the remaining requests shortly before `-http.maxGracefulShutdownDuration` expires.

--- a/docs/victoriametrics/Quick-Start.md
+++ b/docs/victoriametrics/Quick-Start.md
@@ -467,7 +467,7 @@ For backup configuration, please refer to [vmbackup documentation](https://docs.
 
 ### Graceful shutdown
 
-To gracefully shut down VictoriaMetrics (or any other) process - send `SIGTERM` or `SIGINT` signals anwait until shutdown finishes.
+To gracefully shut down VictoriaMetrics (or any other) process - send `SIGTERM` or `SIGINT` signals and wait until shutdown finishes.
 See [how to send signals to processes](https://stackoverflow.com/questions/33239959/send-signal-to-process-from-command-line).
 
 Graceful shutdown guarantees data safety and graceful handling of the ongoing connections.

--- a/docs/victoriametrics/Quick-Start.md
+++ b/docs/victoriametrics/Quick-Start.md
@@ -465,6 +465,13 @@ It is recommended to read [Replication and data safety](https://docs.victoriamet
 
 For backup configuration, please refer to [vmbackup documentation](https://docs.victoriametrics.com/victoriametrics/vmbackup/).
 
+### Graceful shutdown
+
+To gracefully shut down VictoriaMetrics (or any other) process - send `SIGTERM` or `SIGINT` signals anwait until shutdown finishes.
+See [how to send signals to processes](https://stackoverflow.com/questions/33239959/send-signal-to-process-from-command-line).
+
+Graceful shutdown guarantees data safety and graceful handling of the ongoing connections.
+
 ### Configuring limits
 
 To avoid excessive resource usage or performance degradation, limits must be in place:


### PR DESCRIPTION
Recommendation to gracefuly shutdown process is sometimes overlooked by users. Mentioning it explicitly so it is present in docs as recommendation and can be linkable when sharing with users.

