### PR TITLE
docs: update vmanomaly guide to v1.30.3

### DIFF
--- a/deployment/docker/vmanomaly/vmanomaly-integration/compose.yml
+++ b/deployment/docker/vmanomaly/vmanomaly-integration/compose.yml
@@ -59,7 +59,7 @@ services:
       - '--external.alert.source=explore?orgId=1&left=["now-1h","now","VictoriaMetrics",{"expr": },{"mode":"Metrics"},{"ui":[true,true,true,"none"]}]'
     restart: always
   vmanomaly:
-    image: victoriametrics/vmanomaly:v1.30.2
+    image: victoriametrics/vmanomaly:v1.30.3
     depends_on:
       - "victoriametrics"
     ports:

--- a/docs/anomaly-detection/guides/guide-vmanomaly-vmalert/README.md
+++ b/docs/anomaly-detection/guides/guide-vmanomaly-vmalert/README.md
@@ -400,7 +400,7 @@ services:
     restart: always
   vmanomaly:
     container_name: vmanomaly
-    image: victoriametrics/vmanomaly:v1.30.2
+    image: victoriametrics/vmanomaly:v1.30.3
     depends_on:
       - "victoriametrics"
     ports:


### PR DESCRIPTION
> note: can be merged after v1.30.3 release is live

## Summary

- Update the runnable vmanomaly/vmalert Docker Compose example from v1.30.2 to v1.30.3.
- Keep the guide's inline Docker Compose example on the same version.

## Validation

- Both guide image references now use `victoriametrics/vmanomaly:v1.30.3`.
- `git diff --check` passed.
