### PR TITLE
fix: use GetFloat64 for timestamp parsing in instant query [fj4WqyCCw3C5ShR1RfB7MoBPTpkRrBFYP1uT35g3MvT]

### DIFF
--- a/app/vmalert/datasource/client_prom.go
+++ b/app/vmalert/datasource/client_prom.go
@@ -109,7 +109,7 @@ func (pi *promInstant) Unmarshal(b []byte) error {
 		if len(sample) != 2 {
 			return fmt.Errorf("object `value` in %q should contain 2 values, but contains %d instead", row, len(sample))
 		}
-		r.Timestamps = []int64{sample[0].GetInt64()}
+		r.Timestamps = []int64{int64(sample[0].GetFloat64())}
 		val, err := sample[1].StringBytes()
 		if err != nil {
 			return fmt.Errorf("error when parsing `value` object %q: %w", sample[1], err)


### PR DESCRIPTION
Fix the instant query parser in vmalert to handle floating-point and scientific-notation JSON timestamps.

### Problem

`vmalert` (v1.149.0) uses `fastjson.GetInt64()` to parse timestamps from Prometheus-compatible `/api/v1/query` responses. This only succeeds when the JSON value is an integer literal. When a datasource returns a valid JSON number in floating-point or scientific notation (e.g. `1786458420.123` or `1.78645842E9`), `GetInt64()` returns 0, causing recording rule results to have `timestamp_ms = 0`.

### Fix

Replace `sample[0].GetInt64()` with `sample[0].GetFloat64()` at line 112 of `app/vmalert/datasource/client_prom.go` and cast to `int64`:

```go
r.Timestamps = []int64{int64(sample[0].GetFloat64())}
```

This correctly handles all JSON numeric representations as defined by the Prometheus HTTP API spec.

### Related issue

Fixes #11396
