### PR TITLE
app/vmui: sync ui with vmanget recent changes

### DIFF
--- a/app/vmui/packages/vmui/src/pages/Relabel/index.tsx
+++ b/app/vmui/packages/vmui/src/pages/Relabel/index.tsx
@@ -84,7 +84,7 @@ const Relabel: FC = () => {
             type="textarea"
             label="A time series"
             value={labels}
-            placeholder={`up{job="job_name",instance="host:port"}`}
+            placeholder="up{job=&quot;job_name&quot;,instance=&quot;host:port&quot;}"
             onChange={handleChangeLabels}
             onEnter={handleRunQuery}
           />

--- a/app/vmui/packages/vmui/src/pages/Relabel/index.tsx
+++ b/app/vmui/packages/vmui/src/pages/Relabel/index.tsx
@@ -72,7 +72,7 @@ const Relabel: FC = () => {
         <div className="vm-relabeling-header-configs">
           <TextField
             type="textarea"
-            label="Relabel configs"
+            label="Config"
             value={config}
             autofocus
             onChange={handleChangeConfig}
@@ -82,8 +82,9 @@ const Relabel: FC = () => {
         <div className="vm-relabeling-header__labels">
           <TextField
             type="textarea"
-            label="Labels"
+            label="A time series"
             value={labels}
+            placeholder={`up{job="job_name",instance="host:port"}`}
             onChange={handleChangeLabels}
             onEnter={handleRunQuery}
           />
@@ -97,22 +98,22 @@ const Relabel: FC = () => {
             <Button
               variant="text"
               color="gray"
-              startIcon={<InfoIcon/>}
+              startIcon={<WikiIcon/>}
             >
               Relabeling cookbook
             </Button>
           </a>
           <a
             target="_blank"
-            href="https://docs.victoriametrics.com/victoriametrics/relabeling/"
+            href="https://docs.victoriametrics.com/victoriametrics/relabeling/#relabeling-stages"
             rel="help noreferrer"
           >
             <Button
               variant="text"
               color="gray"
-              startIcon={<WikiIcon/>}
+              startIcon={<InfoIcon/>}
             >
-              Documentation
+              Relabeling Stages
             </Button>
           </a>
           <Button


### PR DESCRIPTION
In https://github.com/VictoriaMetrics/VictoriaMetrics/pull/10607 vmagent metrics relabling debug UI has been refined. There are a [few changes](https://github.com/VictoriaMetrics/VictoriaMetrics/pull/10607#issuecomment-4956698085) that make sense in VMUI too:
- Rename "Labels" to "A time series" to highlight that a single Prometheus time series can be provided in text format.
- Rename "Relabel Configs" to "Config". It should be clear from the page contex what config is meant. Also there are links to documention.
- Add placeholder. It hints what could be placed into "A time series" textarea.
- Add link to Relabel Stages. Same as in vmagent. 
