### PR TITLE
app/vminsert: enable slowness rerouting by default; disable it for replicationFactor > 1

### DIFF
--- a/app/vminsert/netstorage/netstorage.go
+++ b/app/vminsert/netstorage/netstorage.go
@@ -31,7 +31,7 @@ var (
 	replicationFactor  = flag.Int("replicationFactor", 1, "Replication factor for the ingested data, i.e. how many copies to make among distinct -storageNode instances. "+
 		"Note that vmselect must run with -dedup.minScrapeInterval=1ms for data de-duplication when replicationFactor is greater than 1. "+
 		"Higher values for -dedup.minScrapeInterval at vmselect is OK")
-	disableRerouting      = flag.Bool("disableRerouting", true, "Whether to disable re-routing when some of vmstorage nodes accept incoming data at slower speed compared to other storage nodes. Disabled re-routing limits the ingestion rate by the slowest vmstorage node. On the other side, disabled re-routing minimizes the number of active time series in the cluster during rolling restarts and during spikes in series churn rate. See also -disableReroutingOnUnavailable and -dropSamplesOnOverload")
+	disableRerouting      = flag.Bool("disableRerouting", false, "Whether to disable re-routing when some of vmstorage nodes accept incoming data at slower speed compared to other storage nodes. Disabled re-routing limits the ingestion rate by the slowest vmstorage node. On the other side, disabled re-routing minimizes the number of active time series in the cluster during rolling restarts and during spikes in series churn rate. See also -disableReroutingOnUnavailable and -dropSamplesOnOverload")
 	dropSamplesOnOverload = flag.Bool("dropSamplesOnOverload", false, "Whether to drop incoming samples if the destination vmstorage node is overloaded and/or unavailable. This prioritizes cluster availability over consistency, e.g. the cluster continues accepting all the ingested samples, but some of them may be dropped if vmstorage nodes are temporarily unavailable and/or overloaded. The drop of samples happens before the replication, so it's not recommended to use this flag with -replicationFactor enabled.")
 	vmstorageDialTimeout  = flag.Duration("vmstorageDialTimeout", 3*time.Second, "Timeout for establishing RPC connections from vminsert to vmstorage. "+
 		"See also -vmstorageUserTimeout")
@@ -127,7 +127,7 @@ again:
 		return nil
 	}
 	// Slow path: the buf contents doesn't fit sn.buf, so try re-routing it to other vmstorage nodes.
-	if !allowRerouting(sn, sns) {
+	if !allowSlownessRerouting(sn, sns) {
 		sn.brCond.Wait()
 		goto again
 	}
@@ -472,7 +472,7 @@ type storageNode struct {
 	rowsDroppedOnUnsupportedRPC *metrics.Counter
 
 	// avgSaturation tracks the moving average of (send duration / (now - lastSendTime)).
-	// Updated in run(). Used by allowRerouting to decide when to trigger slowness-based rerouting.
+	// Updated in run(). Used by allowSlownessRerouting to decide when to trigger slowness-based rerouting.
 	avgSaturation *variableEWMA
 	lastSendTime  time.Time
 }
@@ -512,12 +512,31 @@ func setStorageNodesBucket(snb *storageNodesBucket) {
 	storageNodes.Store(snb)
 }
 
+// enableSlownessRerouting holds the effective slowness rerouting state computed at Init time.
+// See initSlownessRerouting for the computation logic
+var enableSlownessRerouting bool
+
+// initSlownessRerouting computes and stores the effective value of enableSlownessRerouting.
+// It keeps the -disableRerouting flag value when replicationFactor == 1,
+// and forces rerouting to be disabled when replicationFactor > 1.
+func initSlownessRerouting() {
+	if *replicationFactor > 1 {
+		if !*disableRerouting {
+			logger.Warnf("disabling slowness rerouting (controlled by -disableRerouting) because replicationFactor=%d > 1; slowness rerouting is incompatible with replication and may cause data inconsistencies or even loss", *replicationFactor)
+		}
+		enableSlownessRerouting = false
+		return
+	}
+	enableSlownessRerouting = !*disableRerouting
+}
+
 // Init initializes vmstorage nodes' connections to the given addrs.
 //
 // hashSeed is used for changing the distribution of input time series among addrs.
 //
 // Call MustStop when the initialized vmstorage connections are no longer needed.
 func Init(addrs []string, hashSeed uint64) {
+	initSlownessRerouting()
 	snb := initStorageNodes(addrs, vminsertapi.MetricRowsRpcCall, hashSeed)
 	setStorageNodesBucket(snb)
 	metadataSnb := initStorageNodes(addrs, vminsertapi.MetricMetadataRpcCall, hashSeed)
@@ -705,7 +724,7 @@ func rerouteRowsToReadyStorageNodes(snb *storageNodesBucket, snSource *storageNo
 			// re-generate idxsExclude list, since sn must be put there.
 			idxsExclude = getNotReadyStorageNodeIdxsBlocking(snb, idxsExclude[:0])
 		}
-		if *disableRerouting {
+		if !enableSlownessRerouting {
 			if !sn.sendBufMayBlock(rowBuf) {
 				return rowsProcessed, fmt.Errorf("graceful shutdown started")
 			}
@@ -744,16 +763,16 @@ func rerouteRowsToReadyStorageNodes(snb *storageNodesBucket, snSource *storageNo
 	return rowsProcessed, nil
 }
 
-var reroutingLogger = logger.WithThrottler("allowRerouting", 5*time.Second)
+var reroutingLogger = logger.WithThrottler("allowSlownessRerouting", 5*time.Second)
 
-// allowRerouting determines whether data should be rerouted from snSource to other storage nodes (sns)
+// allowSlownessRerouting determines whether data should be rerouted from snSource to other storage nodes (sns)
 // based on performance metrics.
 //
 // It returns true only when snSource is the slowest node in the cluster
 // and significantly slower than the cluster on average.
 // See the comments below for detailed conditions.
-func allowRerouting(snSource *storageNode, sns []*storageNode) bool {
-	if *disableRerouting {
+func allowSlownessRerouting(snSource *storageNode, sns []*storageNode) bool {
+	if !enableSlownessRerouting {
 		return false
 	}
 
@@ -814,7 +833,7 @@ func allowRerouting(snSource *storageNode, sns []*storageNode) bool {
 // It is expected than *disableRerouting isn't set when calling this function.
 // It is expected that len(snb.sns) >= 2
 func rerouteRowsToFreeStorageNodes(snb *storageNodesBucket, snSource *storageNode, src []byte, getRowHasher func() rowHasher) (int, error) {
-	if *disableRerouting {
+	if !enableSlownessRerouting {
 		logger.Panicf("BUG: disableRerouting must be disabled when calling rerouteRowsToFreeStorageNodes")
 	}
 

--- a/app/vminsert/netstorage/netstorage_test.go
+++ b/app/vminsert/netstorage/netstorage_test.go
@@ -59,10 +59,11 @@ func TestAllowRerouting(t *testing.T) {
 
 		snSource := sns[snSourceIdx]
 
-		actual := allowRerouting(snSource, sns)
+		initSlownessRerouting()
+		actual := allowSlownessRerouting(snSource, sns)
 
 		if actual != expected {
-			t.Errorf("unexpected allowRerouting result for snSourceIdx=%d from %d storages; got %v; want %v", snSourceIdx, len(sns), actual, expected)
+			t.Errorf("unexpected allowSlownessRerouting result for snSourceIdx=%d from %d storages; got %v; want %v", snSourceIdx, len(sns), actual, expected)
 		}
 	}
 

--- a/docs/victoriametrics/Cluster-VictoriaMetrics.md
+++ b/docs/victoriametrics/Cluster-VictoriaMetrics.md
@@ -829,12 +829,9 @@ See also [minimum downtime strategy](#minimum-downtime-strategy).
 
 ## Slowness-based re-routing
 
-By default, `vminsert` nodes limit the cluster's overall ingestion rate to the throughput of the slowest `vmstorage` node. 
-This ensures that incoming metrics are evenly distributed across all `vmstorage` nodes. 
-The downside is that a single slow vmstorage node can throttle the entire cluster.
-
-When `-disableRerouting=false` is enabled on `vminsert`, 
-the cluster will automatically re-route writes away from the slowest vmstorage node to preserve maximum ingestion throughput.
+By default{{% available_from "#" %}}, `vminsert` automatically re-routes writes away from the slowest `vmstorage` node
+to preserve maximum ingestion throughput. This prevents a single slow `vmstorage` node
+from throttling the entire cluster.
 
 Re-routing occurs only when all of the following conditions hold:
 - the storage send buffer is full.
@@ -842,11 +839,15 @@ Re-routing occurs only when all of the following conditions hold:
 - the vmstorage cluster have much lower saturation overall.
 - the vmstorage cluster has at least three ready nodes.
 
-Enable slowness-based re-routing when peak write throughput matters more 
-than minimizing the number of [active time series](https://docs.victoriametrics.com/victoriametrics/faq/#what-is-an-active-time-series)
-or keeping metrics perfectly balanced across nodes.
+Disable slowness-based re-routing with `-disableRerouting=true` when keeping metrics
+perfectly balanced across nodes or minimizing the number of [active time series](https://docs.victoriametrics.com/victoriametrics/faq/#what-is-an-active-time-series) 
+matters more than peak write throughput.
 
-The rerouting and node saturation could be seen at  [VictoriaMetrics - cluster](https://grafana.com/grafana/dashboards/11176) dashboard.
+Slowness-based re-routing is automatically disabled{{% available_from "#" %}} when `-replicationFactor` is greater than `1`,
+because rerouting does not guarantee that replicated copies land on distinct storage nodes,
+which violates the replication contract.
+
+The rerouting and node saturation could be seen at [VictoriaMetrics - cluster](https://grafana.com/grafana/dashboards/11176) dashboard.
 
 ## Capacity planning
 

--- a/docs/victoriametrics/changelog/CHANGELOG.md
+++ b/docs/victoriametrics/changelog/CHANGELOG.md
@@ -26,7 +26,10 @@ See also [LTS releases](https://docs.victoriametrics.com/victoriametrics/lts-rel
 
 ## tip
 
+**Update Note 1:** `vminsert` in [VictoriaMetrics cluster](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/): the default value of `-disableRerouting` flag has changed from `true` to `false`, enabling [slowness-based re-routing](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/#slowness-based-re-routing) by default. Slowness re-routing is automatically disabled when `-replicationFactor` is greater than 1. If you rely on the old behavior, pass `-disableRerouting` command-line flag to `vminsert`. See [#11287](https://github.com/VictoriaMetrics/VictoriaMetrics/pull/11287).
+
 * FEATURE: [vmagent](https://docs.victoriametrics.com/victoriametrics/vmagent/): add `name` label identifying the corresponding `-remoteWrite.url` target to the `vm_persistentqueue_*` metrics exposed by persistent queue. See [#7944](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/7944). Thanks to @tIGO for contribution.
+* FEATURE: `vminsert` in [VictoriaMetrics cluster](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/): enable [slowness-based re-routing](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/#slowness-based-re-routing) by default. Previously, `-disableRerouting` defaulted to `true`, which limited ingestion throughput to the slowest `vmstorage` node. Now `-disableRerouting` defaults to `false`, so `vminsert` automatically routes data away from the slowest `vmstorage` node, improving overall ingestion performance. Slowness re-routing is automatically disabled when `-replicationFactor` is greater than 1. See [#11287](https://github.com/VictoriaMetrics/VictoriaMetrics/pull/11287).
 
 ## [v1.148.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.148.0)
 


### PR DESCRIPTION
[Slowness rerouting](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/#slowness-based-re-routing) was disabled by default in https://github.com/VictoriaMetrics/VictoriaMetrics/commit/a1b298a842040dd99f733e76265207f1e077917e due to rerouting storm issues.

PRs https://github.com/VictoriaMetrics/VictoriaMetrics/pull/9945 and https://github.com/VictoriaMetrics/VictoriaMetrics/pull/10901 fixed the storm: now only the single slowest storage node
is rerouted away from. With these fixes in place, most users benefit from
slowness rerouting being enabled by default.

Slowness rerouting is forcefully disabled when replicationFactor > 1 because:
- rerouting does not guarantee that replicated copies land on distinct storage nodes,
  which violates the replication contract
- rerouting under replication creates significant additional load on the next node