### PR TITLE
feat(cpu-arch): Add RISC-V 64 as target architecture

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,6 +51,8 @@ jobs:
             arch: ppc64le
           - os: linux
             arch: s390x
+          - os: linux
+            arch: riscv64
           - os: darwin
             arch: amd64
           - os: darwin

--- a/Makefile
+++ b/Makefile
@@ -19,8 +19,6 @@ TAR_OWNERSHIP ?= --owner=1000 --group=1000
 
 GOLANGCI_LINT_VERSION := 2.12.2
 
-.PHONY: $(MAKECMDGOALS)
-
 include app/*/Makefile
 include codespell/Makefile
 include docs/Makefile
@@ -28,6 +26,14 @@ include deployment/*/Makefile
 include dashboards/Makefile
 include package/release/Makefile
 include benchmarks/Makefile
+
+MAKE_TARGETS := $(shell awk 'BEGIN{FS=":"} /^[A-Za-z0-9_.\/%$$(){}-][A-Za-z0-9_.\/%$$(){}-]*:($$|[^=])/ {print $$1}' $(MAKEFILE_LIST))
+UNKNOWN_MAKE_TARGETS := $(filter-out $(MAKE_TARGETS),$(MAKECMDGOALS))
+ifneq ($(UNKNOWN_MAKE_TARGETS),)
+$(error unknown make target(s): $(UNKNOWN_MAKE_TARGETS))
+endif
+
+.PHONY: $(MAKECMDGOALS)
 
 all: \
 	victoria-metrics-prod \
@@ -134,6 +140,24 @@ vmutils-linux-s390x: \
 	vmrestore-linux-s390x \
 	vmctl-linux-s390x
 
+vmutils-linux-riscv64: \
+	vmagent-linux-riscv64 \
+	vmalert-linux-riscv64 \
+	vmalert-tool-linux-riscv64 \
+	vmauth-linux-riscv64 \
+	vmbackup-linux-riscv64 \
+	vmrestore-linux-riscv64 \
+	vmctl-linux-riscv64
+
+vmutils-netbsd-amd64: \
+	vmagent-netbsd-amd64 \
+	vmalert-netbsd-amd64 \
+	vmalert-tool-netbsd-amd64 \
+	vmauth-netbsd-amd64 \
+	vmbackup-netbsd-amd64 \
+	vmrestore-netbsd-amd64 \
+	vmctl-netbsd-amd64
+
 vmutils-darwin-amd64: \
 	vmagent-darwin-amd64 \
 	vmalert-darwin-amd64 \
@@ -190,9 +214,12 @@ victoria-metrics-crossbuild: \
 	victoria-metrics-linux-arm64 \
 	victoria-metrics-linux-arm \
 	victoria-metrics-linux-ppc64le \
+	victoria-metrics-linux-s390x \
+	victoria-metrics-linux-riscv64 \
 	victoria-metrics-darwin-amd64 \
 	victoria-metrics-darwin-arm64 \
 	victoria-metrics-freebsd-amd64 \
+	victoria-metrics-netbsd-amd64 \
 	victoria-metrics-openbsd-amd64 \
 	victoria-metrics-windows-amd64
 
@@ -203,9 +230,12 @@ vmutils-crossbuild: \
 	vmutils-linux-arm64 \
 	vmutils-linux-arm \
 	vmutils-linux-ppc64le \
+	vmutils-linux-s390x \
+	vmutils-linux-riscv64 \
 	vmutils-darwin-amd64 \
 	vmutils-darwin-arm64 \
 	vmutils-freebsd-amd64 \
+	vmutils-netbsd-amd64 \
 	vmutils-openbsd-amd64 \
 	vmutils-windows-amd64
 
@@ -267,6 +297,7 @@ release-victoria-metrics: \
 	release-victoria-metrics-linux-arm \
 	release-victoria-metrics-linux-arm64 \
 	release-victoria-metrics-linux-s390x \
+	release-victoria-metrics-linux-riscv64 \
 	release-victoria-metrics-darwin-amd64 \
 	release-victoria-metrics-darwin-arm64 \
 	release-victoria-metrics-freebsd-amd64 \
@@ -287,6 +318,9 @@ release-victoria-metrics-linux-arm64:
 
 release-victoria-metrics-linux-s390x:
 	GOOS=linux GOARCH=s390x $(MAKE) release-victoria-metrics-goos-goarch
+
+release-victoria-metrics-linux-riscv64:
+	GOOS=linux GOARCH=riscv64 $(MAKE) release-victoria-metrics-goos-goarch
 
 release-victoria-metrics-darwin-amd64:
 	GOOS=darwin GOARCH=amd64 $(MAKE) release-victoria-metrics-goos-goarch
@@ -328,6 +362,7 @@ release-vmutils: \
 	release-vmutils-linux-arm64 \
 	release-vmutils-linux-arm \
 	release-vmutils-linux-s390x \
+	release-vmutils-linux-riscv64 \
 	release-vmutils-darwin-amd64 \
 	release-vmutils-darwin-arm64 \
 	release-vmutils-freebsd-amd64 \
@@ -348,6 +383,9 @@ release-vmutils-linux-arm:
 
 release-vmutils-linux-s390x:
 	GOOS=linux GOARCH=s390x $(MAKE) release-vmutils-goos-goarch
+
+release-vmutils-linux-riscv64:
+	GOOS=linux GOARCH=riscv64 $(MAKE) release-vmutils-goos-goarch
 
 release-vmutils-darwin-amd64:
 	GOOS=darwin GOARCH=amd64 $(MAKE) release-vmutils-goos-goarch

--- a/app/victoria-metrics/Makefile
+++ b/app/victoria-metrics/Makefile
@@ -30,6 +30,9 @@ victoria-metrics-linux-386-prod:
 victoria-metrics-linux-s390x-prod:
 	APP_NAME=victoria-metrics $(MAKE) app-via-docker-linux-s390x
 
+victoria-metrics-linux-riscv64-prod:
+	APP_NAME=victoria-metrics $(MAKE) app-via-docker-linux-riscv64
+
 victoria-metrics-darwin-amd64-prod:
 	APP_NAME=victoria-metrics $(MAKE) app-via-docker-darwin-amd64
 
@@ -63,6 +66,9 @@ package-victoria-metrics-arm64:
 package-victoria-metrics-ppc64le:
 	APP_NAME=victoria-metrics $(MAKE) package-via-docker-ppc64le
 
+package-victoria-metrics-riscv64:
+	APP_NAME=victoria-metrics $(MAKE) package-via-docker-riscv64
+
 package-victoria-metrics-386:
 	APP_NAME=victoria-metrics $(MAKE) package-via-docker-386
 
@@ -91,6 +97,9 @@ victoria-metrics-linux-ppc64le:
 victoria-metrics-linux-s390x:
 	APP_NAME=victoria-metrics CGO_ENABLED=0 GOOS=linux GOARCH=s390x $(MAKE) app-local-goos-goarch
 
+victoria-metrics-linux-riscv64:
+	APP_NAME=victoria-metrics GOOS=linux GOARCH=riscv64 $(MAKE) app-local-goos-goarch
+
 victoria-metrics-linux-loong64:
 	APP_NAME=victoria-metrics CGO_ENABLED=0 GOOS=linux GOARCH=loong64 $(MAKE) app-local-goos-goarch
 
@@ -105,6 +114,9 @@ victoria-metrics-darwin-arm64:
 
 victoria-metrics-freebsd-amd64:
 	APP_NAME=victoria-metrics CGO_ENABLED=0 GOOS=freebsd GOARCH=amd64 $(MAKE) app-local-goos-goarch
+
+victoria-metrics-netbsd-amd64:
+	APP_NAME=victoria-metrics CGO_ENABLED=0 GOOS=netbsd GOARCH=amd64 $(MAKE) app-local-goos-goarch
 
 victoria-metrics-openbsd-amd64:
 	APP_NAME=victoria-metrics CGO_ENABLED=0 GOOS=openbsd GOARCH=amd64 $(MAKE) app-local-goos-goarch
@@ -127,11 +139,16 @@ victoria-metrics-package-deb-arm: victoria-metrics-linux-arm-prod
 victoria-metrics-package-deb-arm64: victoria-metrics-linux-arm64-prod
 	./package/package_deb.sh arm64
 
+### Packaging as DEB - riscv64
+victoria-metrics-package-deb-riscv64: victoria-metrics-linux-riscv64-prod
+	./package/package_deb.sh riscv64
+
 ### Packaging as DEB - all
 victoria-metrics-package-deb: \
         victoria-metrics-package-deb-amd64 \
         victoria-metrics-package-deb-arm \
-        victoria-metrics-package-deb-arm64
+        victoria-metrics-package-deb-arm64 \
+        victoria-metrics-package-deb-riscv64
 
 ### Packaging as RPM - amd64
 victoria-metrics-package-rpm-amd64: victoria-metrics-linux-amd64-prod
@@ -141,10 +158,15 @@ victoria-metrics-package-rpm-amd64: victoria-metrics-linux-amd64-prod
 victoria-metrics-package-rpm-arm64: victoria-metrics-linux-arm64-prod
 	./package/package_rpm.sh arm64
 
+### Packaging as RPM - riscv64
+victoria-metrics-package-rpm-riscv64: victoria-metrics-linux-riscv64-prod
+	./package/package_rpm.sh riscv64
+
 ### Packaging as RPM - all
 victoria-metrics-package-rpm: \
         victoria-metrics-package-rpm-amd64 \
-        victoria-metrics-package-rpm-arm64
+        victoria-metrics-package-rpm-arm64 \
+        victoria-metrics-package-rpm-riscv64
 
 ### Packaging as both DEB and RPM - all
 victoria-metrics-package-deb-rpm: \

--- a/app/victoria-metrics/Makefile
+++ b/app/victoria-metrics/Makefile
@@ -98,7 +98,7 @@ victoria-metrics-linux-s390x:
 	APP_NAME=victoria-metrics CGO_ENABLED=0 GOOS=linux GOARCH=s390x $(MAKE) app-local-goos-goarch
 
 victoria-metrics-linux-riscv64:
-	APP_NAME=victoria-metrics GOOS=linux GOARCH=riscv64 $(MAKE) app-local-goos-goarch
+	APP_NAME=victoria-metrics CGO_ENABLED=0 GOOS=linux GOARCH=riscv64 $(MAKE) app-local-goos-goarch
 
 victoria-metrics-linux-loong64:
 	APP_NAME=victoria-metrics CGO_ENABLED=0 GOOS=linux GOARCH=loong64 $(MAKE) app-local-goos-goarch

--- a/app/vmagent/Makefile
+++ b/app/vmagent/Makefile
@@ -30,6 +30,9 @@ vmagent-linux-386-prod:
 vmagent-linux-s390x-prod:
 	APP_NAME=vmagent $(MAKE) app-via-docker-linux-s390x
 
+vmagent-linux-riscv64-prod:
+	APP_NAME=vmagent $(MAKE) app-via-docker-linux-riscv64
+
 vmagent-darwin-amd64-prod:
 	APP_NAME=vmagent $(MAKE) app-via-docker-darwin-amd64
 
@@ -63,6 +66,9 @@ package-vmagent-arm64:
 package-vmagent-ppc64le:
 	APP_NAME=vmagent $(MAKE) package-via-docker-ppc64le
 
+package-vmagent-riscv64:
+	APP_NAME=vmagent $(MAKE) package-via-docker-riscv64
+
 package-vmagent-386:
 	APP_NAME=vmagent $(MAKE) package-via-docker-386
 
@@ -91,6 +97,9 @@ vmagent-linux-ppc64le:
 vmagent-linux-s390x:
 	APP_NAME=vmagent CGO_ENABLED=0 GOOS=linux GOARCH=s390x $(MAKE) app-local-goos-goarch
 
+vmagent-linux-riscv64:
+	APP_NAME=vmagent GOOS=linux GOARCH=riscv64 $(MAKE) app-local-goos-goarch
+
 vmagent-linux-loong64:
 	APP_NAME=vmagent CGO_ENABLED=0 GOOS=linux GOARCH=loong64 $(MAKE) app-local-goos-goarch
 
@@ -105,6 +114,9 @@ vmagent-darwin-arm64:
 
 vmagent-freebsd-amd64:
 	APP_NAME=vmagent CGO_ENABLED=0 GOOS=freebsd GOARCH=amd64 $(MAKE) app-local-goos-goarch
+
+vmagent-netbsd-amd64:
+	APP_NAME=vmagent CGO_ENABLED=0 GOOS=netbsd GOARCH=amd64 $(MAKE) app-local-goos-goarch
 
 vmagent-openbsd-amd64:
 	APP_NAME=vmagent CGO_ENABLED=0 GOOS=openbsd GOARCH=amd64 $(MAKE) app-local-goos-goarch

--- a/app/vmagent/Makefile
+++ b/app/vmagent/Makefile
@@ -98,7 +98,7 @@ vmagent-linux-s390x:
 	APP_NAME=vmagent CGO_ENABLED=0 GOOS=linux GOARCH=s390x $(MAKE) app-local-goos-goarch
 
 vmagent-linux-riscv64:
-	APP_NAME=vmagent GOOS=linux GOARCH=riscv64 $(MAKE) app-local-goos-goarch
+	APP_NAME=vmagent CGO_ENABLED=0 GOOS=linux GOARCH=riscv64 $(MAKE) app-local-goos-goarch
 
 vmagent-linux-loong64:
 	APP_NAME=vmagent CGO_ENABLED=0 GOOS=linux GOARCH=loong64 $(MAKE) app-local-goos-goarch

--- a/app/vmalert-tool/Makefile
+++ b/app/vmalert-tool/Makefile
@@ -30,6 +30,9 @@ vmalert-tool-linux-386-prod:
 vmalert-tool-linux-s390x-prod:
 	APP_NAME=vmalert-tool $(MAKE) app-via-docker-linux-s390x
 
+vmalert-tool-linux-riscv64-prod:
+	APP_NAME=vmalert-tool $(MAKE) app-via-docker-linux-riscv64
+
 vmalert-tool-darwin-amd64-prod:
 	APP_NAME=vmalert-tool $(MAKE) app-via-docker-darwin-amd64
 
@@ -63,6 +66,9 @@ package-vmalert-tool-arm64:
 package-vmalert-tool-ppc64le:
 	APP_NAME=vmalert-tool $(MAKE) package-via-docker-ppc64le
 
+package-vmalert-tool-riscv64:
+	APP_NAME=vmalert-tool $(MAKE) package-via-docker-riscv64
+
 package-vmalert-tool-386:
 	APP_NAME=vmalert-tool $(MAKE) package-via-docker-386
 
@@ -84,6 +90,9 @@ vmalert-tool-linux-ppc64le:
 vmalert-tool-linux-s390x:
 	APP_NAME=vmalert-tool CGO_ENABLED=0 GOOS=linux GOARCH=s390x $(MAKE) app-local-goos-goarch
 
+vmalert-tool-linux-riscv64:
+	APP_NAME=vmalert-tool GOOS=linux GOARCH=riscv64 $(MAKE) app-local-goos-goarch
+
 vmalert-tool-linux-loong64:
 	APP_NAME=vmalert-tool CGO_ENABLED=0 GOOS=linux GOARCH=loong64 $(MAKE) app-local-goos-goarch
 
@@ -98,6 +107,9 @@ vmalert-tool-darwin-arm64:
 
 vmalert-tool-freebsd-amd64:
 	APP_NAME=vmalert-tool CGO_ENABLED=0 GOOS=freebsd GOARCH=amd64 $(MAKE) app-local-goos-goarch
+
+vmalert-tool-netbsd-amd64:
+	APP_NAME=vmalert-tool CGO_ENABLED=0 GOOS=netbsd GOARCH=amd64 $(MAKE) app-local-goos-goarch
 
 vmalert-tool-openbsd-amd64:
 	APP_NAME=vmalert-tool CGO_ENABLED=0 GOOS=openbsd GOARCH=amd64 $(MAKE) app-local-goos-goarch

--- a/app/vmalert-tool/Makefile
+++ b/app/vmalert-tool/Makefile
@@ -91,7 +91,7 @@ vmalert-tool-linux-s390x:
 	APP_NAME=vmalert-tool CGO_ENABLED=0 GOOS=linux GOARCH=s390x $(MAKE) app-local-goos-goarch
 
 vmalert-tool-linux-riscv64:
-	APP_NAME=vmalert-tool GOOS=linux GOARCH=riscv64 $(MAKE) app-local-goos-goarch
+	APP_NAME=vmalert-tool CGO_ENABLED=0 GOOS=linux GOARCH=riscv64 $(MAKE) app-local-goos-goarch
 
 vmalert-tool-linux-loong64:
 	APP_NAME=vmalert-tool CGO_ENABLED=0 GOOS=linux GOARCH=loong64 $(MAKE) app-local-goos-goarch

--- a/app/vmalert/Makefile
+++ b/app/vmalert/Makefile
@@ -30,6 +30,9 @@ vmalert-linux-386-prod:
 vmalert-linux-s390x-prod:
 	APP_NAME=vmalert $(MAKE) app-via-docker-linux-s390x
 
+vmalert-linux-riscv64-prod:
+	APP_NAME=vmalert $(MAKE) app-via-docker-linux-riscv64
+
 vmalert-darwin-amd64-prod:
 	APP_NAME=vmalert $(MAKE) app-via-docker-darwin-amd64
 
@@ -62,6 +65,9 @@ package-vmalert-arm64:
 
 package-vmalert-ppc64le:
 	APP_NAME=vmalert $(MAKE) package-via-docker-ppc64le
+
+package-vmalert-riscv64:
+	APP_NAME=vmalert $(MAKE) package-via-docker-riscv64
 
 package-vmalert-386:
 	APP_NAME=vmalert $(MAKE) package-via-docker-386
@@ -121,6 +127,9 @@ vmalert-linux-ppc64le:
 vmalert-linux-s390x:
 	APP_NAME=vmalert CGO_ENABLED=0 GOOS=linux GOARCH=s390x $(MAKE) app-local-goos-goarch
 
+vmalert-linux-riscv64:
+	APP_NAME=vmalert GOOS=linux GOARCH=riscv64 $(MAKE) app-local-goos-goarch
+
 vmalert-linux-loong64:
 	APP_NAME=vmalert CGO_ENABLED=0 GOOS=linux GOARCH=loong64 $(MAKE) app-local-goos-goarch
 
@@ -135,6 +144,9 @@ vmalert-darwin-arm64:
 
 vmalert-freebsd-amd64:
 	APP_NAME=vmalert CGO_ENABLED=0 GOOS=freebsd GOARCH=amd64 $(MAKE) app-local-goos-goarch
+
+vmalert-netbsd-amd64:
+	APP_NAME=vmalert CGO_ENABLED=0 GOOS=netbsd GOARCH=amd64 $(MAKE) app-local-goos-goarch
 
 vmalert-openbsd-amd64:
 	APP_NAME=vmalert CGO_ENABLED=0 GOOS=openbsd GOARCH=amd64 $(MAKE) app-local-goos-goarch

--- a/app/vmalert/Makefile
+++ b/app/vmalert/Makefile
@@ -128,7 +128,7 @@ vmalert-linux-s390x:
 	APP_NAME=vmalert CGO_ENABLED=0 GOOS=linux GOARCH=s390x $(MAKE) app-local-goos-goarch
 
 vmalert-linux-riscv64:
-	APP_NAME=vmalert GOOS=linux GOARCH=riscv64 $(MAKE) app-local-goos-goarch
+	APP_NAME=vmalert CGO_ENABLED=0 GOOS=linux GOARCH=riscv64 $(MAKE) app-local-goos-goarch
 
 vmalert-linux-loong64:
 	APP_NAME=vmalert CGO_ENABLED=0 GOOS=linux GOARCH=loong64 $(MAKE) app-local-goos-goarch

--- a/app/vmauth/Makefile
+++ b/app/vmauth/Makefile
@@ -30,6 +30,9 @@ vmauth-linux-386-prod:
 vmauth-linux-s390x-prod:
 	APP_NAME=vmauth $(MAKE) app-via-docker-linux-s390x
 
+vmauth-linux-riscv64-prod:
+	APP_NAME=vmauth $(MAKE) app-via-docker-linux-riscv64
+
 vmauth-darwin-amd64-prod:
 	APP_NAME=vmauth $(MAKE) app-via-docker-darwin-amd64
 
@@ -63,6 +66,9 @@ package-vmauth-arm64:
 package-vmauth-ppc64le:
 	APP_NAME=vmauth $(MAKE) package-via-docker-ppc64le
 
+package-vmauth-riscv64:
+	APP_NAME=vmauth $(MAKE) package-via-docker-riscv64
+
 package-vmauth-386:
 	APP_NAME=vmauth $(MAKE) package-via-docker-386
 
@@ -90,6 +96,9 @@ vmauth-linux-ppc64le:
 vmauth-linux-s390x:
 	APP_NAME=vmauth CGO_ENABLED=0 GOOS=linux GOARCH=s390x $(MAKE) app-local-goos-goarch
 
+vmauth-linux-riscv64:
+	APP_NAME=vmauth GOOS=linux GOARCH=riscv64 $(MAKE) app-local-goos-goarch
+
 vmauth-linux-loong64:
 	APP_NAME=vmauth CGO_ENABLED=0 GOOS=linux GOARCH=loong64 $(MAKE) app-local-goos-goarch
 
@@ -104,6 +113,9 @@ vmauth-darwin-arm64:
 
 vmauth-freebsd-amd64:
 	APP_NAME=vmauth CGO_ENABLED=0 GOOS=freebsd GOARCH=amd64 $(MAKE) app-local-goos-goarch
+
+vmauth-netbsd-amd64:
+	APP_NAME=vmauth CGO_ENABLED=0 GOOS=netbsd GOARCH=amd64 $(MAKE) app-local-goos-goarch
 
 vmauth-openbsd-amd64:
 	APP_NAME=vmauth CGO_ENABLED=0 GOOS=openbsd GOARCH=amd64 $(MAKE) app-local-goos-goarch

--- a/app/vmauth/Makefile
+++ b/app/vmauth/Makefile
@@ -97,7 +97,7 @@ vmauth-linux-s390x:
 	APP_NAME=vmauth CGO_ENABLED=0 GOOS=linux GOARCH=s390x $(MAKE) app-local-goos-goarch
 
 vmauth-linux-riscv64:
-	APP_NAME=vmauth GOOS=linux GOARCH=riscv64 $(MAKE) app-local-goos-goarch
+	APP_NAME=vmauth CGO_ENABLED=0 GOOS=linux GOARCH=riscv64 $(MAKE) app-local-goos-goarch
 
 vmauth-linux-loong64:
 	APP_NAME=vmauth CGO_ENABLED=0 GOOS=linux GOARCH=loong64 $(MAKE) app-local-goos-goarch

--- a/app/vmbackup/Makefile
+++ b/app/vmbackup/Makefile
@@ -34,6 +34,9 @@ vmbackup-linux-386-prod:
 vmbackup-linux-s390x-prod:
 	APP_NAME=vmbackup EXTRA_GO_BUILD_TAGS=$(VMBACKUP_GO_BUILD_TAGS) $(MAKE) app-via-docker-linux-s390x
 
+vmbackup-linux-riscv64-prod:
+	APP_NAME=vmbackup EXTRA_GO_BUILD_TAGS=$(VMBACKUP_GO_BUILD_TAGS) $(MAKE) app-via-docker-linux-riscv64
+
 vmbackup-darwin-amd64-prod:
 	APP_NAME=vmbackup EXTRA_GO_BUILD_TAGS=$(VMBACKUP_GO_BUILD_TAGS) $(MAKE) app-via-docker-darwin-amd64
 
@@ -67,6 +70,9 @@ package-vmbackup-arm64:
 package-vmbackup-ppc64le:
 	APP_NAME=vmbackup EXTRA_GO_BUILD_TAGS=$(VMBACKUP_GO_BUILD_TAGS) $(MAKE) package-via-docker-ppc64le
 
+package-vmbackup-riscv64:
+	APP_NAME=vmbackup EXTRA_GO_BUILD_TAGS=$(VMBACKUP_GO_BUILD_TAGS) $(MAKE) package-via-docker-riscv64
+
 package-vmbackup-386:
 	APP_NAME=vmbackup EXTRA_GO_BUILD_TAGS=$(VMBACKUP_GO_BUILD_TAGS) $(MAKE) package-via-docker-386
 
@@ -88,6 +94,9 @@ vmbackup-linux-ppc64le:
 vmbackup-linux-s390x:
 	APP_NAME=vmbackup EXTRA_GO_BUILD_TAGS=$(VMBACKUP_GO_BUILD_TAGS) CGO_ENABLED=0 GOOS=linux GOARCH=s390x $(MAKE) app-local-goos-goarch
 
+vmbackup-linux-riscv64:
+	APP_NAME=vmbackup EXTRA_GO_BUILD_TAGS=$(VMBACKUP_GO_BUILD_TAGS) GOOS=linux GOARCH=riscv64 $(MAKE) app-local-goos-goarch
+
 vmbackup-linux-loong64:
 	APP_NAME=vmbackup EXTRA_GO_BUILD_TAGS=$(VMBACKUP_GO_BUILD_TAGS) CGO_ENABLED=0 GOOS=linux GOARCH=loong64 $(MAKE) app-local-goos-goarch
 
@@ -102,6 +111,9 @@ vmbackup-darwin-arm64:
 
 vmbackup-freebsd-amd64:
 	APP_NAME=vmbackup EXTRA_GO_BUILD_TAGS=$(VMBACKUP_GO_BUILD_TAGS) CGO_ENABLED=0 GOOS=freebsd GOARCH=amd64 $(MAKE) app-local-goos-goarch
+
+vmbackup-netbsd-amd64:
+	APP_NAME=vmbackup EXTRA_GO_BUILD_TAGS=$(VMBACKUP_GO_BUILD_TAGS) CGO_ENABLED=0 GOOS=netbsd GOARCH=amd64 $(MAKE) app-local-goos-goarch
 
 vmbackup-openbsd-amd64:
 	APP_NAME=vmbackup EXTRA_GO_BUILD_TAGS=$(VMBACKUP_GO_BUILD_TAGS) CGO_ENABLED=0 GOOS=openbsd GOARCH=amd64 $(MAKE) app-local-goos-goarch

--- a/app/vmbackup/Makefile
+++ b/app/vmbackup/Makefile
@@ -95,7 +95,7 @@ vmbackup-linux-s390x:
 	APP_NAME=vmbackup EXTRA_GO_BUILD_TAGS=$(VMBACKUP_GO_BUILD_TAGS) CGO_ENABLED=0 GOOS=linux GOARCH=s390x $(MAKE) app-local-goos-goarch
 
 vmbackup-linux-riscv64:
-	APP_NAME=vmbackup EXTRA_GO_BUILD_TAGS=$(VMBACKUP_GO_BUILD_TAGS) GOOS=linux GOARCH=riscv64 $(MAKE) app-local-goos-goarch
+	APP_NAME=vmbackup EXTRA_GO_BUILD_TAGS=$(VMBACKUP_GO_BUILD_TAGS) CGO_ENABLED=0 GOOS=linux GOARCH=riscv64 $(MAKE) app-local-goos-goarch
 
 vmbackup-linux-loong64:
 	APP_NAME=vmbackup EXTRA_GO_BUILD_TAGS=$(VMBACKUP_GO_BUILD_TAGS) CGO_ENABLED=0 GOOS=linux GOARCH=loong64 $(MAKE) app-local-goos-goarch

--- a/app/vmctl/Makefile
+++ b/app/vmctl/Makefile
@@ -30,6 +30,9 @@ vmctl-linux-386-prod:
 vmctl-linux-s390x-prod:
 	APP_NAME=vmctl $(MAKE) app-via-docker-linux-s390x
 
+vmctl-linux-riscv64-prod:
+	APP_NAME=vmctl $(MAKE) app-via-docker-linux-riscv64
+
 vmctl-darwin-amd64-prod:
 	APP_NAME=vmctl $(MAKE) app-via-docker-darwin-amd64
 
@@ -63,6 +66,9 @@ package-vmctl-arm64:
 package-vmctl-ppc64le:
 	APP_NAME=vmctl $(MAKE) package-via-docker-ppc64le
 
+package-vmctl-riscv64:
+	APP_NAME=vmctl $(MAKE) package-via-docker-riscv64
+
 package-vmctl-386:
 	APP_NAME=vmctl $(MAKE) package-via-docker-386
 
@@ -84,6 +90,9 @@ vmctl-linux-ppc64le:
 vmctl-linux-s390x:
 	APP_NAME=vmctl CGO_ENABLED=0 GOOS=linux GOARCH=s390x $(MAKE) app-local-goos-goarch
 
+vmctl-linux-riscv64:
+	APP_NAME=vmctl GOOS=linux GOARCH=riscv64 $(MAKE) app-local-goos-goarch
+
 vmctl-linux-loong64:
 	APP_NAME=vmctl CGO_ENABLED=0 GOOS=linux GOARCH=loong64 $(MAKE) app-local-goos-goarch
 
@@ -98,6 +107,9 @@ vmctl-darwin-arm64:
 
 vmctl-freebsd-amd64:
 	APP_NAME=vmctl CGO_ENABLED=0 GOOS=freebsd GOARCH=amd64 $(MAKE) app-local-goos-goarch
+
+vmctl-netbsd-amd64:
+	APP_NAME=vmctl CGO_ENABLED=0 GOOS=netbsd GOARCH=amd64 $(MAKE) app-local-goos-goarch
 
 vmctl-openbsd-amd64:
 	APP_NAME=vmctl CGO_ENABLED=0 GOOS=openbsd GOARCH=amd64 $(MAKE) app-local-goos-goarch

--- a/app/vmctl/Makefile
+++ b/app/vmctl/Makefile
@@ -91,7 +91,7 @@ vmctl-linux-s390x:
 	APP_NAME=vmctl CGO_ENABLED=0 GOOS=linux GOARCH=s390x $(MAKE) app-local-goos-goarch
 
 vmctl-linux-riscv64:
-	APP_NAME=vmctl GOOS=linux GOARCH=riscv64 $(MAKE) app-local-goos-goarch
+	APP_NAME=vmctl CGO_ENABLED=0 GOOS=linux GOARCH=riscv64 $(MAKE) app-local-goos-goarch
 
 vmctl-linux-loong64:
 	APP_NAME=vmctl CGO_ENABLED=0 GOOS=linux GOARCH=loong64 $(MAKE) app-local-goos-goarch

--- a/app/vmrestore/Makefile
+++ b/app/vmrestore/Makefile
@@ -34,6 +34,9 @@ vmrestore-linux-386-prod:
 vmrestore-linux-s390x-prod:
 	APP_NAME=vmrestore EXTRA_GO_BUILD_TAGS=$(VMRESTORE_GO_BUILD_TAGS) $(MAKE) app-via-docker-linux-s390x
 
+vmrestore-linux-riscv64-prod:
+	APP_NAME=vmrestore EXTRA_GO_BUILD_TAGS=$(VMRESTORE_GO_BUILD_TAGS) $(MAKE) app-via-docker-linux-riscv64
+
 vmrestore-darwin-amd64-prod:
 	APP_NAME=vmrestore EXTRA_GO_BUILD_TAGS=$(VMRESTORE_GO_BUILD_TAGS) $(MAKE) app-via-docker-darwin-amd64
 
@@ -67,6 +70,9 @@ package-vmrestore-arm64:
 package-vmrestore-ppc64le:
 	APP_NAME=vmrestore EXTRA_GO_BUILD_TAGS=$(VMRESTORE_GO_BUILD_TAGS) $(MAKE) package-via-docker-ppc64le
 
+package-vmrestore-riscv64:
+	APP_NAME=vmrestore EXTRA_GO_BUILD_TAGS=$(VMRESTORE_GO_BUILD_TAGS) $(MAKE) package-via-docker-riscv64
+
 package-vmrestore-386:
 	APP_NAME=vmrestore EXTRA_GO_BUILD_TAGS=$(VMRESTORE_GO_BUILD_TAGS) $(MAKE) package-via-docker-386
 
@@ -88,6 +94,9 @@ vmrestore-linux-ppc64le:
 vmrestore-linux-s390x:
 	APP_NAME=vmrestore EXTRA_GO_BUILD_TAGS=$(VMRESTORE_GO_BUILD_TAGS) CGO_ENABLED=0 GOOS=linux GOARCH=s390x $(MAKE) app-local-goos-goarch
 
+vmrestore-linux-riscv64:
+	APP_NAME=vmrestore EXTRA_GO_BUILD_TAGS=$(VMRESTORE_GO_BUILD_TAGS) GOOS=linux GOARCH=riscv64 $(MAKE) app-local-goos-goarch
+
 vmrestore-linux-loong64:
 	APP_NAME=vmrestore EXTRA_GO_BUILD_TAGS=$(VMRESTORE_GO_BUILD_TAGS) CGO_ENABLED=0 GOOS=linux GOARCH=loong64 $(MAKE) app-local-goos-goarch
 
@@ -102,6 +111,9 @@ vmrestore-darwin-arm64:
 
 vmrestore-freebsd-amd64:
 	APP_NAME=vmrestore EXTRA_GO_BUILD_TAGS=$(VMRESTORE_GO_BUILD_TAGS) CGO_ENABLED=0 GOOS=freebsd GOARCH=amd64 $(MAKE) app-local-goos-goarch
+
+vmrestore-netbsd-amd64:
+	APP_NAME=vmrestore EXTRA_GO_BUILD_TAGS=$(VMRESTORE_GO_BUILD_TAGS) CGO_ENABLED=0 GOOS=netbsd GOARCH=amd64 $(MAKE) app-local-goos-goarch
 
 vmrestore-openbsd-amd64:
 	APP_NAME=vmrestore EXTRA_GO_BUILD_TAGS=$(VMRESTORE_GO_BUILD_TAGS) CGO_ENABLED=0 GOOS=openbsd GOARCH=amd64 $(MAKE) app-local-goos-goarch

--- a/app/vmrestore/Makefile
+++ b/app/vmrestore/Makefile
@@ -95,7 +95,7 @@ vmrestore-linux-s390x:
 	APP_NAME=vmrestore EXTRA_GO_BUILD_TAGS=$(VMRESTORE_GO_BUILD_TAGS) CGO_ENABLED=0 GOOS=linux GOARCH=s390x $(MAKE) app-local-goos-goarch
 
 vmrestore-linux-riscv64:
-	APP_NAME=vmrestore EXTRA_GO_BUILD_TAGS=$(VMRESTORE_GO_BUILD_TAGS) GOOS=linux GOARCH=riscv64 $(MAKE) app-local-goos-goarch
+	APP_NAME=vmrestore EXTRA_GO_BUILD_TAGS=$(VMRESTORE_GO_BUILD_TAGS) CGO_ENABLED=0 GOOS=linux GOARCH=riscv64 $(MAKE) app-local-goos-goarch
 
 vmrestore-linux-loong64:
 	APP_NAME=vmrestore EXTRA_GO_BUILD_TAGS=$(VMRESTORE_GO_BUILD_TAGS) CGO_ENABLED=0 GOOS=linux GOARCH=loong64 $(MAKE) app-local-goos-goarch

--- a/deployment/docker/Makefile
+++ b/deployment/docker/Makefile
@@ -189,7 +189,7 @@ app-via-docker-linux-s390x:
 	CGO_ENABLED=0 GOOS=linux GOARCH=s390x $(MAKE) app-via-docker-goos-goarch
 
 app-via-docker-linux-riscv64:
-	GOOS=linux GOARCH=riscv64 $(MAKE) app-via-docker-goos-goarch
+	CGO_ENABLED=0 GOOS=linux GOARCH=riscv64 $(MAKE) app-via-docker-goos-goarch
 
 app-via-docker-darwin-amd64:
 	CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 $(MAKE) app-via-docker-goos-goarch
@@ -232,7 +232,7 @@ package-via-docker-ppc64le:
 	CGO_ENABLED=0 GOARCH=ppc64le $(MAKE) package-via-docker-goarch
 
 package-via-docker-riscv64:
-	GOARCH=riscv64 $(MAKE) package-via-docker-goarch
+	CGO_ENABLED=0 GOARCH=riscv64 $(MAKE) package-via-docker-goarch
 
 package-via-docker-386:
 	CGO_ENABLED=0 GOARCH=386 $(MAKE) package-via-docker-goarch

--- a/deployment/docker/Makefile
+++ b/deployment/docker/Makefile
@@ -82,9 +82,10 @@ publish-via-docker:
 		app-via-docker-linux-arm \
 		app-via-docker-linux-arm64 \
 		app-via-docker-linux-ppc64le \
+		app-via-docker-linux-riscv64 \
 		app-via-docker-linux-386
 	$(DOCKER) buildx build \
-		--platform=linux/amd64,linux/arm,linux/arm64,linux/ppc64le,linux/386 \
+		--platform=linux/amd64,linux/arm,linux/arm64,linux/ppc64le,linux/riscv64,linux/386 \
 		--build-arg certs_image=$(CERTS_IMAGE) \
 		--build-arg root_image=$(ROOT_IMAGE) \
 		--build-arg APP_NAME=$(APP_NAME) \
@@ -105,7 +106,7 @@ publish-via-docker:
 		--push \
 		bin
 	$(DOCKER) buildx build \
-		--platform=linux/amd64,linux/arm,linux/arm64,linux/ppc64le,linux/386 \
+		--platform=linux/amd64,linux/arm,linux/arm64,linux/ppc64le,linux/riscv64,linux/386 \
 		--build-arg certs_image=$(CERTS_IMAGE) \
 		--build-arg root_image=$(ROOT_IMAGE_SCRATCH) \
 		--build-arg APP_NAME=$(APP_NAME) \
@@ -130,6 +131,7 @@ publish-via-docker:
 		$(APP_NAME)-linux-arm-prod \
 		$(APP_NAME)-linux-arm64-prod \
 		$(APP_NAME)-linux-ppc64le-prod \
+		$(APP_NAME)-linux-riscv64-prod \
 		$(APP_NAME)-linux-386-prod
 
 publish-via-docker-from-rc:
@@ -186,6 +188,9 @@ app-via-docker-linux-386:
 app-via-docker-linux-s390x:
 	CGO_ENABLED=0 GOOS=linux GOARCH=s390x $(MAKE) app-via-docker-goos-goarch
 
+app-via-docker-linux-riscv64:
+	GOOS=linux GOARCH=riscv64 $(MAKE) app-via-docker-goos-goarch
+
 app-via-docker-darwin-amd64:
 	CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 $(MAKE) app-via-docker-goos-goarch
 
@@ -225,6 +230,9 @@ package-via-docker-arm:
 
 package-via-docker-ppc64le:
 	CGO_ENABLED=0 GOARCH=ppc64le $(MAKE) package-via-docker-goarch
+
+package-via-docker-riscv64:
+	GOARCH=riscv64 $(MAKE) package-via-docker-goarch
 
 package-via-docker-386:
 	CGO_ENABLED=0 GOARCH=386 $(MAKE) package-via-docker-goarch

--- a/docs/victoriametrics/README.md
+++ b/docs/victoriametrics/README.md
@@ -568,21 +568,22 @@ to your needs or when testing bugfixes.
 1. Run `make victoria-metrics-prod` from the root folder of [the repository](https://github.com/VictoriaMetrics/VictoriaMetrics).
    It builds `victoria-metrics-prod` binary and puts it into the `bin` folder.
 
-### ARM build
+### Linux ARM and RISC-V builds
 
-ARM build may run on Raspberry Pi or on [energy-efficient ARM servers](https://blog.cloudflare.com/arm-takes-wing/).
+ARM builds may run on Raspberry Pi or on [energy-efficient ARM servers](https://blog.cloudflare.com/arm-takes-wing/).
+RISC-V 64 builds produce binaries for Linux `riscv64` systems.
 
-### Development ARM build
+### Development Linux ARM and RISC-V build
 
 1. [Install Go](https://golang.org/doc/install).
-1. Run `make victoria-metrics-linux-arm` or `make victoria-metrics-linux-arm64` from the root folder of [the repository](https://github.com/VictoriaMetrics/VictoriaMetrics).
-   It builds `victoria-metrics-linux-arm` or `victoria-metrics-linux-arm64` binary respectively and puts it into the `bin` folder.
+1. Run `make victoria-metrics-linux-arm`, `make victoria-metrics-linux-arm64`, or `make victoria-metrics-linux-riscv64` from the root folder of [the repository](https://github.com/VictoriaMetrics/VictoriaMetrics).
+   It builds the corresponding `victoria-metrics-linux-arm`, `victoria-metrics-linux-arm64`, or `victoria-metrics-linux-riscv64` binary and puts it into the `bin` folder.
 
-### Production ARM build
+### Production Linux ARM and RISC-V build
 
 1. [Install docker](https://docs.docker.com/install/).
-1. Run `make victoria-metrics-linux-arm-prod` or `make victoria-metrics-linux-arm64-prod` from the root folder of [the repository](https://github.com/VictoriaMetrics/VictoriaMetrics).
-   It builds `victoria-metrics-linux-arm-prod` or `victoria-metrics-linux-arm64-prod` binary respectively and puts it into the `bin` folder.
+1. Run `make victoria-metrics-linux-arm-prod`, `make victoria-metrics-linux-arm64-prod`, or `make victoria-metrics-linux-riscv64-prod` from the root folder of [the repository](https://github.com/VictoriaMetrics/VictoriaMetrics).
+   It builds the corresponding `victoria-metrics-linux-arm-prod`, `victoria-metrics-linux-arm64-prod`, or `victoria-metrics-linux-riscv64-prod` binary and puts it into the `bin` folder.
 
 ### Pure Go build (CGO_ENABLED=0)
 

--- a/docs/victoriametrics/vmagent.md
+++ b/docs/victoriametrics/vmagent.md
@@ -1367,21 +1367,22 @@ by setting it via the `<ROOT_IMAGE>` environment variable. For example, the foll
 ROOT_IMAGE=scratch make package-vmagent
 ```
 
-### ARM build
+### Linux ARM and RISC-V builds
 
-ARM build may run on Raspberry Pi or on [energy-efficient ARM servers](https://blog.cloudflare.com/arm-takes-wing/).
+ARM builds may run on Raspberry Pi or on [energy-efficient ARM servers](https://blog.cloudflare.com/arm-takes-wing/).
+RISC-V 64 builds produce binaries for Linux `riscv64` systems.
 
-### Development ARM build
+### Development Linux ARM and RISC-V build
 
 1. [Install Go](https://golang.org/doc/install).
-1. Run `make vmagent-linux-arm` or `make vmagent-linux-arm64` from the root folder of [the repository](https://github.com/VictoriaMetrics/VictoriaMetrics)
-   It builds `vmagent-linux-arm` or `vmagent-linux-arm64` binary, respectively, and puts it into the `bin` folder.
+1. Run `make vmagent-linux-arm`, `make vmagent-linux-arm64`, or `make vmagent-linux-riscv64` from the root folder of [the repository](https://github.com/VictoriaMetrics/VictoriaMetrics).
+   It builds the corresponding `vmagent-linux-arm`, `vmagent-linux-arm64`, or `vmagent-linux-riscv64` binary and puts it into the `bin` folder.
 
-### Production ARM build
+### Production Linux ARM and RISC-V build
 
 1. [Install Docker](https://docs.docker.com/install/).
-1. Run `make vmagent-linux-arm-prod` or `make vmagent-linux-arm64-prod` from the root folder of [the repository](https://github.com/VictoriaMetrics/VictoriaMetrics).
-   It builds `vmagent-linux-arm-prod` or `vmagent-linux-arm64-prod` binary, respectively, and puts it into the `bin` folder.
+1. Run `make vmagent-linux-arm-prod`, `make vmagent-linux-arm64-prod`, or `make vmagent-linux-riscv64-prod` from the root folder of [the repository](https://github.com/VictoriaMetrics/VictoriaMetrics).
+   It builds the corresponding `vmagent-linux-arm-prod`, `vmagent-linux-arm64-prod`, or `vmagent-linux-riscv64-prod` binary and puts it into the `bin` folder.
 
 ## Profiling
 

--- a/docs/victoriametrics/vmalert.md
+++ b/docs/victoriametrics/vmalert.md
@@ -1516,18 +1516,19 @@ spec:
 1. Run `make vmalert-prod` from the root folder of [the repository](https://github.com/VictoriaMetrics/VictoriaMetrics).
    It builds `vmalert-prod` binary and puts it into the `bin` folder.
 
-### ARM build
+### Linux ARM and RISC-V builds
 
-ARM build may run on Raspberry Pi or on [energy-efficient ARM servers](https://blog.cloudflare.com/arm-takes-wing/).
+ARM builds may run on Raspberry Pi or on [energy-efficient ARM servers](https://blog.cloudflare.com/arm-takes-wing/).
+RISC-V 64 builds produce binaries for Linux `riscv64` systems.
 
-### Development ARM build
+### Development Linux ARM and RISC-V build
 
 1. [Install Go](https://golang.org/doc/install).
-1. Run `make vmalert-linux-arm` or `make vmalert-linux-arm64` from the root folder of [the repository](https://github.com/VictoriaMetrics/VictoriaMetrics).
-   It builds `vmalert-linux-arm` or `vmalert-linux-arm64` binary respectively and puts it into the `bin` folder.
+1. Run `make vmalert-linux-arm`, `make vmalert-linux-arm64`, or `make vmalert-linux-riscv64` from the root folder of [the repository](https://github.com/VictoriaMetrics/VictoriaMetrics).
+   It builds the corresponding `vmalert-linux-arm`, `vmalert-linux-arm64`, or `vmalert-linux-riscv64` binary and puts it into the `bin` folder.
 
-### Production ARM build
+### Production Linux ARM and RISC-V build
 
 1. [Install docker](https://docs.docker.com/install/).
-1. Run `make vmalert-linux-arm-prod` or `make vmalert-linux-arm64-prod` from the root folder of [the repository](https://github.com/VictoriaMetrics/VictoriaMetrics).
-   It builds `vmalert-linux-arm-prod` or `vmalert-linux-arm64-prod` binary respectively and puts it into the `bin` folder.
+1. Run `make vmalert-linux-arm-prod`, `make vmalert-linux-arm64-prod`, or `make vmalert-linux-riscv64-prod` from the root folder of [the repository](https://github.com/VictoriaMetrics/VictoriaMetrics).
+   It builds the corresponding `vmalert-linux-arm-prod`, `vmalert-linux-arm64-prod`, or `vmalert-linux-riscv64-prod` binary and puts it into the `bin` folder.

--- a/docs/victoriametrics/vmctl/vmctl.md
+++ b/docs/victoriametrics/vmctl/vmctl.md
@@ -280,21 +280,22 @@ by setting it via `<ROOT_IMAGE>` environment variable. For example, the followin
 ROOT_IMAGE=scratch make package-vmctl
 ```
 
-### ARM build
+### Linux ARM and RISC-V builds
 
-ARM build may run on Raspberry Pi or on [energy-efficient ARM servers](https://blog.cloudflare.com/arm-takes-wing/).
+ARM builds may run on Raspberry Pi or on [energy-efficient ARM servers](https://blog.cloudflare.com/arm-takes-wing/).
+RISC-V 64 builds produce binaries for Linux `riscv64` systems.
 
-#### Development ARM build
+#### Development Linux ARM and RISC-V build
 
 1. [Install Go](https://golang.org/doc/install).
-1. Run `make vmctl-linux-arm` or `make vmctl-linux-arm64` from the root folder of [the repository](https://github.com/VictoriaMetrics/VictoriaMetrics).
-   It builds `vmctl-linux-arm` or `vmctl-linux-arm64` binary respectively and puts it into the `bin` folder.
+1. Run `make vmctl-linux-arm`, `make vmctl-linux-arm64`, or `make vmctl-linux-riscv64` from the root folder of [the repository](https://github.com/VictoriaMetrics/VictoriaMetrics).
+   It builds the corresponding `vmctl-linux-arm`, `vmctl-linux-arm64`, or `vmctl-linux-riscv64` binary and puts it into the `bin` folder.
 
-#### Production ARM build
+#### Production Linux ARM and RISC-V build
 
 1. [Install docker](https://docs.docker.com/install/).
-1. Run `make vmctl-linux-arm-prod` or `make vmctl-linux-arm64-prod` from the root folder of [the repository](https://github.com/VictoriaMetrics/VictoriaMetrics).
-   It builds `vmctl-linux-arm-prod` or `vmctl-linux-arm64-prod` binary respectively and puts it into the `bin` folder.
+1. Run `make vmctl-linux-arm-prod`, `make vmctl-linux-arm64-prod`, or `make vmctl-linux-riscv64-prod` from the root folder of [the repository](https://github.com/VictoriaMetrics/VictoriaMetrics).
+   It builds the corresponding `vmctl-linux-arm-prod`, `vmctl-linux-arm64-prod`, or `vmctl-linux-riscv64-prod` binary and puts it into the `bin` folder.
 
 ## Command-line flags
 

--- a/package/package_deb.sh
+++ b/package/package_deb.sh
@@ -16,6 +16,9 @@ elif [[ "$ARCH" == "arm64" ]]; then
 elif [[ "$ARCH" == "arm" ]]; then
     DEB_ARCH=armhf
     EXENAME_SRC="victoria-metrics-linux-arm-prod"
+elif [[ "$ARCH" == "riscv64" ]]; then
+    DEB_ARCH=riscv64
+    EXENAME_SRC="victoria-metrics-linux-riscv64-prod"
 else
     echo "*** Unknown arch $ARCH"
     exit 1

--- a/package/package_rpm.sh
+++ b/package/package_rpm.sh
@@ -19,6 +19,9 @@ if [[ "$ARCH" == "amd64" ]]; then
 elif [[ "$ARCH" == "arm64" ]]; then
     RPM_ARCH=aarch64
     EXENAME_SRC="victoria-metrics-linux-arm64-prod"
+elif [[ "$ARCH" == "riscv64" ]]; then
+    RPM_ARCH=riscv64
+    EXENAME_SRC="victoria-metrics-linux-riscv64-prod"
 else
     echo "*** Unknown arch $ARCH"
     exit 1

--- a/package/release/Makefile
+++ b/package/release/Makefile
@@ -1,7 +1,7 @@
 GITHUB_RELEASE_SPEC_FILE="/tmp/vm-github-release-$(TAG)"
 GITHUB_DEBUG_FILE="/tmp/vm-github-debug"
 
-GITHUB_ASSETS_COUNT ?= 112
+GITHUB_ASSETS_COUNT ?= 120
 
 github-token-check:
 ifndef GITHUB_TOKEN


### PR DESCRIPTION
I used v1.148.0 tag's commit (d94a85a) as base for this PR.
This PR adding rv64 as the target build CPU architecture. I checked some binaries on my Debian rv64 virtual machine and on physical SBC (VisionFire2). Binaries are starting and not segfaulting.
Please, review.