### PR TITLE
lib/logstorage: return discarded in-memory parts to pool

### DIFF
--- a/lib/storage/partition.go
+++ b/lib/storage/partition.go
@@ -1290,6 +1290,9 @@ func (pt *partition) mergeParts(pws []*partWrapper, stopCh <-chan struct{}, isFi
 		putBlockStreamReader(bsr)
 	}
 	if err != nil {
+		if mpNew != nil {
+			putInmemoryPart(mpNew)
+		}
 		return err
 	}
 	if mpNew != nil {
@@ -1444,6 +1447,8 @@ func (pt *partition) openCreatedPart(ph *partHeader, pws []*partWrapper, mpNew *
 		// The created part is empty. Remove it
 		if mpNew == nil {
 			fs.MustRemoveDir(dstPartPath)
+		} else {
+			putInmemoryPart(mpNew)
 		}
 		return nil
 	}


### PR DESCRIPTION
Returns interrupted or empty in-memory merge results to the pool