### PR TITLE
Docs: Add missing frontmatter in READMEs. Remove duplicate URLs

### DIFF
--- a/docs/ai-tools/README.md
+++ b/docs/ai-tools/README.md
@@ -1,3 +1,11 @@
+---
+build:
+  list: never
+  publishResources: false
+  render: never
+sitemap:
+  disable: true
+---
 VictoriaMetrics Observability Stack integrates with AI assistants through [MCP servers](https://docs.victoriametrics.com/ai-tools/#mcp-servers)
 and [agent skills](https://docs.victoriametrics.com/ai-tools/#agent-skills).
 The integrations allow AI agents and automation tools to query Metrics, Logs, and Traces, analyze telemetry data, 

--- a/docs/guides/connecting-vm-components-to-cloud-storage/README.md
+++ b/docs/guides/connecting-vm-components-to-cloud-storage/README.md
@@ -1,3 +1,11 @@
+---
+build:
+  list: never
+  publishResources: false
+  render: never
+sitemap:
+  disable: true
+---
 Several VictoriaMetrics components can connect to cloud storage to read or write object data.
 
 The following table shows the supported types of storage for each component:

--- a/docs/guides/grafana-vmauth-openid-configuration/README.md
+++ b/docs/guides/grafana-vmauth-openid-configuration/README.md
@@ -1,3 +1,11 @@
+---
+build:
+  list: never
+  publishResources: false
+  render: never
+sitemap:
+  disable: true
+---
 Using [Grafana](https://grafana.com/) with [vmauth](https://docs.victoriametrics.com/victoriametrics/vmauth/) is an effective way to provide [multi-tenant](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/#multitenancy) access to your metrics, logs, and traces.
 vmauth provides a way to authenticate users using [JWT tokens](https://en.wikipedia.org/wiki/JSON_Web_Token) {{% available_from "v1.138.0" %}} issued by an external identity provider.
 Those tokens can include information about the user and their tenant, which vmauth can use to restrict access so users only see metrics in their own tenant.

--- a/docs/opentelemetry/README.md
+++ b/docs/opentelemetry/README.md
@@ -1,3 +1,11 @@
+---
+build:
+  list: never
+  publishResources: false
+  render: never
+sitemap:
+  disable: true
+---
 VictoriaMetrics software provides native [OpenTelemetry](https://opentelemetry.io/) ingestion across **metrics**, **logs**, and **traces** via dedicated components.
 This allows running OpenTelemetry-based observability pipeline with VictoriaMetrics software as your backend.
 

--- a/docs/playgrounds/README.md
+++ b/docs/playgrounds/README.md
@@ -1,3 +1,11 @@
+---
+build:
+  list: never
+  publishResources: false
+  render: never
+sitemap:
+  disable: true
+---
 VictoriaMetrics offers public playgrounds where you can try the full observability stack online.
 
 Some playgrounds are based on the [OpenTelemetry Astronomy Shop demo](https://github.com/open-telemetry/opentelemetry-demo), a sample microservices application that generates realistic metrics, logs, and traces. Other playgrounds use benchmark workloads such as [prometheus-benchmark](https://github.com/VictoriaMetrics/prometheus-benchmark) to demonstrate ingestion and query performance for Prometheus-compatible systems.


### PR DESCRIPTION
Some README.md do not have a frontmatter. This leads to duplicated URLs when published. 

For example, these two URLs render the same page, which leads to duplication. The first one should return 404.
- https://docs.victoriametrics.com/opentelemetry/readme/index.html 
- https://docs.victoriametrics.com/opentelemetry/

This PR adds missing frontmatter so all duplicate URLs are removed and never rendered.

```yaml
---
build:
  list: never
  publishResources: false
  render: never
sitemap:
  disable: true
---
```

(issue reported by @hagen1778, thank you!)