### PR TITLE
docs: explain new HA option with `-vmselectAddr`

### DIFF
--- a/docs/victoriametrics/README.md
+++ b/docs/victoriametrics/README.md
@@ -1280,7 +1280,7 @@ to each configured remote destination:
 ```
 
 Each configured `--remoteWrite.url` creates its own replication queue in case the remote destination is unavailable.
-See more about [on-disk persistence in vmagent](https://docs.victoriametrics.com/vmagent/index.html#on-disk-persistence).
+See more about [on-disk persistence in vmagent](https://docs.victoriametrics.com/victoriametrics/vmagent/#on-disk-persistence).
 
 Once the remote destination is available, vmagent will drain the queue and restore data consistency between destinations.
 

--- a/docs/victoriametrics/README.md
+++ b/docs/victoriametrics/README.md
@@ -1323,7 +1323,7 @@ and merge the results. This option is only possible if VictoriaMetrics single-no
 flowchart LR
     Client["Query Client<br/>Grafana / vmalert"]
 
-    VMSELECT["vmselect<br/>Query all destinations <br><code>-dedup.minScrapeInterval=1ms</code>"]
+    VMSELECT["vmselect<br/>Query all destinations <br><code>-dedup.minScrapeInterval=1ms -replicationFactor=2</code>"]
 
     VM1["VictoriaMetrics-1<br/>Single-node<br/><code>-vmselectAddr=:8401</code>"]
     VM2["VictoriaMetrics-2<br/>Single-node<br/><code>-vmselectAddr=:8401</code>"]
@@ -1339,7 +1339,8 @@ flowchart LR
 Option 2 is more costly, as all remote destinations are queried at once and responses must be merged before returning
 the final result. But this option can tolerate data gaps among destinations by merging responses from all VictoriaMetrics instances.
 Since vmselect will be querying identical data across VictoriaMetrics instances, it should be configured
-with `-dedup.minScrapeInterval=1ms` to remove the duplicates during the merge.
+with `-dedup.minScrapeInterval=1ms` to remove the duplicates during the merge. Configure vmselect with `-replicationFactor=N`,
+where `N` is the number of remote destinations, so it could tolerate unavailability of these destinations.
 
 See [VMDistributed](https://docs.victoriametrics.com/operator/resources/vmdistributed/) Kubernetes operator resource for an example.
 

--- a/docs/victoriametrics/README.md
+++ b/docs/victoriametrics/README.md
@@ -1268,7 +1268,7 @@ See also [resource usage limits at VictoriaMetrics cluster](https://docs.victori
 
 VictoriaMetrics supports high availability for both writes and reads by combining replication with multiple instances.
 
-## High availability for writes
+### High availability for writes
 
 You can achieve **high availability for writes** using replication:
 

--- a/docs/victoriametrics/README.md
+++ b/docs/victoriametrics/README.md
@@ -1266,38 +1266,42 @@ See also [resource usage limits at VictoriaMetrics cluster](https://docs.victori
 
 ## High availability
 
-Achieve **high availability for writes** using replication:
+VictoriaMetrics supports high availability for both writes and reads by combining replication with multiple instances.
+
+You can achieve **high availability for writes** using replication:
 
 * Run two or more identically configured VictoriaMetrics instances in distinct datacenters (availability zones);
-* Replicate collected metrics simultaneously into these instances via one or more [vmagents](https://docs.victoriametrics.com/victoriametrics/vmagent/).
+* Replicate collected metrics simultaneously into all these instances via one or more [vmagents](https://docs.victoriametrics.com/victoriametrics/vmagent/).
 
-In this setup, vmagent should be configured [to replicate data](https://docs.victoriametrics.com/victoriametrics/vmagent/#replication-and-high-availability)
-to each configured remote destination:
+In this setup, configure vmagent [to replicate data](https://docs.victoriametrics.com/victoriametrics/vmagent/#replication-and-high-availability)
+to each remote destination:
 ```sh
 /path/to/vmagent \
   -remoteWrite.url=https://victoriametrics-1:8428/api/v1/write \
   -remoteWrite.url=https://victoriametrics-2:8428/api/v1/write
 ```
 
-Each configured `--remoteWrite.url` creates its own replication queue in case the remote destination is unavailable.
+Each `--remoteWrite.url` creates its own replication queue. The queue temporarily stores data on disk while a remote destination is unavailable.
 See more about [on-disk persistence in vmagent](https://docs.victoriametrics.com/victoriametrics/vmagent/#on-disk-persistence).
 
-Once the remote destination is available, vmagent will drain the queue and restore data consistency between destinations.
+When the remote destination becomes available, vmagent drains the queue and restores data consistency across destinations.
 
 > The max size of the on-disk queue can be increased by [horizontally sharding vmagents](https://docs.victoriametrics.com/victoriametrics/vmagent/#scraping-big-number-of-targets).
-> For achieving vmagent's high availability, run multiple identically configured replicas of vmagents. In this case, the load
-> on the remote destinations will increase proportionally to the number of vmagent replicas. The duplicated data in remote destinations
-> has to be [deduplicated](#deduplication) on the VictoriaMetrics side.
+> To achieve high availability for vmagent itself, run multiple identically configured vmagent replicas.
+> In this case, the load on the remote destinations will increase proportionally to the number of vmagent replicas. The duplicated data in remote destinations
+> has to be [deduplicated](https://docs.victoriametrics.com/victoriametrics/#deduplication) on the VictoriaMetrics side.
 
-Achieve **high availability for reads** by choosing one of the following options.
+You can achieve **high availability for reads** by choosing one of the following options:
 
-1. Use load balancer to query the first VictoriaMetrics instance and fail over to the second instance if the first instance becomes temporarily unavailable.
-  This can be done via [vmauth](https://docs.victoriametrics.com/victoriametrics/vmauth/) according to [these docs](https://docs.victoriametrics.com/victoriametrics/vmauth/#high-availability).
-1. Use [vmselect](https://docs.victoriametrics.com/victoriametrics/vmselect/) to query all remote destinations at once
-  and merge the results. This option is only possible if VictoriaMetrics single-node instances are configured with `-vmselectAddr` flag. See more details in [these docs](https://docs.victoriametrics.com/victoriametrics/#multi-tenancy).
+- Load balancer: Use a load balancer to ensure read operations are always routed to an available VictoriaMetrics instance.
+- Top-level vmselect: Use vmselect to query all available VictoriaMetrics instances and merge the results
 
-**Option 1.** Use load balancer to query the first VictoriaMetrics instance and fail over to the second instance if the first instance becomes temporarily unavailable.
-This can be done via [vmauth](https://docs.victoriametrics.com/victoriametrics/vmauth/) according to [these docs](https://docs.victoriametrics.com/victoriametrics/vmauth/#high-availability).
+### Load balancer
+
+In this mode, we use a load balancer to query the main VictoriaMetrics instance and fail over to a secondary instance if the first one becomes temporarily unavailable.
+
+This can be done using [vmauth](https://docs.victoriametrics.com/victoriametrics/vmauth/) configured in [high-availability mode](https://docs.victoriametrics.com/victoriametrics/vmauth/#high-availability).
+
 ```mermaid
 flowchart LR
     Client["Query Client<br/>Grafana/vmalert"]
@@ -1313,17 +1317,26 @@ flowchart LR
     VMAUTH -.->|"2. Fail over if VM1<br/>is unavailable"| VM2
 ```
 
-This option is the most cost-efficient, as only one of VictoriaMetrics instances is queried at a time.
-However, during short recovery periods of the unavailable instance, the read queries could be routed to this instance and  
-return incomplete results, while queue on vmagents is still being drained. 
+This is the most cost-efficient option because only one VictoriaMetrics instance is queried at a time.
 
-**Option 2.**  Use [vmselect](https://docs.victoriametrics.com/victoriametrics/vmselect/) to query all remote destinations at once
-and merge the results. This option is only possible if VictoriaMetrics single-node instances are configured with `-vmselectAddr` flag. See more details in [these docs](https://docs.victoriametrics.com/victoriametrics/#multi-tenancy).
+The downside is that when one instance goes down and then comes back up, the load balancer may immediately start sending read queries to the recovering instance, even though it hasn't caught up yet. During this short recovery window:
+
+- The recovering VictoriaMetrics instance has not yet ingested all the data that was queued while it was down.
+- vmagent nodes may still be draining their backlogged queues into that instance
+- Read queries routed to the recovering instance can return incomplete results, because some recent data may still be in transit or not yet visible.
+
+### Top-level vmselect
+
+In this option, we use a top-level [vmselect](https://docs.victoriametrics.com/victoriametrics/vmselect/) to query all remote destinations simultaneously and merge the results.
+
+This option is only possible if VictoriaMetrics single-node instances are configured with the `-vmselectAddr` flag. See more details in the [VictoriaMetrics multi-tenancy section](https://docs.victoriametrics.com/victoriametrics/#multi-tenancy).
+
 ```mermaid
 flowchart LR
     Client["Query Client<br/>Grafana / vmalert"]
 
-    VMSELECT["vmselect<br/>Query all destinations <br><code>-dedup.minScrapeInterval=1ms -replicationFactor=2</code>"]
+    VMSELECT["vmselect<br/>Query all destinations<br/>
+     <code><pre>-dedup.minScrapeInterval=1ms<br/>-replicationFactor=2</pre></code>"]
 
     VM1["VictoriaMetrics-1<br/>Single-node<br/><code>-vmselectAddr=:8401</code>"]
     VM2["VictoriaMetrics-2<br/>Single-node<br/><code>-vmselectAddr=:8401</code>"]
@@ -1336,13 +1349,13 @@ flowchart LR
     VMSELECT -->|"Merged and deduplicated results"| Client
 ```
 
-Option 2 is more costly, as all remote destinations are queried at once and responses must be merged before returning
-the final result. But this option can tolerate data gaps among destinations by merging responses from all VictoriaMetrics instances.
-Since vmselect will be querying identical data across VictoriaMetrics instances, it should be configured
-with `-dedup.minScrapeInterval=1ms` to remove the duplicates during the merge. Configure vmselect with `-replicationFactor=N`,
-where `N` is the number of remote destinations, so it could tolerate unavailability of these destinations.
+This option requires more resources because it queries all remote destinations simultaneously and merges their responses before returning the final result.
 
-See [VMDistributed](https://docs.victoriametrics.com/operator/resources/vmdistributed/) Kubernetes operator resource for an example.
+The benefit is that it can handle data gaps across destinations by merging responses from all VictoriaMetrics instances. Thus, a single recovering instance is less likely to cause incomplete results, unlike in the load balancer case.
+
+Since vmselect queries identical data across multiple VictoriaMetrics instances, configure it with `-dedup.minScrapeInterval=1ms` to remove duplicate samples during merging. Also set `-replicationFactor=N` on vmselect, where `N` equals the number of remote storage destinations, so that queries can tolerate the unavailability of up to `N-1` destinations.
+
+See [VMDistributed](https://docs.victoriametrics.com/operator/resources/vmdistributed/) Kubernetes operator resource for an example of configuring vmselect with deduplication and replication.
 
 ## Deduplication
 

--- a/docs/victoriametrics/README.md
+++ b/docs/victoriametrics/README.md
@@ -1271,7 +1271,7 @@ Achieve **high availability for writes** using replication:
 * Run two or more identically configured VictoriaMetrics instances in distinct datacenters (availability zones);
 * Replicate collected metrics simultaneously into these instances via one or more [vmagents](https://docs.victoriametrics.com/victoriametrics/vmagent/).
 
-In this setup, vmagent should be configured [to replicate data](https://docs.victoriametrics.com/vmagent/index.html#replication-and-high-availability)
+In this setup, vmagent should be configured [to replicate data](https://docs.victoriametrics.com/victoriametrics/vmagent/#replication-and-high-availability)
 to each configured remote destination:
 ```sh
 /path/to/vmagent \

--- a/docs/victoriametrics/README.md
+++ b/docs/victoriametrics/README.md
@@ -1266,45 +1266,80 @@ See also [resource usage limits at VictoriaMetrics cluster](https://docs.victori
 
 ## High availability
 
-The general approach for achieving high availability is the following:
+Achieve **high availability for writes** using replication:
 
-* To run two identically configured VictoriaMetrics instances in distinct datacenters (availability zones);
-* To store the collected data simultaneously into these instances via [vmagent](https://docs.victoriametrics.com/victoriametrics/vmagent/) or Prometheus.
-* To query the first VictoriaMetrics instance and to fail over to the second instance when the first instance becomes temporarily unavailable.
-  This can be done via [vmauth](https://docs.victoriametrics.com/victoriametrics/vmauth/) according to [these docs](https://docs.victoriametrics.com/victoriametrics/vmauth/#high-availability).
+* Run two or more identically configured VictoriaMetrics instances in distinct datacenters (availability zones);
+* Replicate collected metrics simultaneously into these instances via one or more [vmagents](https://docs.victoriametrics.com/victoriametrics/vmagent/).
 
-Such a setup guarantees that the collected data isn't lost when one of VictoriaMetrics instance becomes unavailable.
-The collected data continues to be written to the available VictoriaMetrics instance, so it should be available for querying.
-Both [vmagent](https://docs.victoriametrics.com/victoriametrics/vmagent/) and Prometheus buffer the collected data locally if they cannot send it
-to the configured remote storage. So the collected data will be written to the temporarily unavailable VictoriaMetrics instance
-after it becomes available.
-
-If you use [vmagent](https://docs.victoriametrics.com/victoriametrics/vmagent/) for storing the data into VictoriaMetrics,
-then it can be configured with multiple `-remoteWrite.url` command-line flags, where every flag points to the VictoriaMetrics
-instance in a particular availability zone, in order to replicate the collected data to all the VictoriaMetrics instances.
-For example, the following command instructs `vmagent` to replicate data to `vm-az1` and `vm-az2` instances of VictoriaMetrics:
-
+In this setup, vmagent should be configured [to replicate data](https://docs.victoriametrics.com/vmagent/index.html#replication-and-high-availability)
+to each configured remote destination:
 ```sh
 /path/to/vmagent \
-  -remoteWrite.url=http://<vm-az1>:8428/api/v1/write \
-  -remoteWrite.url=http://<vm-az2>:8428/api/v1/write
+  -remoteWrite.url=https://victoriametrics-1:8428/api/v1/write \
+  -remoteWrite.url=https://victoriametrics-2:8428/api/v1/write
 ```
 
-If you use Prometheus for collecting and writing the data to VictoriaMetrics,
-then the following [`remote_write`](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#remote_write) section
-in Prometheus config can be used for replicating the collected data to `vm-az1` and `vm-az2` VictoriaMetrics instances:
+Each configured `--remoteWrite.url` creates its own replication queue in case if the remote destination is unavailable.
+See more about [on-disk persistence in vmagent](https://docs.victoriametrics.com/vmagent/index.html#on-disk-persistence).
 
-```yaml
-remote_write:
-  - url: http://<vm-az1>:8428/api/v1/write
-  - url: http://<vm-az2>:8428/api/v1/write
+Once the remote destination is available, vmagent will drain the queue and restore data consistency between destinations.
+
+> The max size of the on-disk queue can be increased by [horizontally sharding vmagents](http://localhost:1313/victoriametrics/vmagent/#scraping-big-number-of-targets).
+> For achieving vmagent's high availability, run multiple identically configured replicas of vmagents. In this case, the load
+> on the remote destinations will increase proportionally to the number of vmagent replicas. The duplicated data in remote destinations
+> has to be [deduplicated](#deduplication) on the VictoriaMetrics side.
+
+Achieve **high availability for reads** by choosing one of the following options.
+
+1. Use load balancer to query the first VictoriaMetrics instance and fail over to the second instance if the first instance becomes temporarily unavailable.
+  This can be done via [vmauth](https://docs.victoriametrics.com/victoriametrics/vmauth/) according to [these docs](https://docs.victoriametrics.com/victoriametrics/vmauth/#high-availability).
+1. Use [vmselect](https://docs.victoriametrics.com/victoriametrics/vmselect/) to query all remote destinations at once
+  and merge the results. This option is only possible if VictoriaMetrics single-node instances are configured with `-vmselectAddr` flag. See more details in [these docs](https://docs.victoriametrics.com/victoriametrics/#multi-tenancy).
+
+**Option 1.** Use load balancer to query the first VictoriaMetrics instance and fail over to the second instance if the first instance becomes temporarily unavailable.
+This can be done via [vmauth](https://docs.victoriametrics.com/victoriametrics/vmauth/) according to [these docs](https://docs.victoriametrics.com/victoriametrics/vmauth/#high-availability).
+```mermaid
+flowchart LR
+    Client["Query Client<br/>Grafana/vmalert"]
+
+    VMAUTH["vmauth<br/>Load Balancer / Failover"]
+
+    VM1["VictoriaMetrics-1<br/>Primary read target"]
+    VM2["VictoriaMetrics-2<br/>Failover read target"]
+
+    Client -->|"Read query"| VMAUTH
+
+    VMAUTH -->|"1. Send queries"| VM1
+    VMAUTH -.->|"2. Fail over if VM1<br/>is unavailable"| VM2
 ```
 
-It is recommended to use [vmagent](https://docs.victoriametrics.com/victoriametrics/vmagent/) instead of Prometheus for highly loaded setups,
-since it uses lower amounts of RAM, CPU and network bandwidth than Prometheus.
+This option is the most cost-efficient, as only one of VictoriaMetrics instances is queried at a time.
+However, during short recovery periods of the unavailable instance, the read queries could be routed to this instance and  
+return incomplete results, while queue on vmagents is still being drained. 
 
-If you use identically configured [vmagent](https://docs.victoriametrics.com/victoriametrics/vmagent/) instances for collecting the same data
-and sending it to VictoriaMetrics, then do not forget enabling [deduplication](#deduplication) at VictoriaMetrics side.
+**Option 2.**  Use [vmselect](https://docs.victoriametrics.com/victoriametrics/vmselect/) to query all remote destinations at once
+and merge the results. This option is only possible if VictoriaMetrics single-node instances are configured with `-vmselectAddr` flag. See more details in [these docs](https://docs.victoriametrics.com/victoriametrics/#multi-tenancy).
+```mermaid
+flowchart LR
+    Client["Query Client<br/>Grafana / vmalert"]
+
+    VMSELECT["vmselect<br/>Query all destinations <br><code>-dedup.minScrapeInterval=1ms</code>"]
+
+    VM1["VictoriaMetrics-1<br/>Single-node<br/><code>-vmselectAddr=:8401</code>"]
+    VM2["VictoriaMetrics-2<br/>Single-node<br/><code>-vmselectAddr=:8401</code>"]
+
+    Client -->|"Read query"| VMSELECT
+
+    VMSELECT --> VM1
+    VMSELECT --> VM2
+
+    VMSELECT -->|"Merged and deduplicated results"| Client
+```
+
+Option 2 is more costly, as all remote destinations are queried at once and responses must be merged before returning
+the final result. But this option can tolerate data gaps among destinations by merging responses from all VictoriaMetrics instances.
+Since vmselect will be querying identical data across VictoriaMetrics instances, it should be configured
+with `-dedup.minScrapeInterval=1ms` to remove the duplicates during the merge.
 
 See [VMDistributed](https://docs.victoriametrics.com/operator/resources/vmdistributed/) Kubernetes operator resource for an example.
 

--- a/docs/victoriametrics/README.md
+++ b/docs/victoriametrics/README.md
@@ -1289,7 +1289,7 @@ See more about [on-disk persistence in vmagent](https://docs.victoriametrics.com
 When the remote destination becomes available, vmagent drains the queue and restores data consistency across destinations.
 
 > The max size of the on-disk queue can be increased by [horizontally sharding vmagents](https://docs.victoriametrics.com/victoriametrics/vmagent/#scraping-big-number-of-targets).
-> To achieve high availability for vmagent itself run multiple identically configured vmagent replicas.
+> To achieve high availability for vmagent itself, run multiple identically configured vmagent replicas.
 > In this case, the load on the remote destinations will increase proportionally to the number of vmagent replicas. The duplicated data in remote destinations
 > has to be [deduplicated](https://docs.victoriametrics.com/victoriametrics/#deduplication) on the VictoriaMetrics side.
 

--- a/docs/victoriametrics/README.md
+++ b/docs/victoriametrics/README.md
@@ -1268,6 +1268,8 @@ See also [resource usage limits at VictoriaMetrics cluster](https://docs.victori
 
 VictoriaMetrics supports high availability for both writes and reads by combining replication with multiple instances.
 
+## High availability for writes
+
 You can achieve **high availability for writes** using replication:
 
 * Run two or more identically configured VictoriaMetrics instances in distinct datacenters (availability zones);
@@ -1291,12 +1293,14 @@ When the remote destination becomes available, vmagent drains the queue and rest
 > In this case, the load on the remote destinations will increase proportionally to the number of vmagent replicas. The duplicated data in remote destinations
 > has to be [deduplicated](https://docs.victoriametrics.com/victoriametrics/#deduplication) on the VictoriaMetrics side.
 
+### High availability for reads
+
 You can achieve **high availability for reads** by choosing one of the following options:
 
 - Load balancer: Use a load balancer to ensure read operations are always routed to an available VictoriaMetrics instance.
 - Top-level vmselect: Use vmselect to query all available VictoriaMetrics instances and merge the results
 
-### Load balancer
+**Load balancer for reads**
 
 In this mode, we use a load balancer to query the main VictoriaMetrics instance and fail over to a secondary instance if the first one becomes temporarily unavailable.
 
@@ -1325,7 +1329,7 @@ The downside is that when one instance goes down and then comes back up, the loa
 - vmagent nodes may still be draining their backlogged queues into that instance
 - Read queries routed to the recovering instance can return incomplete results, because some recent data may still be in transit or not yet visible.
 
-### Top-level vmselect
+**Top-level vmselect for reads**
 
 In this option, we use a top-level [vmselect](https://docs.victoriametrics.com/victoriametrics/vmselect/) to query all remote destinations simultaneously and merge the results.
 

--- a/docs/victoriametrics/README.md
+++ b/docs/victoriametrics/README.md
@@ -1323,17 +1323,21 @@ flowchart LR
 
 This is the most cost-efficient option because only one VictoriaMetrics instance is queried at a time.
 
-The downside is that when one instance goes down and then comes back up, the load balancer may immediately start sending read queries to the recovering instance, even though it hasn't caught up yet. During this short recovery window:
+The downside is that when one instance goes down and then comes back up, the load balancer may immediately start sending
+read queries to the recovering instance, even though it hasn't caught up with vmagent's queue yet and may return incomplete results.
 
-- The recovering VictoriaMetrics instance has not yet ingested all the data that was queued while it was down.
-- vmagent nodes may still be draining their backlogged queues into that instance
-- Read queries routed to the recovering instance can return incomplete results, because some recent data may still be in transit or not yet visible.
+This shortcoming can be mitigated by removing the catching up instance from the vmauth config until the queue on vmagents
+is drained. This mechanism is automatically applied when using [k8s VMDistributed](https://docs.victoriametrics.com/operator/resources/vmdistributed/) resource.
+
+Another option is to use top-level vmselect as described below.
 
 **Top-level vmselect for reads**
 
-In this option, we use a top-level [vmselect](https://docs.victoriametrics.com/victoriametrics/vmselect/) to query all remote destinations simultaneously and merge the results.
+In this option, we use a top-level [vmselect](https://docs.victoriametrics.com/victoriametrics/vmselect/) to query all 
+remote destinations simultaneously and merge the results.
 
-This option is only possible if VictoriaMetrics single-node instances are configured with the `-vmselectAddr` flag. See more details in the [VictoriaMetrics multi-tenancy section](https://docs.victoriametrics.com/victoriametrics/#multi-tenancy).
+This option is only possible if VictoriaMetrics single-node instances are configured with the `-vmselectAddr` flag. 
+See more details in the [VictoriaMetrics multi-tenancy section](https://docs.victoriametrics.com/victoriametrics/#multi-tenancy).
 
 ```mermaid
 flowchart LR
@@ -1353,13 +1357,16 @@ flowchart LR
     VMSELECT -->|"Merged and deduplicated results"| Client
 ```
 
-This option requires more resources because it queries all remote destinations simultaneously and merges their responses before returning the final result.
+This option requires extra resources on vmselect because it queries all remote destinations simultaneously and merges 
+their responses before returning the final result.
 
-The benefit is that it can handle data gaps across destinations by merging responses from all VictoriaMetrics instances. Thus, a single recovering instance is less likely to cause incomplete results, unlike in the load balancer case.
+The benefit is that it can handle data gaps across destinations by merging responses from all VictoriaMetrics instances.
+Thus, a single recovering instance can't cause incomplete results, as gaps will be filled with samples from the healthy instance.
 
-Since vmselect queries identical data across multiple VictoriaMetrics instances, configure it with `-dedup.minScrapeInterval=1ms` to remove duplicate samples during merging. Also set `-replicationFactor=N` on vmselect, where `N` equals the number of remote storage destinations, so that queries can tolerate the unavailability of up to `N-1` destinations.
-
-See [VMDistributed](https://docs.victoriametrics.com/operator/resources/vmdistributed/) Kubernetes operator resource for an example of configuring vmselect with deduplication and replication.
+Since vmselect fetches replicated data from VictoriaMetrics instances, it must be deduplicated before processing. 
+Configure vmselect with `-dedup.minScrapeInterval=1ms` to remove duplicated samples during merging. 
+Also set `-replicationFactor=N` on vmselect, where `N` equals the number of remote storage destinations, so that queries
+can tolerate the unavailability of up to `N-1` destinations.
 
 ## Deduplication
 

--- a/docs/victoriametrics/README.md
+++ b/docs/victoriametrics/README.md
@@ -1289,7 +1289,7 @@ See more about [on-disk persistence in vmagent](https://docs.victoriametrics.com
 When the remote destination becomes available, vmagent drains the queue and restores data consistency across destinations.
 
 > The max size of the on-disk queue can be increased by [horizontally sharding vmagents](https://docs.victoriametrics.com/victoriametrics/vmagent/#scraping-big-number-of-targets).
-> To achieve high availability for vmagent itself, run multiple identically configured vmagent replicas.
+> To achieve high availability for vmagent itself run multiple identically configured vmagent replicas.
 > In this case, the load on the remote destinations will increase proportionally to the number of vmagent replicas. The duplicated data in remote destinations
 > has to be [deduplicated](https://docs.victoriametrics.com/victoriametrics/#deduplication) on the VictoriaMetrics side.
 
@@ -1321,22 +1321,21 @@ flowchart LR
     VMAUTH -.->|"2. Fail over if VM1<br/>is unavailable"| VM2
 ```
 
-This is the most cost-efficient option because only one VictoriaMetrics instance is queried at a time.
+This is the most cost-efficient option because it queries only one VictoriaMetrics instance at a time.
 
 The downside is that when one instance goes down and then comes back up, the load balancer may immediately start sending
 read queries to the recovering instance, even though it hasn't caught up with vmagent's queue yet and may return incomplete results.
 
-This shortcoming can be mitigated by removing the catching up instance from the vmauth config until the queue on vmagents
-is drained. This mechanism is automatically applied when using [k8s VMDistributed](https://docs.victoriametrics.com/operator/resources/vmdistributed/) resource.
+This shortcoming can be mitigated during sequential upgrades by removing the catching-up instance from the vmauth configuration until the vmagent queues are drained. During sequential upgrades, this mechanism is automatically applied when using the [Kubernetes VMDistributed](https://docs.victoriametrics.com/operator/resources/vmdistributed/) resource. After an outage, you must remove the recovered instance manually until its vmagent queues are drained.
 
 Another option is to use top-level vmselect as described below.
 
 **Top-level vmselect for reads**
 
-In this option, we use a top-level [vmselect](https://docs.victoriametrics.com/victoriametrics/vmselect/) to query all 
+In this option, we use a top-level [vmselect](https://docs.victoriametrics.com/victoriametrics/vmselect/) to query all
 remote destinations simultaneously and merge the results.
 
-This option is only possible if VictoriaMetrics single-node instances are configured with the `-vmselectAddr` flag. 
+This option is only possible if VictoriaMetrics single-node instances are configured with the `-vmselectAddr` flag.
 See more details in the [VictoriaMetrics multi-tenancy section](https://docs.victoriametrics.com/victoriametrics/#multi-tenancy).
 
 ```mermaid
@@ -1357,14 +1356,14 @@ flowchart LR
     VMSELECT -->|"Merged and deduplicated results"| Client
 ```
 
-This option requires extra resources on vmselect because it queries all remote destinations simultaneously and merges 
+This option requires extra resources on vmselect because it queries all remote destinations simultaneously and merges
 their responses before returning the final result.
 
-The benefit is that it can handle data gaps across destinations by merging responses from all VictoriaMetrics instances.
+The benefit is that it can handle data gaps across destinations by merging responses from all VictoriaMetrics instances (as long as at least one instance has all the data without gaps).
 Thus, a single recovering instance can't cause incomplete results, as gaps will be filled with samples from the healthy instance.
 
-Since vmselect fetches replicated data from VictoriaMetrics instances, it must be deduplicated before processing. 
-Configure vmselect with `-dedup.minScrapeInterval=1ms` to remove duplicated samples during merging. 
+Since vmselect fetches replicated data from VictoriaMetrics instances, it must be deduplicated before processing.
+Configure vmselect with `-dedup.minScrapeInterval=1ms` to remove duplicated samples during merging.
 Also set `-replicationFactor=N` on vmselect, where `N` equals the number of remote storage destinations, so that queries
 can tolerate the unavailability of up to `N-1` destinations.
 

--- a/docs/victoriametrics/README.md
+++ b/docs/victoriametrics/README.md
@@ -1284,7 +1284,7 @@ See more about [on-disk persistence in vmagent](https://docs.victoriametrics.com
 
 Once the remote destination is available, vmagent will drain the queue and restore data consistency between destinations.
 
-> The max size of the on-disk queue can be increased by [horizontally sharding vmagents](http://localhost:1313/victoriametrics/vmagent/#scraping-big-number-of-targets).
+> The max size of the on-disk queue can be increased by [horizontally sharding vmagents](https://docs.victoriametrics.com/victoriametrics/vmagent/#scraping-big-number-of-targets).
 > For achieving vmagent's high availability, run multiple identically configured replicas of vmagents. In this case, the load
 > on the remote destinations will increase proportionally to the number of vmagent replicas. The duplicated data in remote destinations
 > has to be [deduplicated](#deduplication) on the VictoriaMetrics side.

--- a/docs/victoriametrics/README.md
+++ b/docs/victoriametrics/README.md
@@ -1279,7 +1279,7 @@ to each configured remote destination:
   -remoteWrite.url=https://victoriametrics-2:8428/api/v1/write
 ```
 
-Each configured `--remoteWrite.url` creates its own replication queue in case if the remote destination is unavailable.
+Each configured `--remoteWrite.url` creates its own replication queue in case the remote destination is unavailable.
 See more about [on-disk persistence in vmagent](https://docs.victoriametrics.com/vmagent/index.html#on-disk-persistence).
 
 Once the remote destination is available, vmagent will drain the queue and restore data consistency between destinations.


### PR DESCRIPTION
With single-node support of `-vmselectAddr` users can build an HA topology using vmselect, that wasn't available before.
The new option is more preferable for data completeness but is more resource-costly.

Adding docs how this can be achieved.

Related to https://github.com/VictoriaMetrics/VictoriaMetrics/pull/11334

