### PR TITLE
app/vmagent: properly stop remotewrite in TestInsertHandler teardown

### DIFF
--- a/app/vmagent/prometheusimport/request_handler_test.go
+++ b/app/vmagent/prometheusimport/request_handler_test.go
@@ -52,6 +52,7 @@ func setUp() {
 
 func tearDown() {
 	protoparserutil.StopUnmarshalWorkers()
+	remotewrite.Stop()
 	srv.Close()
 	logger.ResetOutputForTest()
 	tmpDataDir := flag.Lookup("remoteWrite.tmpDataPath").Value.String()

--- a/app/vmagent/remotewrite/remotewrite.go
+++ b/app/vmagent/remotewrite/remotewrite.go
@@ -245,6 +245,8 @@ func Init() {
 	dropDanglingQueues()
 
 	// Start config reloader.
+	configReloaderStopCh = make(chan struct{})
+	configReloaderWG = sync.WaitGroup{}
 	configReloaderWG.Go(func() {
 		for {
 			select {
@@ -331,7 +333,7 @@ func initRemoteWriteCtxs(urls []string) {
 }
 
 var (
-	configReloaderStopCh = make(chan struct{})
+	configReloaderStopCh chan struct{}
 	configReloaderWG     sync.WaitGroup
 )
 


### PR DESCRIPTION
The test was not calling `remotewrite.Stop()` in tearDown, which left file descriptors for the persisted queue open. Running the test multiple times would eventually exhaust fd limits and cause a panic.

Adding `remotewrite.Stop()` exposed a second issue: `configReloaderStopCh` was initialized at package level, so it was already closed after the first `Stop()` call. Re-initializing Init() (as in `go test ./app/vmagent/prometheusimport/ -count=2`) would then panic on a closed channel.

Fixed by moving `configReloaderStopCh` and `configReloaderWG` initialization into Init(), so each Init/Stop cycle starts with a fresh channel.

Decoupled from https://github.com/VictoriaMetrics/VictoriaMetrics/pull/11354, where @zasdaym originally identified the issue.