### PR TITLE
docs: document vmalert-tool test start time change and add CHANGELOG entry (#11437)

### DIFF
--- a/docs/victoriametrics/changelog/CHANGELOG.md
+++ b/docs/victoriametrics/changelog/CHANGELOG.md
@@ -139,6 +139,8 @@ The v1.148.x line will be supported for at least 12 months since [v1.148.0](http
 
 Released at 2026-07-20
 
+**Update Note 1:** [vmalert-tool](https://docs.victoriametrics.com/victoriametrics/vmalert-tool/): the default start timestamp of tests has changed in [#11219](https://github.com/VictoriaMetrics/VictoriaMetrics/pull/11219) from `1970-01-01T00:00:00` to `2000-01-01T00:00:00` to enable global index disablement. As a result, tests involving functions that depend on the current time, such as `time()` and `day_of_*()`, may produce different results. See [#11437](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/11437).
+
 * SECURITY: upgrade Go builder from Go1.26.4 to Go1.26.5. See [the list of issues addressed in Go1.26.5](https://github.com/golang/go/issues?q=milestone%3AGo1.26.5%20label%3ACherryPickApproved).
 
 * FEATURE: [MetricsQL](https://docs.victoriametrics.com/victoriametrics/metricsql/): support `fill` modifiers to allow missing series on either side of a binary operation to be filled with a provided default value. See [#10598](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/10598).

--- a/docs/victoriametrics/vmalert-tool.md
+++ b/docs/victoriametrics/vmalert-tool.md
@@ -282,6 +282,12 @@ groups:
         expr: count_over_time(up[5m:])
 ```
 
+### Time within tests
+
+In all tests, functions that depend on the current time, such as `time()` and `day_of_*()`, return consistent values.
+
+By default, at the start of test evaluation, `time()` returns `946684800` (Unix timestamp: January 1, 2000, at 00:00:00 UTC). The `eval_time` field specifies a duration relative to this test start time. Therefore, by default, `time()` returns `946684800 + eval_time`.
+
 ### Debug mode
 
 vmalert-tool can print additional log messages for specific alerting rules, similar to [vmalert](https://docs.victoriametrics.com/victoriametrics/vmalert/#debug-mode), by following these steps:
@@ -292,15 +298,15 @@ vmalert-tool can print additional log messages for specific alerting rules, simi
 The additional log messages include tips for alert state transformations, timestamp and result of each evaluation:
 
 ```shell-session
-2024-12-10T12:10:26.339Z	info	VictoriaMetrics/app/vmalert/rule/alerting.go:212	DEBUG rule "TestGroup":"TestRule" (14686524233356632740) at 1970-01-01T00:00:00Z: query returned 0 samples (elapsed: 2.148792ms)
-2024-12-10T12:10:26.339Z	info	VictoriaMetrics/app/vmalert/datasource/client.go:254	DEBUG datasource request: executing POST request with params "http://127.0.0.1:8880/prometheus/api/v1/query?query=test_metric+%3E+0&step=300s&time=1970-01-01T00%3A01%3A00Z"
-2024-12-10T12:10:26.339Z	info	VictoriaMetrics/app/vmalert/rule/alerting.go:212	DEBUG rule "TestGroup":"TestRule" (14686524233356632740) at 1970-01-01T00:01:00Z: query returned 0 samples (elapsed: 277µs)
-2024-12-10T12:10:26.339Z	info	VictoriaMetrics/app/vmalert/datasource/client.go:254	DEBUG datasource request: executing POST request with params "http://127.0.0.1:8880/prometheus/api/v1/query?query=test_metric+%3E+0&step=300s&time=1970-01-01T00%3A02%3A00Z"
-2024-12-10T12:10:26.340Z	info	VictoriaMetrics/app/vmalert/rule/alerting.go:212	DEBUG rule "TestGroup":"TestRule" (14686524233356632740) at 1970-01-01T00:02:00Z: query returned 1 samples (elapsed: 566.083µs)
-2024-12-10T12:10:26.340Z	info	VictoriaMetrics/app/vmalert/rule/alerting.go:212	DEBUG rule "TestGroup":"TestRule" (14686524233356632740) at 1970-01-01T00:02:00Z: alert 11669695145351808068 {alertgroup="TestGroup",alertname="TestRule"} created in state PENDING
-2024-12-10T12:10:26.343Z	info	VictoriaMetrics/app/vmalert/datasource/client.go:254	DEBUG datasource request: executing POST request with params "http://127.0.0.1:8880/prometheus/api/v1/query?query=test_metric+%3E+0&step=300s&time=1970-01-01T00%3A03%3A00Z"
-2024-12-10T12:10:26.344Z	info	VictoriaMetrics/app/vmalert/rule/alerting.go:212	DEBUG rule "TestGroup":"TestRule" (14686524233356632740) at 1970-01-01T00:03:00Z: query returned 1 samples (elapsed: 822.958µs)
-2024-12-10T12:10:26.344Z	info	VictoriaMetrics/app/vmalert/rule/alerting.go:212	DEBUG rule "TestGroup":"TestRule" (14686524233356632740) at 1970-01-01T00:03:00Z: alert 11669695145351808068 {alertgroup="TestGroup",alertname="TestRule"} PENDING => FIRING: 1m0s since becoming active at 1970-01-01 00:02:00 +0000 UTC
+2024-12-10T12:10:26.339Z	info	VictoriaMetrics/app/vmalert/rule/alerting.go:212	DEBUG rule "TestGroup":"TestRule" (14686524233356632740) at 2000-01-01T00:00:00Z: query returned 0 samples (elapsed: 2.148792ms)
+2024-12-10T12:10:26.339Z	info	VictoriaMetrics/app/vmalert/datasource/client.go:254	DEBUG datasource request: executing POST request with params "http://127.0.0.1:8880/prometheus/api/v1/query?query=test_metric+%3E+0&step=300s&time=2000-01-01T00%3A01%3A00Z"
+2024-12-10T12:10:26.339Z	info	VictoriaMetrics/app/vmalert/rule/alerting.go:212	DEBUG rule "TestGroup":"TestRule" (14686524233356632740) at 2000-01-01T00:01:00Z: query returned 0 samples (elapsed: 277µs)
+2024-12-10T12:10:26.339Z	info	VictoriaMetrics/app/vmalert/datasource/client.go:254	DEBUG datasource request: executing POST request with params "http://127.0.0.1:8880/prometheus/api/v1/query?query=test_metric+%3E+0&step=300s&time=2000-01-01T00%3A02%3A00Z"
+2024-12-10T12:10:26.340Z	info	VictoriaMetrics/app/vmalert/rule/alerting.go:212	DEBUG rule "TestGroup":"TestRule" (14686524233356632740) at 2000-01-01T00:02:00Z: query returned 1 samples (elapsed: 566.083µs)
+2024-12-10T12:10:26.340Z	info	VictoriaMetrics/app/vmalert/rule/alerting.go:212	DEBUG rule "TestGroup":"TestRule" (14686524233356632740) at 2000-01-01T00:02:00Z: alert 11669695145351808068 {alertgroup="TestGroup",alertname="TestRule"} created in state PENDING
+2024-12-10T12:10:26.343Z	info	VictoriaMetrics/app/vmalert/datasource/client.go:254	DEBUG datasource request: executing POST request with params "http://127.0.0.1:8880/prometheus/api/v1/query?query=test_metric+%3E+0&step=300s&time=2000-01-01T00%3A03%3A00Z"
+2024-12-10T12:10:26.344Z	info	VictoriaMetrics/app/vmalert/rule/alerting.go:212	DEBUG rule "TestGroup":"TestRule" (14686524233356632740) at 2000-01-01T00:03:00Z: query returned 1 samples (elapsed: 822.958µs)
+2024-12-10T12:10:26.344Z	info	VictoriaMetrics/app/vmalert/rule/alerting.go:212	DEBUG rule "TestGroup":"TestRule" (14686524233356632740) at 2000-01-01T00:03:00Z: alert 11669695145351808068 {alertgroup="TestGroup",alertname="TestRule"} PENDING => FIRING: 1m0s since becoming active at 2000-01-01 00:02:00 +0000 UTC
 ```
 
 ### Configuration


### PR DESCRIPTION
Updates the vmalert-tool documentation and CHANGELOG to reflect the change of `testStartTime` from `1970-01-01` to `2000-01-01` (issue #11219).

Changes:

1. **docs/victoriametrics/vmalert-tool.md**: Added a note in the "Test file format" section documenting that the test harness seeds the clock at `2000-01-01T00:00:00Z` (Unix timestamp `946684800`), and refreshed the debug output example to use the new start time.

2. **docs/victoriametrics/changelog/CHANGELOG.md**: Added a tip entry documenting this as a breaking change for unit test files using absolute timestamps, with migration instructions.

Fixes #11437
