### PR TITLE
Docs: Add meta descriptions for SEO optimization

### DIFF
--- a/docs/ai-tools/_index.md
+++ b/docs/ai-tools/_index.md
@@ -1,5 +1,6 @@
 ---
 title: AI tools
+description: "MCP servers and AI assistant integrations for querying metrics, logs, and traces with natural language."
 weight: 61
 menu:
   docs:

--- a/docs/ai-tools/_index.md
+++ b/docs/ai-tools/_index.md
@@ -1,6 +1,6 @@
 ---
 title: AI tools
-description: "MCP servers and AI assistant integrations for querying metrics, logs, and traces with natural language."
+description: "MCP servers, skills, and AI assistant integrations for querying metrics, logs, and traces with natural language."
 weight: 61
 menu:
   docs:

--- a/docs/anomaly-detection/CHANGELOG.md
+++ b/docs/anomaly-detection/CHANGELOG.md
@@ -1,6 +1,7 @@
 ---
 weight: 7
 title: CHANGELOG
+description: "Release history for vmanomaly."
 menu:
   docs:
     identifier: "vmanomaly-changelog"

--- a/docs/anomaly-detection/FAQ.md
+++ b/docs/anomaly-detection/FAQ.md
@@ -1,6 +1,7 @@
 ---
 weight: 6
 title: FAQ
+description: "Frequently asked questions about vmanomaly."
 menu:
   docs:
     identifier: "vmanomaly-faq"

--- a/docs/anomaly-detection/Migration.md
+++ b/docs/anomaly-detection/Migration.md
@@ -1,6 +1,7 @@
 ---
 weight: 5
 title: Migration
+description: "Migration guide to the latest vmanomaly version."
 menu:
   docs:
     identifier: "vmanomaly-migration"

--- a/docs/anomaly-detection/Presets.md
+++ b/docs/anomaly-detection/Presets.md
@@ -1,6 +1,7 @@
 ---
 weight: 2
 title: Presets
+description: "Preconfigured anomaly detection configurations for widely-recognized metrics (e.g., node_exporter)"
 menu:
   docs:
     parent: "anomaly-detection"

--- a/docs/anomaly-detection/QuickStart.md
+++ b/docs/anomaly-detection/QuickStart.md
@@ -1,6 +1,7 @@
 ---
 weight: 1
 title: Quick Start
+description: "Get started with vmanomaly. Install, configure, and run anomaly detection."
 menu:
   docs:
     parent: "anomaly-detection"

--- a/docs/anomaly-detection/Scaling-vmanomaly.md
+++ b/docs/anomaly-detection/Scaling-vmanomaly.md
@@ -1,6 +1,7 @@
 ---
 weight: 3
 title: Scaling vmanomaly
+description: "High availability and horizontal scaling for vmanomaly."
 menu:
   docs:
     identifier: "vmanomaly-scaling"

--- a/docs/anomaly-detection/Self-monitoring.md
+++ b/docs/anomaly-detection/Self-monitoring.md
@@ -1,6 +1,7 @@
 ---
 weight: 4
 title: Self-monitoring
+description: "Track vmanomaly health and operational performance."
 menu:
   docs:
     identifier: "vmanomaly-self-monitoring"

--- a/docs/anomaly-detection/UI.md
+++ b/docs/anomaly-detection/UI.md
@@ -1,6 +1,7 @@
 ---
 weight: 2
 title: UI
+description: "Built-in vmui-like UI for exploring anomaly detection results."
 menu:
   docs:
     parent: "anomaly-detection"

--- a/docs/anomaly-detection/_index.md
+++ b/docs/anomaly-detection/_index.md
@@ -1,5 +1,6 @@
 ---
 title: Anomaly Detection
+description: "Use vmanomaly to detect unusual patterns in metrics and logs. Learn how to configure models, run inference, monitor the service, and connect results to"
 weight: 50
 menu:
   docs:

--- a/docs/anomaly-detection/_index.md
+++ b/docs/anomaly-detection/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Anomaly Detection
-description: "Use vmanomaly to detect unusual patterns in metrics and logs. Learn how to configure models, run inference, monitor the service, and connect results to"
+description: "Use vmanomaly to detect anomalies in metrics and logs. Configure models, run inference, monitor the service, and connect results to alerts and dashboards."
 weight: 50
 menu:
   docs:

--- a/docs/anomaly-detection/components/_index.md
+++ b/docs/anomaly-detection/components/_index.md
@@ -1,5 +1,6 @@
 ---
 title: Components
+description: "Architecture overview. Models, reader, writer, scheduler, monitoring, settings, server."
 weight: 3
 menu:
   docs:

--- a/docs/anomaly-detection/components/models.md
+++ b/docs/anomaly-detection/components/models.md
@@ -1,5 +1,6 @@
 ---
 title: Models
+description: "Model types and configuration. Built-in and custom anomaly detection models."
 weight: 1
 menu:
   docs:

--- a/docs/anomaly-detection/components/monitoring.md
+++ b/docs/anomaly-detection/components/monitoring.md
@@ -1,5 +1,6 @@
 ---
 title: Monitoring
+description: "Self-monitoring via push and pull models."
 weight: 5
 menu:
   docs:

--- a/docs/anomaly-detection/components/reader.md
+++ b/docs/anomaly-detection/components/reader.md
@@ -1,5 +1,6 @@
 ---
 title: Reader
+description: "Data reader configuration. MetricsQL queries from VictoriaMetrics or LogsQL from VictoriaLogs/VictoriaTraces."
 weight: 2
 menu:
   docs:

--- a/docs/anomaly-detection/components/scheduler.md
+++ b/docs/anomaly-detection/components/scheduler.md
@@ -1,5 +1,6 @@
 ---
 title: Scheduler
+description: "Scheduling configuration. Inference frequency and training time range."
 weight: 3
 menu:
   docs:

--- a/docs/anomaly-detection/components/server.md
+++ b/docs/anomaly-detection/components/server.md
@@ -1,5 +1,6 @@
 ---
 title: Server
+description: "HTTP server. REST API, /metrics endpoint, and web UI."
 weight: 7
 menu:
   docs:

--- a/docs/anomaly-detection/components/settings.md
+++ b/docs/anomaly-detection/components/settings.md
@@ -1,5 +1,6 @@
 ---
 title: Settings
+description: "Global settings for the anomaly detection service."
 weight: 6
 menu:
   docs:

--- a/docs/anomaly-detection/components/writer.md
+++ b/docs/anomaly-detection/components/writer.md
@@ -1,5 +1,6 @@
 ---
 title: Writer
+description: "Data writer. Write anomaly scores back to VictoriaMetrics."
 weight: 4
 menu:
   docs:

--- a/docs/anomaly-detection/guides/_index.md
+++ b/docs/anomaly-detection/guides/_index.md
@@ -1,5 +1,6 @@
 ---
 title: Guides
+description: "Step-by-step guides for deploying, configuring, integrating, and operating vmanomaly for anomaly detection."
 weight: 3
 menu:
   docs:

--- a/docs/anomaly-detection/guides/guide-vmanomaly-vmalert/_index.md
+++ b/docs/anomaly-detection/guides/guide-vmanomaly-vmalert/_index.md
@@ -1,6 +1,7 @@
 ---
 weight: 1
 title: Anomaly Detection and Alerting Setup
+description: "Tutorial integrating vmanomaly with vmalert, Alertmanager, and Grafana."
 menu:
   docs:
     parent: "anomaly-detection-guides"

--- a/docs/guides/_index.md
+++ b/docs/guides/_index.md
@@ -1,6 +1,7 @@
 ---
 weight: 0
 title: Guides
+description: "Practical guides for deploying and operating VictoriaMetrics."
 disableToc: true
 
 menu:

--- a/docs/guides/collecting-openshift-logs-with-victoria-logs/_index.md
+++ b/docs/guides/collecting-openshift-logs-with-victoria-logs/_index.md
@@ -1,6 +1,7 @@
 ---
 weight: 12
 title: Collecting OpenShift logs with Victoria Logs
+description: "Collect and store OpenShift cluster logs in VictoriaLogs."
 menu:
   docs:
     parent: "guides"

--- a/docs/guides/connecting-vm-components-to-cloud-storage/_index.md
+++ b/docs/guides/connecting-vm-components-to-cloud-storage/_index.md
@@ -1,6 +1,7 @@
 ---
 weight: 5
 title: Connecting VictoriaMetrics components to cloud storage
+description: "Configure VictoriaMetrics components to use object storage for data, backups, and other storage workflows."
 menu:
   docs:
     parent: guides

--- a/docs/guides/getting-started-with-opentelemetry/_index.md
+++ b/docs/guides/getting-started-with-opentelemetry/_index.md
@@ -1,6 +1,7 @@
 ---
 weight: 5
 title: How to use OpenTelemetry with VictoriaMetrics and VictoriaLogs
+description: "Use OpenTelemetry with VictoriaMetrics and VictoriaLogs on Kubernetes."
 menu:
   docs:
     parent: "guides"

--- a/docs/guides/getting-started-with-vm-operator/_index.md
+++ b/docs/guides/getting-started-with-vm-operator/_index.md
@@ -1,7 +1,7 @@
 ---
 weight: 4
 title: Getting started with VM Operator
-description: "Deploy VM stack on Kubernetes with the Operator."
+description: "Deploy the VictoriaMetrics stack on Kubernetes with the Kubernetes Operator."
 menu:
   docs:
     parent: "guides"

--- a/docs/guides/getting-started-with-vm-operator/_index.md
+++ b/docs/guides/getting-started-with-vm-operator/_index.md
@@ -1,6 +1,7 @@
 ---
 weight: 4
 title: Getting started with VM Operator
+description: "Deploy VM stack on Kubernetes with the Operator."
 menu:
   docs:
     parent: "guides"

--- a/docs/guides/grafana-vmauth-openid-configuration/_index.md
+++ b/docs/guides/grafana-vmauth-openid-configuration/_index.md
@@ -1,6 +1,7 @@
 ---
 weight: 5
 title: Setup vmauth - Multi-Tenant Access with Grafana & OIDC
+description: "Multi-tenant access for metrics, logs, and traces with Grafana and OIDC."
 menu:
   docs:
     parent: guides

--- a/docs/guides/grafana-vmgateway-openid-configuration/_index.md
+++ b/docs/guides/grafana-vmgateway-openid-configuration/_index.md
@@ -1,6 +1,7 @@
 ---
 weight: 16
 title: Setup vmgateway - Multi-Tenant Access with Grafana & OIDC
+description: "Configure vmgateway with Grafana and OpenID Connect for authenticated, multi-tenant access to VictoriaMetrics data."
 menu: false
 tags:
   - metrics

--- a/docs/guides/guide-delete-or-replace-metrics/_index.md
+++ b/docs/guides/guide-delete-or-replace-metrics/_index.md
@@ -1,6 +1,7 @@
 ---
 weight: 7
 title: How to delete or replace metrics in VictoriaMetrics
+description: "Guide to deleting or replacing time series data."
 menu:
   docs:
     parent: "guides"

--- a/docs/guides/guide-vmcluster-multiple-retention-setup/_index.md
+++ b/docs/guides/guide-vmcluster-multiple-retention-setup/_index.md
@@ -1,6 +1,7 @@
 ---
 weight: 10
 title: Multi Retention Setup within VictoriaMetrics Cluster
+description: "Configure multiple retention periods in VM Cluster."
 menu:
   docs:
     parent: "guides"

--- a/docs/guides/k8s-ha-monitoring-via-vm-cluster/_index.md
+++ b/docs/guides/k8s-ha-monitoring-via-vm-cluster/_index.md
@@ -1,6 +1,7 @@
 ---
 weight: 9
 title: HA monitoring setup in Kubernetes via VictoriaMetrics Cluster
+description: "High-availability Kubernetes monitoring with replication."
 menu:
   docs:
     parent: "guides"

--- a/docs/guides/k8s-monitoring-via-vm-cluster/_index.md
+++ b/docs/guides/k8s-monitoring-via-vm-cluster/_index.md
@@ -1,6 +1,7 @@
 ---
 weight: 3
 title: Kubernetes monitoring with VictoriaMetrics Cluster
+description: "Monitor Kubernetes with VM Cluster."
 menu:
   docs:
     parent: "guides"

--- a/docs/guides/k8s-monitoring-via-vm-single/_index.md
+++ b/docs/guides/k8s-monitoring-via-vm-single/_index.md
@@ -1,6 +1,7 @@
 ---
 weight: 2
 title: Kubernetes monitoring via VictoriaMetrics Single
+description: "Monitor Kubernetes with single-node VictoriaMetrics and Helm."
 menu:
   docs:
     parent: "guides"

--- a/docs/guides/k8s-ui-headlamp/_index.md
+++ b/docs/guides/k8s-ui-headlamp/_index.md
@@ -1,6 +1,7 @@
 ---
 weight: 13
 title: Headlamp Kubernetes UI and VictoriaMetrics
+description: "Point Headlamp's Prometheus integration at VictoriaMetrics."
 menu:
   docs:
     parent: "guides"

--- a/docs/guides/migrate-from-influx/_index.md
+++ b/docs/guides/migrate-from-influx/_index.md
@@ -1,5 +1,6 @@
 ---
 title: Migrate from InfluxDB to VictoriaMetrics
+description: "Differences and approaches for migrating from InfluxDB."
 weight: 8
 menu:
   docs:

--- a/docs/guides/multi-regional-setup-dedicated-regions/_index.md
+++ b/docs/guides/multi-regional-setup-dedicated-regions/_index.md
@@ -1,6 +1,7 @@
 ---
 weight: 11
 title: 'VictoriaMetrics Multi-Regional Setup: Dedicated Monitoring'
+description: "Collect metrics across regions with dedicated monitoring."
 menu:
   docs:
     parent: guides

--- a/docs/guides/understand-your-setup-size/_index.md
+++ b/docs/guides/understand-your-setup-size/_index.md
@@ -1,6 +1,7 @@
 ---
 weight: 9
 title: Understand Your Setup Size
+description: "Capacity planning. Active time series, ingestion rate, churn rate, QPS."
 menu:
   docs:
     parent: "guides"

--- a/docs/guides/vm-architectures/_index.md
+++ b/docs/guides/vm-architectures/_index.md
@@ -1,6 +1,7 @@
 ---
 weight: 14
 title: VictoriaMetrics topologies
+description: "Choose the right deployment topology for risk tolerance and performance needs."
 menu:
   docs:
     parent: "guides"

--- a/docs/guides/vmagent-openid-configuration/_index.md
+++ b/docs/guides/vmagent-openid-configuration/_index.md
@@ -1,6 +1,7 @@
 ---
 weight: 5
 title: Setup vmagent - Multi-Tenant remote write & OIDC
+description: "Multi-tenant remote write with OIDC and JWT tokens."
 menu:
   docs:
     parent: guides

--- a/docs/guides/vmalert-datasource-managed-alerts-grafana/_index.md
+++ b/docs/guides/vmalert-datasource-managed-alerts-grafana/_index.md
@@ -1,6 +1,7 @@
 ---
 weight: 16
 title: Datasource-Managed Alerts with vmalert and Grafana
+description: "Scalable alerting topology with vmalert and Grafana."
 menu:
   docs:
     parent: "guides"

--- a/docs/opentelemetry/_index.md
+++ b/docs/opentelemetry/_index.md
@@ -1,5 +1,6 @@
 ---
 title: OpenTelemetry
+description: "Native OTLP ingestion for metrics (VictoriaMetrics), logs (VictoriaLogs), and traces (VictoriaTraces). Contains configuration, data mapping, and demos."
 weight: 60
 menu:
   docs:

--- a/docs/opentelemetry/_index.md
+++ b/docs/opentelemetry/_index.md
@@ -1,6 +1,6 @@
 ---
 title: OpenTelemetry
-description: "Native OTLP ingestion for metrics (VictoriaMetrics), logs (VictoriaLogs), and traces (VictoriaTraces). Contains configuration, data mapping, and demos."
+description: "OTLP ingestion for metrics, logs, and traces in VictoriaMetrics, VictoriaLogs, and VictoriaTraces, with signal correlation and configuration guides."
 weight: 60
 menu:
   docs:

--- a/docs/playgrounds/_index.md
+++ b/docs/playgrounds/_index.md
@@ -1,5 +1,6 @@
 ---
 title: Playgrounds
+description: "Public demo environments for VictoriaMetrics, VictoriaLogs, and VictoriaTraces."
 weight: 63
 menu:
   docs:

--- a/docs/victoriametrics/Articles.md
+++ b/docs/victoriametrics/Articles.md
@@ -1,6 +1,7 @@
 ---
 weight: 29
 title: Articles
+description: "Third-party articles, slides, and videos about VictoriaMetrics."
 menu:
   docs:
     parent: 'victoriametrics'

--- a/docs/victoriametrics/BestPractices.md
+++ b/docs/victoriametrics/BestPractices.md
@@ -1,6 +1,7 @@
 ---
 weight: 22
 title: Best practices
+description: "Production best practices for installation, configuration, hardware sizing, and maintenance."
 menu:
   docs:
     identifier: vm-best-practices

--- a/docs/victoriametrics/CONTRIBUTING.md
+++ b/docs/victoriametrics/CONTRIBUTING.md
@@ -1,6 +1,7 @@
 ---
 weight: 400
 title: Contributing
+description: "Guidelines for contributing to VictoriaMetrics."
 menu:
   docs:
     identifier: vm-contributing

--- a/docs/victoriametrics/CaseStudies.md
+++ b/docs/victoriametrics/CaseStudies.md
@@ -1,6 +1,7 @@
 ---
 weight: 25
 title: Case studies and talks
+description: "Production case studies from Grammarly, Roblox, Wix, Spotify, adidas, and more."
 menu:
   docs:
     parent: "victoriametrics"

--- a/docs/victoriametrics/Cluster-VictoriaMetrics.md
+++ b/docs/victoriametrics/Cluster-VictoriaMetrics.md
@@ -6,6 +6,7 @@ menu:
     parent: 'victoriametrics'
     weight: 2
 title: Cluster version
+description: "Deploy and configure cluster mode with vminsert, vmselect, and vmstorage components, including replication and multi-tenancy."
 tags:
   - metrics
 aliases:

--- a/docs/victoriametrics/FAQ.md
+++ b/docs/victoriametrics/FAQ.md
@@ -1,6 +1,7 @@
 ---
 weight: 24
 title: FAQ
+description: "Frequently asked questions comparing VM with Prometheus, InfluxDB, TimescaleDB, M3DB, Thanos, and Cortex."
 menu:
   docs:
     parent: 'victoriametrics'

--- a/docs/victoriametrics/LTS-releases.md
+++ b/docs/victoriametrics/LTS-releases.md
@@ -1,6 +1,7 @@
 ---
 weight: 300
 title: Long-term support releases
+description: "Long-term support release lines for enterprise customers."
 menu:
   docs:
     parent: 'victoriametrics'

--- a/docs/victoriametrics/MetricsQL.md
+++ b/docs/victoriametrics/MetricsQL.md
@@ -1,6 +1,7 @@
 ---
 weight: 23
 title: MetricsQL
+description: "Query language reference. Enhanced PromQL with additional functions, histogram helpers, and subquery support."
 menu:
   docs:
     parent: 'victoriametrics'

--- a/docs/victoriametrics/PerTenantStatistic.md
+++ b/docs/victoriametrics/PerTenantStatistic.md
@@ -1,6 +1,7 @@
 ---
 weight: 81
 title: Cluster Per Tenant Statistic
+description: "Enterprise cluster per-tenant usage tracking."
 menu:
   docs:
     identifier: vm-cluster-per-tenant-statistic

--- a/docs/victoriametrics/Quick-Start.md
+++ b/docs/victoriametrics/Quick-Start.md
@@ -1,6 +1,7 @@
 ---
 weight: 1
 title: Quick start
+description: "Get up and running with VictoriaMetrics. Download, run, scrape, and query."
 menu:
   docs:
     identifier: vm-quick-start

--- a/docs/victoriametrics/Release-Guide.md
+++ b/docs/victoriametrics/Release-Guide.md
@@ -1,6 +1,7 @@
 ---
 weight: 501
 title: Release process guidance
+description: "Guidance for preparing, testing, and publishing VictoriaMetrics releases."
 menu:
   docs:
     parent: 'victoriametrics'

--- a/docs/victoriametrics/Single-server-VictoriaMetrics.md
+++ b/docs/victoriametrics/Single-server-VictoriaMetrics.md
@@ -6,6 +6,7 @@ menu:
     parent: victoriametrics
     weight: 1
 title: Single-node version
+description: "Deploy and configure the single-node version, including CLI flags, storage, and HTTP API."
 tags:
   - metrics
 aliases:

--- a/docs/victoriametrics/Troubleshooting.md
+++ b/docs/victoriametrics/Troubleshooting.md
@@ -1,6 +1,7 @@
 ---
 weight: 35
 title: Troubleshooting
+description: "Common issues. High memory usage, slow queries, cardinality problems, ingestion failures."
 menu:
   docs:
     parent: 'victoriametrics'

--- a/docs/victoriametrics/_index.md
+++ b/docs/victoriametrics/_index.md
@@ -1,6 +1,6 @@
 ---
 title: VictoriaMetrics
-description: "Learn about VictoriaMetrics extensions to PromQL and the additional query features available in MetricsQL."
+description: "Fast, cost-effective, and scalable time series database for monitoring and managing metrics data."
 menu:
   docs:
     weight: 10

--- a/docs/victoriametrics/_index.md
+++ b/docs/victoriametrics/_index.md
@@ -1,5 +1,6 @@
 ---
 title: VictoriaMetrics
+description: "Learn about VictoriaMetrics extensions to PromQL and the additional query features available in MetricsQL."
 menu:
   docs:
     weight: 10

--- a/docs/victoriametrics/changelog/CHANGELOG_2020.md
+++ b/docs/victoriametrics/changelog/CHANGELOG_2020.md
@@ -1,6 +1,7 @@
 ---
 weight: 8
 title: Year 2020
+description: "Release history for all VictoriaMetrics components (YEAR 2020)"
 search:
   weight: 0.1
 menu:

--- a/docs/victoriametrics/changelog/CHANGELOG_2021.md
+++ b/docs/victoriametrics/changelog/CHANGELOG_2021.md
@@ -1,6 +1,7 @@
 ---
 weight: 7
 title: Year 2021
+description: "Release history for all VictoriaMetrics components (YEAR 2021)"
 search:
   weight: 0.1
 menu:

--- a/docs/victoriametrics/changelog/CHANGELOG_2022.md
+++ b/docs/victoriametrics/changelog/CHANGELOG_2022.md
@@ -1,6 +1,7 @@
 ---
 weight: 6
 title: Year 2022
+description: "Release history for all VictoriaMetrics components (YEAR 2022)"
 search:
   weight: 0.1
 menu:

--- a/docs/victoriametrics/changelog/CHANGELOG_2023.md
+++ b/docs/victoriametrics/changelog/CHANGELOG_2023.md
@@ -1,6 +1,7 @@
 ---
 weight: 5
 title: Year 2023
+description: "Release history for all VictoriaMetrics components (YEAR 2023)"
 search:
   weight: 0.1
 menu:

--- a/docs/victoriametrics/changelog/CHANGELOG_2024.md
+++ b/docs/victoriametrics/changelog/CHANGELOG_2024.md
@@ -1,6 +1,7 @@
 ---
 weight: 4
 title: Year 2024
+description: "Release history for all VictoriaMetrics components (YEAR 2024)"
 search:
   weight: 0.1
 menu:

--- a/docs/victoriametrics/changelog/CHANGELOG_2025.md
+++ b/docs/victoriametrics/changelog/CHANGELOG_2025.md
@@ -1,6 +1,7 @@
 ---
 weight: 3
 title: Year 2025
+description: "Release history for all VictoriaMetrics components (YEAR 2025)"
 search:
   weight: 0.1
 menu:

--- a/docs/victoriametrics/changelog/CHANGELOG_2026.md
+++ b/docs/victoriametrics/changelog/CHANGELOG_2026.md
@@ -1,6 +1,7 @@
 ---
 weight: 2
 title: Year 2026
+description: "Release history for all VictoriaMetrics components (YEAR 2026)"
 search:
   weight: 0.1
 menu:

--- a/docs/victoriametrics/changelog/_index.md
+++ b/docs/victoriametrics/changelog/_index.md
@@ -1,6 +1,7 @@
 ---
 weight: 100
 title: CHANGELOG
+description: "Release history for all VictoriaMetrics components."
 menu:
   docs:
     identifier: vm-changelog

--- a/docs/victoriametrics/data-ingestion/Alloy.md
+++ b/docs/victoriametrics/data-ingestion/Alloy.md
@@ -1,5 +1,6 @@
 ---
 title: Grafana Alloy
+description: "Configure Grafana Alloy to send metrics to VictoriaMetrics."
 weight: 3
 menu:
   docs:

--- a/docs/victoriametrics/data-ingestion/OpenTelemetry-Collector.md
+++ b/docs/victoriametrics/data-ingestion/OpenTelemetry-Collector.md
@@ -1,5 +1,6 @@
 ---
 title: OpenTelemetry Collector
+description: "Configure OTel Collector with OTLP HTTP exporter."
 weight: 7
 menu:
   docs:

--- a/docs/victoriametrics/data-ingestion/Proxmox.md
+++ b/docs/victoriametrics/data-ingestion/Proxmox.md
@@ -1,5 +1,6 @@
 ---
 title: Proxmox
+description: "Send Proxmox VE/PBS metrics to VictoriaMetrics."
 weight: 6
 menu:
   docs:

--- a/docs/victoriametrics/data-ingestion/Telegraf.md
+++ b/docs/victoriametrics/data-ingestion/Telegraf.md
@@ -1,5 +1,6 @@
 ---
 title: Telegraf
+description: "Configure Telegraf to ship metrics to VictoriaMetrics."
 weight: 5
 menu:
   docs:

--- a/docs/victoriametrics/data-ingestion/Vector.md
+++ b/docs/victoriametrics/data-ingestion/Vector.md
@@ -1,5 +1,6 @@
 ---
 title: Vector
+description: "Configure Vector with Prometheus remote write sink."
 weight: 4
 menu:
   docs:

--- a/docs/victoriametrics/data-ingestion/_index.md
+++ b/docs/victoriametrics/data-ingestion/_index.md
@@ -1,5 +1,6 @@
 ---
 title: Data Ingestion 
+description: "Supported ingestion protocols. Prometheus remote write, InfluxDB, Graphite, OpenTSDB, Datadog, New Relic, OpenTelemetry, CSV, JSON, and native binary."
 weight: 0
 menu:
   docs:

--- a/docs/victoriametrics/data-ingestion/vmagent.md
+++ b/docs/victoriametrics/data-ingestion/vmagent.md
@@ -1,5 +1,6 @@
 ---
 title: vmagent
+description: "Using vmagent as a data ingestion agent."
 weight: 2
 menu:
   docs:

--- a/docs/victoriametrics/enterprise.md
+++ b/docs/victoriametrics/enterprise.md
@@ -1,6 +1,7 @@
 ---
 weight: 80
 title: Enterprise
+description: "Enterprise features. Downsampling, backup automation, multi-tenancy, advanced security."
 menu:
   docs:
     identifier: vm-enterprise

--- a/docs/victoriametrics/goals.md
+++ b/docs/victoriametrics/goals.md
@@ -1,6 +1,7 @@
 ---
 weight: 500
 title: Development Goals
+description: "Development goals and priorities for the VictoriaMetrics project."
 menu:
   docs:
     weight: 500

--- a/docs/victoriametrics/integrations/OpenShift.md
+++ b/docs/victoriametrics/integrations/OpenShift.md
@@ -1,5 +1,6 @@
 ---
 title: OpenShift
+description: "OpenShift Container Platform remote write integration."
 weight: 10
 menu:
   docs:

--- a/docs/victoriametrics/integrations/_index.md
+++ b/docs/victoriametrics/integrations/_index.md
@@ -1,5 +1,6 @@
 ---
 title: Integrations
+description: "Overview of all supported integrations."
 weight: 13
 menu:
   docs:

--- a/docs/victoriametrics/integrations/bindplane.md
+++ b/docs/victoriametrics/integrations/bindplane.md
@@ -1,5 +1,6 @@
 ---
 title: Bindplane
+description: "Configure Bindplane to collect and send metrics to VictoriaMetrics."
 weight: 12
 menu:
   docs:

--- a/docs/victoriametrics/integrations/datadog.md
+++ b/docs/victoriametrics/integrations/datadog.md
@@ -1,5 +1,6 @@
 ---
 title: Datadog
+description: "Receiving metrics from DataDog agent, DogStatsD, and Lambda Extension."
 weight: 4
 menu:
   docs:

--- a/docs/victoriametrics/integrations/grafana/_index.md
+++ b/docs/victoriametrics/integrations/grafana/_index.md
@@ -1,5 +1,6 @@
 ---
 title: Grafana
+description: "Using VictoriaMetrics with Grafana via Prometheus or VM datasource plugin."
 weight: 1
 menu:
   docs:

--- a/docs/victoriametrics/integrations/graphite.md
+++ b/docs/victoriametrics/integrations/graphite.md
@@ -1,5 +1,6 @@
 ---
 title: Graphite
+description: "Receiving Graphite/StatsD metrics and Graphite query language support."
 weight: 3
 menu:
   docs:

--- a/docs/victoriametrics/integrations/influxdb.md
+++ b/docs/victoriametrics/integrations/influxdb.md
@@ -1,5 +1,6 @@
 ---
 title: InfluxDB
+description: "Receiving InfluxDB line protocol and migration guide."
 weight: 5
 menu:
   docs:

--- a/docs/victoriametrics/integrations/kafka.md
+++ b/docs/victoriametrics/integrations/kafka.md
@@ -1,5 +1,6 @@
 ---
 title: Kafka
+description: "Enterprise vmagent Kafka consumer/producer for metrics."
 weight: 9
 menu:
   docs:

--- a/docs/victoriametrics/integrations/newrelic.md
+++ b/docs/victoriametrics/integrations/newrelic.md
@@ -1,5 +1,6 @@
 ---
 title: NewRelic
+description: "Receiving metrics from NewRelic infrastructure agent."
 weight: 7
 menu:
   docs:

--- a/docs/victoriametrics/integrations/opentelemetry.md
+++ b/docs/victoriametrics/integrations/opentelemetry.md
@@ -1,5 +1,6 @@
 ---
 title: OpenTelemetry
+description: "Native OTLP metrics protocol support."
 weight: 13
 menu:
   docs:

--- a/docs/victoriametrics/integrations/opentsdb.md
+++ b/docs/victoriametrics/integrations/opentsdb.md
@@ -1,5 +1,6 @@
 ---
 title: OpenTSDB
+description: "Receiving OpenTSDB telnet and HTTP metrics."
 weight: 6
 menu:
   docs:

--- a/docs/victoriametrics/integrations/perses.md
+++ b/docs/victoriametrics/integrations/perses.md
@@ -1,6 +1,7 @@
 ---
 weight: 11
 title: Perses
+description: "Using VictoriaMetrics with Perses dashboards."
 menu:
   docs:
     identifier: integrations-vm-perses

--- a/docs/victoriametrics/integrations/prometheus.md
+++ b/docs/victoriametrics/integrations/prometheus.md
@@ -1,5 +1,6 @@
 ---
 title: Prometheus
+description: "Using VictoriaMetrics as remote storage for Prometheus."
 weight: 2
 menu:
   docs:

--- a/docs/victoriametrics/integrations/pubsub.md
+++ b/docs/victoriametrics/integrations/pubsub.md
@@ -1,5 +1,6 @@
 ---
 title: Google PubSub
+description: "Enterprise vmagent Google PubSub integration."
 weight: 8
 menu:
   docs:

--- a/docs/victoriametrics/integrations/zabbixconnector.md
+++ b/docs/victoriametrics/integrations/zabbixconnector.md
@@ -1,5 +1,6 @@
 ---
 title: Zabbix Connector
+description: "Receiving metrics from Zabbix Connector."
 weight: 10
 menu:
   docs:

--- a/docs/victoriametrics/keyConcepts/_index.md
+++ b/docs/victoriametrics/keyConcepts/_index.md
@@ -1,6 +1,7 @@
 ---
 weight: 34
 title: Key concepts
+description: "Metrics data model, time series, cardinality, push vs pull model, and query types."
 menu:
   docs:
     identifier: vm-key-concepts

--- a/docs/victoriametrics/query-stats.md
+++ b/docs/victoriametrics/query-stats.md
@@ -1,6 +1,7 @@
 ---
 weight: 82
 title: Query execution stats
+description: "Enterprise query execution statistics logging."
 menu:
   docs:
     parent: 'victoriametrics'

--- a/docs/victoriametrics/relabeling.md
+++ b/docs/victoriametrics/relabeling.md
@@ -1,6 +1,7 @@
 ---
 weight: 38
 title: Relabeling cookbook
+description: "Metrics relabeling cookbook. Filtering, label manipulation, and enrichment patterns."
 menu:
   docs:
     parent: "victoriametrics"

--- a/docs/victoriametrics/scrape_config_examples.md
+++ b/docs/victoriametrics/scrape_config_examples.md
@@ -1,6 +1,7 @@
 ---
 weight: 37
 title: Scrape config examples
+description: "Scrape configuration examples for static configs, file-based, HTTP-based, and Kubernetes target discovery."
 menu:
   docs:
     parent: 'victoriametrics'

--- a/docs/victoriametrics/sd_configs.md
+++ b/docs/victoriametrics/sd_configs.md
@@ -1,6 +1,7 @@
 ---
 weight: 36
 title: Prometheus service discovery
+description: "Supported Prometheus-compatible service discovery mechanisms (Azure, Consul, DNS, Docker, EC2, GCE, Kubernetes, OpenStack, and more)"
 menu:
   docs:
     parent: 'victoriametrics'

--- a/docs/victoriametrics/stream-aggregation/_index.md
+++ b/docs/victoriametrics/stream-aggregation/_index.md
@@ -1,7 +1,7 @@
 ---
 weight: 39
 title: Streaming aggregation
-description: "Real-time stream aggregation in vmagent and single-node VM, including output functions such as count, sum, avg, min, max, histogram_bucket, rate, increase, and more."
+description: "Real-time stream aggregation in vmagent and single-node VM, including output functions such as count, sum, avg, min, max, histogram_bucket, rate, and increase."
 menu:
   docs:
     parent: 'victoriametrics'

--- a/docs/victoriametrics/stream-aggregation/_index.md
+++ b/docs/victoriametrics/stream-aggregation/_index.md
@@ -1,7 +1,7 @@
 ---
 weight: 39
 title: Streaming aggregation
-description: "Real-time stream aggregation in vmagent and single-node VM, including output functions (count, sum, avg, min, max, histogram_bucket, rate, increase, quantile,"
+description: "Real-time stream aggregation in vmagent and single-node VM, including output functions such as count, sum, avg, min, max, histogram_bucket, rate, increase, and more."
 menu:
   docs:
     parent: 'victoriametrics'

--- a/docs/victoriametrics/stream-aggregation/_index.md
+++ b/docs/victoriametrics/stream-aggregation/_index.md
@@ -1,6 +1,7 @@
 ---
 weight: 39
 title: Streaming aggregation
+description: "Real-time stream aggregation in vmagent and single-node VM, including output functions (count, sum, avg, min, max, histogram_bucket, rate, increase, quantile,"
 menu:
   docs:
     parent: 'victoriametrics'

--- a/docs/victoriametrics/stream-aggregation/configuration.md
+++ b/docs/victoriametrics/stream-aggregation/configuration.md
@@ -1,5 +1,6 @@
 ---
 title: Configuration
+description: "Detailed configuration reference for stream aggregation rules, match/filter patterns, and deduplication."
 weight: 1
 menu:
   docs:

--- a/docs/victoriametrics/url-examples.md
+++ b/docs/victoriametrics/url-examples.md
@@ -1,6 +1,7 @@
 ---
 weight: 33
 title: API examples
+description: "Copy-paste examples for commonly used VictoriaMetrics HTTP APIs."
 menu:
   docs:
     parent: 'victoriametrics'

--- a/docs/victoriametrics/vmagent.md
+++ b/docs/victoriametrics/vmagent.md
@@ -5,6 +5,7 @@ menu:
     parent: victoriametrics
     weight: 3
 title: vmagent
+description: "agent for metrics collection, supporting both push and pull models, service discovery, relabeling, sharding, replication, on-disk buffering."
 tags:
   - metrics
 aliases:

--- a/docs/victoriametrics/vmalert-tool.md
+++ b/docs/victoriametrics/vmalert-tool.md
@@ -5,6 +5,7 @@ menu:
     parent: victoriametrics
     weight: 12
 title: vmalert-tool
+description: "Command-line tool for unit testing alerting and recording rules."
 tags:
   - metrics
 aliases:

--- a/docs/victoriametrics/vmalert.md
+++ b/docs/victoriametrics/vmalert.md
@@ -5,6 +5,7 @@ menu:
     parent: victoriametrics
     weight: 4
 title: vmalert
+description: "Alerting and recording rule evaluation with Alertmanager integration and multi-tenancy support."
 tags:
   - metrics
   - logs

--- a/docs/victoriametrics/vmauth.md
+++ b/docs/victoriametrics/vmauth.md
@@ -5,6 +5,7 @@ menu:
     parent: victoriametrics
     weight: 5
 title: vmauth
+description: "HTTP auth proxy, load balancer, and request router with support for basic auth, bearer tokens, per-user routing, and IP-based filters."
 tags:
   - metrics
 aliases:

--- a/docs/victoriametrics/vmbackup.md
+++ b/docs/victoriametrics/vmbackup.md
@@ -5,6 +5,7 @@ menu:
     parent: victoriametrics
     weight: 6
 title: vmbackup
+description: "Backup VictoriaMetrics data to GCS, S3, Azure Blob, or local filesystem with incremental backups."
 tags:
   - metrics
 aliases:

--- a/docs/victoriametrics/vmbackupmanager.md
+++ b/docs/victoriametrics/vmbackupmanager.md
@@ -5,6 +5,7 @@ menu:
     parent: victoriametrics
     weight: 10
 title: vmbackupmanager
+description: "Automated backup scheduling, retention policies, and restoration management for VictoriaMetrics data. Requires an Enterprise license."
 tags:
   - metrics
   - enterprise

--- a/docs/victoriametrics/vmctl/_index.md
+++ b/docs/victoriametrics/vmctl/_index.md
@@ -5,6 +5,7 @@ menu:
     parent: victoriametrics
     weight: 8
 title: vmctl
+description: "Data migration tool overview. Migrate from Prometheus, InfluxDB, OpenTSDB, Thanos, Mimir, Cortex, Promscale, and VictoriaMetrics native."
 tags:
   - metrics
 aliases:

--- a/docs/victoriametrics/vmctl/cortex.md
+++ b/docs/victoriametrics/vmctl/cortex.md
@@ -1,5 +1,6 @@
 ---
 title: Cortex
+description: "Migrate historical metrics from Cortex to VictoriaMetrics with vmctl."
 weight: 6
 menu:
   docs:

--- a/docs/victoriametrics/vmctl/influxdb.md
+++ b/docs/victoriametrics/vmctl/influxdb.md
@@ -1,5 +1,6 @@
 ---
 title: InfluxDB
+description: "Migrate historical data from InfluxDB v1."
 weight: 2
 menu:
   docs:

--- a/docs/victoriametrics/vmctl/mimir.md
+++ b/docs/victoriametrics/vmctl/mimir.md
@@ -1,5 +1,6 @@
 ---
 title: Mimir
+description: "Migrate historical metrics from Grafana Mimir to VictoriaMetrics with vmctl."
 weight: 8
 menu:
   docs:

--- a/docs/victoriametrics/vmctl/opentsdb.md
+++ b/docs/victoriametrics/vmctl/opentsdb.md
@@ -1,5 +1,6 @@
 ---
 title: OpenTSDB
+description: "Migrate historical data from OpenTSDB."
 weight: 3
 menu:
   docs:

--- a/docs/victoriametrics/vmctl/prometheus.md
+++ b/docs/victoriametrics/vmctl/prometheus.md
@@ -1,5 +1,6 @@
 ---
 title: Prometheus
+description: "Migrate historical data from Prometheus snapshots."
 weight: 1
 menu:
   docs:

--- a/docs/victoriametrics/vmctl/promscale.md
+++ b/docs/victoriametrics/vmctl/promscale.md
@@ -1,5 +1,6 @@
 ---
 title: Promscale
+description: "Migrate historical metrics from Promscale to VictoriaMetrics with vmctl."
 weight: 7
 menu:
   docs:

--- a/docs/victoriametrics/vmctl/remoteread.md
+++ b/docs/victoriametrics/vmctl/remoteread.md
@@ -1,5 +1,6 @@
 ---
 title: Remote Read
+description: "Migrate data via Prometheus remote read API (Cortex, Mimir, Promscale, Thanos)"
 weight: 4
 menu:
   docs:

--- a/docs/victoriametrics/vmctl/thanos.md
+++ b/docs/victoriametrics/vmctl/thanos.md
@@ -1,5 +1,6 @@
 ---
 title: Thanos
+description: "Migrate data from Thanos blocks via snapshot or remote-read."
 weight: 5
 menu:
   docs:

--- a/docs/victoriametrics/vmctl/thanos.md
+++ b/docs/victoriametrics/vmctl/thanos.md
@@ -1,6 +1,6 @@
 ---
 title: Thanos
-description: "Migrate data from Thanos blocks via snapshot or remote-read."
+description: "Migrate data from Thanos snapshot blocks to VictoriaMetrics."
 weight: 5
 menu:
   docs:

--- a/docs/victoriametrics/vmctl/victoriametrics.md
+++ b/docs/victoriametrics/vmctl/victoriametrics.md
@@ -1,5 +1,6 @@
 ---
 title: VictoriaMetrics
+description: "Migrate data between VM installations via native binary protocol."
 weight: 9
 menu:
   docs:

--- a/docs/victoriametrics/vmgateway.md
+++ b/docs/victoriametrics/vmgateway.md
@@ -5,6 +5,7 @@ menu:
     parent: victoriametrics
     weight: 9
 title: vmgateway
+description: "Configure vmgateway as a gateway for routing, load balancing, and multi-tenant access to VictoriaMetrics."
 tags:
   - metrics
   - enterprise

--- a/docs/victoriametrics/vmgateway.md
+++ b/docs/victoriametrics/vmgateway.md
@@ -5,7 +5,7 @@ menu:
     parent: victoriametrics
     weight: 9
 title: vmgateway
-description: "Configure vmgateway as a gateway for routing, load balancing, and multi-tenant access to VictoriaMetrics."
+description: "Proxy for the VictoriaMetrics TSDB providing per-tenant rate limiting and token-based access control."
 tags:
   - metrics
   - enterprise

--- a/docs/victoriametrics/vmrestore.md
+++ b/docs/victoriametrics/vmrestore.md
@@ -5,7 +5,7 @@ menu:
     parent: victoriametrics
     weight: 7
 title: vmrestore
-description: "Restore VictoriaMetrics data from backups with support for partial restores."
+description: "Restore VictoriaMetrics data from backups with support for resumable and incremental restores."
 tags:
   - metrics
 aliases:

--- a/docs/victoriametrics/vmrestore.md
+++ b/docs/victoriametrics/vmrestore.md
@@ -5,6 +5,7 @@ menu:
     parent: victoriametrics
     weight: 7
 title: vmrestore
+description: "Restore VictoriaMetrics data from backups with support for partial restores."
 tags:
   - metrics
 aliases:


### PR DESCRIPTION
This PR add meta descriptions to every page in the docs in this repository. Right now, we have one general meta description for every page. This PR adds page-specific descriptions.

Meta descriptions are not likely to improve rankings on search engines but can improve CTRs. They can also be used to keep LLMs.txt updated as new pages are added (by adding an automation later).

The descriptions were taken from LLMs.txt, so they were already reviewed in https://github.com/VictoriaMetrics/vmdocs/pull/251

I only tweaked those that needed trimming to fit into the 160 SEO character limit. We also revised them with our SEO specialist (Jonathan). So I think it's a good staring point.

I'm going to open a PR for every repository that contributes to the docs and add descriptions so eventually every page in the docs has a dedicated meta descriptions.