### PR TITLE
lib/netutil: do not unlink unix socket with a live listener

### DIFF
--- a/lib/netutil/unixlistener.go
+++ b/lib/netutil/unixlistener.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"syscall"
+	"time"
 
 	"github.com/VictoriaMetrics/metrics"
 )
@@ -17,9 +19,10 @@ func NewUnixListener(name, addr string) (*UnixListener, error) {
 	// In case if app was stopped ungracefully, e.g. OOM or SIGKILL,
 	// ListenUnix returns bind: address already in use error
 	// which requires manual intervention
-	if err := os.Remove(addr); err != nil && !errors.Is(err, os.ErrNotExist) {
-		return nil, fmt.Errorf("cannot remove exist socket path: %q: %w", addr, err)
+	if err := removePreviousSocketFile(addr); err != nil {
+		return nil, err
 	}
+
 	ul, err := net.ListenUnix("unix", &net.UnixAddr{Name: addr, Net: "unix"})
 	if err != nil {
 		return nil, err
@@ -28,6 +31,7 @@ func NewUnixListener(name, addr string) (*UnixListener, error) {
 	// Override them to restrict file permissions with current user.
 	perm := os.FileMode(0600)
 	if err := os.Chmod(addr, perm); err != nil {
+		_ = ul.Close()
 		return nil, fmt.Errorf("cannot set permissions for socket path %q: %w", addr, err)
 	}
 
@@ -40,6 +44,34 @@ func NewUnixListener(name, addr string) (*UnixListener, error) {
 	}
 	uln.cm.init(ms, "vm_unixlistener", name, addr)
 	return uln, nil
+}
+
+func removePreviousSocketFile(addr string) error {
+	// Check the file type before dialing, since connect() to a non-socket file
+	// returns syscall.ECONNREFUSED, so a typo in addr would unlink an unrelated file.
+	if fi, err := os.Lstat(addr); err == nil && fi.Mode()&os.ModeSocket == 0 {
+		return fmt.Errorf("file %q already exists and is not a socket", addr)
+	}
+
+	conn, err := net.DialTimeout("unix", addr, 100*time.Millisecond)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			// File does not exist.
+			return nil
+		}
+		if errors.Is(err, syscall.ECONNREFUSED) {
+			// File exists, but there is no listener.
+			// This may happen in case of unclean shutdown, so remove it.
+			if err := os.Remove(addr); err != nil {
+				return fmt.Errorf("cannot remove exist socket path: %w", err)
+			}
+			return nil
+		}
+		// Could be access denied or other unrelated errors.
+		return fmt.Errorf("cannot dial socket path %q: %w", addr, err)
+	}
+	_ = conn.Close()
+	return fmt.Errorf("another process is already listening on %q", addr)
 }
 
 // UnixListener listens for the addr passed to NewUnixListener.

--- a/lib/netutil/unixlistener_test.go
+++ b/lib/netutil/unixlistener_test.go
@@ -1,0 +1,105 @@
+package netutil
+
+import (
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestUnixListenerSuccess(t *testing.T) {
+	f := func(addr string) {
+		t.Helper()
+
+		uln, err := NewUnixListener(t.Name(), addr)
+		if err != nil {
+			t.Fatalf("unexpected error creating unix listener: %s", err)
+		}
+		defer uln.Close()
+
+		fi, err := os.Stat(addr)
+		if err != nil {
+			t.Fatalf("unexpected error stating unix address: %s", err)
+		}
+		gotPerm := fi.Mode().Perm()
+		wantPerm := os.FileMode(0600)
+		if gotPerm != wantPerm {
+			t.Fatalf("unexpected socket permissions: got %o, want %o", gotPerm, wantPerm)
+		}
+	}
+
+	tmpDir := t.TempDir()
+
+	// Socket file does not exist.
+	socketPath := filepath.Join(tmpDir, "1.sock")
+	f(socketPath)
+
+	// Socket file exists, no live listeners.
+	socketPath = filepath.Join(tmpDir, "2.sock")
+	createStaleSocket(t, socketPath)
+	f(socketPath)
+}
+
+func TestUnixListenerFailure(t *testing.T) {
+	f := func(addr string) {
+		t.Helper()
+
+		uln, err := NewUnixListener(t.Name(), addr)
+		if err == nil {
+			_ = uln.Close()
+			t.Fatalf("expecting non-nil error, got nil")
+		}
+
+		// Ensure file wasn't deleted.
+		if _, err := os.Stat(addr); err != nil {
+			t.Fatalf("cannot stat unix socket: %s", err)
+		}
+	}
+
+	tmpDir := t.TempDir()
+
+	// Must fail when existing socket file returns permissions denied error.
+	if os.Geteuid() == 0 {
+		// Current user is root.
+		// Skip this test case, since permission checks are bypassed for root.
+		t.Logf("skipping permissions denied test, since current user is root")
+	} else {
+		socketPath := filepath.Join(tmpDir, "1.sock")
+		createStaleSocket(t, socketPath)
+		if err := os.Chmod(socketPath, 0111); err != nil {
+			t.Fatalf("cannot chmod socket %q: %s", socketPath, err)
+		}
+		f(socketPath)
+	}
+
+	// Socket file already has a listener.
+	socketPath := filepath.Join(tmpDir, "2.sock")
+	uln, err := NewUnixListener(t.Name(), socketPath)
+	if err != nil {
+		t.Fatalf("cannot create unix listener: %s", err)
+	}
+	f(socketPath)
+	_ = uln.Close()
+
+	// Non-socket file exists at the socket path.
+	socketPath = filepath.Join(tmpDir, "3.txt")
+	file, err := os.Create(socketPath)
+	if err != nil {
+		t.Fatalf("cannot create file: %s", err)
+	}
+	_ = file.Close()
+	f(socketPath)
+}
+
+func createStaleSocket(t *testing.T, addr string) {
+	t.Helper()
+	l, err := net.ListenUnix("unix", &net.UnixAddr{Name: addr, Net: "unix"})
+	if err != nil {
+		t.Fatalf("cannot create stale socket %q: %s", addr, err)
+	}
+	// Keep the socket file after close in order to emulate unclean shutdown.
+	l.SetUnlinkOnClose(false)
+	if err := l.Close(); err != nil {
+		t.Fatalf("cannot close unix listener: %s", err)
+	}
+}


### PR DESCRIPTION
This prevents a new server from silently replacing a running one on the same unix socket.

This is a follow-up commit for #11434
