### PR TITLE
lib/promscrape: add vm_promscrape_scrape_configs_invalid metric

### DIFF
--- a/docs/victoriametrics/changelog/CHANGELOG.md
+++ b/docs/victoriametrics/changelog/CHANGELOG.md
@@ -26,7 +26,7 @@ See also [LTS releases](https://docs.victoriametrics.com/victoriametrics/lts-rel
 
 ## tip
 
-* BUGFIX: [vmagent](https://docs.victoriametrics.com/victoriametrics/vmagent/): add `vm_promscrape_scrape_configs_invalid` metric tracking `scrape_config` entries dropped during the last config reload (e.g. because of an unsupported `relabel_configs` regex such as a Perl-style negative lookahead). Previously such a `scrape_config` was silently excluded from scraping with only a log line, so the affected target never appeared even as "down", and alerting based on scrape target availability never fired. See [#8426](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8426).
+* BUGFIX: [vmagent](https://docs.victoriametrics.com/victoriametrics/vmagent/), `vminsert` in [VictoriaMetrics cluster](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/), and [vmsingle](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/): add `vm_promscrape_scrape_configs_invalid` metric tracking `scrape_config` entries dropped during the last successful config reload (e.g. because of an unsupported `relabel_configs` regex such as a Perl-style negative lookahead). Previously such a `scrape_config` was silently excluded from scraping with only a log line, so the affected target never appeared even as "down", and alerting based on scrape target availability never fired. See [#8426](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8426).
 
 ## [v1.149.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.149.0)
 

--- a/docs/victoriametrics/changelog/CHANGELOG.md
+++ b/docs/victoriametrics/changelog/CHANGELOG.md
@@ -26,6 +26,8 @@ See also [LTS releases](https://docs.victoriametrics.com/victoriametrics/lts-rel
 
 ## tip
 
+* BUGFIX: [vmagent](https://docs.victoriametrics.com/victoriametrics/vmagent/): add `vm_promscrape_scrape_configs_invalid` metric tracking `scrape_config` entries dropped during the last config reload (e.g. because of an unsupported `relabel_configs` regex such as a Perl-style negative lookahead). Previously such a `scrape_config` was silently excluded from scraping with only a log line, so the affected target never appeared even as "down", and alerting based on scrape target availability never fired. See [#8426](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8426).
+
 ## [v1.149.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.149.0)
 
 Release candidate

--- a/lib/promscrape/config.go
+++ b/lib/promscrape/config.go
@@ -569,6 +569,10 @@ func (cfg *Config) parseData(data []byte, path string) error {
 	}
 	tailScrapeConfigs := cfg.ScrapeConfigs[len(validScrapeConfigs):]
 	cfg.ScrapeConfigs = validScrapeConfigs
+	// Surface how many scrape_config entries were dropped above so operators
+	// can alert on it - otherwise a misconfigured job (e.g. an unsupported
+	// relabel_config regex) simply disappears with no scrapable signal at all.
+	scrapeConfigsInvalid.Set(float64(len(tailScrapeConfigs)))
 	for i := range tailScrapeConfigs {
 		tailScrapeConfigs[i] = nil
 	}

--- a/lib/promscrape/config_test.go
+++ b/lib/promscrape/config_test.go
@@ -354,6 +354,60 @@ scrape_configs:
 	checkEqualScrapeWorks(t, sws, swsExpected)
 }
 
+// TestInvalidScrapeConfigIsCountedAndSkipped is a regression test for
+// https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8426: a
+// scrape_config whose relabel_configs regex is unsupported by Go's regexp
+// package (e.g. a Perl-style negative lookahead) is silently dropped from
+// cfg.ScrapeConfigs with only a log line, and no scrapable signal ever
+// indicates it happened. Valid jobs alongside it must still load normally,
+// and scrapeConfigsInvalid must reflect the number of dropped jobs so
+// operators can alert on it instead of a job just vanishing unnoticed.
+func TestInvalidScrapeConfigIsCountedAndSkipped(t *testing.T) {
+	data := `
+scrape_configs:
+- job_name: valid
+  static_configs:
+  - targets: ["host1:80"]
+- job_name: invalid
+  relabel_configs:
+  - source_labels: [__meta_kubernetes_node_label_foo]
+    regex: "(?!bar).+"
+    action: keep
+  static_configs:
+  - targets: ["host2:80"]
+`
+	var cfg Config
+	if err := cfg.parseData([]byte(data), "sss"); err != nil {
+		t.Fatalf("cannot parse data: %s", err)
+	}
+
+	if len(cfg.ScrapeConfigs) != 1 {
+		t.Fatalf("unexpected number of scrape configs loaded; got %d; want 1", len(cfg.ScrapeConfigs))
+	}
+	if cfg.ScrapeConfigs[0].JobName != "valid" {
+		t.Fatalf("unexpected scrape config loaded; got job_name=%q; want %q", cfg.ScrapeConfigs[0].JobName, "valid")
+	}
+
+	if got := scrapeConfigsInvalid.Get(); got != 1 {
+		t.Fatalf("unexpected scrapeConfigsInvalid value; got %v; want 1", got)
+	}
+
+	// Reloading with an all-valid config must reset the gauge back to 0,
+	// so a subsequent fix to the scrape_configs is reflected promptly.
+	dataFixed := `
+scrape_configs:
+- job_name: valid
+  static_configs:
+  - targets: ["host1:80"]
+`
+	if err := cfg.parseData([]byte(dataFixed), "sss"); err != nil {
+		t.Fatalf("cannot parse fixed data: %s", err)
+	}
+	if got := scrapeConfigsInvalid.Get(); got != 0 {
+		t.Fatalf("unexpected scrapeConfigsInvalid value after reload with valid config; got %v; want 0", got)
+	}
+}
+
 func TestBlackboxExporter(t *testing.T) {
 	// See https://github.com/VictoriaMetrics/VictoriaMetrics/issues/684
 	data := `

--- a/lib/promscrape/scraper.go
+++ b/lib/promscrape/scraper.go
@@ -222,6 +222,15 @@ var (
 	configReloadErrors = configMetricsSet.NewCounter(`vm_promscrape_config_reloads_errors_total`)
 	configSuccess      = configMetricsSet.NewGauge(`vm_promscrape_config_last_reload_successful`, nil)
 	configTimestamp    = configMetricsSet.NewCounter(`vm_promscrape_config_last_reload_success_timestamp_seconds`)
+
+	// scrapeConfigsInvalid tracks scrape_config entries dropped during the
+	// most recent successful reload because getScrapeWorkConfig() couldn't
+	// build them (e.g. an unsupported relabel_config regex). Such entries
+	// are silently excluded from ScrapeConfigs, so without this gauge a
+	// misconfigured job simply vanishes - it isn't even shown as a "down"
+	// target - and any alerting based on scrape target availability never
+	// fires. See https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8426
+	scrapeConfigsInvalid = configMetricsSet.NewGauge(`vm_promscrape_scrape_configs_invalid`, nil)
 )
 
 type scrapeConfigs struct {


### PR DESCRIPTION
Fixes #8426

## What this PR does / why we need it

When a `scrape_config`'s `relabel_configs` regex is unsupported by Go's `regexp` package (e.g. a Perl-style negative lookahead like `(?!feature_node)`), `getScrapeWorkConfig` returns an error and the whole `scrape_config` is silently dropped from `cfg.ScrapeConfigs` in `parseData` (`lib/promscrape/config.go`), with only a log line:

```
skipping `scrape_config` for job_name=%s because of error: %s
```

The overall config reload still succeeds (`vm_promscrape_config_last_reload_successful` stays `1`), and the affected job never appears in the scrape targets list — not even as "down". As reported in #8426, this means alerting based on scrape target availability never fires, and the only way to notice is to read vmagent's logs.

## Fix

Added `vm_promscrape_scrape_configs_invalid`, a gauge in the same `configMetricsSet` as the existing `vm_promscrape_config_*` metrics (`lib/promscrape/scraper.go`), set in `parseData` to the number of `scrape_config` entries dropped for this reason during the most recent successful reload (`lib/promscrape/config.go`). This reuses the already-computed `tailScrapeConfigs` slice length rather than adding a separate counter to the loop.

This intentionally does *not* reuse `vm_promscrape_config_reloads_errors_total` — that metric means "the entire reload failed" (e.g. malformed YAML), which is a different and more severe condition than "the reload succeeded but N of M scrape_config entries were unusable".

## Testing

Added `TestInvalidScrapeConfigIsCountedAndSkipped` in `lib/promscrape/config_test.go`, following the existing `cfg.parseData([]byte(data), "sss")` pattern used by `TestAddressWithFullURL`/`TestBlackboxExporter` in the same file. It:
- Parses a config with one valid `scrape_config` and one with a negative-lookahead regex (the exact pattern from the issue's repro), and asserts only the valid job is loaded and `vm_promscrape_scrape_configs_invalid` reads `1`.
- Reloads with an all-valid config afterward and asserts the gauge resets to `0`.

Verified via `git stash` that reverting only `lib/promscrape/config.go` and `lib/promscrape/scraper.go` (keeping the new test) makes the package fail to *compile* (`scrapeConfigsInvalid` undefined) — a clear demonstration the metric didn't exist before. Restoring the fix makes the test pass.

`go build ./lib/promscrape/... ./app/vmagent/...`, `go vet ./lib/promscrape/...`, and `go test ./lib/promscrape/` all pass with no regressions.

Also added a `## tip` CHANGELOG.md entry following the existing `BUGFIX: [vmagent]: ...` format.
