### PR TITLE
dashboards: remove ID field

### DIFF
--- a/dashboards/alert-statistics.json
+++ b/dashboards/alert-statistics.json
@@ -59,7 +59,6 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": null,
   "links": [
     {
       "icon": "doc",

--- a/dashboards/backupmanager.json
+++ b/dashboards/backupmanager.json
@@ -77,7 +77,6 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": null,
   "links": [
     {
       "icon": "doc",

--- a/dashboards/clusterbytenant.json
+++ b/dashboards/clusterbytenant.json
@@ -25,7 +25,6 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
-  "id": 3,
   "links": [
     {
       "icon": "doc",

--- a/dashboards/metrics-explorer.json
+++ b/dashboards/metrics-explorer.json
@@ -1144,6 +1144,5 @@
   "title": "VictoriaMetrics - metrics explorer",
   "uid": "adqm4hz",
   "version": 1,
-  "weekStart": "",
-  "id": null
+  "weekStart": ""
 }

--- a/dashboards/operator.json
+++ b/dashboards/operator.json
@@ -37,7 +37,6 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 0,
   "links": [
     {
       "icon": "doc",

--- a/dashboards/victoriametrics-cluster.json
+++ b/dashboards/victoriametrics-cluster.json
@@ -62,7 +62,6 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
-  "id": 0,
   "links": [
     {
       "icon": "doc",

--- a/dashboards/victoriametrics.json
+++ b/dashboards/victoriametrics.json
@@ -62,7 +62,6 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
-  "id": 13,
   "links": [
     {
       "icon": "doc",

--- a/dashboards/vm/backupmanager.json
+++ b/dashboards/vm/backupmanager.json
@@ -78,7 +78,6 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": null,
   "links": [
     {
       "icon": "doc",

--- a/dashboards/vm/clusterbytenant.json
+++ b/dashboards/vm/clusterbytenant.json
@@ -26,7 +26,6 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
-  "id": 3,
   "links": [
     {
       "icon": "doc",

--- a/dashboards/vm/operator.json
+++ b/dashboards/vm/operator.json
@@ -38,7 +38,6 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 0,
   "links": [
     {
       "icon": "doc",

--- a/dashboards/vm/victoriametrics-cluster.json
+++ b/dashboards/vm/victoriametrics-cluster.json
@@ -63,7 +63,6 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
-  "id": 0,
   "links": [
     {
       "icon": "doc",

--- a/dashboards/vm/victoriametrics.json
+++ b/dashboards/vm/victoriametrics.json
@@ -63,7 +63,6 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
-  "id": 13,
   "links": [
     {
       "icon": "doc",

--- a/dashboards/vm/vmagent.json
+++ b/dashboards/vm/vmagent.json
@@ -51,7 +51,6 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
-  "id": 3,
   "links": [
     {
       "icon": "doc",

--- a/dashboards/vm/vmalert.json
+++ b/dashboards/vm/vmalert.json
@@ -51,7 +51,6 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
-  "id": 3,
   "links": [
     {
       "icon": "doc",

--- a/dashboards/vm/vmauth.json
+++ b/dashboards/vm/vmauth.json
@@ -72,7 +72,6 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
-  "id": null,
   "links": [
     {
       "icon": "doc",

--- a/dashboards/vmagent.json
+++ b/dashboards/vmagent.json
@@ -50,7 +50,6 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
-  "id": 3,
   "links": [
     {
       "icon": "doc",

--- a/dashboards/vmalert.json
+++ b/dashboards/vmalert.json
@@ -50,7 +50,6 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
-  "id": 3,
   "links": [
     {
       "icon": "doc",

--- a/dashboards/vmauth.json
+++ b/dashboards/vmauth.json
@@ -71,7 +71,6 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
-  "id": null,
   "links": [
     {
       "icon": "doc",


### PR DESCRIPTION
Remove ID fields from dashboards. These aren't required and were causing imports to fail for some users.