### PR TITLE
lib/storage: check early whether an indexDB contains the time range

### DIFF
--- a/lib/storage/index_db.go
+++ b/lib/storage/index_db.go
@@ -1295,7 +1295,7 @@ func (db *indexDB) GetTSDBStatus(qt *querytracer.Tracer, tfss []*TagFilters, dat
 
 	if !db.legacyContainsDate(date) {
 		qt.Printf("indexDB doesn't contain data for the given date: %s", dateToString(date))
-		return nil, nil
+		return &TSDBStatus{}, nil
 	}
 
 	is := db.getIndexSearch(deadline)

--- a/lib/storage/index_db.go
+++ b/lib/storage/index_db.go
@@ -99,7 +99,7 @@ type indexDB struct {
 	// legacy indexDBs, since these indexDBs are readonly.
 	// This field cannot be used for the partition indexDBs, since they may receive data
 	// with bigger timestamps at any time.
-	legacyMinMissingTimestampByKey map[string]int64
+	legacyMinMissingTimestampByKey map[TenantToken]int64
 	// protects legacyMinMissingTimestampByKey
 	legacyMinMissingTimestampByKeyLock sync.Mutex
 
@@ -174,7 +174,7 @@ func mustOpenIndexDB(id uint64, tr TimeRange, name, path string, s *Storage, isR
 	tfssCache := lrucache.NewCache(getTagFiltersCacheSize)
 	tb := mergeset.MustOpenTable(path, dataFlushInterval, tfssCache.Reset, 0, mergeTagToMetricIDsRows, isReadOnly)
 	db := &indexDB{
-		legacyMinMissingTimestampByKey: make(map[string]int64),
+		legacyMinMissingTimestampByKey: make(map[TenantToken]int64),
 		id:                             id,
 		tr:                             tr,
 		name:                           name,
@@ -508,6 +508,11 @@ func (db *indexDB) SearchLabelNames(qt *querytracer.Tracer, tfss []*TagFilters, 
 	qt = qt.NewChild("search label names: filters=%s, timeRange=%s, maxLabelNames=%d, maxMetrics=%d", tfss, &tr, maxLabelNames, maxMetrics)
 	defer qt.Done()
 
+	if !db.legacyContainsTimeRange(tr) {
+		qt.Printf("indexDB doesn't contain data for the given time range: %v", &tr)
+		return nil, nil
+	}
+
 	is := db.getIndexSearch(deadline)
 	lns, err := is.searchLabelNamesWithFiltersOnTimeRange(qt, tfss, tr, maxLabelNames, maxMetrics)
 	db.putIndexSearch(is)
@@ -709,6 +714,11 @@ func (is *indexSearch) getLabelNamesForMetricIDs(qt *querytracer.Tracer, metricI
 func (db *indexDB) SearchLabelValues(qt *querytracer.Tracer, labelName string, tfss []*TagFilters, tr TimeRange, maxLabelValues, maxMetrics int, deadline uint64) (map[string]struct{}, error) {
 	qt = qt.NewChild("search label values: labelName=%q, filters=%s, timeRange=%s, maxLabelValues=%d, maxMetrics=%d", labelName, tfss, &tr, maxLabelValues, maxMetrics)
 	defer qt.Done()
+
+	if !db.legacyContainsTimeRange(tr) {
+		qt.Printf("indexDB doesn't contain data for the given time range: %v", &tr)
+		return nil, nil
+	}
 
 	key := labelName
 	if key == "__name__" {
@@ -958,6 +968,11 @@ func (db *indexDB) SearchTagValueSuffixes(qt *querytracer.Tracer, tr TimeRange, 
 		&tr, tagKey, tagValuePrefix, delimiter, maxTagValueSuffixes)
 	defer qt.Done()
 
+	if !db.legacyContainsTimeRange(tr) {
+		qt.Printf("indexDB doesn't contain data for the given time range: %v", &tr)
+		return nil, nil
+	}
+
 	// TODO: cache results?
 
 	is := db.getIndexSearch(deadline)
@@ -1091,6 +1106,11 @@ func (is *indexSearch) searchTagValueSuffixesForPrefix(nsPrefix byte, prefix []b
 func (db *indexDB) SearchGraphitePaths(qt *querytracer.Tracer, tr TimeRange, qHead, qTail []byte, maxPaths int, deadline uint64) (map[string]struct{}, error) {
 	qt = qt.NewChild("search graphite paths: timeRange=%s, qHead=%q, qTail=%q, maxPaths=%d", &tr, bytesutil.ToUnsafeString(qHead), bytesutil.ToUnsafeString(qTail), maxPaths)
 	defer qt.Done()
+
+	if !db.legacyContainsTimeRange(tr) {
+		qt.Printf("indexDB doesn't contain data for the given time range: %v", &tr)
+		return nil, nil
+	}
 
 	n := bytes.IndexAny(qTail, "*[{")
 	if n < 0 {
@@ -1272,6 +1292,11 @@ func (is *indexSearch) getSeriesCount() (uint64, error) {
 func (db *indexDB) GetTSDBStatus(qt *querytracer.Tracer, tfss []*TagFilters, date uint64, focusLabel string, topN, maxMetrics int, deadline uint64) (*TSDBStatus, error) {
 	qt = qt.NewChild("collect TSDB status: filters=%s, date=%s, focusLabel=%q, topN=%d, maxMetrics=%d", tfss, dateToString(date), focusLabel, topN, maxMetrics)
 	defer qt.Done()
+
+	if !db.legacyContainsDate(date) {
+		qt.Printf("indexDB doesn't contain data for the given date: %s", dateToString(date))
+		return nil, nil
+	}
 
 	is := db.getIndexSearch(deadline)
 	defer db.putIndexSearch(is)
@@ -1720,6 +1745,11 @@ func (db *indexDB) SearchTSIDs(qt *querytracer.Tracer, tfss []*TagFilters, tr Ti
 	qt = qt.NewChild("search TSIDs: filters=%s, timeRange=%s, maxMetrics=%d", tfss, &tr, maxMetrics)
 	defer qt.Done()
 
+	if !db.legacyContainsTimeRange(tr) {
+		qt.Printf("indexDB doesn't contain data for the given time range: %v", &tr)
+		return nil, nil
+	}
+
 	metricIDs, err := db.searchMetricIDs(qt, tfss, tr, maxMetrics, deadline)
 	if err != nil {
 		return nil, db.wrapError("search TSIDs", err)
@@ -1802,6 +1832,11 @@ func (db *indexDB) searchMetricName(dst []byte, metricID uint64, noCache bool) (
 func (db *indexDB) SearchMetricNames(qt *querytracer.Tracer, tfss []*TagFilters, tr TimeRange, maxMetrics int, deadline uint64) ([]string, error) {
 	qt = qt.NewChild("search metric names: filters=%s, timeRange=%s, maxMetrics=%d", tfss, &tr, maxMetrics)
 	defer qt.Done()
+
+	if !db.legacyContainsTimeRange(tr) {
+		qt.Printf("indexDB doesn't contain data for the given time range: %v", &tr)
+		return nil, nil
+	}
 
 	metricIDs, err := db.searchMetricIDs(qt, tfss, tr, maxMetrics, deadline)
 	if err != nil {
@@ -2219,18 +2254,12 @@ func (is *indexSearch) searchMetricIDsInternal(qt *querytracer.Tracer, tfss []*T
 	qt = qt.NewChild("search for metric ids: filters=%s, timeRange=%s, maxMetrics=%d", tfss, &tr, maxMetrics)
 	defer qt.Done()
 
-	metricIDs := &uint64set.Set{}
-
-	if !is.legacyContainsTimeRange(tr) {
-		qt.Printf("indexdb doesn't contain data for the given timeRange=%s", &tr)
-		return metricIDs, nil
-	}
-
 	if tr.MinTimestamp >= is.db.s.minTimestampForCompositeIndex {
 		tfss = convertToCompositeTagFilterss(tfss)
 		qt.Printf("composite filters=%s", tfss)
 	}
 
+	metricIDs := &uint64set.Set{}
 	for _, tfs := range tfss {
 		if len(tfs.tfs) == 0 {
 			// An empty filters must be equivalent to `{__name__!=""}`

--- a/lib/storage/index_db_legacy.go
+++ b/lib/storage/index_db_legacy.go
@@ -7,7 +7,6 @@ import (
 	"strconv"
 	"sync/atomic"
 
-	"github.com/VictoriaMetrics/VictoriaMetrics/lib/bytesutil"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/encoding"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/fs"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/logger"
@@ -87,48 +86,60 @@ func mustOpenLegacyIndexDB(path string, s *Storage) *legacyIndexDB {
 	return legacyIDB
 }
 
-func (is *indexSearch) legacyContainsTimeRange(tr TimeRange) bool {
-	if tr == globalIndexTimeRange {
+func (db *indexDB) legacyContainsDate(date uint64) bool {
+	tr := TimeRange{
+		MinTimestamp: int64(date) * msecPerDay,
+		MaxTimestamp: int64(date+1)*msecPerDay - 1,
+	}
+	return db.legacyContainsTimeRange(tr)
+}
+
+func (db *indexDB) legacyContainsTimeRange(tr TimeRange) bool {
+	if db.s.disablePerDayIndex {
+		// If per-day index is disabled, there is no way to tell if indexDB
+		// contains data for the given time range. Assume that it does.
 		return true
 	}
 
-	db := is.db
 	if !db.noRegisterNewSeries.Load() {
 		// indexDB could register new time series - it is not safe to cache minMissingTimestamp
 		return true
 	}
 
-	// use common prefix as a key for minMissingTimestamp
-	// it's needed to properly track timestamps for cluster version
-	// which uses tenant labels for the index search
-	kb := &is.kb
-	kb.B = is.marshalCommonPrefix(kb.B[:0], nsPrefixDateToMetricID)
-	key := kb.B
-
+	// vmsingle does not have tenants and therefore has just one key.
+	// While vmstorage can potentially have many tenants and the actual
+	// accountID and projectID will be set from the request.
+	key := TenantToken{
+		AccountID: 0,
+		ProjectID: 0,
+	}
 	db.legacyMinMissingTimestampByKeyLock.Lock()
-	minMissingTimestamp, ok := db.legacyMinMissingTimestampByKey[string(key)]
+	minMissingTimestamp, ok := db.legacyMinMissingTimestampByKey[key]
 	db.legacyMinMissingTimestampByKeyLock.Unlock()
 
 	if ok && tr.MinTimestamp >= minMissingTimestamp {
+		// Fast path.
 		return false
 	}
-	if is.legacyContainsTimeRangeSlow(kb, tr) {
+
+	// Slow path.
+	is := db.getIndexSearch(noDeadline)
+	defer db.putIndexSearch(is)
+	if is.legacyContainsTimeRange(tr) {
 		return true
 	}
 
 	db.legacyMinMissingTimestampByKeyLock.Lock()
-	minMissingTimestamp, ok = db.legacyMinMissingTimestampByKey[string(key)]
+	minMissingTimestamp, ok = db.legacyMinMissingTimestampByKey[key]
 	if !ok || tr.MinTimestamp < minMissingTimestamp {
-		db.legacyMinMissingTimestampByKey[string(key)] = tr.MinTimestamp
+		db.legacyMinMissingTimestampByKey[key] = tr.MinTimestamp
 	}
 	db.legacyMinMissingTimestampByKeyLock.Unlock()
 
 	return false
 }
 
-func (is *indexSearch) legacyContainsTimeRangeSlow(prefixBuf *bytesutil.ByteBuffer, tr TimeRange) bool {
-	ts := &is.ts
-
+func (is *indexSearch) legacyContainsTimeRange(tr TimeRange) bool {
 	// Verify whether the tr.MinTimestamp is included into `ts` or is smaller than the minimum date stored in `ts`.
 	// Do not check whether tr.MaxTimestamp is included into `ts` or is bigger than the max date stored in `ts` for performance reasons.
 	// This means that this func can return true if `tr` is located below the min date stored in `ts`.
@@ -136,12 +147,17 @@ func (is *indexSearch) legacyContainsTimeRangeSlow(prefixBuf *bytesutil.ByteBuff
 	// The main practical case allows skipping searching in prev indexdb (`ts`) when `tr`
 	// is located above the max date stored there.
 	minDate := uint64(tr.MinTimestamp) / msecPerDay
-	prefix := prefixBuf.B
-	prefixBuf.B = encoding.MarshalUint64(prefixBuf.B, minDate)
-	ts.Seek(prefixBuf.B)
+
+	kb := &is.kb
+	kb.B = is.marshalCommonPrefix(kb.B[:0], nsPrefixDateToMetricID)
+	prefix := kb.B
+	kb.B = encoding.MarshalUint64(kb.B, minDate)
+
+	ts := &is.ts
+	ts.Seek(kb.B)
 	if !ts.NextItem() {
 		if err := ts.Error(); err != nil {
-			logger.Panicf("FATAL: error when searching for minDate=%d, prefix %q: %s", minDate, prefixBuf.B, err)
+			logger.Panicf("FATAL: error when searching for minDate=%d, prefix %q: %s", minDate, kb.B, err)
 		}
 		return false
 	}

--- a/lib/storage/index_db_legacy_test.go
+++ b/lib/storage/index_db_legacy_test.go
@@ -29,11 +29,7 @@ func TestLegacyContainsTimeRange(t *testing.T) {
 
 	f := func(idb *indexDB, tr TimeRange, want bool) {
 		t.Helper()
-		is := idb.getIndexSearch(noDeadline)
-		defer idb.putIndexSearch(is)
-
-		got := is.legacyContainsTimeRange(tr)
-
+		got := idb.legacyContainsTimeRange(tr)
 		if got != want {
 			t.Fatalf("legacyContainsTimeRange(%s) for index db %s returns unexpected result: got %t, want %t", tr.String(), idb.name, got, want)
 		}
@@ -97,8 +93,8 @@ func TestLegacyContainsTimeRange(t *testing.T) {
 	f(legacyIDBs.getIDBCurr(), tr, true)
 	f(idb, tr, true)
 
-	// Fully inside trPt, overlaps with trPrev on the right side and trCurr on
-	// the left side.
+	// Fully inside trPt, overlaps with trPrev on the right side and with trCurr
+	// on the left side.
 	tr = TimeRange{
 		MinTimestamp: time.Date(2025, 1, 7, 0, 0, 0, 0, time.UTC).UnixMilli(),
 		MaxTimestamp: time.Date(2025, 1, 21, 23, 59, 59, 999_999_999, time.UTC).UnixMilli(),

--- a/lib/storage/index_db_test.go
+++ b/lib/storage/index_db_test.go
@@ -2241,15 +2241,16 @@ func TestIndexSearchLegacyContainsTimeRange_Concurrent(t *testing.T) {
 	for i := range concurrency {
 		ts := minTimestamp + msecPerDay*i
 		wg.Go(func() {
-			is := idb.getIndexSearch(noDeadline)
-			_ = is.legacyContainsTimeRange(TimeRange{ts, ts})
-			idb.putIndexSearch(is)
+			_ = idb.legacyContainsTimeRange(TimeRange{ts, ts})
 		})
 	}
 	wg.Wait()
 
-	key := marshalCommonPrefix(nil, nsPrefixDateToMetricID)
-	if got, want := idb.legacyMinMissingTimestampByKey[string(key)], minTimestamp; got != want {
+	key := TenantToken{
+		AccountID: 0,
+		ProjectID: 0,
+	}
+	if got, want := idb.legacyMinMissingTimestampByKey[key], minTimestamp; got != want {
 		t.Fatalf("unexpected min timestamp: got %v, want %v", time.UnixMilli(got).UTC(), time.UnixMilli(want).UTC())
 	}
 }

--- a/lib/storage/storage_legacy_test.go
+++ b/lib/storage/storage_legacy_test.go
@@ -33,16 +33,22 @@ func TestLegacyStorage_SearchMetricNames(t *testing.T) {
 		return mrs, want
 	}
 	const numMetrics = 1000
-	tr := TimeRange{
+	tr1 := TimeRange{
 		MinTimestamp: time.Date(2023, 6, 1, 0, 0, 0, 0, time.UTC).UnixMilli(),
 		MaxTimestamp: time.Date(2024, 5, 31, 23, 59, 59, 999_999_999, time.UTC).UnixMilli(),
 	}
-	legacyData, wantLegacy := genData(numMetrics, "legacy", tr)
-	newData, wantNew := genData(numMetrics, "new", tr)
-	wantNew = append(wantNew, wantLegacy...)
-	slices.Sort(wantNew)
+	tr2 := TimeRange{
+		MinTimestamp: time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC).UnixMilli(),
+		MaxTimestamp: time.Date(2024, 6, 30, 23, 59, 59, 999_999_999, time.UTC).UnixMilli(),
+	}
+	legacyData, wantLegacy := genData(numMetrics, "legacy", tr1)
+	new1Data, wantNew1 := genData(numMetrics, "new1", tr1)
+	new2Data, wantNew2 := genData(numMetrics, "new2", tr2)
+	newData := slices.Concat(new1Data, new2Data)
+	wantLegacyAndNew1 := slices.Concat(wantLegacy, wantNew1)
+	slices.Sort(wantLegacyAndNew1)
 
-	assertSearchResults := func(s *Storage, want []string) {
+	assertSearchResults := func(s *Storage, tr TimeRange, want []string) {
 		t.Helper()
 		tfsAll := NewTagFilters()
 		if err := tfsAll.Add([]byte("__name__"), []byte(".*"), false, true); err != nil {
@@ -67,10 +73,11 @@ func TestLegacyStorage_SearchMetricNames(t *testing.T) {
 	}
 
 	assertLegacyData := func(s *Storage) {
-		assertSearchResults(s, wantLegacy)
+		assertSearchResults(s, tr1, wantLegacy)
 	}
 	assertNewData := func(s *Storage) {
-		assertSearchResults(s, wantNew)
+		assertSearchResults(s, tr1, wantLegacyAndNew1)
+		assertSearchResults(s, tr2, wantNew2)
 	}
 	testSearchOpWithLegacyIndexDBs(t, legacyData, newData, assertLegacyData, assertNewData)
 }
@@ -95,15 +102,22 @@ func TestLegacyStorage_SearchLabelNames(t *testing.T) {
 		return mrs, want
 	}
 	const numMetrics = 1000
-	tr := TimeRange{
+	tr1 := TimeRange{
 		MinTimestamp: time.Date(2023, 6, 1, 0, 0, 0, 0, time.UTC).UnixMilli(),
 		MaxTimestamp: time.Date(2024, 5, 31, 23, 59, 59, 999_999_999, time.UTC).UnixMilli(),
 	}
-	legacyData, wantLegacy := genData(numMetrics, "legacy", tr)
-	newData, wantNew := genData(numMetrics, "new", tr)
-	wantNew = append(wantNew, wantLegacy...)
+	tr2 := TimeRange{
+		MinTimestamp: time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC).UnixMilli(),
+		MaxTimestamp: time.Date(2024, 6, 30, 23, 59, 59, 999_999_999, time.UTC).UnixMilli(),
+	}
+	legacyData, wantLegacy := genData(numMetrics, "legacy", tr1)
+	new1Data, wantNew1 := genData(numMetrics, "new1", tr1)
+	new2Data, wantNew2 := genData(numMetrics, "new2", tr2)
+	newData := slices.Concat(new1Data, new2Data)
+	wantLegacyAndNew1 := slices.Concat(wantLegacy, wantNew1)
+	slices.Sort(wantLegacyAndNew1)
 
-	assertSearchResults := func(s *Storage, want []string) {
+	assertSearchResults := func(s *Storage, tr TimeRange, want []string) {
 		t.Helper()
 		got, err := s.SearchLabelNames(nil, nil, tr, 1e9, 1e9, noDeadline)
 		if err != nil {
@@ -118,12 +132,16 @@ func TestLegacyStorage_SearchLabelNames(t *testing.T) {
 	assertLegacyData := func(s *Storage) {
 		want := append(wantLegacy, "__name__")
 		slices.Sort(want)
-		assertSearchResults(s, want)
+		assertSearchResults(s, tr1, want)
 	}
 	assertNewData := func(s *Storage) {
-		want := append(wantNew, "__name__")
+		want := append(wantLegacyAndNew1, "__name__")
 		slices.Sort(want)
-		assertSearchResults(s, want)
+		assertSearchResults(s, tr1, want)
+
+		want = append(wantNew2, "__name__")
+		slices.Sort(want)
+		assertSearchResults(s, tr2, want)
 	}
 	testSearchOpWithLegacyIndexDBs(t, legacyData, newData, assertLegacyData, assertNewData)
 }
@@ -148,16 +166,22 @@ func TestLegacyStorage_SearchLabelValues(t *testing.T) {
 		return mrs, want
 	}
 	const numMetrics = 1000
-	tr := TimeRange{
+	tr1 := TimeRange{
 		MinTimestamp: time.Date(2023, 6, 1, 0, 0, 0, 0, time.UTC).UnixMilli(),
 		MaxTimestamp: time.Date(2024, 5, 31, 23, 59, 59, 999_999_999, time.UTC).UnixMilli(),
 	}
-	legacyData, wantLegacy := genData(numMetrics, "legacy", tr)
-	newData, wantNew := genData(numMetrics, "new", tr)
-	wantNew = append(wantNew, wantLegacy...)
-	slices.Sort(wantNew)
+	tr2 := TimeRange{
+		MinTimestamp: time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC).UnixMilli(),
+		MaxTimestamp: time.Date(2024, 6, 30, 23, 59, 59, 999_999_999, time.UTC).UnixMilli(),
+	}
+	legacyData, wantLegacy := genData(numMetrics, "legacy", tr1)
+	new1Data, wantNew1 := genData(numMetrics, "new1", tr1)
+	new2Data, wantNew2 := genData(numMetrics, "new2", tr2)
+	newData := slices.Concat(new1Data, new2Data)
+	wantLegacyAndNew1 := slices.Concat(wantLegacy, wantNew1)
+	slices.Sort(wantLegacyAndNew1)
 
-	assertSearchResults := func(s *Storage, want []string) {
+	assertSearchResults := func(s *Storage, tr TimeRange, want []string) {
 		t.Helper()
 		got, err := s.SearchLabelValues(nil, "label", nil, tr, 1e9, 1e9, noDeadline)
 		if err != nil {
@@ -171,11 +195,12 @@ func TestLegacyStorage_SearchLabelValues(t *testing.T) {
 
 	assertLegacyData := func(s *Storage) {
 		t.Helper()
-		assertSearchResults(s, wantLegacy)
+		assertSearchResults(s, tr1, wantLegacy)
 	}
 	assertNewData := func(s *Storage) {
 		t.Helper()
-		assertSearchResults(s, wantNew)
+		assertSearchResults(s, tr1, wantLegacyAndNew1)
+		assertSearchResults(s, tr2, wantNew2)
 	}
 	testSearchOpWithLegacyIndexDBs(t, legacyData, newData, assertLegacyData, assertNewData)
 }
@@ -197,16 +222,22 @@ func TestLegacyStorage_SearchTagValueSuffixes(t *testing.T) {
 		return mrs, want
 	}
 	const numMetrics = 1000
-	tr := TimeRange{
+	tr1 := TimeRange{
 		MinTimestamp: time.Date(2023, 6, 1, 0, 0, 0, 0, time.UTC).UnixMilli(),
 		MaxTimestamp: time.Date(2024, 5, 31, 23, 59, 59, 999_999_999, time.UTC).UnixMilli(),
 	}
-	legacyData, wantLegacy := genData(numMetrics, "legacy", tr)
-	newData, wantNew := genData(numMetrics, "new", tr)
-	wantNew = append(wantNew, wantLegacy...)
-	slices.Sort(wantNew)
+	tr2 := TimeRange{
+		MinTimestamp: time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC).UnixMilli(),
+		MaxTimestamp: time.Date(2024, 6, 30, 23, 59, 59, 999_999_999, time.UTC).UnixMilli(),
+	}
+	legacyData, wantLegacy := genData(numMetrics, "legacy", tr1)
+	new1Data, wantNew1 := genData(numMetrics, "new1", tr1)
+	new2Data, wantNew2 := genData(numMetrics, "new2", tr2)
+	newData := slices.Concat(new1Data, new2Data)
+	wantLegacyAndNew1 := slices.Concat(wantLegacy, wantNew1)
+	slices.Sort(wantLegacyAndNew1)
 
-	assertSearchResults := func(s *Storage, want []string) {
+	assertSearchResults := func(s *Storage, tr TimeRange, want []string) {
 		t.Helper()
 		got, err := s.SearchTagValueSuffixes(nil, tr, "", "prefix.", '.', 1e9, noDeadline)
 		if err != nil {
@@ -221,11 +252,12 @@ func TestLegacyStorage_SearchTagValueSuffixes(t *testing.T) {
 
 	assertLegacyData := func(s *Storage) {
 		t.Helper()
-		assertSearchResults(s, wantLegacy)
+		assertSearchResults(s, tr1, wantLegacy)
 	}
 	assertNewData := func(s *Storage) {
 		t.Helper()
-		assertSearchResults(s, wantNew)
+		assertSearchResults(s, tr1, wantLegacyAndNew1)
+		assertSearchResults(s, tr2, wantNew2)
 	}
 	testSearchOpWithLegacyIndexDBs(t, legacyData, newData, assertLegacyData, assertNewData)
 }
@@ -247,16 +279,22 @@ func TestLegacyStorage_SearchGraphitePaths(t *testing.T) {
 		return mrs, want
 	}
 	const numMetrics = 1000
-	tr := TimeRange{
+	tr1 := TimeRange{
 		MinTimestamp: time.Date(2023, 6, 1, 0, 0, 0, 0, time.UTC).UnixMilli(),
 		MaxTimestamp: time.Date(2024, 5, 31, 23, 59, 59, 999_999_999, time.UTC).UnixMilli(),
 	}
-	legacyData, wantLegacy := genData(numMetrics, "legacy", tr)
-	newData, wantNew := genData(numMetrics, "new", tr)
-	wantNew = append(wantNew, wantLegacy...)
-	slices.Sort(wantNew)
+	tr2 := TimeRange{
+		MinTimestamp: time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC).UnixMilli(),
+		MaxTimestamp: time.Date(2024, 6, 30, 23, 59, 59, 999_999_999, time.UTC).UnixMilli(),
+	}
+	legacyData, wantLegacy := genData(numMetrics, "legacy", tr1)
+	new1Data, wantNew1 := genData(numMetrics, "new1", tr1)
+	new2Data, wantNew2 := genData(numMetrics, "new2", tr2)
+	newData := slices.Concat(new1Data, new2Data)
+	wantLegacyAndNew1 := slices.Concat(wantLegacy, wantNew1)
+	slices.Sort(wantLegacyAndNew1)
 
-	assertSearchResults := func(s *Storage, want []string) {
+	assertSearchResults := func(s *Storage, tr TimeRange, want []string) {
 		t.Helper()
 		got, err := s.SearchGraphitePaths(nil, tr, []byte("*.*"), 1e9, noDeadline)
 		if err != nil {
@@ -271,16 +309,17 @@ func TestLegacyStorage_SearchGraphitePaths(t *testing.T) {
 
 	assertLegacyData := func(s *Storage) {
 		t.Helper()
-		assertSearchResults(s, wantLegacy)
+		assertSearchResults(s, tr1, wantLegacy)
 	}
 	assertNewData := func(s *Storage) {
 		t.Helper()
-		assertSearchResults(s, wantNew)
+		assertSearchResults(s, tr1, wantLegacyAndNew1)
+		assertSearchResults(s, tr2, wantNew2)
 	}
 	testSearchOpWithLegacyIndexDBs(t, legacyData, newData, assertLegacyData, assertNewData)
 }
 
-func TestLegacyStorage_Search(t *testing.T) {
+func TestLegacyStorage_SearchData(t *testing.T) {
 	genData := func(numMetrics int, prefix string, tr TimeRange) []MetricRow {
 		mrs := make([]MetricRow, numMetrics)
 		for i := range numMetrics {
@@ -295,14 +334,20 @@ func TestLegacyStorage_Search(t *testing.T) {
 		return mrs
 	}
 	const numMetrics = 1000
-	tr := TimeRange{
+	tr1 := TimeRange{
 		MinTimestamp: time.Date(2023, 6, 1, 0, 0, 0, 0, time.UTC).UnixMilli(),
 		MaxTimestamp: time.Date(2024, 5, 31, 23, 59, 59, 999_999_999, time.UTC).UnixMilli(),
 	}
-	legacyData := genData(numMetrics, "legacy", tr)
-	newData := genData(numMetrics, "new", tr)
+	tr2 := TimeRange{
+		MinTimestamp: time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC).UnixMilli(),
+		MaxTimestamp: time.Date(2024, 6, 30, 23, 59, 59, 999_999_999, time.UTC).UnixMilli(),
+	}
+	legacyData := genData(numMetrics, "legacy", tr1)
+	new1Data := genData(numMetrics, "new1", tr1)
+	new2Data := genData(numMetrics, "new2", tr2)
+	newData := slices.Concat(new1Data, new2Data)
 
-	assertSearchResults := func(s *Storage, want []MetricRow) {
+	assertSearchResults := func(s *Storage, tr TimeRange, want []MetricRow) {
 		tfsAll := NewTagFilters()
 		if err := tfsAll.Add([]byte("__name__"), []byte(".*"), false, true); err != nil {
 			t.Fatalf("unexpected error in TagFilters.Add: %v", err)
@@ -314,13 +359,13 @@ func TestLegacyStorage_Search(t *testing.T) {
 
 	assertLegacyData := func(s *Storage) {
 		t.Helper()
-		want := legacyData
-		assertSearchResults(s, want)
+		assertSearchResults(s, tr1, legacyData)
 	}
 	assertNewData := func(s *Storage) {
 		t.Helper()
-		want := slices.Concat(legacyData, newData)
-		assertSearchResults(s, want)
+		want := slices.Concat(legacyData, new1Data)
+		assertSearchResults(s, tr1, want)
+		assertSearchResults(s, tr2, new2Data)
 	}
 	testSearchOpWithLegacyIndexDBs(t, legacyData, newData, assertLegacyData, assertNewData)
 }


### PR DESCRIPTION
Each indexDB public method that accepts a time range or date now performs this check explicitly and the very beginning. This check existed before, but was not obvious and performed in the middle of the search request. Performing this check early allows to avoid any unnecessary computations an sometimes even index searches.

Related to #11196.