### PR TITLE
lib/storage: fix concurrent forced data flush

### DIFF
--- a/lib/storage/partition.go
+++ b/lib/storage/partition.go
@@ -17,6 +17,7 @@ import (
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/fs"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/logger"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/memory"
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/syncwg"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/timeutil"
 )
 
@@ -130,6 +131,9 @@ type partition struct {
 	// wg.Add() must be called under partsLock after checking whether stopCh isn't closed.
 	// This should prevent from calling wg.Add() after stopCh is closed and wg.Wait() is called.
 	wg sync.WaitGroup
+
+	// Use syncwg instead of sync, since Add/Wait may be called from concurrent goroutines.
+	flushPendingItemsWG syncwg.WaitGroup
 }
 
 // partWrapper is a wrapper for the part.
@@ -881,6 +885,9 @@ func (pt *partition) MustClose() {
 func (pt *partition) DebugFlush() {
 	pt.idb.tb.DebugFlush()
 	pt.flushPendingRows(true)
+
+	// Wait for background flushers to finish.
+	pt.flushPendingItemsWG.Wait()
 }
 
 func (pt *partition) startInmemoryPartsMergers() {
@@ -1011,7 +1018,9 @@ func (pt *partition) pendingRowsFlusher() {
 }
 
 func (pt *partition) flushPendingRows(isFinal bool) {
+	pt.flushPendingItemsWG.Add(1)
 	pt.rawRows.flush(pt.flushRowssToInmemoryParts, isFinal)
+	pt.flushPendingItemsWG.Done()
 }
 
 func (pt *partition) flushInmemoryRowsToFiles() {

--- a/lib/storage/raw_row.go
+++ b/lib/storage/raw_row.go
@@ -236,24 +236,16 @@ func (rrss *rawRowsShards) updateFlushDeadline() {
 	rrss.flushDeadlineMs.Store(time.Now().Add(pendingRowsFlushInterval).UnixMilli())
 }
 
-// flush calls flush callback on all rawRows that are stored in rrss internal
-// buffers and are ready to be flushed.
-//
-// A rawRow is ready to be flushed either when it has spent enough time in rrss
-// internal buffers (see pendingRowsFlushInterval) or if the operation is final
-// and the rawRow needs to be flushed immediately.
-//
-// The flushed rawRows are removed from rrss internal buffers.
 func (rrss *rawRowsShards) flush(flush func(rrs [][]rawRow), isFinal bool) {
-	rrss.rowssToFlushLock.Lock()
-	defer rrss.rowssToFlushLock.Unlock()
-
 	var dst [][]rawRow
+
 	currentTimeMs := time.Now().UnixMilli()
 	flushDeadlineMs := rrss.flushDeadlineMs.Load()
 	if isFinal || currentTimeMs >= flushDeadlineMs {
+		rrss.rowssToFlushLock.Lock()
 		dst = rrss.rowssToFlush
 		rrss.rowssToFlush = nil
+		rrss.rowssToFlushLock.Unlock()
 	}
 
 	for i := range rrss.shards {

--- a/lib/storage/raw_row.go
+++ b/lib/storage/raw_row.go
@@ -243,7 +243,7 @@ func (rrss *rawRowsShards) updateFlushDeadline() {
 // internal buffers (see pendingRowsFlushInterval) or if the operation is final
 // and the rawRow needs to be flushed immediately.
 //
-// The flushed rawRows are removed from rrss intenal buffers.
+// The flushed rawRows are removed from rrss internal buffers.
 func (rrss *rawRowsShards) flush(flush func(rrs [][]rawRow), isFinal bool) {
 	rrss.rowssToFlushLock.Lock()
 	defer rrss.rowssToFlushLock.Unlock()

--- a/lib/storage/raw_row.go
+++ b/lib/storage/raw_row.go
@@ -236,16 +236,24 @@ func (rrss *rawRowsShards) updateFlushDeadline() {
 	rrss.flushDeadlineMs.Store(time.Now().Add(pendingRowsFlushInterval).UnixMilli())
 }
 
+// flush calls flush callback on all rawRows that are stored in rrss internal
+// buffers and are ready to be flushed.
+//
+// A rawRow is ready to be flushed either when it has spent enough time in rrss
+// internal buffers (see pendingRowsFlushInterval) or if the operation is final
+// and the rawRow needs to be flushed immediately.
+//
+// The flushed rawRows are removed from rrss intenal buffers.
 func (rrss *rawRowsShards) flush(flush func(rrs [][]rawRow), isFinal bool) {
-	var dst [][]rawRow
+	rrss.rowssToFlushLock.Lock()
+	defer rrss.rowssToFlushLock.Unlock()
 
+	var dst [][]rawRow
 	currentTimeMs := time.Now().UnixMilli()
 	flushDeadlineMs := rrss.flushDeadlineMs.Load()
 	if isFinal || currentTimeMs >= flushDeadlineMs {
-		rrss.rowssToFlushLock.Lock()
 		dst = rrss.rowssToFlush
 		rrss.rowssToFlush = nil
-		rrss.rowssToFlushLock.Unlock()
 	}
 
 	for i := range rrss.shards {

--- a/lib/storage/search_test.go
+++ b/lib/storage/search_test.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 	"regexp"
 	"sort"
+	"sync"
 	"testing"
 	"testing/quick"
 	"time"
@@ -189,6 +190,61 @@ func TestSearch_VariousTimeRanges(t *testing.T) {
 	}
 
 	testStorageOpOnVariousTimeRanges(t, f)
+}
+
+func TestStorageAddThenSearchConcurrently(t *testing.T) {
+	defer testRemoveAll(t)
+
+	s := MustOpenStorage(t.Name(), OpenOptions{})
+	defer s.MustClose()
+
+	const numMetrics = 100
+	f := func(workerID int, tr TimeRange) error {
+		mrs := make([]MetricRow, numMetrics)
+		step := (tr.MaxTimestamp - tr.MinTimestamp) / int64(numMetrics)
+		for i := range numMetrics {
+			name := fmt.Sprintf("metric_%d_%d", workerID, i)
+			mn := MetricName{MetricGroup: []byte(name)}
+			mrs[i].MetricNameRaw = mn.marshalRaw(nil)
+			mrs[i].Timestamp = tr.MinTimestamp + int64(i)*step
+			mrs[i].Value = float64(i)
+		}
+		s.AddRows(mrs, defaultPrecisionBits)
+		s.DebugFlush()
+
+		tfs := NewTagFilters()
+		re := fmt.Sprintf(`metric_%d.*`, workerID)
+		if err := tfs.Add(nil, []byte(re), false, true); err != nil {
+			return fmt.Errorf("tfs.Add(%q) failed unexpectedly: %w", re, err)
+		}
+		return testAssertSearchResult(s, tr, tfs, mrs)
+	}
+
+	const concurrency = 10
+	var wg sync.WaitGroup
+	errs := make([]error, concurrency)
+	for workerID := range concurrency {
+		wg.Go(func() {
+			for m := time.Month(1); m <= 12; m++ {
+				tr := TimeRange{
+					MinTimestamp: time.Date(2025, m, 1, 0, 0, 0, 0, time.UTC).UnixMilli(),
+					MaxTimestamp: time.Date(2025, m+1, 0, 0, 0, 0, 0, time.UTC).UnixMilli() - 1,
+				}
+				err := f(workerID, tr)
+				if err != nil {
+					errs[workerID] = fmt.Errorf("worker %d failed on tr=%v: %w", workerID, &tr, err)
+					break
+				}
+			}
+		})
+	}
+	wg.Wait()
+
+	for _, err := range errs {
+		if err != nil {
+			t.Errorf("%s", err)
+		}
+	}
 }
 
 func testSearchInternal(s *Storage, tr TimeRange, mrs []MetricRow) error {

--- a/lib/storage/search_test.go
+++ b/lib/storage/search_test.go
@@ -203,24 +203,25 @@ func TestStorageAddThenSearchConcurrently(t *testing.T) {
 		mrs := make([]MetricRow, numMetrics)
 		step := (tr.MaxTimestamp - tr.MinTimestamp) / int64(numMetrics)
 		for i := range numMetrics {
-			name := fmt.Sprintf("metric_%d_%d", workerID, i)
+			name := fmt.Sprintf("metric_%04d_%04d", workerID, i)
 			mn := MetricName{MetricGroup: []byte(name)}
 			mrs[i].MetricNameRaw = mn.marshalRaw(nil)
 			mrs[i].Timestamp = tr.MinTimestamp + int64(i)*step
 			mrs[i].Value = float64(i)
 		}
+
 		s.AddRows(mrs, defaultPrecisionBits)
 		s.DebugFlush()
 
 		tfs := NewTagFilters()
-		re := fmt.Sprintf(`metric_%d.*`, workerID)
+		re := fmt.Sprintf(`metric_%04d.*`, workerID)
 		if err := tfs.Add(nil, []byte(re), false, true); err != nil {
 			return fmt.Errorf("tfs.Add(%q) failed unexpectedly: %w", re, err)
 		}
 		return testAssertSearchResult(s, tr, tfs, mrs)
 	}
 
-	const concurrency = 10
+	const concurrency = 20
 	var wg sync.WaitGroup
 	errs := make([]error, concurrency)
 	for workerID := range concurrency {

--- a/lib/storage/search_test.go
+++ b/lib/storage/search_test.go
@@ -192,7 +192,12 @@ func TestSearch_VariousTimeRanges(t *testing.T) {
 	testStorageOpOnVariousTimeRanges(t, f)
 }
 
-func TestStorageAddThenSearchConcurrently(t *testing.T) {
+// TestStorageAddFlushSearchDataConcurrently verifies that concurrent goroutines
+// can read their own writes.
+//
+// This test focuses on reading the data. For reading the index see
+// TestStorageAddFlushSearchMetricNamesConcurrently in storage_test.go.
+func TestStorageAddFlushSearchDataConcurrently(t *testing.T) {
 	defer testRemoveAll(t)
 
 	s := MustOpenStorage(t.Name(), OpenOptions{})

--- a/lib/storage/storage_test.go
+++ b/lib/storage/storage_test.go
@@ -4325,7 +4325,12 @@ func TestStorage_futureTimestamps(t *testing.T) {
 	})
 }
 
-func TestStorageAddThenSearchMetricNamesConcurrently(t *testing.T) {
+// TestStorageAddFlushSearchMetricNamesConcurrently verifies that concurrent
+// goroutines can read their own writes.
+//
+// This test focuses on reading the index. For reading the data see
+// TestStorageAddFlushSearchDataConcurrently in search_test.go.
+func TestStorageAddFlushSearchMetricNamesConcurrently(t *testing.T) {
 	defer testRemoveAll(t)
 
 	s := MustOpenStorage(t.Name(), OpenOptions{})

--- a/lib/storage/storage_test.go
+++ b/lib/storage/storage_test.go
@@ -4324,3 +4324,77 @@ func TestStorage_futureTimestamps(t *testing.T) {
 		})
 	})
 }
+
+func TestStorageAddThenSearchMetricNamesConcurrently(t *testing.T) {
+	defer testRemoveAll(t)
+
+	s := MustOpenStorage(t.Name(), OpenOptions{})
+	defer s.MustClose()
+
+	const numMetrics = 100
+	f := func(workerID int, tr TimeRange) error {
+		mrs := make([]MetricRow, numMetrics)
+		want := make([]string, numMetrics)
+		step := (tr.MaxTimestamp - tr.MinTimestamp) / int64(numMetrics)
+		for i := range numMetrics {
+			timestamp := tr.MinTimestamp + int64(i)*step
+			name := fmt.Sprintf("metric_%04d_%d", workerID, timestamp)
+			want[i] = name
+			mn := MetricName{MetricGroup: []byte(name)}
+			mrs[i].MetricNameRaw = mn.marshalRaw(nil)
+			mrs[i].Timestamp = timestamp
+		}
+
+		s.AddRows(mrs, defaultPrecisionBits)
+		s.DebugFlush()
+
+		tfs := NewTagFilters()
+		re := fmt.Sprintf(`metric_%04d.*`, workerID)
+		if err := tfs.Add(nil, []byte(re), false, true); err != nil {
+			return fmt.Errorf("tfs.Add(%q) failed unexpectedly: %w", re, err)
+		}
+		got, err := s.SearchMetricNames(nil, []*TagFilters{tfs}, tr, 1e9, noDeadline)
+		if err != nil {
+			return fmt.Errorf("SearchMetricNames(%v) failed unexpectedly: %w", tfs, err)
+		}
+		for i, name := range got {
+			var mn MetricName
+			if err := mn.UnmarshalString(name); err != nil {
+				return fmt.Errorf("Could not unmarshal metric name %q: %w", name, err)
+			}
+			got[i] = string(mn.MetricGroup)
+		}
+		slices.Sort(got)
+
+		if diff := cmp.Diff(want, got); diff != "" {
+			return fmt.Errorf("unexpected metric names (-want, +got):\n%s", diff)
+		}
+		return nil
+	}
+
+	const concurrency = 20
+	var wg sync.WaitGroup
+	errs := make([]error, concurrency)
+	for workerID := range concurrency {
+		wg.Go(func() {
+			for m := time.Month(1); m <= 12; m++ {
+				tr := TimeRange{
+					MinTimestamp: time.Date(2025, m, 1, 0, 0, 0, 0, time.UTC).UnixMilli(),
+					MaxTimestamp: time.Date(2025, m+1, 0, 0, 0, 0, 0, time.UTC).UnixMilli() - 1,
+				}
+				err := f(workerID, tr)
+				if err != nil {
+					errs[workerID] = fmt.Errorf("worker %d failed on tr=%v: %w", workerID, &tr, err)
+					break
+				}
+			}
+		})
+	}
+	wg.Wait()
+
+	for _, err := range errs {
+		if err != nil {
+			t.Errorf("%s", err)
+		}
+	}
+}


### PR DESCRIPTION
Concurrent goroutines that ingest, flush, and then read their own data may not see it. See `TestStorageAddFlushSearchDataConcurrently` in this PR.

This is not the case for reading index. See `TestStorageAddFlushSearchMetricNamesConcurrently`. This is because index table handles concurrent flushes correctly while data table don't. The solution is to use the same mechanism in data table (`flushPendingItemsWG`). 

The issue was originally discovered when rewriting the series deletion test in #11271.