### PR TITLE
Split to SplitSeq to save 1 allocation

### DIFF
--- a/app/vmagent/remotewrite/obfuscate.go
+++ b/app/vmagent/remotewrite/obfuscate.go
@@ -95,9 +95,9 @@ func (rwctx *remoteWriteCtx) initObfuscateLabels() {
 	}
 	idx := rwctx.idx
 	rwObfuscateLabels := obfuscateLabels.GetOptionalArg(idx)
-	rwObfuscateLabelsList := strings.Split(rwObfuscateLabels, "^^")
+	rwObfuscateLabelsList := strings.SplitSeq(rwObfuscateLabels, "^^")
 
-	for _, label := range rwObfuscateLabelsList {
+	for label := range rwObfuscateLabelsList {
 		if label == "" {
 			continue
 		}

--- a/app/vmalert/web.go
+++ b/app/vmalert/web.go
@@ -411,8 +411,8 @@ func newRulesFilter(r *http.Request) (*rulesFilter, *httpserver.ErrorWithStatusC
 		states = vs["filter"]
 	}
 	for _, s := range states {
-		values := strings.Split(s, ",")
-		for _, v := range values {
+		values := strings.SplitSeq(s, ",")
+		for v := range values {
 			if len(v) == 0 {
 				continue
 			}

--- a/app/vmauth/main.go
+++ b/app/vmauth/main.go
@@ -670,7 +670,7 @@ func removeHopHeaders(h http.Header) {
 	// remove hop-by-hop headers listed in the "Connection" header of h.
 	// See RFC 7230, section 6.1
 	for _, f := range h["Connection"] {
-		for _, sf := range strings.Split(f, ",") {
+		for sf := range strings.SplitSeq(f, ",") {
 			if sf = textproto.TrimString(sf); sf != "" {
 				h.Del(sf)
 			}

--- a/apptest/client.go
+++ b/apptest/client.go
@@ -183,7 +183,7 @@ func (c *metricsClient) GetMetric(t *testing.T, metricName string) float64 {
 	if statusCode != http.StatusOK {
 		t.Fatalf("unexpected status code: got %d, want %d", statusCode, http.StatusOK)
 	}
-	for _, metric := range strings.Split(metrics, "\n") {
+	for metric := range strings.SplitSeq(metrics, "\n") {
 		value, found := strings.CutPrefix(metric, metricName)
 		if found {
 			value = strings.Trim(value, " ")
@@ -209,7 +209,7 @@ func (c *metricsClient) GetMetricsByPrefix(t *testing.T, prefix string) []float6
 	if statusCode != http.StatusOK {
 		t.Fatalf("unexpected status code: got %d, want %d", statusCode, http.StatusOK)
 	}
-	for _, metric := range strings.Split(metrics, "\n") {
+	for metric := range strings.SplitSeq(metrics, "\n") {
 		if !strings.HasPrefix(metric, prefix) {
 			continue
 		}
@@ -238,7 +238,7 @@ func (c *metricsClient) GetMetricsByRegexp(t *testing.T, re *regexp.Regexp) []fl
 	if statusCode != http.StatusOK {
 		t.Fatalf("unexpected status code: got %d, want %d", statusCode, http.StatusOK)
 	}
-	for _, metric := range strings.Split(metrics, "\n") {
+	for metric := range strings.SplitSeq(metrics, "\n") {
 		if !re.MatchString(metric) {
 			continue
 		}

--- a/apptest/tests/opentsdb_server_test.go
+++ b/apptest/tests/opentsdb_server_test.go
@@ -152,7 +152,7 @@ func parseQuery(m string) (string, map[string]string, bool) {
 	metric, tagStr, _ := strings.Cut(parts[2], "{")
 	tags := make(map[string]string, 4)
 	tagStr = strings.TrimSuffix(tagStr, "}")
-	for _, kv := range strings.Split(tagStr, ",") {
+	for kv := range strings.SplitSeq(tagStr, ",") {
 		if k, v, ok := strings.Cut(kv, "="); ok {
 			tags[k] = v
 		}

--- a/lib/cgroup/cpu.go
+++ b/lib/cgroup/cpu.go
@@ -158,7 +158,7 @@ func parseCPUMax(data string) (float64, error) {
 func countCPUs(data string) int {
 	data = strings.TrimSpace(data)
 	n := 0
-	for _, s := range strings.Split(data, ",") {
+	for s := range strings.SplitSeq(data, ",") {
 		n++
 		if !strings.Contains(s, "-") {
 			if _, err := strconv.Atoi(s); err != nil {

--- a/lib/cgroup/util.go
+++ b/lib/cgroup/util.go
@@ -57,8 +57,8 @@ func readCgroupV2SubPath(cgroupPath string) (string, error) {
 
 // grepFirstMatch searches match line at data and returns item from it by index with given delimiter.
 func grepFirstMatch(data string, match string, index int, delimiter string) (string, error) {
-	lines := strings.Split(string(data), "\n")
-	for _, s := range lines {
+	lines := strings.SplitSeq(string(data), "\n")
+	for s := range lines {
 		if !strings.Contains(s, match) {
 			continue
 		}

--- a/lib/httpserver/path_test.go
+++ b/lib/httpserver/path_test.go
@@ -10,8 +10,8 @@ func TestParsePathAndHeadersSuccess(t *testing.T) {
 	f := func(path, headers, prefix, authToken, suffix string) {
 		t.Helper()
 		header := make(http.Header)
-		hs := strings.Split(headers, ";")
-		for _, h := range hs {
+		hs := strings.SplitSeq(headers, ";")
+		for h := range hs {
 			if h == "" {
 				continue
 			}

--- a/lib/logger/json_fields.go
+++ b/lib/logger/json_fields.go
@@ -14,8 +14,8 @@ func setLoggerJSONFields() {
 	if *loggerJSONFields == "" {
 		return
 	}
-	fields := strings.Split(*loggerJSONFields, ",")
-	for _, f := range fields {
+	fields := strings.SplitSeq(*loggerJSONFields, ",")
+	for f := range fields {
 		f = strings.TrimSpace(f)
 		v := strings.Split(f, ":")
 		if len(v) != 2 {


### PR DESCRIPTION
This change start using SplitSeq instead of Split for splits that gets iterated over the result, this save 1 allocation, and keeps the code equally readable. This is not improve performance in any key point, so the reason for this PR is to settle the pattern in the codebase and, if in the future we use this same pattern, use the right one.
