### PR TITLE
.github/build: fix Go build cache collisions between cross-compile targets

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,11 +73,19 @@ jobs:
         id: go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
-          cache-dependency-path: |
-            go.sum
-            Makefile
-            app/**/Makefile
+          cache: false
           go-version-file: 'go.mod'
+
+      - name: Cache Go build artifacts
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: go-build-${{ matrix.os }}-${{ matrix.arch }}-${{ hashFiles('go.sum', 'Makefile') }}
+          restore-keys: |
+            go-build-${{ matrix.os }}-${{ matrix.arch }}-
+
       - run: go version
 
       - name: Build victoria-metrics for ${{ matrix.os }}-${{ matrix.arch }}


### PR DESCRIPTION
setup-go's built-in cache uses the runner's OS/arch in the key, not the
target GOOS/GOARCH. When multiple cross-compile jobs run in parallel on
the same runner, they share the same cache key and overwrite each other.

Replace setup-go caching (cache: false) with an explicit actions/cache
step whose key includes matrix.os and matrix.arch, giving each target
its own isolated cache slot. 

The change significantly improves build time. See screenshots.

On master:
<img width="1062" height="638" alt="Screenshot 2026-08-05 at 18 02 43" src="https://github.com/user-attachments/assets/008bf237-4116-4f65-81fe-30d50bb39295" />
<img width="1047" height="625" alt="Screenshot 2026-08-05 at 18 02 59" src="https://github.com/user-attachments/assets/3abc047f-9430-4ae9-a50a-2bfad13d7e5d" />

This commit:
<img width="1073" height="744" alt="Screenshot 2026-08-05 at 17 57 56" src="https://github.com/user-attachments/assets/3cc0d3eb-b88a-472d-8261-2f25f6788256" />
<img width="1058" height="744" alt="Screenshot 2026-08-05 at 17 58 03" src="https://github.com/user-attachments/assets/9c592596-7577-4503-8482-080bd739a4ac" />
