### PR TITLE
lib/storage: add context for canceling requests

### DIFF
--- a/app/vmselect/clusternative/vmselect.go
+++ b/app/vmselect/clusternative/vmselect.go
@@ -1,6 +1,7 @@
 package clusternative
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"sync"
@@ -48,88 +49,88 @@ func NewVMSelectServer(addr string) (*vmselectapi.Server, error) {
 // vmstorageAPI impelements vmselectapi.API
 type vmstorageAPI struct{}
 
-func (api *vmstorageAPI) InitSearch(qt *querytracer.Tracer, sq *storage.SearchQuery, deadline uint64) (vmselectapi.BlockIterator, error) {
-	dl := searchutil.DeadlineFromTimestamp(deadline)
+func (api *vmstorageAPI) InitSearch(ctx context.Context, qt *querytracer.Tracer, sq *storage.SearchQuery) (vmselectapi.BlockIterator, error) {
+	dl := searchutil.DeadlineFromContext(ctx)
 	bi := newBlockIterator(qt, true, sq, dl)
 	return bi, nil
 }
 
-func (api *vmstorageAPI) Tenants(qt *querytracer.Tracer, tr storage.TimeRange, deadline uint64) ([]string, error) {
-	dl := searchutil.DeadlineFromTimestamp(deadline)
+func (api *vmstorageAPI) Tenants(ctx context.Context, qt *querytracer.Tracer, tr storage.TimeRange) ([]string, error) {
+	dl := searchutil.DeadlineFromContext(ctx)
 	res, err := netstorage.Tenants(qt, tr, dl)
 	return res, wrapClusterNativeError(err)
 }
 
-func (api *vmstorageAPI) SearchMetricNames(qt *querytracer.Tracer, sq *storage.SearchQuery, deadline uint64) ([]string, error) {
-	dl := searchutil.DeadlineFromTimestamp(deadline)
+func (api *vmstorageAPI) SearchMetricNames(ctx context.Context, qt *querytracer.Tracer, sq *storage.SearchQuery) ([]string, error) {
+	dl := searchutil.DeadlineFromContext(ctx)
 	metricNames, _, err := netstorage.SearchMetricNames(qt, true, sq, dl)
 	return metricNames, wrapClusterNativeError(err)
 }
 
-func (api *vmstorageAPI) LabelValues(qt *querytracer.Tracer, sq *storage.SearchQuery, labelName string, maxLabelValues int, deadline uint64) ([]string, error) {
+func (api *vmstorageAPI) LabelValues(ctx context.Context, qt *querytracer.Tracer, sq *storage.SearchQuery, labelName string, maxLabelValues int) ([]string, error) {
 	if maxLabelValues <= 0 || maxLabelValues > *maxTagValues {
 		maxLabelValues = *maxTagValues
 	}
-	dl := searchutil.DeadlineFromTimestamp(deadline)
+	dl := searchutil.DeadlineFromContext(ctx)
 	labelValues, _, err := netstorage.LabelValues(qt, true, labelName, sq, maxLabelValues, dl)
 	return labelValues, wrapClusterNativeError(err)
 }
 
-func (api *vmstorageAPI) TagValueSuffixes(qt *querytracer.Tracer, accountID, projectID uint32, tr storage.TimeRange, tagKey, tagValuePrefix string, delimiter byte,
-	maxSuffixes int, deadline uint64) ([]string, error) {
+func (api *vmstorageAPI) TagValueSuffixes(ctx context.Context, qt *querytracer.Tracer, accountID, projectID uint32, tr storage.TimeRange, tagKey, tagValuePrefix string, delimiter byte,
+	maxSuffixes int) ([]string, error) {
 	if maxSuffixes <= 0 || maxSuffixes > *maxTagValueSuffixesPerSearch {
 		maxSuffixes = *maxTagValueSuffixesPerSearch
 	}
-	dl := searchutil.DeadlineFromTimestamp(deadline)
+	dl := searchutil.DeadlineFromContext(ctx)
 	suffixes, _, err := netstorage.TagValueSuffixes(qt, accountID, projectID, true, tr, tagKey, tagValuePrefix, delimiter, maxSuffixes, dl)
 	return suffixes, wrapClusterNativeError(err)
 }
 
-func (api *vmstorageAPI) LabelNames(qt *querytracer.Tracer, sq *storage.SearchQuery, maxLabelNames int, deadline uint64) ([]string, error) {
+func (api *vmstorageAPI) LabelNames(ctx context.Context, qt *querytracer.Tracer, sq *storage.SearchQuery, maxLabelNames int) ([]string, error) {
 	if maxLabelNames <= 0 || maxLabelNames > *maxTagKeys {
 		maxLabelNames = *maxTagKeys
 	}
-	dl := searchutil.DeadlineFromTimestamp(deadline)
+	dl := searchutil.DeadlineFromContext(ctx)
 	labelNames, _, err := netstorage.LabelNames(qt, true, sq, maxLabelNames, dl)
 	return labelNames, wrapClusterNativeError(err)
 }
 
-func (api *vmstorageAPI) SeriesCount(qt *querytracer.Tracer, accountID, projectID uint32, deadline uint64) (uint64, error) {
-	dl := searchutil.DeadlineFromTimestamp(deadline)
+func (api *vmstorageAPI) SeriesCount(ctx context.Context, qt *querytracer.Tracer, accountID, projectID uint32) (uint64, error) {
+	dl := searchutil.DeadlineFromContext(ctx)
 	seriesCount, _, err := netstorage.SeriesCount(qt, accountID, projectID, true, dl)
 	return seriesCount, wrapClusterNativeError(err)
 }
 
-func (api *vmstorageAPI) TSDBStatus(qt *querytracer.Tracer, sq *storage.SearchQuery, focusLabel string, topN int, deadline uint64) (*storage.TSDBStatus, error) {
-	dl := searchutil.DeadlineFromTimestamp(deadline)
+func (api *vmstorageAPI) TSDBStatus(ctx context.Context, qt *querytracer.Tracer, sq *storage.SearchQuery, focusLabel string, topN int) (*storage.TSDBStatus, error) {
+	dl := searchutil.DeadlineFromContext(ctx)
 	tsdbStatus, _, err := netstorage.TSDBStatus(qt, true, sq, focusLabel, topN, dl)
 	return tsdbStatus, wrapClusterNativeError(err)
 }
 
-func (api *vmstorageAPI) DeleteSeries(qt *querytracer.Tracer, sq *storage.SearchQuery, deadline uint64) (int, error) {
-	dl := searchutil.DeadlineFromTimestamp(deadline)
+func (api *vmstorageAPI) DeleteSeries(ctx context.Context, qt *querytracer.Tracer, sq *storage.SearchQuery) (int, error) {
+	dl := searchutil.DeadlineFromContext(ctx)
 	deletedTotal, err := netstorage.DeleteSeries(qt, sq, dl)
 	return deletedTotal, wrapClusterNativeError(err)
 }
 
-func (api *vmstorageAPI) RegisterMetricNames(qt *querytracer.Tracer, mrs []storage.MetricRow, deadline uint64) error {
-	dl := searchutil.DeadlineFromTimestamp(deadline)
+func (api *vmstorageAPI) RegisterMetricNames(ctx context.Context, qt *querytracer.Tracer, mrs []storage.MetricRow) error {
+	dl := searchutil.DeadlineFromContext(ctx)
 	return wrapClusterNativeError(netstorage.RegisterMetricNames(qt, mrs, dl))
 }
 
-func (api *vmstorageAPI) ResetMetricNamesUsageStats(qt *querytracer.Tracer, deadline uint64) error {
-	dl := searchutil.DeadlineFromTimestamp(deadline)
+func (api *vmstorageAPI) ResetMetricNamesUsageStats(ctx context.Context, qt *querytracer.Tracer) error {
+	dl := searchutil.DeadlineFromContext(ctx)
 	return wrapClusterNativeError(netstorage.ResetMetricNamesStats(qt, dl))
 }
 
-func (api *vmstorageAPI) GetMetricNamesUsageStats(qt *querytracer.Tracer, tt *storage.TenantToken, le, limit int, matchPattern string, deadline uint64) (metricnamestats.StatsResult, error) {
-	dl := searchutil.DeadlineFromTimestamp(deadline)
+func (api *vmstorageAPI) GetMetricNamesUsageStats(ctx context.Context, qt *querytracer.Tracer, tt *storage.TenantToken, le, limit int, matchPattern string) (metricnamestats.StatsResult, error) {
+	dl := searchutil.DeadlineFromContext(ctx)
 	statResult, err := netstorage.GetMetricNamesStats(qt, tt, le, limit, matchPattern, dl)
 	return statResult, wrapClusterNativeError(err)
 }
 
-func (api *vmstorageAPI) GetMetadataRecords(qt *querytracer.Tracer, tt *storage.TenantToken, limit int, metricName string, deadline uint64) ([]*metricsmetadata.Row, error) {
-	dl := searchutil.DeadlineFromTimestamp(deadline)
+func (api *vmstorageAPI) GetMetadataRecords(ctx context.Context, qt *querytracer.Tracer, tt *storage.TenantToken, limit int, metricName string) ([]*metricsmetadata.Row, error) {
+	dl := searchutil.DeadlineFromContext(ctx)
 	meta, _, err := netstorage.GetMetricsMetadata(qt, tt, true, limit, metricName, dl)
 	return meta, wrapClusterNativeError(err)
 }
@@ -172,7 +173,7 @@ func newBlockIterator(qt *querytracer.Tracer, denyPartialResponse bool, sq *stor
 	return bi
 }
 
-func (bi *blockIterator) NextBlock(dst []byte) ([]byte, bool) {
+func (bi *blockIterator) NextBlock(ctx context.Context, dst []byte) ([]byte, bool) {
 	wi, ok := <-bi.workCh
 	if !ok {
 		return nil, false
@@ -191,7 +192,8 @@ func (bi *blockIterator) MustClose() {
 	var buf []byte
 	var ok bool
 	for {
-		buf, ok = bi.NextBlock(buf[:0])
+		ctx := context.Background()
+		buf, ok = bi.NextBlock(ctx, buf[:0])
 		if !ok {
 			break
 		}

--- a/app/vmselect/searchutil/searchutil.go
+++ b/app/vmselect/searchutil/searchutil.go
@@ -1,6 +1,7 @@
 package searchutil
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"net/http"
@@ -104,6 +105,17 @@ func NewDeadline(startTime time.Time, timeout time.Duration, flagHint string) De
 func DeadlineFromTimestamp(timestamp uint64) Deadline {
 	startTime := time.Now()
 	timeout := time.Unix(int64(timestamp), 0).Sub(startTime)
+	return NewDeadline(startTime, timeout, "")
+}
+
+// DeadlineFromContext returns deadline from the given context.
+func DeadlineFromContext(ctx context.Context) Deadline {
+	startTime := time.Now()
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		return Deadline{}
+	}
+	timeout := deadline.Sub(startTime)
 	return NewDeadline(startTime, timeout, "")
 }
 

--- a/app/vmstorage/vmstorage.go
+++ b/app/vmstorage/vmstorage.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"sync"
@@ -129,14 +130,14 @@ func (vms *VMStorage) IsReadOnly() bool {
 	return vms.s.IsReadOnly()
 }
 
-func (vms *VMStorage) InitSearch(qt *querytracer.Tracer, sq *storage.SearchQuery, deadline uint64) (vmselectapi.BlockIterator, error) {
-	return vms.initSearch(qt, sq, marshalDefault, deadline)
+func (vms *VMStorage) InitSearch(ctx context.Context, qt *querytracer.Tracer, sq *storage.SearchQuery) (vmselectapi.BlockIterator, error) {
+	return vms.initSearch(ctx, qt, sq, marshalDefault)
 }
 
-func (vms *VMStorage) initSearch(qt *querytracer.Tracer, sq *storage.SearchQuery, marshal marshalFunc, deadline uint64) (vmselectapi.BlockIterator, error) {
+func (vms *VMStorage) initSearch(ctx context.Context, qt *querytracer.Tracer, sq *storage.SearchQuery, marshal marshalFunc) (vmselectapi.BlockIterator, error) {
 	tr := sq.GetTimeRange()
 	maxMetrics := vms.getMaxMetrics(sq.MaxMetrics)
-	tfss, err := vms.setupTfss(qt, sq, tr, maxMetrics, deadline)
+	tfss, err := vms.setupTfss(ctx, qt, sq, tr, maxMetrics)
 	if err != nil {
 		return nil, err
 	}
@@ -145,7 +146,7 @@ func (vms *VMStorage) initSearch(qt *querytracer.Tracer, sq *storage.SearchQuery
 	}
 	bi := getBlockIterator()
 	bi.marshal = marshal
-	bi.sr.Init(qt, vms.s, tfss, tr, maxMetrics, deadline)
+	bi.sr.Init(ctx, qt, vms.s, tfss, tr, maxMetrics)
 	if err := bi.sr.Error(); err != nil {
 		bi.MustClose()
 		return nil, err
@@ -195,8 +196,8 @@ func getBlockIterator() *blockIterator {
 	return v.(*blockIterator)
 }
 
-func (bi *blockIterator) NextBlock(dst []byte) ([]byte, bool) {
-	if !bi.sr.NextMetricBlock() {
+func (bi *blockIterator) NextBlock(ctx context.Context, dst []byte) ([]byte, bool) {
+	if !bi.sr.NextMetricBlock(ctx) {
 		return dst, false
 	}
 	mb := &bi.mb
@@ -211,7 +212,7 @@ func (bi *blockIterator) Error() error {
 }
 
 // SearchMetricNames returns metric names for the given tfss on the given tr.
-func (vms *VMStorage) SearchMetricNames(qt *querytracer.Tracer, sq *storage.SearchQuery, deadline uint64) ([]string, error) {
+func (vms *VMStorage) SearchMetricNames(ctx context.Context, qt *querytracer.Tracer, sq *storage.SearchQuery) ([]string, error) {
 	tr := sq.GetTimeRange()
 	maxMetrics := sq.MaxMetrics
 	if maxMetrics <= 0 {
@@ -219,19 +220,19 @@ func (vms *VMStorage) SearchMetricNames(qt *querytracer.Tracer, sq *storage.Sear
 		// see https://github.com/VictoriaMetrics/VictoriaMetrics/issues/7857
 		maxMetrics = vms.maxUniqueTimeSeriesCalculated
 	}
-	tfss, err := vms.setupTfss(qt, sq, tr, maxMetrics, deadline)
+	tfss, err := vms.setupTfss(ctx, qt, sq, tr, maxMetrics)
 	if err != nil {
 		return nil, err
 	}
 	if len(tfss) == 0 {
 		return nil, fmt.Errorf("missing tag filters")
 	}
-	return vms.s.SearchMetricNames(qt, tfss, tr, maxMetrics, deadline)
+	return vms.s.SearchMetricNames(ctx, qt, tfss, tr, maxMetrics)
 }
 
 // SearchLabelValues searches for label values for the given labelName, tfss and
 // tr.
-func (vms *VMStorage) LabelValues(qt *querytracer.Tracer, sq *storage.SearchQuery, labelName string, maxLabelValues int, deadline uint64) ([]string, error) {
+func (vms *VMStorage) LabelValues(ctx context.Context, qt *querytracer.Tracer, sq *storage.SearchQuery, labelName string, maxLabelValues int) ([]string, error) {
 	tr := sq.GetTimeRange()
 	if maxLabelValues <= 0 || maxLabelValues > *maxTagValues {
 		maxLabelValues = *maxTagValues
@@ -242,11 +243,11 @@ func (vms *VMStorage) LabelValues(qt *querytracer.Tracer, sq *storage.SearchQuer
 		// see https://github.com/VictoriaMetrics/VictoriaMetrics/issues/7857
 		maxMetrics = vms.maxUniqueTimeSeriesCalculated
 	}
-	tfss, err := vms.setupTfss(qt, sq, tr, maxMetrics, deadline)
+	tfss, err := vms.setupTfss(ctx, qt, sq, tr, maxMetrics)
 	if err != nil {
 		return nil, err
 	}
-	return vms.s.SearchLabelValues(qt, sq.AccountID, sq.ProjectID, labelName, tfss, tr, maxLabelValues, maxMetrics, deadline)
+	return vms.s.SearchLabelValues(ctx, qt, sq.AccountID, sq.ProjectID, labelName, tfss, tr, maxLabelValues, maxMetrics)
 }
 
 // TagValueSuffixes returns all the tag value suffixes for the given tagKey and
@@ -255,12 +256,12 @@ func (vms *VMStorage) LabelValues(qt *querytracer.Tracer, sq *storage.SearchQuer
 // This allows implementing
 // https://graphite-api.readthedocs.io/en/latest/api.html#metrics-find or
 // similar APIs.
-func (vms *VMStorage) TagValueSuffixes(qt *querytracer.Tracer, accountID, projectID uint32, tr storage.TimeRange, tagKey, tagValuePrefix string, delimiter byte,
-	maxSuffixes int, deadline uint64) ([]string, error) {
+func (vms *VMStorage) TagValueSuffixes(ctx context.Context, qt *querytracer.Tracer, accountID, projectID uint32, tr storage.TimeRange, tagKey, tagValuePrefix string, delimiter byte,
+	maxSuffixes int) ([]string, error) {
 	if maxSuffixes <= 0 || maxSuffixes > *maxTagValueSuffixesPerSearch {
 		maxSuffixes = *maxTagValueSuffixesPerSearch
 	}
-	suffixes, err := vms.s.SearchTagValueSuffixes(qt, accountID, projectID, tr, tagKey, tagValuePrefix, delimiter, maxSuffixes, deadline)
+	suffixes, err := vms.s.SearchTagValueSuffixes(ctx, qt, accountID, projectID, tr, tagKey, tagValuePrefix, delimiter, maxSuffixes)
 	if err != nil {
 		return nil, err
 	}
@@ -272,7 +273,7 @@ func (vms *VMStorage) TagValueSuffixes(qt *querytracer.Tracer, accountID, projec
 }
 
 // SearchLabelNames searches for tag keys matching the given tfss on tr.
-func (vms *VMStorage) LabelNames(qt *querytracer.Tracer, sq *storage.SearchQuery, maxLabelNames int, deadline uint64) ([]string, error) {
+func (vms *VMStorage) LabelNames(ctx context.Context, qt *querytracer.Tracer, sq *storage.SearchQuery, maxLabelNames int) ([]string, error) {
 	tr := sq.GetTimeRange()
 	if maxLabelNames <= 0 || maxLabelNames > *maxTagKeys {
 		maxLabelNames = *maxTagKeys
@@ -283,23 +284,23 @@ func (vms *VMStorage) LabelNames(qt *querytracer.Tracer, sq *storage.SearchQuery
 		// see https://github.com/VictoriaMetrics/VictoriaMetrics/issues/7857
 		maxMetrics = vms.maxUniqueTimeSeriesCalculated
 	}
-	tfss, err := vms.setupTfss(qt, sq, tr, maxMetrics, deadline)
+	tfss, err := vms.setupTfss(ctx, qt, sq, tr, maxMetrics)
 	if err != nil {
 		return nil, err
 	}
-	return vms.s.SearchLabelNames(qt, sq.AccountID, sq.ProjectID, tfss, tr, maxLabelNames, maxMetrics, deadline)
+	return vms.s.SearchLabelNames(ctx, qt, sq.AccountID, sq.ProjectID, tfss, tr, maxLabelNames, maxMetrics)
 }
 
-func (vms *VMStorage) SeriesCount(_ *querytracer.Tracer, accountID, projectID uint32, deadline uint64) (uint64, error) {
-	return vms.s.GetSeriesCount(accountID, projectID, deadline)
+func (vms *VMStorage) SeriesCount(ctx context.Context, qt *querytracer.Tracer, accountID, projectID uint32) (uint64, error) {
+	return vms.s.GetSeriesCount(ctx, accountID, projectID)
 }
 
-func (vms *VMStorage) Tenants(qt *querytracer.Tracer, tr storage.TimeRange, deadline uint64) ([]string, error) {
-	return vms.s.SearchTenants(qt, tr, deadline)
+func (vms *VMStorage) Tenants(ctx context.Context, qt *querytracer.Tracer, tr storage.TimeRange) ([]string, error) {
+	return vms.s.SearchTenants(ctx, qt, tr)
 }
 
 // GetTSDBStatus returns TSDB status for given filters on the given date.
-func (vms *VMStorage) TSDBStatus(qt *querytracer.Tracer, sq *storage.SearchQuery, focusLabel string, topN int, deadline uint64) (*storage.TSDBStatus, error) {
+func (vms *VMStorage) TSDBStatus(ctx context.Context, qt *querytracer.Tracer, sq *storage.SearchQuery, focusLabel string, topN int) (*storage.TSDBStatus, error) {
 	tr := sq.GetTimeRange()
 	maxMetrics := sq.MaxMetrics
 	if maxMetrics <= 0 {
@@ -307,18 +308,18 @@ func (vms *VMStorage) TSDBStatus(qt *querytracer.Tracer, sq *storage.SearchQuery
 		// see https://github.com/VictoriaMetrics/VictoriaMetrics/issues/7857
 		maxMetrics = vms.maxUniqueTimeSeriesCalculated
 	}
-	tfss, err := vms.setupTfss(qt, sq, tr, maxMetrics, deadline)
+	tfss, err := vms.setupTfss(ctx, qt, sq, tr, maxMetrics)
 	if err != nil {
 		return nil, err
 	}
 	date := uint64(sq.MinTimestamp) / (24 * 3600 * 1000)
-	return vms.s.GetTSDBStatus(qt, sq.AccountID, sq.ProjectID, tfss, date, focusLabel, topN, maxMetrics, deadline)
+	return vms.s.GetTSDBStatus(ctx, qt, sq.AccountID, sq.ProjectID, tfss, date, focusLabel, topN, maxMetrics)
 }
 
 // DeleteSeries deletes series matching tfss.
 //
 // Returns the number of deleted series.
-func (vms *VMStorage) DeleteSeries(qt *querytracer.Tracer, sq *storage.SearchQuery, deadline uint64) (int, error) {
+func (vms *VMStorage) DeleteSeries(ctx context.Context, qt *querytracer.Tracer, sq *storage.SearchQuery) (int, error) {
 	tr := sq.GetTimeRange()
 	maxMetrics := sq.MaxMetrics
 	if maxMetrics <= 0 {
@@ -326,33 +327,33 @@ func (vms *VMStorage) DeleteSeries(qt *querytracer.Tracer, sq *storage.SearchQue
 		// see https://github.com/VictoriaMetrics/VictoriaMetrics/issues/7857
 		maxMetrics = vms.maxUniqueTimeSeriesCalculated
 	}
-	tfss, err := vms.setupTfss(qt, sq, tr, maxMetrics, deadline)
+	tfss, err := vms.setupTfss(ctx, qt, sq, tr, maxMetrics)
 	if err != nil {
 		return 0, err
 	}
 	if len(tfss) == 0 {
 		return 0, fmt.Errorf("missing tag filters")
 	}
-	return vms.s.DeleteSeries(qt, tfss, maxMetrics)
+	return vms.s.DeleteSeries(ctx, qt, tfss, maxMetrics)
 }
 
-func (vms *VMStorage) RegisterMetricNames(qt *querytracer.Tracer, mrs []storage.MetricRow, _ uint64) error {
+func (vms *VMStorage) RegisterMetricNames(ctx context.Context, qt *querytracer.Tracer, mrs []storage.MetricRow) error {
 	vms.s.RegisterMetricNames(qt, mrs)
 	return nil
 }
 
 // GetMetricNamesUsageStats returns metric name usage stats.
-func (vms *VMStorage) GetMetricNamesUsageStats(qt *querytracer.Tracer, tt *storage.TenantToken, limit, le int, matchPattern string, _ uint64) (metricnamestats.StatsResult, error) {
-	return vms.s.GetMetricNamesStats(qt, tt, limit, le, matchPattern), nil
+func (vms *VMStorage) GetMetricNamesUsageStats(ctx context.Context, qt *querytracer.Tracer, tt *storage.TenantToken, limit, le int, matchPattern string) (metricnamestats.StatsResult, error) {
+	return vms.s.GetMetricNamesStats(ctx, qt, tt, limit, le, matchPattern), nil
 }
 
 // ResetMetricNamesStats resets state for metric names usage tracker
-func (vms *VMStorage) ResetMetricNamesUsageStats(qt *querytracer.Tracer, _ uint64) error {
+func (vms *VMStorage) ResetMetricNamesUsageStats(ctx context.Context, qt *querytracer.Tracer) error {
 	vms.s.ResetMetricNamesStats(qt)
 	return nil
 }
 
-func (vms *VMStorage) setupTfss(qt *querytracer.Tracer, sq *storage.SearchQuery, tr storage.TimeRange, maxMetrics int, deadline uint64) ([]*storage.TagFilters, error) {
+func (vms *VMStorage) setupTfss(ctx context.Context, qt *querytracer.Tracer, sq *storage.SearchQuery, tr storage.TimeRange, maxMetrics int) ([]*storage.TagFilters, error) {
 	tfss := make([]*storage.TagFilters, 0, len(sq.TagFilterss))
 	accountID := sq.AccountID
 	projectID := sq.ProjectID
@@ -363,7 +364,7 @@ func (vms *VMStorage) setupTfss(qt *querytracer.Tracer, sq *storage.SearchQuery,
 			if string(tf.Key) == "__graphite__" {
 				query := tf.Value
 				qtChild := qt.NewChild("searching for series matching __graphite__=%q", query)
-				paths, err := vms.s.SearchGraphitePaths(qtChild, accountID, projectID, tr, query, maxMetrics, deadline)
+				paths, err := vms.s.SearchGraphitePaths(ctx, qtChild, accountID, projectID, tr, query, maxMetrics)
 				qtChild.Donef("found %d series", len(paths))
 				if err != nil {
 					return nil, fmt.Errorf("error when searching for Graphite paths for query %q: %w", query, err)
@@ -385,8 +386,8 @@ func (vms *VMStorage) setupTfss(qt *querytracer.Tracer, sq *storage.SearchQuery,
 	return tfss, nil
 }
 
-func (vms *VMStorage) GetMetadataRecords(qt *querytracer.Tracer, tt *storage.TenantToken, limit int, metricName string, deadline uint64) ([]*metricsmetadata.Row, error) {
-	return vms.s.GetMetadataRows(qt, tt, limit, metricName, deadline)
+func (vms *VMStorage) GetMetadataRecords(ctx context.Context, qt *querytracer.Tracer, tt *storage.TenantToken, limit int, metricName string) ([]*metricsmetadata.Row, error) {
+	return vms.s.GetMetadataRows(ctx, qt, tt, limit, metricName)
 }
 
 // deleteSnapshot deletes a snapshot by its name.

--- a/docs/victoriametrics/changelog/CHANGELOG.md
+++ b/docs/victoriametrics/changelog/CHANGELOG.md
@@ -26,6 +26,8 @@ See also [LTS releases](https://docs.victoriametrics.com/victoriametrics/lts-rel
 
 ## tip
 
+* FEATURE: [vmsingle](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/) and `vmstorage` in [VictoriaMetrics cluster](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/): properly cancel on-going indexDB requests when client disconnects and during graceful shutdown. See [#11472](https://github.com/VictoriaMetrics/VictoriaMetrics/pull/11472).
+
 ## [v1.151.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.151.0)
 
 Released at 2026-08-31

--- a/lib/storage/index_db.go
+++ b/lib/storage/index_db.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"bytes"
 	"container/heap"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -385,17 +386,14 @@ type indexSearch struct {
 
 	accountID uint32
 	projectID uint32
-
-	// deadline in unix timestamp seconds for the given search.
-	deadline uint64
 }
 
 // getIndexSearch returns an indexSearch with default configuration
-func (db *indexDB) getIndexSearch(accountID, projectID uint32, deadline uint64) *indexSearch {
-	return db.getIndexSearchInternal(accountID, projectID, deadline, false)
+func (db *indexDB) getIndexSearch(accountID, projectID uint32) *indexSearch {
+	return db.getIndexSearchInternal(accountID, projectID, false)
 }
 
-func (db *indexDB) getIndexSearchInternal(accountID, projectID uint32, deadline uint64, sparse bool) *indexSearch {
+func (db *indexDB) getIndexSearchInternal(accountID, projectID uint32, sparse bool) *indexSearch {
 	v := db.indexSearchPool.Get()
 	if v == nil {
 		v = &indexSearch{
@@ -406,7 +404,6 @@ func (db *indexDB) getIndexSearchInternal(accountID, projectID uint32, deadline 
 	is.accountID = accountID
 	is.projectID = projectID
 	is.ts.Init(db.tb, sparse)
-	is.deadline = deadline
 	return is
 }
 
@@ -416,7 +413,6 @@ func (db *indexDB) putIndexSearch(is *indexSearch) {
 	is.mp.Reset()
 	is.accountID = 0
 	is.projectID = 0
-	is.deadline = 0
 
 	db.indexSearchPool.Put(is)
 }
@@ -520,7 +516,7 @@ var indexItemsPool sync.Pool
 
 // SearchLabelNames returns all the label names, which match the given tfss on
 // the given tr.
-func (db *indexDB) SearchLabelNames(qt *querytracer.Tracer, accountID, projectID uint32, tfss []*TagFilters, tr TimeRange, maxLabelNames, maxMetrics int, deadline uint64) (map[string]struct{}, error) {
+func (db *indexDB) SearchLabelNames(ctx context.Context, qt *querytracer.Tracer, accountID, projectID uint32, tfss []*TagFilters, tr TimeRange, maxLabelNames, maxMetrics int) (map[string]struct{}, error) {
 	qt = qt.NewChild("search label names: filters=%s, timeRange=%s, maxLabelNames=%d, maxMetrics=%d", tfss, &tr, maxLabelNames, maxMetrics)
 	defer qt.Done()
 
@@ -529,8 +525,8 @@ func (db *indexDB) SearchLabelNames(qt *querytracer.Tracer, accountID, projectID
 		return nil, nil
 	}
 
-	is := db.getIndexSearch(accountID, projectID, deadline)
-	lns, err := is.searchLabelNamesWithFiltersOnTimeRange(qt, tfss, tr, maxLabelNames, maxMetrics)
+	is := db.getIndexSearch(accountID, projectID)
+	lns, err := is.searchLabelNamesWithFiltersOnTimeRange(ctx, qt, tfss, tr, maxLabelNames, maxMetrics)
 	db.putIndexSearch(is)
 	if err != nil {
 		return nil, db.wrapError("search label names", err)
@@ -540,10 +536,10 @@ func (db *indexDB) SearchLabelNames(qt *querytracer.Tracer, accountID, projectID
 	return lns, nil
 }
 
-func (is *indexSearch) searchLabelNamesWithFiltersOnTimeRange(qt *querytracer.Tracer, tfss []*TagFilters, tr TimeRange, maxLabelNames, maxMetrics int) (map[string]struct{}, error) {
+func (is *indexSearch) searchLabelNamesWithFiltersOnTimeRange(ctx context.Context, qt *querytracer.Tracer, tfss []*TagFilters, tr TimeRange, maxLabelNames, maxMetrics int) (map[string]struct{}, error) {
 	if tr == globalIndexTimeRange {
 		qtChild := qt.NewChild("search for label names in global index: filters=%s", tfss)
-		lns, err := is.searchLabelNamesWithFiltersOnDate(qtChild, tfss, globalIndexDate, maxLabelNames, maxMetrics)
+		lns, err := is.searchLabelNamesWithFiltersOnDate(ctx, qtChild, tfss, globalIndexDate, maxLabelNames, maxMetrics)
 		qtChild.Done()
 		return lns, err
 	}
@@ -559,8 +555,8 @@ func (is *indexSearch) searchLabelNamesWithFiltersOnTimeRange(qt *querytracer.Tr
 		wg.Go(func() {
 			defer qtChild.Done()
 
-			isLocal := is.db.getIndexSearch(is.accountID, is.projectID, is.deadline)
-			lnsLocal, err := isLocal.searchLabelNamesWithFiltersOnDate(qtChild, tfss, date, maxLabelNames, maxMetrics)
+			isLocal := is.db.getIndexSearch(is.accountID, is.projectID)
+			lnsLocal, err := isLocal.searchLabelNamesWithFiltersOnDate(ctx, qtChild, tfss, date, maxLabelNames, maxMetrics)
 			is.db.putIndexSearch(isLocal)
 			mu.Lock()
 			defer mu.Unlock()
@@ -585,11 +581,11 @@ func (is *indexSearch) searchLabelNamesWithFiltersOnTimeRange(qt *querytracer.Tr
 	return lns, errGlobal
 }
 
-func (is *indexSearch) searchLabelNamesWithFiltersOnDate(qt *querytracer.Tracer, tfss []*TagFilters, date uint64, maxLabelNames, maxMetrics int) (map[string]struct{}, error) {
+func (is *indexSearch) searchLabelNamesWithFiltersOnDate(ctx context.Context, qt *querytracer.Tracer, tfss []*TagFilters, date uint64, maxLabelNames, maxMetrics int) (map[string]struct{}, error) {
 	var filter *uint64set.Set
 	if !isSingleMetricNameFilter(tfss) {
 		var err error
-		filter, err = is.searchMetricIDsWithFiltersOnDate(qt, tfss, date, maxMetrics)
+		filter, err = is.searchMetricIDsWithFiltersOnDate(ctx, qt, tfss, date, maxMetrics)
 		if err != nil {
 			return nil, err
 		}
@@ -599,7 +595,10 @@ func (is *indexSearch) searchLabelNamesWithFiltersOnDate(qt *querytracer.Tracer,
 			// This should help https://github.com/VictoriaMetrics/VictoriaMetrics/issues/2978
 			metricIDs := filter.AppendTo(nil)
 			qt.Printf("sort %d metricIDs", len(metricIDs))
-			lns := is.getLabelNamesForMetricIDs(qt, metricIDs, maxLabelNames)
+			lns, err := is.getLabelNamesForMetricIDs(ctx, qt, metricIDs, maxLabelNames)
+			if err != nil {
+				return nil, err
+			}
 			return lns, nil
 		}
 	}
@@ -631,8 +630,8 @@ func (is *indexSearch) searchLabelNamesWithFiltersOnDate(qt *querytracer.Tracer,
 	lns := make(map[string]struct{})
 	for len(lns) < maxLabelNames && ts.NextItem() {
 		if loopsPaceLimiter&paceLimiterFastIterationsMask == 0 {
-			if err := checkSearchDeadlineAndPace(is.deadline); err != nil {
-				return nil, err
+			if isContextDone(ctx) {
+				return nil, ctx.Err()
 			}
 		}
 		loopsPaceLimiter++
@@ -685,7 +684,7 @@ func (is *indexSearch) searchLabelNamesWithFiltersOnDate(qt *querytracer.Tracer,
 	return lns, nil
 }
 
-func (is *indexSearch) getLabelNamesForMetricIDs(qt *querytracer.Tracer, metricIDs []uint64, maxLabelNames int) map[string]struct{} {
+func (is *indexSearch) getLabelNamesForMetricIDs(ctx context.Context, qt *querytracer.Tracer, metricIDs []uint64, maxLabelNames int) (map[string]struct{}, error) {
 	lns := make(map[string]struct{})
 	if len(metricIDs) > 0 {
 		lns["__name__"] = struct{}{}
@@ -696,7 +695,14 @@ func (is *indexSearch) getLabelNamesForMetricIDs(qt *querytracer.Tracer, metricI
 	var mn MetricName
 	foundLabelNames := 0
 	var buf []byte
+	loopsPaceLimiter := 0
 	for _, metricID := range metricIDs {
+		if loopsPaceLimiter&paceLimiterFastIterationsMask == 0 {
+			if isContextDone(ctx) {
+				return nil, ctx.Err()
+			}
+		}
+		loopsPaceLimiter++
 		if dmis.Has(metricID) {
 			// skip deleted IDs from result
 			continue
@@ -717,21 +723,21 @@ func (is *indexSearch) getLabelNamesForMetricIDs(qt *querytracer.Tracer, metricI
 				lns[string(tag.Key)] = struct{}{}
 				if len(lns) >= maxLabelNames {
 					qt.Printf("hit the limit on the number of unique label names: %d", maxLabelNames)
-					return lns
+					return lns, nil
 				}
 			}
 		}
 	}
 	qt.Printf("get %d distinct label names from %d metricIDs", foundLabelNames, len(metricIDs))
-	return lns
+	return lns, nil
 }
 
 // SearchTenants returns all tenants on the given tr.
-func (db *indexDB) SearchTenants(qt *querytracer.Tracer, tr TimeRange, deadline uint64) (map[string]struct{}, error) {
+func (db *indexDB) SearchTenants(ctx context.Context, qt *querytracer.Tracer, tr TimeRange) (map[string]struct{}, error) {
 	qt = qt.NewChild("search for tenants on timeRange=%s", &tr)
 	defer qt.Done()
-	is := db.getIndexSearch(0, 0, deadline)
-	tenants, err := is.searchTenantsOnTimeRange(qt, tr)
+	is := db.getIndexSearch(0, 0)
+	tenants, err := is.searchTenantsOnTimeRange(ctx, qt, tr)
 	db.putIndexSearch(is)
 	if err != nil {
 		return nil, err
@@ -740,13 +746,13 @@ func (db *indexDB) SearchTenants(qt *querytracer.Tracer, tr TimeRange, deadline 
 	return tenants, nil
 }
 
-func (is *indexSearch) searchTenantsOnTimeRange(qt *querytracer.Tracer, tr TimeRange) (map[string]struct{}, error) {
+func (is *indexSearch) searchTenantsOnTimeRange(ctx context.Context, qt *querytracer.Tracer, tr TimeRange) (map[string]struct{}, error) {
 	minDate := uint64(tr.MinTimestamp) / msecPerDay
 	maxDate := uint64(tr.MaxTimestamp-1) / msecPerDay
 	if maxDate == 0 || minDate > maxDate || maxDate-minDate > maxDaysForPerDaySearch {
 		qtChild := qt.NewChild("search for tenants in global index")
 		defer qtChild.Done()
-		return is.searchTenantsOnDate(0)
+		return is.searchTenantsOnDate(ctx, 0)
 	}
 	var mu sync.Mutex
 	wg := getWaitGroup()
@@ -758,8 +764,8 @@ func (is *indexSearch) searchTenantsOnTimeRange(qt *querytracer.Tracer, tr TimeR
 		wg.Go(func() {
 			defer qtChild.Done()
 
-			isLocal := is.db.getIndexSearch(0, 0, is.deadline)
-			tenantsLocal, err := isLocal.searchTenantsOnDate(date)
+			isLocal := is.db.getIndexSearch(0, 0)
+			tenantsLocal, err := isLocal.searchTenantsOnDate(ctx, date)
 			is.db.putIndexSearch(isLocal)
 			mu.Lock()
 			defer mu.Unlock()
@@ -781,7 +787,7 @@ func (is *indexSearch) searchTenantsOnTimeRange(qt *querytracer.Tracer, tr TimeR
 	return tenants, errGlobal
 }
 
-func (is *indexSearch) searchTenantsOnDate(date uint64) (map[string]struct{}, error) {
+func (is *indexSearch) searchTenantsOnDate(ctx context.Context, date uint64) (map[string]struct{}, error) {
 	unmarshalCommonPrefixWithDate := func(src []byte) (byte, uint32, uint32, uint64, error) {
 		tail, prefix, accountID, projectID, err := unmarshalCommonPrefix(src)
 		if err != nil {
@@ -813,8 +819,8 @@ func (is *indexSearch) searchTenantsOnDate(date uint64) (map[string]struct{}, er
 	ts.Seek(kb.B)
 	for ts.NextItem() {
 		if loopsPaceLimiter&paceLimiterFastIterationsMask == 0 {
-			if err := checkSearchDeadlineAndPace(is.deadline); err != nil {
-				return nil, err
+			if isContextDone(ctx) {
+				return nil, ctx.Err()
 			}
 		}
 		loopsPaceLimiter++
@@ -860,7 +866,7 @@ func (is *indexSearch) searchTenantsOnDate(date uint64) (map[string]struct{}, er
 }
 
 // SearchLabelValues returns label values for the given labelName, tfss and tr.
-func (db *indexDB) SearchLabelValues(qt *querytracer.Tracer, accountID, projectID uint32, labelName string, tfss []*TagFilters, tr TimeRange, maxLabelValues, maxMetrics int, deadline uint64) (map[string]struct{}, error) {
+func (db *indexDB) SearchLabelValues(ctx context.Context, qt *querytracer.Tracer, accountID, projectID uint32, labelName string, tfss []*TagFilters, tr TimeRange, maxLabelValues, maxMetrics int) (map[string]struct{}, error) {
 	qt = qt.NewChild("search label values: labelName=%q, filters=%s, timeRange=%s, maxLabelNames=%d, maxMetrics=%d", labelName, tfss, &tr, maxLabelValues, maxMetrics)
 	defer qt.Done()
 
@@ -878,8 +884,8 @@ func (db *indexDB) SearchLabelValues(qt *querytracer.Tracer, accountID, projectI
 		// without any filters and limits and then later applying the filter and the limit to the found label values.
 		qt.Printf("search up to %d values for the label %q on the time range %s", maxMetrics, labelName, &tr)
 
-		is := db.getIndexSearch(accountID, projectID, deadline)
-		lvs, err := is.searchLabelValuesOnTimeRange(qt, labelName, nil, tr, maxMetrics, maxMetrics)
+		is := db.getIndexSearch(accountID, projectID)
+		lvs, err := is.searchLabelValuesOnTimeRange(ctx, qt, labelName, nil, tr, maxMetrics, maxMetrics)
 		db.putIndexSearch(is)
 		if err != nil {
 			return nil, db.wrapError("search label values", err)
@@ -904,8 +910,8 @@ func (db *indexDB) SearchLabelValues(qt *querytracer.Tracer, accountID, projectI
 		qt.Printf("fall back to slow search because only a subset of label values is found")
 	}
 
-	is := db.getIndexSearch(accountID, projectID, deadline)
-	lvs, err := is.searchLabelValuesOnTimeRange(qt, labelName, tfss, tr, maxMetrics, maxMetrics)
+	is := db.getIndexSearch(accountID, projectID)
+	lvs, err := is.searchLabelValuesOnTimeRange(ctx, qt, labelName, tfss, tr, maxMetrics, maxMetrics)
 	db.putIndexSearch(is)
 	if err != nil {
 		return nil, db.wrapError("search label values", err)
@@ -931,10 +937,10 @@ func filterLabelValues(accountID, projectID uint32, lvs map[string]struct{}, tf 
 	}
 }
 
-func (is *indexSearch) searchLabelValuesOnTimeRange(qt *querytracer.Tracer, labelName string, tfss []*TagFilters, tr TimeRange, maxLabelValues, maxMetrics int) (map[string]struct{}, error) {
+func (is *indexSearch) searchLabelValuesOnTimeRange(ctx context.Context, qt *querytracer.Tracer, labelName string, tfss []*TagFilters, tr TimeRange, maxLabelValues, maxMetrics int) (map[string]struct{}, error) {
 	if tr == globalIndexTimeRange {
 		qtChild := qt.NewChild("search for label values in global index: labelName=%q, filters=%s", labelName, tfss)
-		lvs, err := is.searchLabelValuesOnDate(qtChild, labelName, tfss, globalIndexDate, maxLabelValues, maxMetrics)
+		lvs, err := is.searchLabelValuesOnDate(ctx, qtChild, labelName, tfss, globalIndexDate, maxLabelValues, maxMetrics)
 		qtChild.Done()
 
 		// Skip empty values, since they have no any meaning.
@@ -955,8 +961,8 @@ func (is *indexSearch) searchLabelValuesOnTimeRange(qt *querytracer.Tracer, labe
 		wg.Go(func() {
 			defer qtChild.Done()
 
-			isLocal := is.db.getIndexSearch(is.accountID, is.projectID, is.deadline)
-			lvsLocal, err := isLocal.searchLabelValuesOnDate(qtChild, labelName, tfss, date, maxLabelValues, maxMetrics)
+			isLocal := is.db.getIndexSearch(is.accountID, is.projectID)
+			lvsLocal, err := isLocal.searchLabelValuesOnDate(ctx, qtChild, labelName, tfss, date, maxLabelValues, maxMetrics)
 			is.db.putIndexSearch(isLocal)
 			mu.Lock()
 			defer mu.Unlock()
@@ -986,7 +992,7 @@ func (is *indexSearch) searchLabelValuesOnTimeRange(qt *querytracer.Tracer, labe
 	return lvs, errGlobal
 }
 
-func (is *indexSearch) searchLabelValuesOnDate(qt *querytracer.Tracer, labelName string, tfss []*TagFilters, date uint64, maxLabelValues, maxMetrics int) (map[string]struct{}, error) {
+func (is *indexSearch) searchLabelValuesOnDate(ctx context.Context, qt *querytracer.Tracer, labelName string, tfss []*TagFilters, date uint64, maxLabelValues, maxMetrics int) (map[string]struct{}, error) {
 	if labelName == "__name__" {
 		// __name__ label is encoded as empty string in indexdb.
 		labelName = ""
@@ -995,7 +1001,7 @@ func (is *indexSearch) searchLabelValuesOnDate(qt *querytracer.Tracer, labelName
 	var filter *uint64set.Set
 	if !useCompositeScan {
 		var err error
-		filter, err = is.searchMetricIDsWithFiltersOnDate(qt, tfss, date, maxMetrics)
+		filter, err = is.searchMetricIDsWithFiltersOnDate(ctx, qt, tfss, date, maxMetrics)
 		if err != nil {
 			return nil, err
 		}
@@ -1005,7 +1011,10 @@ func (is *indexSearch) searchLabelValuesOnDate(qt *querytracer.Tracer, labelName
 			// This should help https://github.com/VictoriaMetrics/VictoriaMetrics/issues/2978
 			metricIDs := filter.AppendTo(nil)
 			qt.Printf("sort %d metricIDs", len(metricIDs))
-			lvs := is.getLabelValuesForMetricIDs(qt, labelName, metricIDs, maxLabelValues)
+			lvs, err := is.getLabelValuesForMetricIDs(ctx, qt, labelName, metricIDs, maxLabelValues)
+			if err != nil {
+				return nil, err
+			}
 			return lvs, nil
 		}
 	}
@@ -1032,8 +1041,8 @@ func (is *indexSearch) searchLabelValuesOnDate(qt *querytracer.Tracer, labelName
 	ts.Seek(prefix)
 	for len(lvs) < maxLabelValues && ts.NextItem() {
 		if loopsPaceLimiter&paceLimiterFastIterationsMask == 0 {
-			if err := checkSearchDeadlineAndPace(is.deadline); err != nil {
-				return nil, err
+			if isContextDone(ctx) {
+				return nil, ctx.Err()
 			}
 		}
 		loopsPaceLimiter++
@@ -1068,7 +1077,7 @@ func (is *indexSearch) searchLabelValuesOnDate(qt *querytracer.Tracer, labelName
 	return lvs, nil
 }
 
-func (is *indexSearch) getLabelValuesForMetricIDs(qt *querytracer.Tracer, labelName string, metricIDs []uint64, maxLabelValues int) map[string]struct{} {
+func (is *indexSearch) getLabelValuesForMetricIDs(ctx context.Context, qt *querytracer.Tracer, labelName string, metricIDs []uint64, maxLabelValues int) (map[string]struct{}, error) {
 	if labelName == "" {
 		labelName = "__name__"
 	}
@@ -1078,7 +1087,14 @@ func (is *indexSearch) getLabelValuesForMetricIDs(qt *querytracer.Tracer, labelN
 	var mn MetricName
 	foundLabelValues := 0
 	var buf []byte
+	loopsPaceLimiter := 0
 	for _, metricID := range metricIDs {
+		if loopsPaceLimiter&paceLimiterFastIterationsMask == 0 {
+			if isContextDone(ctx) {
+				return nil, ctx.Err()
+			}
+		}
+		loopsPaceLimiter++
 		if dmis.Has(metricID) {
 			// skip deleted IDs from result
 			continue
@@ -1099,12 +1115,12 @@ func (is *indexSearch) getLabelValuesForMetricIDs(qt *querytracer.Tracer, labelN
 			lvs[string(tagValue)] = struct{}{}
 			if len(lvs) >= maxLabelValues {
 				qt.Printf("hit the limit on the number of unique label values for label %q: %d", labelName, maxLabelValues)
-				return lvs
+				return lvs, nil
 			}
 		}
 	}
 	qt.Printf("get %d distinct values for label %q from %d metricIDs", foundLabelValues, labelName, len(metricIDs))
-	return lvs
+	return lvs, nil
 }
 
 // SearchTagValueSuffixes returns all the tag value suffixes for the given tagKey and tagValuePrefix on the given tr.
@@ -1112,7 +1128,7 @@ func (is *indexSearch) getLabelValuesForMetricIDs(qt *querytracer.Tracer, labelN
 // This allows implementing https://graphite-api.readthedocs.io/en/latest/api.html#metrics-find or similar APIs.
 //
 // If it returns maxTagValueSuffixes suffixes, then it is likely more than maxTagValueSuffixes suffixes is found.
-func (db *indexDB) SearchTagValueSuffixes(qt *querytracer.Tracer, accountID, projectID uint32, tr TimeRange, tagKey, tagValuePrefix string, delimiter byte, maxTagValueSuffixes int, deadline uint64) (map[string]struct{}, error) {
+func (db *indexDB) SearchTagValueSuffixes(ctx context.Context, qt *querytracer.Tracer, accountID, projectID uint32, tr TimeRange, tagKey, tagValuePrefix string, delimiter byte, maxTagValueSuffixes int) (map[string]struct{}, error) {
 	qt = qt.NewChild("search tag value suffixes for timeRange=%s, tagKey=%q, tagValuePrefix=%q, delimiter=%c, maxTagValueSuffixes=%d",
 		&tr, tagKey, tagValuePrefix, delimiter, maxTagValueSuffixes)
 	defer qt.Done()
@@ -1124,8 +1140,8 @@ func (db *indexDB) SearchTagValueSuffixes(qt *querytracer.Tracer, accountID, pro
 
 	// TODO: cache results?
 
-	is := db.getIndexSearch(accountID, projectID, deadline)
-	tvss, err := is.searchTagValueSuffixesForTimeRange(tr, tagKey, tagValuePrefix, delimiter, maxTagValueSuffixes)
+	is := db.getIndexSearch(accountID, projectID)
+	tvss, err := is.searchTagValueSuffixesForTimeRange(ctx, tr, tagKey, tagValuePrefix, delimiter, maxTagValueSuffixes)
 	db.putIndexSearch(is)
 	if err != nil {
 		return nil, db.wrapError("search tag value suffixes", err)
@@ -1137,9 +1153,9 @@ func (db *indexDB) SearchTagValueSuffixes(qt *querytracer.Tracer, accountID, pro
 	return tvss, nil
 }
 
-func (is *indexSearch) searchTagValueSuffixesForTimeRange(tr TimeRange, tagKey, tagValuePrefix string, delimiter byte, maxTagValueSuffixes int) (map[string]struct{}, error) {
+func (is *indexSearch) searchTagValueSuffixesForTimeRange(ctx context.Context, tr TimeRange, tagKey, tagValuePrefix string, delimiter byte, maxTagValueSuffixes int) (map[string]struct{}, error) {
 	if tr == globalIndexTimeRange {
-		return is.searchTagValueSuffixesAll(tagKey, tagValuePrefix, delimiter, maxTagValueSuffixes)
+		return is.searchTagValueSuffixesAll(ctx, tagKey, tagValuePrefix, delimiter, maxTagValueSuffixes)
 	}
 
 	minDate, maxDate := tr.DateRange()
@@ -1151,8 +1167,8 @@ func (is *indexSearch) searchTagValueSuffixesForTimeRange(tr TimeRange, tagKey, 
 	for minDate <= maxDate {
 		date := minDate
 		wg.Go(func() {
-			isLocal := is.db.getIndexSearch(is.accountID, is.projectID, is.deadline)
-			tvssLocal, err := isLocal.searchTagValueSuffixesForDate(date, tagKey, tagValuePrefix, delimiter, maxTagValueSuffixes)
+			isLocal := is.db.getIndexSearch(is.accountID, is.projectID)
+			tvssLocal, err := isLocal.searchTagValueSuffixesForDate(ctx, date, tagKey, tagValuePrefix, delimiter, maxTagValueSuffixes)
 			is.db.putIndexSearch(isLocal)
 			mu.Lock()
 			defer mu.Unlock()
@@ -1177,7 +1193,7 @@ func (is *indexSearch) searchTagValueSuffixesForTimeRange(tr TimeRange, tagKey, 
 	return tvss, errGlobal
 }
 
-func (is *indexSearch) searchTagValueSuffixesAll(tagKey, tagValuePrefix string, delimiter byte, maxTagValueSuffixes int) (map[string]struct{}, error) {
+func (is *indexSearch) searchTagValueSuffixesAll(ctx context.Context, tagKey, tagValuePrefix string, delimiter byte, maxTagValueSuffixes int) (map[string]struct{}, error) {
 	kb := &is.kb
 	nsPrefix := byte(nsPrefixTagToMetricIDs)
 	kb.B = is.marshalCommonPrefix(kb.B[:0], nsPrefix)
@@ -1185,10 +1201,10 @@ func (is *indexSearch) searchTagValueSuffixesAll(tagKey, tagValuePrefix string, 
 	kb.B = marshalTagValue(kb.B, bytesutil.ToUnsafeBytes(tagValuePrefix))
 	kb.B = kb.B[:len(kb.B)-1] // remove tagSeparatorChar from the end of kb.B
 	prefix := append([]byte(nil), kb.B...)
-	return is.searchTagValueSuffixesForPrefix(nsPrefix, prefix, len(tagValuePrefix), delimiter, maxTagValueSuffixes)
+	return is.searchTagValueSuffixesForPrefix(ctx, nsPrefix, prefix, len(tagValuePrefix), delimiter, maxTagValueSuffixes)
 }
 
-func (is *indexSearch) searchTagValueSuffixesForDate(date uint64, tagKey, tagValuePrefix string, delimiter byte, maxTagValueSuffixes int) (map[string]struct{}, error) {
+func (is *indexSearch) searchTagValueSuffixesForDate(ctx context.Context, date uint64, tagKey, tagValuePrefix string, delimiter byte, maxTagValueSuffixes int) (map[string]struct{}, error) {
 	nsPrefix := byte(nsPrefixDateTagToMetricIDs)
 	kb := &is.kb
 	kb.B = is.marshalCommonPrefix(kb.B[:0], nsPrefix)
@@ -1197,10 +1213,10 @@ func (is *indexSearch) searchTagValueSuffixesForDate(date uint64, tagKey, tagVal
 	kb.B = marshalTagValue(kb.B, bytesutil.ToUnsafeBytes(tagValuePrefix))
 	kb.B = kb.B[:len(kb.B)-1] // remove tagSeparatorChar from the end of kb.B
 	prefix := append([]byte(nil), kb.B...)
-	return is.searchTagValueSuffixesForPrefix(nsPrefix, prefix, len(tagValuePrefix), delimiter, maxTagValueSuffixes)
+	return is.searchTagValueSuffixesForPrefix(ctx, nsPrefix, prefix, len(tagValuePrefix), delimiter, maxTagValueSuffixes)
 }
 
-func (is *indexSearch) searchTagValueSuffixesForPrefix(nsPrefix byte, prefix []byte, tagValuePrefixLen int, delimiter byte, maxTagValueSuffixes int) (map[string]struct{}, error) {
+func (is *indexSearch) searchTagValueSuffixesForPrefix(ctx context.Context, nsPrefix byte, prefix []byte, tagValuePrefixLen int, delimiter byte, maxTagValueSuffixes int) (map[string]struct{}, error) {
 	kb := &is.kb
 	ts := &is.ts
 	mp := &is.mp
@@ -1210,8 +1226,8 @@ func (is *indexSearch) searchTagValueSuffixesForPrefix(nsPrefix byte, prefix []b
 	tvss := make(map[string]struct{})
 	for len(tvss) < maxTagValueSuffixes && ts.NextItem() {
 		if loopsPaceLimiter&paceLimiterFastIterationsMask == 0 {
-			if err := checkSearchDeadlineAndPace(is.deadline); err != nil {
-				return nil, err
+			if isContextDone(ctx) {
+				return nil, ctx.Err()
 			}
 		}
 		loopsPaceLimiter++
@@ -1252,7 +1268,7 @@ func (is *indexSearch) searchTagValueSuffixesForPrefix(nsPrefix byte, prefix []b
 	return tvss, nil
 }
 
-func (db *indexDB) SearchGraphitePaths(qt *querytracer.Tracer, accountID, projectID uint32, tr TimeRange, qHead, qTail []byte, maxPaths int, deadline uint64) (map[string]struct{}, error) {
+func (db *indexDB) SearchGraphitePaths(ctx context.Context, qt *querytracer.Tracer, accountID, projectID uint32, tr TimeRange, qHead, qTail []byte, maxPaths int) (map[string]struct{}, error) {
 	qt = qt.NewChild("search graphite paths: timeRange=%s, qHead=%q, qTail=%q, maxPaths=%d", &tr, bytesutil.ToUnsafeString(qHead), bytesutil.ToUnsafeString(qTail), maxPaths)
 	defer qt.Done()
 
@@ -1265,7 +1281,7 @@ func (db *indexDB) SearchGraphitePaths(qt *querytracer.Tracer, accountID, projec
 	if n < 0 {
 		// Verify that qHead matches a metric name.
 		qHead = append(qHead, qTail...)
-		suffixes, err := db.SearchTagValueSuffixes(qt, accountID, projectID, tr, "", bytesutil.ToUnsafeString(qHead), '.', 1, deadline)
+		suffixes, err := db.SearchTagValueSuffixes(ctx, qt, accountID, projectID, tr, "", bytesutil.ToUnsafeString(qHead), '.', 1)
 		if err != nil {
 			return nil, db.wrapError("search graphite paths", err)
 		}
@@ -1285,7 +1301,7 @@ func (db *indexDB) SearchGraphitePaths(qt *querytracer.Tracer, accountID, projec
 		return map[string]struct{}{string(qHead): {}}, nil
 	}
 	qHead = append(qHead, qTail[:n]...)
-	suffixes, err := db.SearchTagValueSuffixes(qt, accountID, projectID, tr, "", bytesutil.ToUnsafeString(qHead), '.', maxPaths, deadline)
+	suffixes, err := db.SearchTagValueSuffixes(ctx, qt, accountID, projectID, tr, "", bytesutil.ToUnsafeString(qHead), '.', maxPaths)
 	if err != nil {
 		return nil, db.wrapError("search graphite paths", err)
 	}
@@ -1322,7 +1338,7 @@ func (db *indexDB) SearchGraphitePaths(qt *querytracer.Tracer, accountID, projec
 			continue
 		}
 		qHead = append(qHead[:qHeadLen], suffix...)
-		ps, err := db.SearchGraphitePaths(qt, accountID, projectID, tr, qHead, qTail, maxPaths, deadline)
+		ps, err := db.SearchGraphitePaths(ctx, qt, accountID, projectID, tr, qHead, qTail, maxPaths)
 		if err != nil {
 			return nil, db.wrapError("search graphite paths", err)
 		}
@@ -1398,17 +1414,17 @@ func getRegexpPartsForGraphiteQuery(q string) ([]string, string) {
 // GetSeriesCount returns the approximate number of unique timeseries for the given (accountID, projectID).
 //
 // It includes the deleted series.
-func (db *indexDB) GetSeriesCount(accountID, projectID uint32, deadline uint64) (uint64, error) {
-	is := db.getIndexSearch(accountID, projectID, deadline)
+func (db *indexDB) GetSeriesCount(ctx context.Context, accountID, projectID uint32) (uint64, error) {
+	is := db.getIndexSearch(accountID, projectID)
 	defer db.putIndexSearch(is)
-	count, err := is.getSeriesCount()
+	count, err := is.getSeriesCount(ctx)
 	if err != nil {
 		return 0, db.wrapError("get series count", err)
 	}
 	return count, nil
 }
 
-func (is *indexSearch) getSeriesCount() (uint64, error) {
+func (is *indexSearch) getSeriesCount(ctx context.Context) (uint64, error) {
 	ts := &is.ts
 	kb := &is.kb
 	loopsPaceLimiter := 0
@@ -1417,8 +1433,8 @@ func (is *indexSearch) getSeriesCount() (uint64, error) {
 	ts.Seek(kb.B)
 	for ts.NextItem() {
 		if loopsPaceLimiter&paceLimiterFastIterationsMask == 0 {
-			if err := checkSearchDeadlineAndPace(is.deadline); err != nil {
-				return 0, err
+			if isContextDone(ctx) {
+				return 0, ctx.Err()
 			}
 		}
 		loopsPaceLimiter++
@@ -1438,7 +1454,7 @@ func (is *indexSearch) getSeriesCount() (uint64, error) {
 }
 
 // GetTSDBStatus returns topN entries for tsdb status for the given tfss, date and focusLabel.
-func (db *indexDB) GetTSDBStatus(qt *querytracer.Tracer, accountID, projectID uint32, tfss []*TagFilters, date uint64, focusLabel string, topN, maxMetrics int, deadline uint64) (*TSDBStatus, error) {
+func (db *indexDB) GetTSDBStatus(ctx context.Context, qt *querytracer.Tracer, accountID, projectID uint32, tfss []*TagFilters, date uint64, focusLabel string, topN, maxMetrics int) (*TSDBStatus, error) {
 	qt = qt.NewChild("collect TSDB status: filters=%s, date=%s, focusLabel=%q, topN=%d, maxMetrics=%d", tfss, dateToString(date), focusLabel, topN, maxMetrics)
 	defer qt.Done()
 
@@ -1447,9 +1463,9 @@ func (db *indexDB) GetTSDBStatus(qt *querytracer.Tracer, accountID, projectID ui
 		return &TSDBStatus{}, nil
 	}
 
-	is := db.getIndexSearch(accountID, projectID, deadline)
+	is := db.getIndexSearch(accountID, projectID)
 	defer db.putIndexSearch(is)
-	status, err := is.getTSDBStatus(qt, tfss, date, focusLabel, topN, maxMetrics)
+	status, err := is.getTSDBStatus(ctx, qt, tfss, date, focusLabel, topN, maxMetrics)
 	if err != nil {
 		return nil, db.wrapError("collect TSDB status", err)
 	}
@@ -1457,8 +1473,8 @@ func (db *indexDB) GetTSDBStatus(qt *querytracer.Tracer, accountID, projectID ui
 }
 
 // getTSDBStatus returns topN entries for tsdb status for the given tfss, date and focusLabel.
-func (is *indexSearch) getTSDBStatus(qt *querytracer.Tracer, tfss []*TagFilters, date uint64, focusLabel string, topN, maxMetrics int) (*TSDBStatus, error) {
-	filter, err := is.searchMetricIDsWithFiltersOnDate(qt, tfss, date, maxMetrics)
+func (is *indexSearch) getTSDBStatus(ctx context.Context, qt *querytracer.Tracer, tfss []*TagFilters, date uint64, focusLabel string, topN, maxMetrics int) (*TSDBStatus, error) {
+	filter, err := is.searchMetricIDsWithFiltersOnDate(ctx, qt, tfss, date, maxMetrics)
 	if err != nil {
 		return nil, err
 	}
@@ -1492,8 +1508,8 @@ func (is *indexSearch) getTSDBStatus(qt *querytracer.Tracer, tfss []*TagFilters,
 	ts.Seek(prefix)
 	for ts.NextItem() {
 		if loopsPaceLimiter&paceLimiterFastIterationsMask == 0 {
-			if err := checkSearchDeadlineAndPace(is.deadline); err != nil {
-				return nil, err
+			if isContextDone(ctx) {
+				return nil, ctx.Err()
 			}
 		}
 		loopsPaceLimiter++
@@ -1684,17 +1700,17 @@ func (th *topHeap) Pop() any {
 	panic(fmt.Errorf("BUG: Pop shouldn't be called"))
 }
 
-func (db *indexDB) DeleteSeries(qt *querytracer.Tracer, tfss []*TagFilters, maxMetrics int) (*uint64set.Set, error) {
+func (db *indexDB) DeleteSeries(ctx context.Context, qt *querytracer.Tracer, tfss []*TagFilters, maxMetrics int) (*uint64set.Set, error) {
 	qt = qt.NewChild("delete series: filters=%s, maxMetrics=%d", tfss, maxMetrics)
 	defer qt.Done()
 
-	is := db.getIndexSearch(tfss[0].accountID, tfss[0].projectID, noDeadline)
+	is := db.getIndexSearch(tfss[0].accountID, tfss[0].projectID)
 	defer db.putIndexSearch(is)
 
 	// Unconditionally search global index since a given day in per-day
 	// index may not contain the full set of metricIDs that correspond
 	// to the tfss.
-	metricIDs, err := is.searchMetricIDs(qt, tfss, globalIndexTimeRange, maxMetrics)
+	metricIDs, err := is.searchMetricIDs(ctx, qt, tfss, globalIndexTimeRange, maxMetrics)
 	if err != nil {
 		return nil, db.wrapError("delete series", err)
 	}
@@ -1809,7 +1825,7 @@ func (db *indexDB) updateDeletedMetricIDs(metricIDs *uint64set.Set) {
 }
 
 func (db *indexDB) mustLoadDeletedMetricIDs() {
-	is := db.getIndexSearch(0, 0, noDeadline)
+	is := db.getIndexSearch(0, 0)
 	dmis, err := is.loadDeletedMetricIDs()
 	db.putIndexSearch(is)
 	if err != nil {
@@ -1844,7 +1860,7 @@ func (is *indexSearch) loadDeletedMetricIDs() (*uint64set.Set, error) {
 }
 
 // searchMetricIDs returns metricIDs for the given tfss and tr.
-func (db *indexDB) searchMetricIDs(qt *querytracer.Tracer, tfss []*TagFilters, tr TimeRange, maxMetrics int, deadline uint64) (*uint64set.Set, error) {
+func (db *indexDB) searchMetricIDs(ctx context.Context, qt *querytracer.Tracer, tfss []*TagFilters, tr TimeRange, maxMetrics int) (*uint64set.Set, error) {
 	qt = qt.NewChild("search metricIDs: filters=%s, timeRange=%s", tfss, &tr)
 	defer qt.Done()
 
@@ -1868,8 +1884,8 @@ func (db *indexDB) searchMetricIDs(qt *querytracer.Tracer, tfss []*TagFilters, t
 	// Slow path - search for metricIDs in the db
 	accountID := tfss[0].accountID
 	projectID := tfss[0].projectID
-	is := db.getIndexSearch(accountID, projectID, deadline)
-	metricIDs, err := is.searchMetricIDs(qt, tfss, tr, maxMetrics)
+	is := db.getIndexSearch(accountID, projectID)
+	metricIDs, err := is.searchMetricIDs(ctx, qt, tfss, tr, maxMetrics)
 	db.putIndexSearch(is)
 	if err != nil {
 		return nil, fmt.Errorf("failed to search metricIDs: %w", err)
@@ -1892,7 +1908,7 @@ func (db *indexDB) wrapError(op string, err error) error {
 //
 // The method will fail if the number of found TSIDs exceeds maxMetrics or the
 // search has not completed within the specified deadline.
-func (db *indexDB) SearchTSIDs(qt *querytracer.Tracer, tfss []*TagFilters, tr TimeRange, maxMetrics int, deadline uint64) ([]TSID, error) {
+func (db *indexDB) SearchTSIDs(ctx context.Context, qt *querytracer.Tracer, tfss []*TagFilters, tr TimeRange, maxMetrics int) ([]TSID, error) {
 	qt = qt.NewChild("search TSIDs: filters=%s, timeRange=%s, maxMetrics=%d", tfss, &tr, maxMetrics)
 	defer qt.Done()
 
@@ -1905,7 +1921,7 @@ func (db *indexDB) SearchTSIDs(qt *querytracer.Tracer, tfss []*TagFilters, tr Ti
 		return nil, nil
 	}
 
-	metricIDs, err := db.searchMetricIDs(qt, tfss, tr, maxMetrics, deadline)
+	metricIDs, err := db.searchMetricIDs(ctx, qt, tfss, tr, maxMetrics)
 	if err != nil {
 		return nil, db.wrapError("search TSIDs", err)
 	}
@@ -1917,12 +1933,13 @@ func (db *indexDB) SearchTSIDs(qt *querytracer.Tracer, tfss []*TagFilters, tr Ti
 	metricIDsToDelete := &uint64set.Set{}
 	i := 0
 	paceLimiter := 0
-	is := db.getIndexSearch(tfss[0].accountID, tfss[0].projectID, deadline)
+	is := db.getIndexSearch(tfss[0].accountID, tfss[0].projectID)
 	defer db.putIndexSearch(is)
 	metricIDs.ForEach(func(metricIDs []uint64) bool {
 		for _, metricID := range metricIDs {
 			if paceLimiter&paceLimiterSlowIterationsMask == 0 {
-				if err = checkSearchDeadlineAndPace(deadline); err != nil {
+				if isContextDone(ctx) {
+					err = ctx.Err()
 					return false
 				}
 			}
@@ -1979,12 +1996,12 @@ func (db *indexDB) SearchTSIDs(qt *querytracer.Tracer, tfss []*TagFilters, tr Ti
 // searchMetricName appends metric name for the given metricID to dst
 // and returns the result.
 func (db *indexDB) searchMetricName(dst []byte, metricID uint64, accountID, projectID uint32, noCache bool) ([]byte, bool) {
-	is := db.getIndexSearchInternal(accountID, projectID, noDeadline, noCache)
+	is := db.getIndexSearchInternal(accountID, projectID, noCache)
 	defer db.putIndexSearch(is)
 	return is.searchMetricName(dst, metricID)
 }
 
-func (db *indexDB) SearchMetricNames(qt *querytracer.Tracer, tfss []*TagFilters, tr TimeRange, maxMetrics int, deadline uint64) ([]string, error) {
+func (db *indexDB) SearchMetricNames(ctx context.Context, qt *querytracer.Tracer, tfss []*TagFilters, tr TimeRange, maxMetrics int) ([]string, error) {
 	qt = qt.NewChild("search metric names: filters=%s, timeRange=%s, maxMetrics=%d", tfss, &tr, maxMetrics)
 	defer qt.Done()
 
@@ -1997,7 +2014,7 @@ func (db *indexDB) SearchMetricNames(qt *querytracer.Tracer, tfss []*TagFilters,
 		return nil, nil
 	}
 
-	metricIDs, err := db.searchMetricIDs(qt, tfss, tr, maxMetrics, deadline)
+	metricIDs, err := db.searchMetricIDs(ctx, qt, tfss, tr, maxMetrics)
 	if err != nil {
 		return nil, db.wrapError("search metric names", err)
 	}
@@ -2010,12 +2027,13 @@ func (db *indexDB) SearchMetricNames(qt *querytracer.Tracer, tfss []*TagFilters,
 	var metricName []byte
 	var ok bool
 	paceLimiter := 0
-	is := db.getIndexSearch(tfss[0].accountID, tfss[0].projectID, deadline)
+	is := db.getIndexSearch(tfss[0].accountID, tfss[0].projectID)
 	defer db.putIndexSearch(is)
 	metricIDs.ForEach(func(metricIDs []uint64) bool {
 		for _, metricID := range metricIDs {
 			if paceLimiter&paceLimiterSlowIterationsMask == 0 {
-				if err = checkSearchDeadlineAndPace(deadline); err != nil {
+				if isContextDone(ctx) {
+					err = ctx.Err()
 					return false
 				}
 			}
@@ -2154,7 +2172,7 @@ func (is *indexSearch) getTSIDByMetricID(dst *TSID, metricID uint64) bool {
 
 // updateMetricIDsByMetricNameMatch matches metricName values for the given srcMetricIDs against tfs
 // and adds matching metrics to metricIDs.
-func (is *indexSearch) updateMetricIDsByMetricNameMatch(qt *querytracer.Tracer, metricIDs, srcMetricIDs *uint64set.Set, tfs []*tagFilter) error {
+func (is *indexSearch) updateMetricIDsByMetricNameMatch(ctx context.Context, qt *querytracer.Tracer, metricIDs, srcMetricIDs *uint64set.Set, tfs []*tagFilter) error {
 	qt = qt.NewChild("filter out %d metric ids with filters=%s", srcMetricIDs.Len(), tfs)
 	defer qt.Done()
 
@@ -2172,8 +2190,8 @@ func (is *indexSearch) updateMetricIDsByMetricNameMatch(qt *querytracer.Tracer, 
 	defer PutMetricName(mn)
 	for loopsPaceLimiter, metricID := range sortedMetricIDs {
 		if loopsPaceLimiter&paceLimiterSlowIterationsMask == 0 {
-			if err := checkSearchDeadlineAndPace(is.deadline); err != nil {
-				return err
+			if isContextDone(ctx) {
+				return ctx.Err()
 			}
 		}
 		var ok bool
@@ -2362,7 +2380,7 @@ func isSingleMetricNameFilter(tfss []*TagFilters) bool {
 	return len(tfss) == 1 && len(tfss[0].tfs) == 1 && getMetricNameFilter(tfss[0]) != nil
 }
 
-func (is *indexSearch) searchMetricIDsWithFiltersOnDate(qt *querytracer.Tracer, tfss []*TagFilters, date uint64, maxMetrics int) (*uint64set.Set, error) {
+func (is *indexSearch) searchMetricIDsWithFiltersOnDate(ctx context.Context, qt *querytracer.Tracer, tfss []*TagFilters, date uint64, maxMetrics int) (*uint64set.Set, error) {
 	if len(tfss) == 0 {
 		return nil, nil
 	}
@@ -2377,7 +2395,7 @@ func (is *indexSearch) searchMetricIDsWithFiltersOnDate(qt *querytracer.Tracer, 
 		}
 	}
 
-	metricIDs, err := is.searchMetricIDsInternal(qt, tfss, tr, maxMetrics)
+	metricIDs, err := is.searchMetricIDsInternal(ctx, qt, tfss, tr, maxMetrics)
 	if err != nil {
 		return nil, err
 	}
@@ -2387,8 +2405,8 @@ func (is *indexSearch) searchMetricIDsWithFiltersOnDate(qt *querytracer.Tracer, 
 // searchMetricIDs returns metricIDs for the given tfss and tr.
 //
 // The returned metricIDs are sorted.
-func (is *indexSearch) searchMetricIDs(qt *querytracer.Tracer, tfss []*TagFilters, tr TimeRange, maxMetrics int) (*uint64set.Set, error) {
-	metricIDs, err := is.searchMetricIDsInternal(qt, tfss, tr, maxMetrics)
+func (is *indexSearch) searchMetricIDs(ctx context.Context, qt *querytracer.Tracer, tfss []*TagFilters, tr TimeRange, maxMetrics int) (*uint64set.Set, error) {
+	metricIDs, err := is.searchMetricIDsInternal(ctx, qt, tfss, tr, maxMetrics)
 	if err != nil {
 		return nil, err
 	}
@@ -2411,7 +2429,7 @@ func errTooManyTimeseries(maxMetrics int) error {
 		"see https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#resource-usage-limits", maxMetrics)
 }
 
-func (is *indexSearch) searchMetricIDsInternal(qt *querytracer.Tracer, tfss []*TagFilters, tr TimeRange, maxMetrics int) (*uint64set.Set, error) {
+func (is *indexSearch) searchMetricIDsInternal(ctx context.Context, qt *querytracer.Tracer, tfss []*TagFilters, tr TimeRange, maxMetrics int) (*uint64set.Set, error) {
 	qt = qt.NewChild("search for metric ids: filters=%s, timeRange=%s, maxMetrics=%d", tfss, &tr, maxMetrics)
 	defer qt.Done()
 
@@ -2431,7 +2449,7 @@ func (is *indexSearch) searchMetricIDsInternal(qt *querytracer.Tracer, tfss []*T
 		}
 		qtChild := qt.NewChild("update metric ids: filters=%s, timeRange=%s", tfs, &tr)
 		prevMetricIDsLen := metricIDs.Len()
-		err := is.updateMetricIDsForTagFilters(qtChild, metricIDs, tfs, tr, maxMetrics+1)
+		err := is.updateMetricIDsForTagFilters(ctx, qtChild, metricIDs, tfs, tr, maxMetrics+1)
 		qtChild.Donef("updated %d metric ids", metricIDs.Len()-prevMetricIDsLen)
 		if err != nil {
 			return nil, err
@@ -2443,20 +2461,20 @@ func (is *indexSearch) searchMetricIDsInternal(qt *querytracer.Tracer, tfss []*T
 	return metricIDs, nil
 }
 
-func (is *indexSearch) updateMetricIDsForTagFilters(qt *querytracer.Tracer, metricIDs *uint64set.Set, tfs *TagFilters, tr TimeRange, maxMetrics int) error {
+func (is *indexSearch) updateMetricIDsForTagFilters(ctx context.Context, qt *querytracer.Tracer, metricIDs *uint64set.Set, tfs *TagFilters, tr TimeRange, maxMetrics int) error {
 	if tr != globalIndexTimeRange {
 		// Fast path - search metricIDs by date range in the per-day inverted
 		// index.
 		qt.Printf("search metric ids in the per-day index")
 		is.db.dateRangeSearchCalls.Add(1)
 		minDate, maxDate := tr.DateRange()
-		return is.updateMetricIDsForDateRange(qt, metricIDs, tfs, minDate, maxDate, maxMetrics)
+		return is.updateMetricIDsForDateRange(ctx, qt, metricIDs, tfs, minDate, maxDate, maxMetrics)
 	}
 
 	// Slow path - search metricIDs in the global inverted index.
 	qt.Printf("search metric ids in the global index")
 	is.db.globalSearchCalls.Add(1)
-	m, err := is.getMetricIDsForDateAndFilters(qt, globalIndexDate, tfs, maxMetrics)
+	m, err := is.getMetricIDsForDateAndFilters(ctx, qt, globalIndexDate, tfs, maxMetrics)
 	if err != nil {
 		return err
 	}
@@ -2464,14 +2482,14 @@ func (is *indexSearch) updateMetricIDsForTagFilters(qt *querytracer.Tracer, metr
 	return nil
 }
 
-func (is *indexSearch) getMetricIDsForTagFilter(qt *querytracer.Tracer, tf *tagFilter, maxMetrics int, maxLoopsCount int64) (*uint64set.Set, int64, error) {
+func (is *indexSearch) getMetricIDsForTagFilter(ctx context.Context, qt *querytracer.Tracer, tf *tagFilter, maxMetrics int, maxLoopsCount int64) (*uint64set.Set, int64, error) {
 	if tf.isNegative {
 		logger.Panicf("BUG: isNegative must be false")
 	}
 	metricIDs := &uint64set.Set{}
 	if len(tf.orSuffixes) > 0 {
 		// Fast path for orSuffixes - seek for rows for each value from orSuffixes.
-		loopsCount, err := is.updateMetricIDsForOrSuffixes(tf, metricIDs, maxMetrics, maxLoopsCount)
+		loopsCount, err := is.updateMetricIDsForOrSuffixes(ctx, tf, metricIDs, maxMetrics, maxLoopsCount)
 		qt.Printf("found %d metric ids for filter={%s} using exact search; spent %d loops", metricIDs.Len(), tf, loopsCount)
 		if err != nil {
 			return nil, loopsCount, fmt.Errorf("error when searching for metricIDs for tagFilter in fast path: %w; tagFilter=%s", err, tf)
@@ -2480,7 +2498,7 @@ func (is *indexSearch) getMetricIDsForTagFilter(qt *querytracer.Tracer, tf *tagF
 	}
 
 	// Slow path - scan for all the rows with the given prefix.
-	loopsCount, err := is.getMetricIDsForTagFilterSlow(tf, metricIDs.Add, maxLoopsCount)
+	loopsCount, err := is.getMetricIDsForTagFilterSlow(ctx, tf, metricIDs.Add, maxLoopsCount)
 	qt.Printf("found %d metric ids for filter={%s} using prefix search; spent %d loops", metricIDs.Len(), tf, loopsCount)
 	if err != nil {
 		return nil, loopsCount, fmt.Errorf("error when searching for metricIDs for tagFilter in slow path: %w; tagFilter=%s", err, tf)
@@ -2490,7 +2508,7 @@ func (is *indexSearch) getMetricIDsForTagFilter(qt *querytracer.Tracer, tf *tagF
 
 var errTooManyLoops = fmt.Errorf("too many loops is needed for applying this filter")
 
-func (is *indexSearch) getMetricIDsForTagFilterSlow(tf *tagFilter, f func(metricID uint64), maxLoopsCount int64) (int64, error) {
+func (is *indexSearch) getMetricIDsForTagFilterSlow(ctx context.Context, tf *tagFilter, f func(metricID uint64), maxLoopsCount int64) (int64, error) {
 	if len(tf.orSuffixes) > 0 {
 		logger.Panicf("BUG: the getMetricIDsForTagFilterSlow must be called only for empty tf.orSuffixes; got %s", tf.orSuffixes)
 	}
@@ -2507,8 +2525,8 @@ func (is *indexSearch) getMetricIDsForTagFilterSlow(tf *tagFilter, f func(metric
 	ts.Seek(prefix)
 	for ts.NextItem() {
 		if loopsPaceLimiter&paceLimiterMediumIterationsMask == 0 {
-			if err := checkSearchDeadlineAndPace(is.deadline); err != nil {
-				return loopsCount, err
+			if isContextDone(ctx) {
+				return loopsCount, ctx.Err()
 			}
 		}
 		loopsPaceLimiter++
@@ -2580,7 +2598,7 @@ func (is *indexSearch) getMetricIDsForTagFilterSlow(tf *tagFilter, f func(metric
 	return loopsCount, nil
 }
 
-func (is *indexSearch) updateMetricIDsForOrSuffixes(tf *tagFilter, metricIDs *uint64set.Set, maxMetrics int, maxLoopsCount int64) (int64, error) {
+func (is *indexSearch) updateMetricIDsForOrSuffixes(ctx context.Context, tf *tagFilter, metricIDs *uint64set.Set, maxMetrics int, maxLoopsCount int64) (int64, error) {
 	if tf.isNegative {
 		logger.Panicf("BUG: isNegative must be false")
 	}
@@ -2591,7 +2609,7 @@ func (is *indexSearch) updateMetricIDsForOrSuffixes(tf *tagFilter, metricIDs *ui
 		kb.B = append(kb.B[:0], tf.prefix...)
 		kb.B = append(kb.B, orSuffix...)
 		kb.B = append(kb.B, tagSeparatorChar)
-		lc, err := is.updateMetricIDsForOrSuffix(kb.B, metricIDs, maxMetrics, maxLoopsCount-loopsCount)
+		lc, err := is.updateMetricIDsForOrSuffix(ctx, kb.B, metricIDs, maxMetrics, maxLoopsCount-loopsCount)
 		loopsCount += lc
 		if err != nil {
 			return loopsCount, err
@@ -2603,7 +2621,7 @@ func (is *indexSearch) updateMetricIDsForOrSuffixes(tf *tagFilter, metricIDs *ui
 	return loopsCount, nil
 }
 
-func (is *indexSearch) updateMetricIDsForOrSuffix(prefix []byte, metricIDs *uint64set.Set, maxMetrics int, maxLoopsCount int64) (int64, error) {
+func (is *indexSearch) updateMetricIDsForOrSuffix(ctx context.Context, prefix []byte, metricIDs *uint64set.Set, maxMetrics int, maxLoopsCount int64) (int64, error) {
 	ts := &is.ts
 	mp := &is.mp
 	var loopsCount int64
@@ -2611,8 +2629,8 @@ func (is *indexSearch) updateMetricIDsForOrSuffix(prefix []byte, metricIDs *uint
 	ts.Seek(prefix)
 	for metricIDs.Len() < maxMetrics && ts.NextItem() {
 		if loopsPaceLimiter&paceLimiterFastIterationsMask == 0 {
-			if err := checkSearchDeadlineAndPace(is.deadline); err != nil {
-				return loopsCount, err
+			if isContextDone(ctx) {
+				return loopsCount, ctx.Err()
 			}
 		}
 		loopsPaceLimiter++
@@ -2636,10 +2654,10 @@ func (is *indexSearch) updateMetricIDsForOrSuffix(prefix []byte, metricIDs *uint
 	return loopsCount, nil
 }
 
-func (is *indexSearch) updateMetricIDsForDateRange(qt *querytracer.Tracer, metricIDs *uint64set.Set, tfs *TagFilters, minDate, maxDate uint64, maxMetrics int) error {
+func (is *indexSearch) updateMetricIDsForDateRange(ctx context.Context, qt *querytracer.Tracer, metricIDs *uint64set.Set, tfs *TagFilters, minDate, maxDate uint64, maxMetrics int) error {
 	if minDate == maxDate {
 		// Fast path - query only a single date.
-		m, err := is.getMetricIDsForDateAndFilters(qt, minDate, tfs, maxMetrics)
+		m, err := is.getMetricIDsForDateAndFilters(ctx, qt, minDate, tfs, maxMetrics)
 		if err != nil {
 			return err
 		}
@@ -2660,8 +2678,8 @@ func (is *indexSearch) updateMetricIDsForDateRange(qt *querytracer.Tracer, metri
 		wg.Go(func() {
 			defer qtChild.Done()
 
-			isLocal := is.db.getIndexSearch(is.accountID, is.projectID, is.deadline)
-			m, err := isLocal.getMetricIDsForDateAndFilters(qtChild, date, tfs, maxMetrics)
+			isLocal := is.db.getIndexSearch(is.accountID, is.projectID)
+			m, err := isLocal.getMetricIDsForDateAndFilters(ctx, qtChild, date, tfs, maxMetrics)
 			is.db.putIndexSearch(isLocal)
 			mu.Lock()
 			defer mu.Unlock()
@@ -2688,7 +2706,7 @@ func (is *indexSearch) updateMetricIDsForDateRange(qt *querytracer.Tracer, metri
 	return nil
 }
 
-func (is *indexSearch) getMetricIDsForDateAndFilters(qt *querytracer.Tracer, date uint64, tfs *TagFilters, maxMetrics int) (*uint64set.Set, error) {
+func (is *indexSearch) getMetricIDsForDateAndFilters(ctx context.Context, qt *querytracer.Tracer, date uint64, tfs *TagFilters, maxMetrics int) (*uint64set.Set, error) {
 	if qt.Enabled() {
 		qt = qt.NewChild("search for metric ids on a particular day: filters=%s, date=%s, maxMetrics=%d", tfs, dateToString(date), maxMetrics)
 		defer qt.Done()
@@ -2760,7 +2778,7 @@ func (is *indexSearch) getMetricIDsForDateAndFilters(qt *querytracer.Tracer, dat
 			continue
 		}
 		maxLoopsCount := getFirstPositiveLoopsCount(tfws[i+1:])
-		m, loopsCount, err := is.getMetricIDsForDateTagFilter(qtChild, tf, date, tfs.commonPrefix, maxDateMetrics, maxLoopsCount)
+		m, loopsCount, err := is.getMetricIDsForDateTagFilter(ctx, qtChild, tf, date, tfs.commonPrefix, maxDateMetrics, maxLoopsCount)
 		if err != nil {
 			if errors.Is(err, errTooManyLoops) {
 				// The tf took too many loops compared to the next filter. Postpone applying this filter.
@@ -2794,7 +2812,7 @@ func (is *indexSearch) getMetricIDsForDateAndFilters(qt *querytracer.Tracer, dat
 		// Populate all the metricIDs for the given (date),
 		// so later they can be filtered out with negative filters.
 		qt.Printf("all the filters are negative or match more than %d time series; fall back to searching for all the metric ids", maxDateMetrics)
-		m, err := is.getMetricIDsForDate(date, maxDateMetrics)
+		m, err := is.getMetricIDsForDate(ctx, date, maxDateMetrics)
 		if err != nil {
 			return nil, fmt.Errorf("cannot obtain all the metricIDs: %w", err)
 		}
@@ -2854,7 +2872,7 @@ func (is *indexSearch) getMetricIDsForDateAndFilters(qt *querytracer.Tracer, dat
 		if maxLoopsCount == int64Max {
 			maxLoopsCount = int64(metricIDsLen) * loopsCountPerMetricNameMatch
 		}
-		m, filterLoopsCount, err := is.getMetricIDsForDateTagFilter(qtChild, tf, date, tfs.commonPrefix, intMax, maxLoopsCount)
+		m, filterLoopsCount, err := is.getMetricIDsForDateTagFilter(ctx, qtChild, tf, date, tfs.commonPrefix, intMax, maxLoopsCount)
 		if err != nil {
 			if errors.Is(err, errTooManyLoops) {
 				// Postpone tf, since it took more loops than the next filter may need.
@@ -2886,7 +2904,7 @@ func (is *indexSearch) getMetricIDsForDateAndFilters(qt *querytracer.Tracer, dat
 		// Apply the postponed filters via metricName match.
 		qt.Printf("apply postponed filters=%s to %d metrics ids", tfsPostponed, metricIDs.Len())
 		var m uint64set.Set
-		if err := is.updateMetricIDsByMetricNameMatch(qt, &m, metricIDs, tfsPostponed); err != nil {
+		if err := is.updateMetricIDsByMetricNameMatch(ctx, qt, &m, metricIDs, tfsPostponed); err != nil {
 			return nil, err
 		}
 		return &m, nil
@@ -3106,7 +3124,7 @@ func (is *indexSearch) hasMetricIDSlow(metricID uint64, accountID, projectID uin
 	return true
 }
 
-func (is *indexSearch) getMetricIDsForDateTagFilter(qt *querytracer.Tracer, tf *tagFilter, date uint64, commonPrefix []byte,
+func (is *indexSearch) getMetricIDsForDateTagFilter(ctx context.Context, qt *querytracer.Tracer, tf *tagFilter, date uint64, commonPrefix []byte,
 	maxMetrics int, maxLoopsCount int64) (*uint64set.Set, int64, error) {
 	if qt.Enabled() {
 		qt = qt.NewChild("get metric ids for filter and date: filter={%s}, date=%s, maxMetrics=%d, maxLoopsCount=%d", tf, dateToString(date), maxMetrics, maxLoopsCount)
@@ -3124,7 +3142,7 @@ func (is *indexSearch) getMetricIDsForDateTagFilter(qt *querytracer.Tracer, tf *
 	tfNew := *tf
 	tfNew.isNegative = false // isNegative for the original tf is handled by the caller.
 	tfNew.prefix = kb.B
-	metricIDs, loopsCount, err := is.getMetricIDsForTagFilter(qt, &tfNew, maxMetrics, maxLoopsCount)
+	metricIDs, loopsCount, err := is.getMetricIDsForTagFilter(ctx, qt, &tfNew, maxMetrics, maxLoopsCount)
 	if err != nil {
 		return nil, loopsCount, err
 	}
@@ -3140,7 +3158,7 @@ func (is *indexSearch) getMetricIDsForDateTagFilter(qt *querytracer.Tracer, tf *
 	if err := tfGross.Init(prefix, tf.key, []byte(".+"), false, true); err != nil {
 		logger.Panicf(`BUG: cannot init tag filter: {%q=~".+"}: %s`, tf.key, err)
 	}
-	m, lc, err := is.getMetricIDsForTagFilter(qt, &tfGross, maxMetrics, maxLoopsCount)
+	m, lc, err := is.getMetricIDsForTagFilter(ctx, qt, &tfGross, maxMetrics, maxLoopsCount)
 	loopsCount += lc
 	if err != nil {
 		return nil, loopsCount, err
@@ -3184,28 +3202,28 @@ func appendDateTagFilterCacheKey(dst []byte, indexDBName string, date uint64, tf
 	return dst
 }
 
-func (is *indexSearch) getMetricIDsForDate(date uint64, maxMetrics int) (*uint64set.Set, error) {
+func (is *indexSearch) getMetricIDsForDate(ctx context.Context, date uint64, maxMetrics int) (*uint64set.Set, error) {
 	// Extract all the metricIDs from (date, __name__=value)->metricIDs entries.
 	kb := kbPool.Get()
 	defer kbPool.Put(kb)
 	kb.B = is.marshalCommonPrefixForDate(kb.B[:0], date)
 	kb.B = marshalTagValue(kb.B, nil)
 	var metricIDs uint64set.Set
-	if err := is.updateMetricIDsForPrefix(kb.B, &metricIDs, maxMetrics); err != nil {
+	if err := is.updateMetricIDsForPrefix(ctx, kb.B, &metricIDs, maxMetrics); err != nil {
 		return nil, err
 	}
 	return &metricIDs, nil
 }
 
-func (is *indexSearch) updateMetricIDsForPrefix(prefix []byte, metricIDs *uint64set.Set, maxMetrics int) error {
+func (is *indexSearch) updateMetricIDsForPrefix(ctx context.Context, prefix []byte, metricIDs *uint64set.Set, maxMetrics int) error {
 	ts := &is.ts
 	mp := &is.mp
 	loopsPaceLimiter := 0
 	ts.Seek(prefix)
 	for ts.NextItem() {
 		if loopsPaceLimiter&paceLimiterFastIterationsMask == 0 {
-			if err := checkSearchDeadlineAndPace(is.deadline); err != nil {
-				return err
+			if isContextDone(ctx) {
+				return ctx.Err()
 			}
 		}
 		loopsPaceLimiter++

--- a/lib/storage/index_db_legacy.go
+++ b/lib/storage/index_db_legacy.go
@@ -124,7 +124,7 @@ func (db *indexDB) legacyContainsTimeRange(accountID, projectID uint32, tr TimeR
 	}
 
 	// Slow path.
-	is := db.getIndexSearch(accountID, projectID, noDeadline)
+	is := db.getIndexSearch(accountID, projectID)
 	defer db.putIndexSearch(is)
 	if is.legacyContainsTimeRange(tr) {
 		return true

--- a/lib/storage/index_db_test.go
+++ b/lib/storage/index_db_test.go
@@ -569,7 +569,7 @@ func testIndexDBGetOrCreateTSIDByName(db *indexDB, accountsCount, projectsCount,
 	tenants := make(map[string]struct{})
 
 	// Usage of 0:0 is ok, since getTSIDByMetricName uses accountID and projectID from metric name.
-	is := db.getIndexSearch(0, 0, noDeadline)
+	is := db.getIndexSearch(0, 0)
 
 	var metricNameBuf []byte
 	for i := range 401 {
@@ -646,7 +646,7 @@ func testIndexDBCheckTSIDByName(db *indexDB, mns []MetricName, tsids []TSID, ten
 		metricName := mn.Marshal(nil)
 
 		// Usage of 0:0 is ok, since getTSIDByMetricName uses accountID and projectID from metric name.
-		is := db.getIndexSearch(0, 0, noDeadline)
+		is := db.getIndexSearch(0, 0)
 		if !is.getTSIDByMetricName(&tsidLocal, metricName, date) {
 			return fmt.Errorf("cannot obtain tsid #%d for mn %s", i, mn)
 		}
@@ -681,7 +681,7 @@ func testIndexDBCheckTSIDByName(db *indexDB, mns []MetricName, tsids []TSID, ten
 		}
 
 		// Test SearchLabelValues
-		lvs, err := db.SearchLabelValues(nil, mn.AccountID, mn.ProjectID, "__name__", nil, tr, 1e5, 1e9, noDeadline)
+		lvs, err := db.SearchLabelValues(noDeadlineContext, nil, mn.AccountID, mn.ProjectID, "__name__", nil, tr, 1e5, 1e9)
 		if err != nil {
 			return fmt.Errorf("error in SearchLabelValues(labelName=%q): %w", "__name__", err)
 		}
@@ -695,7 +695,7 @@ func testIndexDBCheckTSIDByName(db *indexDB, mns []MetricName, tsids []TSID, ten
 		}
 		for i := range mn.Tags {
 			tag := &mn.Tags[i]
-			lvs, err := db.SearchLabelValues(nil, mn.AccountID, mn.ProjectID, string(tag.Key), nil, tr, 1e5, 1e9, noDeadline)
+			lvs, err := db.SearchLabelValues(noDeadlineContext, nil, mn.AccountID, mn.ProjectID, string(tag.Key), nil, tr, 1e5, 1e9)
 			if err != nil {
 				return fmt.Errorf("error in SearchLabelValues(labelName=%q): %w", tag.Key, err)
 			}
@@ -708,7 +708,7 @@ func testIndexDBCheckTSIDByName(db *indexDB, mns []MetricName, tsids []TSID, ten
 
 	// Test SearchLabelNames (empty filters)
 	for k, labelNames := range allLabelNames {
-		lns, err := db.SearchLabelNames(nil, k.AccountID, k.ProjectID, nil, tr, 1e5, 1e9, noDeadline)
+		lns, err := db.SearchLabelNames(noDeadlineContext, nil, k.AccountID, k.ProjectID, nil, tr, 1e5, 1e9)
 		if err != nil {
 			return fmt.Errorf("error in SearchLabelNames(empty filter): %w", err)
 		}
@@ -723,7 +723,7 @@ func testIndexDBCheckTSIDByName(db *indexDB, mns []MetricName, tsids []TSID, ten
 	}
 
 	// Test SearchTenants
-	tenantsGotMap, err := db.SearchTenants(nil, tr, noDeadline)
+	tenantsGotMap, err := db.SearchTenants(noDeadlineContext, nil, tr)
 	if err != nil {
 		return fmt.Errorf("error in SearchTenants: %w", err)
 	}
@@ -737,7 +737,7 @@ func testIndexDBCheckTSIDByName(db *indexDB, mns []MetricName, tsids []TSID, ten
 	// would return more timeseries than needed.
 	if !isConcurrent {
 		for k, tc := range timeseriesCounters {
-			n, err := db.GetSeriesCount(k.AccountID, k.ProjectID, noDeadline)
+			n, err := db.GetSeriesCount(noDeadlineContext, k.AccountID, k.ProjectID)
 			if err != nil {
 				return fmt.Errorf("unexpected error in GetSeriesCount(%v): %w", k, err)
 			}
@@ -769,7 +769,7 @@ func testIndexDBCheckTSIDByName(db *indexDB, mns []MetricName, tsids []TSID, ten
 		if err := tfs.Add(nil, nil, true, false); err != nil {
 			return fmt.Errorf("cannot add no-op negative filter: %w", err)
 		}
-		tsidsFound, err := db.SearchTSIDs(nil, []*TagFilters{tfs}, tr, 1e5, noDeadline)
+		tsidsFound, err := db.SearchTSIDs(noDeadlineContext, nil, []*TagFilters{tfs}, tr, 1e5)
 		if err != nil {
 			return fmt.Errorf("cannot search by exact tag filter: %w", err)
 		}
@@ -778,7 +778,7 @@ func testIndexDBCheckTSIDByName(db *indexDB, mns []MetricName, tsids []TSID, ten
 		}
 
 		// Verify tag cache.
-		tsidsCached, err := db.SearchTSIDs(nil, []*TagFilters{tfs}, tr, 1e5, noDeadline)
+		tsidsCached, err := db.SearchTSIDs(noDeadlineContext, nil, []*TagFilters{tfs}, tr, 1e5)
 		if err != nil {
 			return fmt.Errorf("cannot search by exact tag filter: %w", err)
 		}
@@ -790,7 +790,7 @@ func testIndexDBCheckTSIDByName(db *indexDB, mns []MetricName, tsids []TSID, ten
 		if err := tfs.Add(nil, mn.MetricGroup, true, false); err != nil {
 			return fmt.Errorf("cannot add negative filter for zeroing search results: %w", err)
 		}
-		tsidsFound, err = db.SearchTSIDs(nil, []*TagFilters{tfs}, tr, 1e5, noDeadline)
+		tsidsFound, err = db.SearchTSIDs(noDeadlineContext, nil, []*TagFilters{tfs}, tr, 1e5)
 		if err != nil {
 			return fmt.Errorf("cannot search by exact tag filter with full negative: %w", err)
 		}
@@ -808,7 +808,7 @@ func testIndexDBCheckTSIDByName(db *indexDB, mns []MetricName, tsids []TSID, ten
 		if err := tfs.Add(nil, []byte(re), false, true); err != nil {
 			return fmt.Errorf("cannot create regexp tag filter for Graphite wildcard")
 		}
-		tsidsFound, err = db.SearchTSIDs(nil, []*TagFilters{tfs}, tr, 1e5, noDeadline)
+		tsidsFound, err = db.SearchTSIDs(noDeadlineContext, nil, []*TagFilters{tfs}, tr, 1e5)
 		if err != nil {
 			return fmt.Errorf("cannot search by regexp tag filter for Graphite wildcard: %w", err)
 		}
@@ -825,7 +825,7 @@ func testIndexDBCheckTSIDByName(db *indexDB, mns []MetricName, tsids []TSID, ten
 		if err := tfs.Add([]byte("non-existent-tag"), []byte("foo|"), false, true); err != nil {
 			return fmt.Errorf("cannot create regexp tag filter for non-existing tag: %w", err)
 		}
-		tsidsFound, err = db.SearchTSIDs(nil, []*TagFilters{tfs}, tr, 1e5, noDeadline)
+		tsidsFound, err = db.SearchTSIDs(noDeadlineContext, nil, []*TagFilters{tfs}, tr, 1e5)
 		if err != nil {
 			return fmt.Errorf("cannot search with a filter matching empty tag: %w", err)
 		}
@@ -845,7 +845,7 @@ func testIndexDBCheckTSIDByName(db *indexDB, mns []MetricName, tsids []TSID, ten
 		if err := tfs.Add([]byte("non-existent-tag2"), []byte("bar|"), false, true); err != nil {
 			return fmt.Errorf("cannot create regexp tag filter for non-existing tag2: %w", err)
 		}
-		tsidsFound, err = db.SearchTSIDs(nil, []*TagFilters{tfs}, tr, 1e5, noDeadline)
+		tsidsFound, err = db.SearchTSIDs(noDeadlineContext, nil, []*TagFilters{tfs}, tr, 1e5)
 		if err != nil {
 			return fmt.Errorf("cannot search with multiple filters matching empty tags: %w", err)
 		}
@@ -873,7 +873,7 @@ func testIndexDBCheckTSIDByName(db *indexDB, mns []MetricName, tsids []TSID, ten
 		if err := tfs.Add(nil, nil, true, true); err != nil {
 			return fmt.Errorf("cannot add no-op negative filter with regexp: %w", err)
 		}
-		tsidsFound, err = db.SearchTSIDs(nil, []*TagFilters{tfs}, tr, 1e5, noDeadline)
+		tsidsFound, err = db.SearchTSIDs(noDeadlineContext, nil, []*TagFilters{tfs}, tr, 1e5)
 		if err != nil {
 			return fmt.Errorf("cannot search by regexp tag filter: %w", err)
 		}
@@ -883,7 +883,7 @@ func testIndexDBCheckTSIDByName(db *indexDB, mns []MetricName, tsids []TSID, ten
 		if err := tfs.Add(nil, mn.MetricGroup, true, true); err != nil {
 			return fmt.Errorf("cannot add negative filter for zeroing search results: %w", err)
 		}
-		tsidsFound, err = db.SearchTSIDs(nil, []*TagFilters{tfs}, tr, 1e5, noDeadline)
+		tsidsFound, err = db.SearchTSIDs(noDeadlineContext, nil, []*TagFilters{tfs}, tr, 1e5)
 		if err != nil {
 			return fmt.Errorf("cannot search by regexp tag filter with full negative: %w", err)
 		}
@@ -899,7 +899,7 @@ func testIndexDBCheckTSIDByName(db *indexDB, mns []MetricName, tsids []TSID, ten
 		if err := tfs.Add(nil, mn.MetricGroup, false, true); err != nil {
 			return fmt.Errorf("cannot create tag filter for MetricGroup matching zero results: %w", err)
 		}
-		tsidsFound, err = db.SearchTSIDs(nil, []*TagFilters{tfs}, tr, 1e5, noDeadline)
+		tsidsFound, err = db.SearchTSIDs(noDeadlineContext, nil, []*TagFilters{tfs}, tr, 1e5)
 		if err != nil {
 			return fmt.Errorf("cannot search by non-existing tag filter: %w", err)
 		}
@@ -915,7 +915,7 @@ func testIndexDBCheckTSIDByName(db *indexDB, mns []MetricName, tsids []TSID, ten
 
 		// Search with empty filter. It should match all the results.
 		tfs.Reset(mn.AccountID, mn.ProjectID)
-		tsidsFound, err = db.SearchTSIDs(nil, []*TagFilters{tfs}, tr, 1e5, noDeadline)
+		tsidsFound, err = db.SearchTSIDs(noDeadlineContext, nil, []*TagFilters{tfs}, tr, 1e5)
 		if err != nil {
 			return fmt.Errorf("cannot search for common prefix: %w", err)
 		}
@@ -928,7 +928,7 @@ func testIndexDBCheckTSIDByName(db *indexDB, mns []MetricName, tsids []TSID, ten
 		if err := tfs.Add(nil, nil, false, false); err != nil {
 			return fmt.Errorf("cannot create tag filter for empty metricGroup: %w", err)
 		}
-		tsidsFound, err = db.SearchTSIDs(nil, []*TagFilters{tfs}, tr, 1e5, noDeadline)
+		tsidsFound, err = db.SearchTSIDs(noDeadlineContext, nil, []*TagFilters{tfs}, tr, 1e5)
 		if err != nil {
 			return fmt.Errorf("cannot search for empty metricGroup: %w", err)
 		}
@@ -945,7 +945,7 @@ func testIndexDBCheckTSIDByName(db *indexDB, mns []MetricName, tsids []TSID, ten
 		if err := tfs2.Add(nil, mn.MetricGroup, false, false); err != nil {
 			return fmt.Errorf("cannot create tag filter for MetricGroup: %w", err)
 		}
-		tsidsFound, err = db.SearchTSIDs(nil, []*TagFilters{tfs1, tfs2}, tr, 1e5, noDeadline)
+		tsidsFound, err = db.SearchTSIDs(noDeadlineContext, nil, []*TagFilters{tfs1, tfs2}, tr, 1e5)
 		if err != nil {
 			return fmt.Errorf("cannot search for empty metricGroup: %w", err)
 		}
@@ -954,7 +954,7 @@ func testIndexDBCheckTSIDByName(db *indexDB, mns []MetricName, tsids []TSID, ten
 		}
 
 		// Verify empty tfss
-		tsidsFound, err = db.SearchTSIDs(nil, nil, tr, 1e5, noDeadline)
+		tsidsFound, err = db.SearchTSIDs(noDeadlineContext, nil, nil, tr, 1e5)
 		if err != nil {
 			return fmt.Errorf("cannot search for nil tfss: %w", err)
 		}
@@ -1519,7 +1519,7 @@ func testIndexDBSearchTSIDs(t *testing.T, disablePerDayIndex bool) {
 	defer s.tb.PutPartition(ptw)
 	db := ptw.pt.idb
 
-	is := db.getIndexSearch(accountID, projectID, noDeadline)
+	is := db.getIndexSearch(accountID, projectID)
 	for day := range days {
 		date := baseDate - uint64(day)
 		var metricIDs uint64set.Set
@@ -1556,11 +1556,11 @@ func testIndexDBSearchTSIDs(t *testing.T, disablePerDayIndex bool) {
 	db.putIndexSearch(is)
 	db.tb.DebugFlush()
 
-	is2 := db.getIndexSearch(accountID, projectID, noDeadline)
+	is2 := db.getIndexSearch(accountID, projectID)
 
 	assertMetricIDs := func(date uint64, maxMetrics int, wantSet *uint64set.Set) {
 		t.Helper()
-		gotSet, err := is2.getMetricIDsForDate(date, maxMetrics)
+		gotSet, err := is2.getMetricIDsForDate(noDeadlineContext, date, maxMetrics)
 		if err != nil {
 			t.Fatalf("getMetricIDsForDate(%d, %d) failed unexpectedly: %s", date, maxMetrics, err)
 		}
@@ -1584,7 +1584,7 @@ func testIndexDBSearchTSIDs(t *testing.T, disablePerDayIndex bool) {
 
 	assertTSIDs := func(tfs *TagFilters, tr TimeRange, want int) {
 		t.Helper()
-		tsids, err := db.SearchTSIDs(nil, []*TagFilters{tfs}, tr, 1e5, noDeadline)
+		tsids, err := db.SearchTSIDs(noDeadlineContext, nil, []*TagFilters{tfs}, tr, 1e5)
 		if err != nil {
 			t.Fatalf("SearchTSIDs(%v, %v) failed unexpectedly: %s", tfs, &tr, err)
 		}
@@ -1652,7 +1652,7 @@ func testIndexDBSearchLabelNames(t *testing.T, disablePerDayIndex bool) {
 	defer s.tb.PutPartition(ptw)
 	db := ptw.pt.idb
 
-	is := db.getIndexSearch(accountID, projectID, noDeadline)
+	is := db.getIndexSearch(accountID, projectID)
 	for day := range days {
 		date := baseDate - uint64(day)
 		for metric := range metricsPerDay {
@@ -1685,7 +1685,7 @@ func testIndexDBSearchLabelNames(t *testing.T, disablePerDayIndex bool) {
 		if tfs != nil {
 			tfss = append(tfss, tfs)
 		}
-		lns, err := db.SearchLabelNames(nil, accountID, projectID, tfss, tr, 10000, 1e9, noDeadline)
+		lns, err := db.SearchLabelNames(noDeadlineContext, nil, accountID, projectID, tfss, tr, 10000, 1e9)
 		if err != nil {
 			t.Fatalf("SearchLabelNames(%v, %v) failed unexpectedly: %s", tfs, &tr, err)
 		}
@@ -1772,7 +1772,7 @@ func testIndexDBSearchLabelValues(t *testing.T, disablePerDayIndex bool) {
 	defer s.tb.PutPartition(ptw)
 	db := ptw.pt.idb
 
-	is := db.getIndexSearch(accountID, projectID, noDeadline)
+	is := db.getIndexSearch(accountID, projectID)
 	for day := range days {
 		date := baseDate - uint64(day)
 		for metric := range metricsPerDay {
@@ -1810,7 +1810,7 @@ func testIndexDBSearchLabelValues(t *testing.T, disablePerDayIndex bool) {
 		if tfs != nil {
 			tfss = append(tfss, tfs)
 		}
-		lvs, err := db.SearchLabelValues(nil, accountID, projectID, labelName, tfss, tr, 10000, 1e9, noDeadline)
+		lvs, err := db.SearchLabelValues(noDeadlineContext, nil, accountID, projectID, labelName, tfss, tr, 10000, 1e9)
 		if err != nil {
 			t.Fatalf("SearchLabelValues(%q, %v, %v) failed unexpectedly: %s", labelName, tfs, &tr, err)
 		}
@@ -1971,7 +1971,7 @@ func testIndexDBDeleteSeries(t *testing.T, disablePerDayIndex bool) {
 	defer s.tb.PutPartition(ptw)
 	db := ptw.pt.idb
 
-	is := db.getIndexSearch(accountID, projectID, noDeadline)
+	is := db.getIndexSearch(accountID, projectID)
 	for day := range days {
 		date := date0 + uint64(day)
 		for metric := range metricsPerDay {
@@ -2008,7 +2008,7 @@ func testIndexDBDeleteSeries(t *testing.T, disablePerDayIndex bool) {
 
 	assertMetricNames := func(tfs *TagFilters, tr TimeRange, want []string) {
 		t.Helper()
-		got, err := db.SearchMetricNames(nil, []*TagFilters{tfs}, tr, 1e9, noDeadline)
+		got, err := db.SearchMetricNames(noDeadlineContext, nil, []*TagFilters{tfs}, tr, 1e9)
 		if err != nil {
 			t.Fatalf("SearchMetricNames(%v, %v) failed unexpectedly: %s", tfs, &tr, err)
 		}
@@ -2036,7 +2036,7 @@ func testIndexDBDeleteSeries(t *testing.T, disablePerDayIndex bool) {
 	}
 	assertMetricNames(tfs, tr, allMetricNames)
 
-	gotMetricIDs, err := db.DeleteSeries(nil, []*TagFilters{tfs}, 1e9)
+	gotMetricIDs, err := db.DeleteSeries(noDeadlineContext, nil, []*TagFilters{tfs}, 1e9)
 	if err != nil {
 		t.Fatalf("DeleteSeries(%v) failed unexpectedly: %s", tfs, err)
 	}
@@ -2078,7 +2078,7 @@ func testIndexDBGetTSDBStatus(t *testing.T, disablePerDayIndex bool) {
 	defer s.tb.PutPartition(ptw)
 	db := ptw.pt.idb
 
-	is := db.getIndexSearch(accountID, projectID, noDeadline)
+	is := db.getIndexSearch(accountID, projectID)
 	for day := range days {
 		date := baseDate - uint64(day)
 		for metric := range metricsPerDay {
@@ -2109,7 +2109,7 @@ func testIndexDBGetTSDBStatus(t *testing.T, disablePerDayIndex bool) {
 	if disablePerDayIndex {
 		tsdbStatusDate = globalIndexDate
 	}
-	status, err := db.GetTSDBStatus(nil, accountID, projectID, nil, tsdbStatusDate, "day", 5, 1e6, noDeadline)
+	status, err := db.GetTSDBStatus(noDeadlineContext, nil, accountID, projectID, nil, tsdbStatusDate, "day", 5, 1e6)
 	if err != nil {
 		t.Fatalf("error in GetTSDBStatus with nil filters: %s", err)
 	}
@@ -2190,7 +2190,7 @@ func testIndexDBGetTSDBStatus(t *testing.T, disablePerDayIndex bool) {
 	if err := tfs.Add([]byte("constant"), []byte("const"), false, false); err != nil {
 		t.Fatalf("cannot add filter: %s", err)
 	}
-	status, err = db.GetTSDBStatus(nil, accountID, projectID, []*TagFilters{tfs}, tsdbStatusDate, "", 5, 1e6, noDeadline)
+	status, err = db.GetTSDBStatus(noDeadlineContext, nil, accountID, projectID, []*TagFilters{tfs}, tsdbStatusDate, "", 5, 1e6)
 	if err != nil {
 		t.Fatalf("error in GetTSDBStatus: %s", err)
 	}
@@ -2207,7 +2207,7 @@ func testIndexDBGetTSDBStatus(t *testing.T, disablePerDayIndex bool) {
 	if err := tfs.Add([]byte("day"), []byte("0"), false, false); err != nil {
 		t.Fatalf("cannot add filter: %s", err)
 	}
-	status, err = db.GetTSDBStatus(nil, accountID, projectID, []*TagFilters{tfs}, tsdbStatusDate, "", 5, 1e6, noDeadline)
+	status, err = db.GetTSDBStatus(noDeadlineContext, nil, accountID, projectID, []*TagFilters{tfs}, tsdbStatusDate, "", 5, 1e6)
 	if err != nil {
 		t.Fatalf("error in GetTSDBStatus: %s", err)
 	}
@@ -2249,7 +2249,7 @@ func testIndexDBGetTSDBStatus(t *testing.T, disablePerDayIndex bool) {
 	if err := tfs.Add([]byte("UniqueId"), []byte("0|1|3"), false, true); err != nil {
 		t.Fatalf("cannot add filter: %s", err)
 	}
-	status, err = db.GetTSDBStatus(nil, accountID, projectID, []*TagFilters{tfs}, tsdbStatusDate, "", 5, 1e6, noDeadline)
+	status, err = db.GetTSDBStatus(noDeadlineContext, nil, accountID, projectID, []*TagFilters{tfs}, tsdbStatusDate, "", 5, 1e6)
 	if err != nil {
 		t.Fatalf("error in GetTSDBStatus: %s", err)
 	}

--- a/lib/storage/index_db_timing_test.go
+++ b/lib/storage/index_db_timing_test.go
@@ -144,8 +144,8 @@ func BenchmarkHeadPostingForMatchers(b *testing.B) {
 		// index instead of per-day index.
 		tr := globalIndexTimeRange
 		for range b.N {
-			is := db.getIndexSearch(tfs.accountID, tfs.projectID, noDeadline)
-			metricIDs, err := is.searchMetricIDs(nil, tfss, tr, 2e9)
+			is := db.getIndexSearch(tfs.accountID, tfs.projectID)
+			metricIDs, err := is.searchMetricIDs(noDeadlineContext, nil, tfss, tr, 2e9)
 			db.putIndexSearch(is)
 			if err != nil {
 				b.Fatalf("unexpected error in searchMetricIDs: %s", err)
@@ -311,7 +311,7 @@ func BenchmarkIndexDBGetTSIDs(b *testing.B) {
 		mnLocal.CopyFrom(&mn)
 		mnLocal.sortTags()
 		for pb.Next() {
-			is := db.getIndexSearch(0, 0, noDeadline)
+			is := db.getIndexSearch(0, 0)
 			for i := range recordsPerLoop {
 				mnLocal.AccountID = uint32(i % accountsCount)
 				mnLocal.ProjectID = uint32(i % projectsCount)

--- a/lib/storage/search.go
+++ b/lib/storage/search.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"strings"
@@ -145,9 +146,6 @@ type Search struct {
 	// tfss contains tag filters used in the search.
 	tfss []*TagFilters
 
-	// deadline in unix timestamp seconds for the current search.
-	deadline uint64
-
 	err error
 
 	needClosing bool
@@ -172,7 +170,6 @@ func (s *Search) reset() {
 	s.ts.reset()
 	s.tr = TimeRange{}
 	s.tfss = nil
-	s.deadline = 0
 	s.err = nil
 	s.needClosing = false
 	s.loops = 0
@@ -186,7 +183,7 @@ func (s *Search) reset() {
 // MustClose must be called when the search is done.
 //
 // Init returns the upper bound on the number of found time series.
-func (s *Search) Init(qt *querytracer.Tracer, storage *Storage, tfss []*TagFilters, tr TimeRange, maxMetrics int, deadline uint64) int {
+func (s *Search) Init(ctx context.Context, qt *querytracer.Tracer, storage *Storage, tfss []*TagFilters, tr TimeRange, maxMetrics int) int {
 	qt = qt.NewChild("init series search: filters=%s, timeRange=%s, maxMetrics=%d", tfss, &tr, maxMetrics)
 	defer qt.Done()
 
@@ -201,10 +198,9 @@ func (s *Search) Init(qt *querytracer.Tracer, storage *Storage, tfss []*TagFilte
 	s.metricsTracker = storage.metricsTracker
 	s.tr = tr
 	s.tfss = tfss
-	s.deadline = deadline
 	s.needClosing = true
 
-	tsids, err := storage.SearchTSIDs(qt, tfss, tr, maxMetrics, deadline)
+	tsids, err := storage.SearchTSIDs(ctx, qt, tfss, tr, maxMetrics)
 
 	// It is ok to call Init on non-nil err.
 	// Init must be called before returning because it will fail
@@ -237,14 +233,14 @@ func (s *Search) Error() error {
 }
 
 // NextMetricBlock proceeds to the next MetricBlockRef.
-func (s *Search) NextMetricBlock() bool {
+func (s *Search) NextMetricBlock(ctx context.Context) bool {
 	if s.err != nil {
 		return false
 	}
 	for s.ts.NextBlock() {
 		if s.loops&paceLimiterSlowIterationsMask == 0 {
-			if err := checkSearchDeadlineAndPace(s.deadline); err != nil {
-				s.err = err
+			if isContextDone(ctx) {
+				s.err = ctx.Err()
 				return false
 			}
 		}
@@ -580,15 +576,19 @@ func (sq *SearchQuery) Unmarshal(src []byte) ([]byte, error) {
 	return src, nil
 }
 
-func checkSearchDeadlineAndPace(deadline uint64) error {
-	if fasttime.UnixTimestamp() > deadline {
-		return ErrDeadlineExceeded
-	}
-	return nil
-}
-
 const (
 	paceLimiterFastIterationsMask   = 1<<16 - 1
 	paceLimiterMediumIterationsMask = 1<<14 - 1
 	paceLimiterSlowIterationsMask   = 1<<12 - 1
 )
+
+var noDeadlineContext = context.Background()
+
+func isContextDone(ctx context.Context) bool {
+	select {
+	case <-ctx.Done():
+		return true
+	default:
+	}
+	return false
+}

--- a/lib/storage/search_test.go
+++ b/lib/storage/search_test.go
@@ -312,10 +312,10 @@ func testAssertSearchResult(st *Storage, tr TimeRange, tfs *TagFilters, want []M
 	}
 
 	var s Search
-	s.Init(nil, st, []*TagFilters{tfs}, tr, 1e5, noDeadline)
+	s.Init(noDeadlineContext, nil, st, []*TagFilters{tfs}, tr, 1e5)
 	defer s.MustClose()
 	var mbs []metricBlock
-	for s.NextMetricBlock() {
+	for s.NextMetricBlock(noDeadlineContext) {
 		var b Block
 		s.MetricBlockRef.BlockRef.MustReadBlock(&b)
 

--- a/lib/storage/search_timing_test.go
+++ b/lib/storage/search_timing_test.go
@@ -28,8 +28,8 @@ func benchmarkSearchData(b *testing.B, s *Storage, tr TimeRange, mrs []MetricRow
 	for b.Loop() {
 		mbs = mbs[:0]
 		var search Search
-		search.Init(nil, s, []*TagFilters{tfss}, tr, 1e9, noDeadline)
-		for search.NextMetricBlock() {
+		search.Init(noDeadlineContext, nil, s, []*TagFilters{tfss}, tr, 1e9)
+		for search.NextMetricBlock(noDeadlineContext) {
 			var (
 				block Block
 				mb    metricBlock

--- a/lib/storage/storage.go
+++ b/lib/storage/storage.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -1346,7 +1347,7 @@ func (s *Storage) checkTimeRange(tr TimeRange) error {
 //
 // The method will fail if the number of found TSIDs exceeds maxMetrics or the
 // search has not completed within the specified deadline.
-func (s *Storage) SearchTSIDs(qt *querytracer.Tracer, tfss []*TagFilters, tr TimeRange, maxMetrics int, deadline uint64) ([]TSID, error) {
+func (s *Storage) SearchTSIDs(ctx context.Context, qt *querytracer.Tracer, tfss []*TagFilters, tr TimeRange, maxMetrics int) ([]TSID, error) {
 	qt = qt.NewChild("search TSIDs: filters=%s, timeRange=%s, maxMetrics=%d", tfss, &tr, maxMetrics)
 	defer qt.Done()
 	if len(tfss) == 0 {
@@ -1358,7 +1359,7 @@ func (s *Storage) SearchTSIDs(qt *querytracer.Tracer, tfss []*TagFilters, tr Tim
 	}
 
 	search := func(qt *querytracer.Tracer, idb *indexDB, tr TimeRange) ([]TSID, error) {
-		return idb.SearchTSIDs(qt, tfss, tr, maxMetrics, deadline)
+		return idb.SearchTSIDs(ctx, qt, tfss, tr, maxMetrics)
 	}
 
 	merge := func(data [][]TSID) []TSID {
@@ -1390,13 +1391,13 @@ func (s *Storage) SearchTSIDs(qt *querytracer.Tracer, tfss []*TagFilters, tr Tim
 //
 // The marshaled metric names must be unmarshaled via
 // MetricName.UnmarshalString().
-func (s *Storage) SearchMetricNames(qt *querytracer.Tracer, tfss []*TagFilters, tr TimeRange, maxMetrics int, deadline uint64) ([]string, error) {
+func (s *Storage) SearchMetricNames(ctx context.Context, qt *querytracer.Tracer, tfss []*TagFilters, tr TimeRange, maxMetrics int) ([]string, error) {
 	qt = qt.NewChild("search metric names: filters=%s, timeRange=%s, maxMetrics: %d", tfss, &tr, maxMetrics)
 	if err := s.checkTimeRange(tr); err != nil {
 		return nil, err
 	}
 	search := func(qt *querytracer.Tracer, idb *indexDB, tr TimeRange) ([]string, error) {
-		return idb.SearchMetricNames(qt, tfss, tr, maxMetrics, deadline)
+		return idb.SearchMetricNames(ctx, qt, tfss, tr, maxMetrics)
 	}
 
 	merge := func(data [][]string) []string {
@@ -1437,7 +1438,7 @@ var ErrDeadlineExceeded = fmt.Errorf("deadline exceeded")
 //
 // If legacy indexDBs are present, the method will also delete the metricIDs
 // from them.
-func (s *Storage) DeleteSeries(qt *querytracer.Tracer, tfss []*TagFilters, maxMetrics int) (int, error) {
+func (s *Storage) DeleteSeries(ctx context.Context, qt *querytracer.Tracer, tfss []*TagFilters, maxMetrics int) (int, error) {
 	qt = qt.NewChild("delete series: filters=%s, maxMetrics=%d", tfss, maxMetrics)
 	defer qt.Done()
 
@@ -1448,7 +1449,7 @@ func (s *Storage) DeleteSeries(qt *querytracer.Tracer, tfss []*TagFilters, maxMe
 	// Not deleting in parallel because the deletion operation is rare.
 
 	all := &uint64set.Set{}
-	legacyDMIs, err := s.legacyDeleteSeries(qt, tfss, maxMetrics)
+	legacyDMIs, err := s.legacyDeleteSeries(ctx, qt, tfss, maxMetrics)
 	if err != nil {
 		return 0, err
 	}
@@ -1463,7 +1464,7 @@ func (s *Storage) DeleteSeries(qt *querytracer.Tracer, tfss []*TagFilters, maxMe
 		if legacyDMIs.Len() > 0 {
 			idb.updateDeletedMetricIDs(legacyDMIs)
 		}
-		dmis, err := idb.DeleteSeries(qt, tfss, maxMetrics)
+		dmis, err := idb.DeleteSeries(ctx, qt, tfss, maxMetrics)
 		if err != nil {
 			return 0, err
 		}
@@ -1478,12 +1479,12 @@ func (s *Storage) DeleteSeries(qt *querytracer.Tracer, tfss []*TagFilters, maxMe
 }
 
 // SearchLabelNames searches for label names matching the given tfss on tr.
-func (s *Storage) SearchLabelNames(qt *querytracer.Tracer, accountID, projectID uint32, tfss []*TagFilters, tr TimeRange, maxLabelNames, maxMetrics int, deadline uint64) ([]string, error) {
+func (s *Storage) SearchLabelNames(ctx context.Context, qt *querytracer.Tracer, accountID, projectID uint32, tfss []*TagFilters, tr TimeRange, maxLabelNames, maxMetrics int) ([]string, error) {
 	qt = qt.NewChild("search for label names: filters=%s, timeRange=%s, maxLabelNames=%d, maxMetrics=%d", tfss, &tr, maxLabelNames, maxMetrics)
 	defer qt.Done()
 
 	search := func(qt *querytracer.Tracer, idb *indexDB, tr TimeRange) (map[string]struct{}, error) {
-		return idb.SearchLabelNames(qt, accountID, projectID, tfss, tr, maxLabelNames, maxMetrics, deadline)
+		return idb.SearchLabelNames(ctx, qt, accountID, projectID, tfss, tr, maxLabelNames, maxMetrics)
 	}
 	res, err := searchAndMergeUniq(qt, s, tr, search, maxLabelNames)
 	if err != nil {
@@ -1494,12 +1495,12 @@ func (s *Storage) SearchLabelNames(qt *querytracer.Tracer, accountID, projectID 
 }
 
 // SearchLabelValues searches for label values for the given labelName, filters and tr.
-func (s *Storage) SearchLabelValues(qt *querytracer.Tracer, accountID, projectID uint32, labelName string, tfss []*TagFilters, tr TimeRange, maxLabelValues, maxMetrics int, deadline uint64) ([]string, error) {
+func (s *Storage) SearchLabelValues(ctx context.Context, qt *querytracer.Tracer, accountID, projectID uint32, labelName string, tfss []*TagFilters, tr TimeRange, maxLabelValues, maxMetrics int) ([]string, error) {
 	qt = qt.NewChild("search for label values: labelName=%q, filters=%s, timeRange=%s, maxLabelNames=%d, maxMetrics=%d", labelName, tfss, &tr, maxLabelValues, maxMetrics)
 	defer qt.Done()
 
 	search := func(qt *querytracer.Tracer, idb *indexDB, tr TimeRange) (map[string]struct{}, error) {
-		return idb.SearchLabelValues(qt, accountID, projectID, labelName, tfss, tr, maxLabelValues, maxMetrics, deadline)
+		return idb.SearchLabelValues(ctx, qt, accountID, projectID, labelName, tfss, tr, maxLabelValues, maxMetrics)
 	}
 	res, err := searchAndMergeUniq(qt, s, tr, search, maxLabelValues)
 	if err != nil {
@@ -1518,9 +1519,9 @@ func (s *Storage) SearchLabelValues(qt *querytracer.Tracer, accountID, projectID
 //
 // If more than maxTagValueSuffixes suffixes is found, then only the first
 // maxTagValueSuffixes suffixes is returned.
-func (s *Storage) SearchTagValueSuffixes(qt *querytracer.Tracer, accountID, projectID uint32, tr TimeRange, tagKey, tagValuePrefix string, delimiter byte, maxTagValueSuffixes int, deadline uint64) ([]string, error) {
+func (s *Storage) SearchTagValueSuffixes(ctx context.Context, qt *querytracer.Tracer, accountID, projectID uint32, tr TimeRange, tagKey, tagValuePrefix string, delimiter byte, maxTagValueSuffixes int) ([]string, error) {
 	search := func(qt *querytracer.Tracer, idb *indexDB, tr TimeRange) (map[string]struct{}, error) {
-		return idb.SearchTagValueSuffixes(qt, accountID, projectID, tr, tagKey, tagValuePrefix, delimiter, maxTagValueSuffixes, deadline)
+		return idb.SearchTagValueSuffixes(ctx, qt, accountID, projectID, tr, tagKey, tagValuePrefix, delimiter, maxTagValueSuffixes)
 	}
 	res, err := searchAndMergeUniq(qt, s, tr, search, maxTagValueSuffixes)
 	if err != nil {
@@ -1532,10 +1533,10 @@ func (s *Storage) SearchTagValueSuffixes(qt *querytracer.Tracer, accountID, proj
 
 // SearchGraphitePaths returns all the matching paths for the given graphite
 // query on the given tr.
-func (s *Storage) SearchGraphitePaths(qt *querytracer.Tracer, accountID, projectID uint32, tr TimeRange, query []byte, maxPaths int, deadline uint64) ([]string, error) {
+func (s *Storage) SearchGraphitePaths(ctx context.Context, qt *querytracer.Tracer, accountID, projectID uint32, tr TimeRange, query []byte, maxPaths int) ([]string, error) {
 	query = replaceAlternateRegexpsWithGraphiteWildcards(query)
 	search := func(qt *querytracer.Tracer, idb *indexDB, tr TimeRange) (map[string]struct{}, error) {
-		return idb.SearchGraphitePaths(qt, accountID, projectID, tr, nil, query, maxPaths, deadline)
+		return idb.SearchGraphitePaths(ctx, qt, accountID, projectID, tr, nil, query, maxPaths)
 	}
 
 	res, err := searchAndMergeUniq(qt, s, tr, search, maxPaths)
@@ -1593,13 +1594,13 @@ func replaceAlternateRegexpsWithGraphiteWildcards(b []byte) []byte {
 // more than one indexDB.
 //
 // It also includes the deleted series.
-func (s *Storage) GetSeriesCount(accountID, projectID uint32, deadline uint64) (uint64, error) {
+func (s *Storage) GetSeriesCount(ctx context.Context, accountID, projectID uint32) (uint64, error) {
 	tr := TimeRange{
 		MinTimestamp: 0,
 		MaxTimestamp: time.Now().UnixMilli(),
 	}
 	search := func(_ *querytracer.Tracer, idb *indexDB, _ TimeRange) (uint64, error) {
-		return idb.GetSeriesCount(accountID, projectID, deadline)
+		return idb.GetSeriesCount(ctx, accountID, projectID)
 	}
 	merge := func(data []uint64) uint64 {
 		var total uint64
@@ -1612,12 +1613,12 @@ func (s *Storage) GetSeriesCount(accountID, projectID uint32, deadline uint64) (
 }
 
 // SearchTenants returns list of registered tenants on the given tr.
-func (s *Storage) SearchTenants(qt *querytracer.Tracer, tr TimeRange, deadline uint64) ([]string, error) {
+func (s *Storage) SearchTenants(ctx context.Context, qt *querytracer.Tracer, tr TimeRange) ([]string, error) {
 	qt = qt.NewChild("search for tenants: timeRange=%s", &tr)
 	defer qt.Done()
 
 	search := func(qt *querytracer.Tracer, idb *indexDB, tr TimeRange) (map[string]struct{}, error) {
-		return idb.SearchTenants(qt, tr, deadline)
+		return idb.SearchTenants(ctx, qt, tr)
 	}
 	res, err := searchAndMergeUniq(qt, s, tr, search, math.MaxInt)
 	if err != nil {
@@ -1632,7 +1633,7 @@ func (s *Storage) SearchTenants(qt *querytracer.Tracer, tr TimeRange, deadline u
 // The method does not provide status for legacy IDBs because merging partition
 // indexDB and legacy indexDB statuses is non-trivial and not many users use
 // this status for historical data.
-func (s *Storage) GetTSDBStatus(qt *querytracer.Tracer, accountID, projectID uint32, tfss []*TagFilters, date uint64, focusLabel string, topN, maxMetrics int, deadline uint64) (*TSDBStatus, error) {
+func (s *Storage) GetTSDBStatus(ctx context.Context, qt *querytracer.Tracer, accountID, projectID uint32, tfss []*TagFilters, date uint64, focusLabel string, topN, maxMetrics int) (*TSDBStatus, error) {
 	qt = qt.NewChild("collect TSDB status: filters=%s, date=%s, focusLabel=%q, topN=%d, maxMetrics=%d", tfss, dateToString(date), focusLabel, topN, maxMetrics)
 	defer qt.Done()
 
@@ -1659,7 +1660,7 @@ func (s *Storage) GetTSDBStatus(qt *querytracer.Tracer, accountID, projectID uin
 	)
 	idbName := ptw.pt.idb.name
 	qt.Printf("collect TSDB status in indexDB %s", idbName)
-	res, err = ptw.pt.idb.GetTSDBStatus(qt, accountID, projectID, tfss, date, focusLabel, topN, maxMetrics, deadline)
+	res, err = ptw.pt.idb.GetTSDBStatus(ctx, qt, accountID, projectID, tfss, date, focusLabel, topN, maxMetrics)
 	if err != nil {
 		return nil, err
 	}
@@ -1670,7 +1671,7 @@ func (s *Storage) GetTSDBStatus(qt *querytracer.Tracer, accountID, projectID uin
 		// fallback to the legacy indexDBs search
 		// since after migration monthly partition may not have stats for time range covered
 		// by partition index.
-		res, err = s.legacyGetTSDBStatus(qt, accountID, projectID, tfss, date, focusLabel, topN, maxMetrics, deadline)
+		res, err = s.legacyGetTSDBStatus(ctx, qt, accountID, projectID, tfss, date, focusLabel, topN, maxMetrics)
 		if err != nil {
 			return nil, err
 		}
@@ -1933,7 +1934,7 @@ func (s *Storage) RegisterMetricNames(qt *querytracer.Tracer, mrs []MetricRow) {
 			}
 			ptw = s.tb.MustGetPartition(mr.Timestamp)
 			idb = ptw.pt.idb
-			is = idb.getIndexSearch(0, 0, noDeadline)
+			is = idb.getIndexSearch(0, 0)
 			deletedMetricIDs = idb.getDeletedMetricIDs()
 		}
 
@@ -2107,7 +2108,7 @@ func (s *Storage) add(rows []rawRow, dstMrs []*MetricRow, mrs []MetricRow, preci
 			}
 			ptw = s.tb.MustGetPartition(r.Timestamp)
 			idb = ptw.pt.idb
-			is = idb.getIndexSearch(0, 0, noDeadline)
+			is = idb.getIndexSearch(0, 0)
 			deletedMetricIDs = idb.getDeletedMetricIDs()
 		}
 
@@ -2349,7 +2350,7 @@ func (s *Storage) prefillNextIndexDB(rows []rawRow, mrs []*MetricRow) error {
 	ptwNext := s.tb.MustGetPartition(nextMonth.UnixMilli())
 	idbNext := ptwNext.pt.idb
 	defer s.tb.PutPartition(ptwNext)
-	isNext := idbNext.getIndexSearch(0, 0, noDeadline)
+	isNext := idbNext.getIndexSearch(0, 0)
 	defer idbNext.putIndexSearch(isNext)
 
 	var firstError error
@@ -2579,7 +2580,7 @@ func (s *Storage) updatePerDateData(rows []rawRow, mrs []*MetricRow, hmPrev, hmC
 			}
 			ptw = s.tb.MustGetPartition(timestamp)
 			idb = ptw.pt.idb
-			is = idb.getIndexSearch(0, 0, noDeadline)
+			is = idb.getIndexSearch(0, 0)
 		}
 
 		if !is.hasDateMetricID(date, metricID, dmid.tsid.AccountID, dmid.tsid.ProjectID) {
@@ -2834,7 +2835,7 @@ func (s *Storage) wasMetricIDMissingBefore(metricID uint64) bool {
 }
 
 // GetMetricNamesStats returns metric names usage stats with give limit and lte predicate
-func (s *Storage) GetMetricNamesStats(_ *querytracer.Tracer, tt *TenantToken, limit, le int, matchPattern string) metricnamestats.StatsResult {
+func (s *Storage) GetMetricNamesStats(_ context.Context, _ *querytracer.Tracer, tt *TenantToken, limit, le int, matchPattern string) metricnamestats.StatsResult {
 	if tt != nil {
 		return s.metricsTracker.GetStatsForTenant(tt.AccountID, tt.ProjectID, limit, le, matchPattern)
 	}
@@ -2849,7 +2850,7 @@ func (s *Storage) ResetMetricNamesStats(_ *querytracer.Tracer) {
 }
 
 // GetMetadataRows returns time series metric names metadata for the given args
-func (s *Storage) GetMetadataRows(qt *querytracer.Tracer, tt *TenantToken, limit int, metricName string, _ uint64) ([]*metricsmetadata.Row, error) {
+func (s *Storage) GetMetadataRows(_ context.Context, qt *querytracer.Tracer, tt *TenantToken, limit int, metricName string) ([]*metricsmetadata.Row, error) {
 	var (
 		res []*metricsmetadata.Row
 	)

--- a/lib/storage/storage.go
+++ b/lib/storage/storage.go
@@ -1425,9 +1425,6 @@ func (s *Storage) SearchMetricNames(ctx context.Context, qt *querytracer.Tracer,
 	return res, nil
 }
 
-// ErrDeadlineExceeded is returned when the request times out.
-var ErrDeadlineExceeded = fmt.Errorf("deadline exceeded")
-
 // DeleteSeries marks as deleted all series matching the given tfss and
 // resets caches where the corresponding TSIDs and MetricIDs may be stored if
 // needed.

--- a/lib/storage/storage_legacy.go
+++ b/lib/storage/storage_legacy.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"context"
 	"path/filepath"
 	"regexp"
 	"slices"
@@ -276,7 +277,7 @@ func (s *Storage) legacyMustRotateIndexDB(currentTime time.Time) {
 	s.legacyNextRotationTimestamp.Store(nextRotationTimestamp)
 }
 
-func (s *Storage) legacyDeleteSeries(qt *querytracer.Tracer, tfss []*TagFilters, maxMetrics int) (*uint64set.Set, error) {
+func (s *Storage) legacyDeleteSeries(ctx context.Context, qt *querytracer.Tracer, tfss []*TagFilters, maxMetrics int) (*uint64set.Set, error) {
 	legacyIDBs := s.getLegacyIndexDBs()
 	defer s.putLegacyIndexDBs(legacyIDBs)
 
@@ -289,7 +290,7 @@ func (s *Storage) legacyDeleteSeries(qt *querytracer.Tracer, tfss []*TagFilters,
 
 	if idbPrev := legacyIDBs.getIDBPrev(); idbPrev != nil {
 		qt.Printf("start deleting from previous legacy indexDB")
-		dmis, err := idbPrev.DeleteSeries(qt, tfss, maxMetrics)
+		dmis, err := idbPrev.DeleteSeries(ctx, qt, tfss, maxMetrics)
 		if err != nil {
 			return nil, err
 		}
@@ -299,7 +300,7 @@ func (s *Storage) legacyDeleteSeries(qt *querytracer.Tracer, tfss []*TagFilters,
 
 	if idbCurr := legacyIDBs.getIDBCurr(); idbCurr != nil {
 		qt.Printf("start deleting from current legacy indexDB")
-		dmis, err := idbCurr.DeleteSeries(qt, tfss, maxMetrics)
+		dmis, err := idbCurr.DeleteSeries(ctx, qt, tfss, maxMetrics)
 		if err != nil {
 			return nil, err
 		}
@@ -372,14 +373,14 @@ func (s *Storage) legacyMustCloseIndexDBs() {
 	}
 }
 
-func (s *Storage) legacyGetTSDBStatus(qt *querytracer.Tracer, accountID, projectID uint32, tfss []*TagFilters, date uint64, focusLabel string, topN, maxMetrics int, deadline uint64) (*TSDBStatus, error) {
+func (s *Storage) legacyGetTSDBStatus(ctx context.Context, qt *querytracer.Tracer, accountID, projectID uint32, tfss []*TagFilters, date uint64, focusLabel string, topN, maxMetrics int) (*TSDBStatus, error) {
 	legacyIDBs := s.getLegacyIndexDBs()
 	defer s.putLegacyIndexDBs(legacyIDBs)
 
 	if legacyIDBs.getIDBCurr() != nil {
 		idbName := legacyIDBs.getIDBCurr().name
 		qt.Printf("collect TSDB status in current legacy indexDB %s", idbName)
-		res, err := legacyIDBs.getIDBCurr().GetTSDBStatus(qt, accountID, projectID, tfss, date, focusLabel, topN, maxMetrics, deadline)
+		res, err := legacyIDBs.getIDBCurr().GetTSDBStatus(ctx, qt, accountID, projectID, tfss, date, focusLabel, topN, maxMetrics)
 		if err != nil {
 			return nil, err
 		}
@@ -394,7 +395,7 @@ func (s *Storage) legacyGetTSDBStatus(qt *querytracer.Tracer, accountID, project
 	if legacyIDBs.getIDBPrev() != nil {
 		idbName := legacyIDBs.getIDBPrev().name
 		qt.Printf("collect TSDB status in previous legacy indexDB %s", idbName)
-		res, err := legacyIDBs.getIDBPrev().GetTSDBStatus(qt, accountID, projectID, tfss, date, focusLabel, topN, maxMetrics, deadline)
+		res, err := legacyIDBs.getIDBPrev().GetTSDBStatus(ctx, qt, accountID, projectID, tfss, date, focusLabel, topN, maxMetrics)
 		if err != nil {
 			return nil, err
 		}

--- a/lib/storage/storage_legacy_test.go
+++ b/lib/storage/storage_legacy_test.go
@@ -61,7 +61,7 @@ func TestLegacyStorage_SearchMetricNames(t *testing.T) {
 			t.Fatalf("unexpected error in TagFilters.Add: %v", err)
 		}
 		tfssAll := []*TagFilters{tfsAll}
-		got, err := s.SearchMetricNames(nil, tfssAll, tr, 1e9, noDeadline)
+		got, err := s.SearchMetricNames(noDeadlineContext, nil, tfssAll, tr, 1e9)
 		if err != nil {
 			t.Fatalf("SearchMetricNames() failed unexpectedly: %v", err)
 		}
@@ -131,7 +131,7 @@ func TestLegacyStorage_SearchLabelNames(t *testing.T) {
 
 	assertSearchResults := func(s *Storage, tr TimeRange, want []string) {
 		t.Helper()
-		got, err := s.SearchLabelNames(nil, accountID, projectID, nil, tr, 1e9, 1e9, noDeadline)
+		got, err := s.SearchLabelNames(noDeadlineContext, nil, accountID, projectID, nil, tr, 1e9, 1e9)
 		if err != nil {
 			t.Fatalf("SearchLabelNames() failed unexpectedly: %v", err)
 		}
@@ -201,7 +201,7 @@ func TestLegacyStorage_SearchLabelValues(t *testing.T) {
 
 	assertSearchResults := func(s *Storage, tr TimeRange, want []string) {
 		t.Helper()
-		got, err := s.SearchLabelValues(nil, accountID, projectID, "label", nil, tr, 1e9, 1e9, noDeadline)
+		got, err := s.SearchLabelValues(noDeadlineContext, nil, accountID, projectID, "label", nil, tr, 1e9, 1e9)
 		if err != nil {
 			t.Fatalf("SearchLabelValues() failed unexpectedly: %v", err)
 		}
@@ -263,7 +263,7 @@ func TestLegacyStorage_SearchTagValueSuffixes(t *testing.T) {
 
 	assertSearchResults := func(s *Storage, tr TimeRange, want []string) {
 		t.Helper()
-		got, err := s.SearchTagValueSuffixes(nil, accountID, projectID, tr, "", "prefix.", '.', 1e9, noDeadline)
+		got, err := s.SearchTagValueSuffixes(noDeadlineContext, nil, accountID, projectID, tr, "", "prefix.", '.', 1e9)
 		if err != nil {
 			t.Fatalf("SearchTagValueSuffixes() failed unexpectedly: %v", err)
 		}
@@ -326,7 +326,7 @@ func TestLegacyStorage_SearchGraphitePaths(t *testing.T) {
 
 	assertSearchResults := func(s *Storage, tr TimeRange, want []string) {
 		t.Helper()
-		got, err := s.SearchGraphitePaths(nil, accountID, projectID, tr, []byte("*.*"), 1e9, noDeadline)
+		got, err := s.SearchGraphitePaths(noDeadlineContext, nil, accountID, projectID, tr, []byte("*.*"), 1e9)
 		if err != nil {
 			t.Fatalf("SearchTagGraphitePaths() failed unexpectedly: %v", err)
 		}
@@ -423,7 +423,7 @@ func TestLegacyStorage_GetSeriesCount(t *testing.T) {
 
 	assertSearchResults := func(s *Storage, want uint64) {
 		t.Helper()
-		got, err := s.GetSeriesCount(accountID, projectID, noDeadline)
+		got, err := s.GetSeriesCount(noDeadlineContext, accountID, projectID)
 		if err != nil {
 			t.Fatalf("GetSeriesCount() failed unexpectedly: %v", err)
 		}
@@ -466,7 +466,7 @@ func TestLegacyStorage_DeleteSeries(t *testing.T) {
 
 	assertSeriesCount := func(s *Storage, want int) {
 		t.Helper()
-		got, err := s.SearchMetricNames(nil, tfssAll, tr, 1e9, noDeadline)
+		got, err := s.SearchMetricNames(noDeadlineContext, nil, tfssAll, tr, 1e9)
 		if err != nil {
 			t.Fatalf("SearchMetricNames() failed unexpectedly: %v", err)
 		}
@@ -485,7 +485,7 @@ func TestLegacyStorage_DeleteSeries(t *testing.T) {
 		want := len(legacyData) + len(newData)
 		assertSeriesCount(s, want)
 
-		got, err := s.DeleteSeries(nil, tfssAll, 1e9)
+		got, err := s.DeleteSeries(noDeadlineContext, nil, tfssAll, 1e9)
 		if err != nil {
 			t.Fatalf("DeleteSeries() failed unexpectedly: %v", err)
 		}
@@ -714,7 +714,7 @@ func TestStorageConvertToLegacy(t *testing.T) {
 		if err := tfs.Add([]byte("__name__"), []byte(".*"), false, true); err != nil {
 			t.Fatalf("unexpected error in TagFilters.Add: %v", err)
 		}
-		got, err := s.SearchMetricNames(nil, []*TagFilters{tfs}, tr, 1e9, noDeadline)
+		got, err := s.SearchMetricNames(noDeadlineContext, nil, []*TagFilters{tfs}, tr, 1e9)
 		if err != nil {
 			t.Fatalf("SearchMetricNames() failed unexpectedly: %v", err)
 		}
@@ -849,7 +849,7 @@ func mustConvertToLegacy(s *Storage, accountID, projectID uint32) *Storage {
 				MaxTimestamp: ts + msecPerDay - 1,
 			}
 			date := uint64(ts / msecPerDay)
-			tsids, err := idb.SearchTSIDs(nil, tfssAll, day, 1e9, noDeadline)
+			tsids, err := idb.SearchTSIDs(noDeadlineContext, nil, tfssAll, day, 1e9)
 			if err != nil {
 				panic(fmt.Sprintf("could not get TSIDs: %v", err))
 			}
@@ -877,7 +877,7 @@ func mustConvertToLegacy(s *Storage, accountID, projectID uint32) *Storage {
 				}
 			}
 		}
-		is := idb.getIndexSearch(accountID, projectID, noDeadline)
+		is := idb.getIndexSearch(accountID, projectID)
 		dmis, err := is.loadDeletedMetricIDs()
 		idb.putIndexSearch(is)
 		if err != nil {
@@ -1045,7 +1045,7 @@ func TestLegacyStorageRotateIndexDB_DeleteSeries(t *testing.T) {
 		t.Fatalf("unexpected error in TagFilters.Add: %v", err)
 	}
 	op := func(s *Storage) {
-		_, err := s.DeleteSeries(nil, []*TagFilters{tfs}, 1e9)
+		_, err := s.DeleteSeries(noDeadlineContext, nil, []*TagFilters{tfs}, 1e9)
 		if err != nil {
 			panic(fmt.Sprintf("DeleteSeries() failed unexpectedly: %v", err))
 		}
@@ -1087,7 +1087,7 @@ func TestLegacyStorageRotateIndexDB_SearchMetricNames(t *testing.T) {
 	}
 	tfss := []*TagFilters{tfs}
 	op := func(s *Storage) {
-		_, err := s.SearchMetricNames(nil, tfss, tr, 1e9, noDeadline)
+		_, err := s.SearchMetricNames(noDeadlineContext, nil, tfss, tr, 1e9)
 		if err != nil {
 			panic(fmt.Sprintf("SearchMetricNames() failed unexpectedly: %v", err))
 		}
@@ -1109,7 +1109,7 @@ func TestLegacyStorageRotateIndexDB_SearchLabelNames(t *testing.T) {
 	mrs := testGenerateMetricRowsWithPrefixForTenantID(rng, accountID, projectID, 1000, "metric", tr)
 
 	testLegacyRotateIndexDB(t, accountID, projectID, mrs, func(s *Storage) {
-		_, err := s.SearchLabelNames(nil, accountID, projectID, []*TagFilters{}, tr, 1e6, 1e6, noDeadline)
+		_, err := s.SearchLabelNames(noDeadlineContext, nil, accountID, projectID, []*TagFilters{}, tr, 1e6, 1e6)
 		if err != nil {
 			panic(fmt.Sprintf("SearchLabelNames() failed unexpectedly: %v", err))
 		}
@@ -1129,7 +1129,7 @@ func TestLegacyStorageRotateIndexDB_SearchLabelValues(t *testing.T) {
 	mrs := testGenerateMetricRowsWithPrefixForTenantID(rng, accountID, projectID, 1000, "metric", tr)
 
 	testLegacyRotateIndexDB(t, accountID, projectID, mrs, func(s *Storage) {
-		_, err := s.SearchLabelValues(nil, accountID, projectID, "__name__", []*TagFilters{}, tr, 1e6, 1e6, noDeadline)
+		_, err := s.SearchLabelValues(noDeadlineContext, nil, accountID, projectID, "__name__", []*TagFilters{}, tr, 1e6, 1e6)
 		if err != nil {
 			panic(fmt.Sprintf("SearchLabelValues() failed unexpectedly: %v", err))
 		}
@@ -1149,7 +1149,7 @@ func TestLegacyStorageRotateIndexDB_SearchTagValueSuffixes(t *testing.T) {
 	mrs := testGenerateMetricRowsWithPrefixForTenantID(rng, accountID, projectID, 1000, "metric.", tr)
 
 	testLegacyRotateIndexDB(t, accountID, projectID, mrs, func(s *Storage) {
-		_, err := s.SearchTagValueSuffixes(nil, accountID, projectID, tr, "", "metric.", '.', 1e6, noDeadline)
+		_, err := s.SearchTagValueSuffixes(noDeadlineContext, nil, accountID, projectID, tr, "", "metric.", '.', 1e6)
 		if err != nil {
 			panic(fmt.Sprintf("SearchTagValueSuffixes() failed unexpectedly: %v", err))
 		}
@@ -1169,7 +1169,7 @@ func TestLegacyStorageRotateIndexDB_SearchGraphitePaths(t *testing.T) {
 	mrs := testGenerateMetricRowsWithPrefixForTenantID(rng, accountID, projectID, 1000, "metric.", tr)
 
 	testLegacyRotateIndexDB(t, accountID, projectID, mrs, func(s *Storage) {
-		_, err := s.SearchGraphitePaths(nil, accountID, projectID, tr, []byte("*.*"), 1e6, noDeadline)
+		_, err := s.SearchGraphitePaths(noDeadlineContext, nil, accountID, projectID, tr, []byte("*.*"), 1e6)
 		if err != nil {
 			panic(fmt.Sprintf("SearchGraphitePaths() failed unexpectedly: %v", err))
 		}
@@ -1189,7 +1189,7 @@ func TestLegacyStorageRotateIndexDB_GetSeriesCount(t *testing.T) {
 	mrs := testGenerateMetricRowsWithPrefixForTenantID(rng, accountID, projectID, 1000, "metric", tr)
 
 	testLegacyRotateIndexDB(t, accountID, projectID, mrs, func(s *Storage) {
-		_, err := s.GetSeriesCount(accountID, projectID, noDeadline)
+		_, err := s.GetSeriesCount(noDeadlineContext, accountID, projectID)
 		if err != nil {
 			panic(fmt.Sprintf("GetSeriesCount() failed unexpectedly: %v", err))
 		}
@@ -1210,7 +1210,7 @@ func TestLegacyStorageRotateIndexDB_GetTSDBStatus(t *testing.T) {
 	date := uint64(tr.MinTimestamp) / msecPerDay
 
 	testLegacyRotateIndexDB(t, accountID, projectID, mrs, func(s *Storage) {
-		_, err := s.GetTSDBStatus(nil, accountID, projectID, nil, date, "", 10, 1e6, noDeadline)
+		_, err := s.GetTSDBStatus(noDeadlineContext, nil, accountID, projectID, nil, date, "", 10, 1e6)
 		if err != nil {
 			panic(fmt.Sprintf("GetTSDBStatus failed unexpectedly: %v", err))
 		}
@@ -1263,8 +1263,8 @@ func TestLegacyStorageRotateIndexDB_Search(t *testing.T) {
 
 	testLegacyRotateIndexDB(t, accountID, projectID, mrs, func(s *Storage) {
 		var search Search
-		search.Init(nil, s, tfss, tr, 1e5, noDeadline)
-		for search.NextMetricBlock() {
+		search.Init(noDeadlineContext, nil, s, tfss, tr, 1e5)
+		for search.NextMetricBlock(noDeadlineContext) {
 			var b Block
 			search.MetricBlockRef.BlockRef.MustReadBlock(&b)
 		}
@@ -1558,7 +1558,7 @@ func TestLegacyStorageGetTSDBStatus(t *testing.T) {
 
 	assertTSDBStatus := func(date uint64, want *TSDBStatus) {
 		t.Helper()
-		got, err := s.GetTSDBStatus(nil, accountID, projectID, nil, date, "", 10, 1e9, noDeadline)
+		got, err := s.GetTSDBStatus(noDeadlineContext, nil, accountID, projectID, nil, date, "", 10, 1e9)
 		if err != nil {
 			t.Fatalf("GetTSDBStatus failed unexpectedly: %v", err)
 		}

--- a/lib/storage/storage_synctest_test.go
+++ b/lib/storage/storage_synctest_test.go
@@ -65,14 +65,14 @@ func TestStorageSearchTSIDs_CorruptedIndex(t *testing.T) {
 		tfssAll := []*TagFilters{tfsAll}
 
 		searchMetricIDs := func() []uint64 {
-			metricIDs, err := idb.searchMetricIDs(nil, tfssAll, tr, 1e9, noDeadline)
+			metricIDs, err := idb.searchMetricIDs(noDeadlineContext, nil, tfssAll, tr, 1e9)
 			if err != nil {
 				panic(fmt.Sprintf("searchMetricIDs() failed unexpectedly: %v", err))
 			}
 			return metricIDs.AppendTo(nil)
 		}
 		searchTSIDs := func() []TSID {
-			tsids, err := s.SearchTSIDs(nil, tfssAll, tr, 1e9, noDeadline)
+			tsids, err := s.SearchTSIDs(noDeadlineContext, nil, tfssAll, tr, 1e9)
 			if err != nil {
 				panic(fmt.Sprintf("SearchTSIDs() failed unexpectedly: %v", err))
 			}
@@ -172,14 +172,14 @@ func TestStorageSearchMetricNames_CorruptedIndex(t *testing.T) {
 		tfssAll := []*TagFilters{tfsAll}
 
 		searchMetricIDs := func() []uint64 {
-			metricIDs, err := idb.searchMetricIDs(nil, tfssAll, tr, 1e9, noDeadline)
+			metricIDs, err := idb.searchMetricIDs(noDeadlineContext, nil, tfssAll, tr, 1e9)
 			if err != nil {
 				panic(fmt.Sprintf("searchMetricIDs() failed unexpectedly: %v", err))
 			}
 			return metricIDs.AppendTo(nil)
 		}
 		searchMetricNames := func() []string {
-			metricNames, err := s.SearchMetricNames(nil, tfssAll, tr, 1e9, noDeadline)
+			metricNames, err := s.SearchMetricNames(noDeadlineContext, nil, tfssAll, tr, 1e9)
 			if err != nil {
 				panic(fmt.Sprintf("SearchMetricNames() failed unexpectedly: %v", err))
 			}
@@ -1221,7 +1221,7 @@ func TestStorage_denyQueriesOutsideRetention(t *testing.T) {
 	}
 	assertMetricNames := func(t *testing.T, s *Storage, tr TimeRange, wantData []string, wantErr bool) {
 		t.Helper()
-		metricNames, err := s.SearchMetricNames(nil, tfssAll, tr, 1e9, noDeadline)
+		metricNames, err := s.SearchMetricNames(noDeadlineContext, nil, tfssAll, tr, 1e9)
 		gotErr := err != nil
 		if gotErr != wantErr {
 			t.Fatalf("SearchMetricNames(): unmet error expectation for timeRange=%v: got %t, want %t (err: %v)", &tr, gotErr, wantErr, err)
@@ -1240,7 +1240,7 @@ func TestStorage_denyQueriesOutsideRetention(t *testing.T) {
 	}
 	assertLabelNames := func(t *testing.T, s *Storage, tr TimeRange, wantData []string, wantErr bool) {
 		t.Helper()
-		gotData, err := s.SearchLabelNames(nil, accountID, projectID, nil, tr, 1e9, 1e9, noDeadline)
+		gotData, err := s.SearchLabelNames(noDeadlineContext, nil, accountID, projectID, nil, tr, 1e9, 1e9)
 		gotErr := err != nil
 		if gotErr != wantErr {
 			t.Fatalf("SearchLabelNames(): unmet error expectation for timeRange=%v: got %t, want %t (err: %v)", &tr, gotErr, wantErr, err)
@@ -1253,7 +1253,7 @@ func TestStorage_denyQueriesOutsideRetention(t *testing.T) {
 	}
 	assertLabelValues := func(t *testing.T, s *Storage, tr TimeRange, wantData []string, wantErr bool) {
 		t.Helper()
-		gotData, err := s.SearchLabelValues(nil, accountID, projectID, "__name__", nil, tr, 1e9, 1e9, noDeadline)
+		gotData, err := s.SearchLabelValues(noDeadlineContext, nil, accountID, projectID, "__name__", nil, tr, 1e9, 1e9)
 		gotErr := err != nil
 		if gotErr != wantErr {
 			t.Fatalf("SearchLabelValues(): unmet error expectation for timeRange=%v: got %t, want %t (err: %v)", &tr, gotErr, wantErr, err)
@@ -1266,7 +1266,7 @@ func TestStorage_denyQueriesOutsideRetention(t *testing.T) {
 	}
 	assertTagValueSuffixes := func(t *testing.T, s *Storage, tr TimeRange, wantData []string, wantErr bool) {
 		t.Helper()
-		gotData, err := s.SearchTagValueSuffixes(nil, accountID, projectID, tr, "", "", '.', 1e9, noDeadline)
+		gotData, err := s.SearchTagValueSuffixes(noDeadlineContext, nil, accountID, projectID, tr, "", "", '.', 1e9)
 		gotErr := err != nil
 		if gotErr != wantErr {
 			t.Fatalf("SearchTagValueSuffixes(): unmet error expectation for timeRange=%v: got %t, want %t (err: %v)", &tr, gotErr, wantErr, err)
@@ -1280,7 +1280,7 @@ func TestStorage_denyQueriesOutsideRetention(t *testing.T) {
 
 	assertGraphitePaths := func(t *testing.T, s *Storage, tr TimeRange, wantData []string, wantErr bool) {
 		t.Helper()
-		gotData, err := s.SearchGraphitePaths(nil, accountID, projectID, tr, []byte("*"), 1e9, noDeadline)
+		gotData, err := s.SearchGraphitePaths(noDeadlineContext, nil, accountID, projectID, tr, []byte("*"), 1e9)
 		gotErr := err != nil
 		if gotErr != wantErr {
 			t.Fatalf("SearchTagValueSuffixes(): unmet error expectation for timeRange=%v: got %t, want %t (err: %v)", &tr, gotErr, wantErr, err)

--- a/lib/storage/storage_test.go
+++ b/lib/storage/storage_test.go
@@ -539,7 +539,7 @@ func TestStorageDeletePendingSeries(t *testing.T) {
 	assertDeleteSeries := func(want int) {
 		t.Helper()
 
-		n, err := s.DeleteSeries(nil, []*TagFilters{tfs}, 1e5)
+		n, err := s.DeleteSeries(noDeadlineContext, nil, []*TagFilters{tfs}, 1e5)
 		if err != nil {
 			t.Fatalf("error in DeleteSeries: %s", err)
 		}
@@ -555,7 +555,7 @@ func TestStorageDeletePendingSeries(t *testing.T) {
 		ts := start
 		n := 0
 		for range numMonths {
-			lns, err := s.SearchLabelNames(nil, accountID, projectID, nil, TimeRange{ts.UnixMilli(), ts.UnixMilli()}, 1e5, 1e9, noDeadline)
+			lns, err := s.SearchLabelNames(noDeadlineContext, nil, accountID, projectID, nil, TimeRange{ts.UnixMilli(), ts.UnixMilli()}, 1e5, 1e9)
 			if err != nil {
 				t.Fatalf("error in SearchLabelNames: %s", err)
 				return
@@ -577,9 +577,9 @@ func TestStorageDeletePendingSeries(t *testing.T) {
 		var search Search
 		defer search.MustClose()
 
-		search.Init(nil, s, []*TagFilters{tfs}, TimeRange{start.UnixMilli(), math.MaxInt64}, 1e5, noDeadline)
+		search.Init(noDeadlineContext, nil, s, []*TagFilters{tfs}, TimeRange{start.UnixMilli(), math.MaxInt64}, 1e5)
 		n := 0
-		for search.NextMetricBlock() {
+		for search.NextMetricBlock(noDeadlineContext) {
 			var b Block
 			search.MetricBlockRef.BlockRef.MustReadBlock(&b)
 			n += b.RowsCount()
@@ -675,7 +675,7 @@ func testStorageDeleteSeriesForWorker(workerNum int, s *Storage, tr TimeRange) e
 	projectID := uint32(123)
 
 	// Verify no label names exist
-	lns, err := s.SearchLabelNames(nil, accountID, projectID, nil, TimeRange{}, 1e5, 1e9, noDeadline)
+	lns, err := s.SearchLabelNames(noDeadlineContext, nil, accountID, projectID, nil, TimeRange{}, 1e5, 1e9)
 	if err != nil {
 		return fmt.Errorf("error in SearchLabelNames() at the start: %w", err)
 	}
@@ -713,7 +713,7 @@ func testStorageDeleteSeriesForWorker(workerNum int, s *Storage, tr TimeRange) e
 	s.DebugFlush()
 
 	// Verify tag values exist
-	tvs, err := s.SearchLabelValues(nil, accountID, projectID, string(workerTag), nil, tr, 1e5, 1e9, noDeadline)
+	tvs, err := s.SearchLabelValues(noDeadlineContext, nil, accountID, projectID, string(workerTag), nil, tr, 1e5, 1e9)
 	if err != nil {
 		return fmt.Errorf("error in SearchLabelValues before metrics removal: %w", err)
 	}
@@ -722,7 +722,7 @@ func testStorageDeleteSeriesForWorker(workerNum int, s *Storage, tr TimeRange) e
 	}
 
 	// Verify tag keys exist
-	lns, err = s.SearchLabelNames(nil, accountID, projectID, nil, tr, 1e5, 1e9, noDeadline)
+	lns, err = s.SearchLabelNames(noDeadlineContext, nil, accountID, projectID, nil, tr, 1e5, 1e9)
 	if err != nil {
 		return fmt.Errorf("error in SearchLabelNames before metrics removal: %w", err)
 	}
@@ -732,10 +732,10 @@ func testStorageDeleteSeriesForWorker(workerNum int, s *Storage, tr TimeRange) e
 
 	countMetricBlocks := func(tfs *TagFilters) (int, error) {
 		var sr Search
-		sr.Init(nil, s, []*TagFilters{tfs}, tr, 1e5, noDeadline)
+		sr.Init(noDeadlineContext, nil, s, []*TagFilters{tfs}, tr, 1e5)
 		defer sr.MustClose()
 		n := 0
-		for sr.NextMetricBlock() {
+		for sr.NextMetricBlock(noDeadlineContext) {
 			n++
 		}
 		if err := sr.Error(); err != nil {
@@ -759,7 +759,7 @@ func testStorageDeleteSeriesForWorker(workerNum int, s *Storage, tr TimeRange) e
 		if n == 0 {
 			return fmt.Errorf("expecting non-zero number of metric blocks for tfs=%s", tfs)
 		}
-		deletedCount, err := s.DeleteSeries(nil, []*TagFilters{tfs}, 1e9)
+		deletedCount, err := s.DeleteSeries(noDeadlineContext, nil, []*TagFilters{tfs}, 1e9)
 		if err != nil {
 			return fmt.Errorf("cannot delete metrics: %w", err)
 		}
@@ -776,7 +776,7 @@ func testStorageDeleteSeriesForWorker(workerNum int, s *Storage, tr TimeRange) e
 		}
 
 		// Try deleting empty tfss
-		deletedCount, err = s.DeleteSeries(nil, nil, 1e9)
+		deletedCount, err = s.DeleteSeries(noDeadlineContext, nil, nil, 1e9)
 		if err != nil {
 			return fmt.Errorf("cannot delete empty tfss: %w", err)
 		}
@@ -798,14 +798,14 @@ func testStorageDeleteSeriesForWorker(workerNum int, s *Storage, tr TimeRange) e
 	if n != 0 {
 		return fmt.Errorf("expecting zero metric blocks after deleting all the metrics; got %d blocks", n)
 	}
-	tvs, err = s.SearchLabelValues(nil, accountID, projectID, string(workerTag), nil, tr, 1e5, 1e9, noDeadline)
+	tvs, err = s.SearchLabelValues(noDeadlineContext, nil, accountID, projectID, string(workerTag), nil, tr, 1e5, 1e9)
 	if err != nil {
 		return fmt.Errorf("error in SearchLabelValues after all the metrics are removed: %w", err)
 	}
 	if len(tvs) != 0 {
 		return fmt.Errorf("found non-empty tag values for %q after metrics removal: %q", workerTag, tvs)
 	}
-	lns, err = s.SearchLabelNames(nil, accountID, projectID, nil, TimeRange{}, 1e5, 1e9, noDeadline)
+	lns, err = s.SearchLabelNames(noDeadlineContext, nil, accountID, projectID, nil, TimeRange{}, 1e5, 1e9)
 	if err != nil {
 		return fmt.Errorf("error in SearchLabelNames after all the metrics are removed: %w", err)
 	}
@@ -869,7 +869,7 @@ func TestStorageDeleteSeries_EmptyFilters(t *testing.T) {
 		if err := tfs.Add([]byte("__name__"), []byte(".*"), false, true); err != nil {
 			t.Fatalf("unexpected error in TagFilters.Add: %v", err)
 		}
-		got, err := s.SearchMetricNames(nil, []*TagFilters{tfs}, tr, 1e9, noDeadline)
+		got, err := s.SearchMetricNames(noDeadlineContext, nil, []*TagFilters{tfs}, tr, 1e9)
 		if err != nil {
 			t.Fatalf("SearchMetricNames() failed unexpectedly: %v", err)
 		}
@@ -890,7 +890,7 @@ func TestStorageDeleteSeries_EmptyFilters(t *testing.T) {
 	// Confirm that metric names have been written to the index.
 	assertAllMetricNames(allMetricNames)
 
-	got, err := s.DeleteSeries(nil, []*TagFilters{}, 1e9)
+	got, err := s.DeleteSeries(noDeadlineContext, nil, []*TagFilters{}, 1e9)
 	if err != nil {
 		t.Fatalf("DeleteSeries() failed unexpectedly: %v", err)
 	}
@@ -929,7 +929,7 @@ func TestStorageDeleteSeries_TooManyTimeseries(t *testing.T) {
 		if err := tfs.Add(nil, []byte("metric.*"), false, true); err != nil {
 			t.Fatalf("unexpected error in TagFilters.Add: %v", err)
 		}
-		got, err := s.DeleteSeries(nil, []*TagFilters{tfs}, opts.maxMetrics)
+		got, err := s.DeleteSeries(noDeadlineContext, nil, []*TagFilters{tfs}, opts.maxMetrics)
 		if got := err != nil; got != opts.wantErr {
 			t.Errorf("unmet error expectation: got %t, want %t", got, opts.wantErr)
 		}
@@ -1042,7 +1042,7 @@ func TestStorageSearchTenantsOnDate(t *testing.T) {
 
 	f := func(tr TimeRange, want []string) {
 		t.Helper()
-		got, err := s.SearchTenants(nil, tr, noDeadline)
+		got, err := s.SearchTenants(noDeadlineContext, nil, tr)
 		if err != nil {
 			t.Fatalf("unexpected error in SearchTenants(%v): %s", tr, err)
 		}
@@ -1201,7 +1201,7 @@ func TestStorageDeleteSeries_CachesAreUpdatedOrReset(t *testing.T) {
 
 	searchMetricNames := func(tfss []*TagFilters, tr TimeRange, wantMetricCount int) {
 		t.Helper()
-		metrics, err := s.SearchMetricNames(nil, tfss, tr, 2, noDeadline)
+		metrics, err := s.SearchMetricNames(noDeadlineContext, nil, tfss, tr, 2)
 		if err != nil {
 			t.Fatalf("SearchMetricNames() failed unexpectedly: %v", err)
 		}
@@ -1413,7 +1413,7 @@ func TestStorageDeleteSeries_CachesAreUpdatedOrReset(t *testing.T) {
 
 	deleteSeries := func(tfss []*TagFilters, want int) {
 		t.Helper()
-		got, err := s.DeleteSeries(nil, tfss, 2)
+		got, err := s.DeleteSeries(noDeadlineContext, nil, tfss, 2)
 		if err != nil {
 			t.Fatalf("DeleteSeries() failed unexpectedly: %v", err)
 		}
@@ -1514,7 +1514,7 @@ func TestStorageDeleteSeriesFromPrevAndCurrIndexDB(t *testing.T) {
 		if err := tfs.Add(nil, []byte(".*"), false, true); err != nil {
 			t.Fatalf("unexpected error in TagFilters.Add: %v", err)
 		}
-		got, err := s.DeleteSeries(nil, []*TagFilters{tfs}, 1e9)
+		got, err := s.DeleteSeries(noDeadlineContext, nil, []*TagFilters{tfs}, 1e9)
 		if err != nil {
 			t.Fatalf("could not delete series unexpectedly: %v", err)
 		}
@@ -1633,7 +1633,7 @@ func testStorageRegisterMetricNames(s *Storage) error {
 		"job",
 	}
 
-	lns, err := s.SearchLabelNames(nil, accountID, projectID, nil, TimeRange{0, math.MaxInt64}, 100, 1e9, noDeadline)
+	lns, err := s.SearchLabelNames(noDeadlineContext, nil, accountID, projectID, nil, TimeRange{0, math.MaxInt64}, 100, 1e9)
 	if err != nil {
 		return fmt.Errorf("error in SearchLabelNames: %w", err)
 	}
@@ -1643,7 +1643,7 @@ func testStorageRegisterMetricNames(s *Storage) error {
 	}
 
 	// Verify that SearchLabelNames returns empty results for incorrect accountID, projectID
-	lns, err = s.SearchLabelNames(nil, accountID+1, projectID+1, nil, TimeRange{}, 100, 1e9, noDeadline)
+	lns, err = s.SearchLabelNames(noDeadlineContext, nil, accountID+1, projectID+1, nil, TimeRange{}, 100, 1e9)
 	if err != nil {
 		return fmt.Errorf("error in SearchTagKeys for incorrect accountID, projectID: %w", err)
 	}
@@ -1659,7 +1659,7 @@ func testStorageRegisterMetricNames(s *Storage) error {
 		MinTimestamp: start,
 		MaxTimestamp: end,
 	}
-	lns, err = s.SearchLabelNames(nil, accountID, projectID, nil, tr, 100, 1e9, noDeadline)
+	lns, err = s.SearchLabelNames(noDeadlineContext, nil, accountID, projectID, nil, tr, 100, 1e9)
 	if err != nil {
 		return fmt.Errorf("error in SearchLabelNames: %w", err)
 	}
@@ -1669,7 +1669,7 @@ func testStorageRegisterMetricNames(s *Storage) error {
 	}
 
 	// Verify that SearchLabelNames with the specified time range returns empty results for incrorrect accountID, projectID
-	lns, err = s.SearchLabelNames(nil, accountID+1, projectID+1, nil, tr, 100, 1e9, noDeadline)
+	lns, err = s.SearchLabelNames(noDeadlineContext, nil, accountID+1, projectID+1, nil, tr, 100, 1e9)
 	if err != nil {
 		return fmt.Errorf("error in SearchLabelNames for incorrect accountID, projectID: %w", err)
 	}
@@ -1678,7 +1678,7 @@ func testStorageRegisterMetricNames(s *Storage) error {
 	}
 
 	// Verify that SearchLabelValues returns correct result.
-	addIDs, err := s.SearchLabelValues(nil, accountID, projectID, "add_id", nil, TimeRange{0, math.MaxInt64}, addsCount+100, 1e9, noDeadline)
+	addIDs, err := s.SearchLabelValues(noDeadlineContext, nil, accountID, projectID, "add_id", nil, TimeRange{0, math.MaxInt64}, addsCount+100, 1e9)
 	if err != nil {
 		return fmt.Errorf("error in SearchLabelValues: %w", err)
 	}
@@ -1688,7 +1688,7 @@ func testStorageRegisterMetricNames(s *Storage) error {
 	}
 
 	// Verify that SearchLabelValues return empty results for incorrect accountID, projectID
-	addIDs, err = s.SearchLabelValues(nil, accountID+1, projectID+1, "add_id", nil, TimeRange{}, addsCount+100, 1e9, noDeadline)
+	addIDs, err = s.SearchLabelValues(noDeadlineContext, nil, accountID+1, projectID+1, "add_id", nil, TimeRange{}, addsCount+100, 1e9)
 	if err != nil {
 		return fmt.Errorf("error in SearchLabelValues for incorrect accountID, projectID: %w", err)
 	}
@@ -1697,7 +1697,7 @@ func testStorageRegisterMetricNames(s *Storage) error {
 	}
 
 	// Verify that SearchLabelValues with the specified time range returns correct result.
-	addIDs, err = s.SearchLabelValues(nil, accountID, projectID, "add_id", nil, tr, addsCount+100, 1e9, noDeadline)
+	addIDs, err = s.SearchLabelValues(noDeadlineContext, nil, accountID, projectID, "add_id", nil, tr, addsCount+100, 1e9)
 	if err != nil {
 		return fmt.Errorf("error in SearchLabelValues: %w", err)
 	}
@@ -1707,7 +1707,7 @@ func testStorageRegisterMetricNames(s *Storage) error {
 	}
 
 	// Verify that SearchLabelValues returns empty results for incorrect accountID, projectID
-	addIDs, err = s.SearchLabelValues(nil, accountID+1, projectID+1, "addd_id", nil, tr, addsCount+100, 1e9, noDeadline)
+	addIDs, err = s.SearchLabelValues(noDeadlineContext, nil, accountID+1, projectID+1, "addd_id", nil, tr, addsCount+100, 1e9)
 	if err != nil {
 		return fmt.Errorf("error in SearchLabelValues for incorrect accoundID, projectID: %w", err)
 	}
@@ -1720,7 +1720,7 @@ func testStorageRegisterMetricNames(s *Storage) error {
 	if err := tfs.Add([]byte("add_id"), []byte("0"), false, false); err != nil {
 		return fmt.Errorf("unexpected error in TagFilters.Add: %w", err)
 	}
-	metricNames, err := s.SearchMetricNames(nil, []*TagFilters{tfs}, tr, metricsPerAdd*addsCount*100+100, noDeadline)
+	metricNames, err := s.SearchMetricNames(noDeadlineContext, nil, []*TagFilters{tfs}, tr, metricsPerAdd*addsCount*100+100)
 	if err != nil {
 		return fmt.Errorf("error in SearchMetricNames: %w", err)
 	}
@@ -1747,7 +1747,7 @@ func testStorageRegisterMetricNames(s *Storage) error {
 	if err := tfs.Add([]byte("add_id"), []byte("0"), false, false); err != nil {
 		return fmt.Errorf("unexpected error in TagFilters.Add: %w", err)
 	}
-	metricNames, err = s.SearchMetricNames(nil, []*TagFilters{tfs}, tr, metricsPerAdd*addsCount*100+100, noDeadline)
+	metricNames, err = s.SearchMetricNames(noDeadlineContext, nil, []*TagFilters{tfs}, tr, metricsPerAdd*addsCount*100+100)
 	if err != nil {
 		return fmt.Errorf("error in SearchMetricNames for incorrect accountID, projectID: %w", err)
 	}
@@ -2301,7 +2301,7 @@ func testCountAllMetricNames(s *Storage, accountID, projectID uint32, tr TimeRan
 	if err := tfsAll.Add([]byte("__name__"), []byte(".*"), false, true); err != nil {
 		panic(fmt.Sprintf("unexpected error in TagFilters.Add: %v", err))
 	}
-	names, err := s.SearchMetricNames(nil, []*TagFilters{tfsAll}, tr, 1e9, noDeadline)
+	names, err := s.SearchMetricNames(noDeadlineContext, nil, []*TagFilters{tfsAll}, tr, 1e9)
 	if err != nil {
 		panic(fmt.Sprintf("SeachMetricNames() failed unexpectedly: %v", err))
 	}
@@ -2348,7 +2348,7 @@ func TestStorageSearchMetricNames_VariousTimeRanges(t *testing.T) {
 		if err := tfss.Add([]byte("__name__"), []byte(".*"), false, true); err != nil {
 			t.Fatalf("unexpected error in TagFilters.Add: %v", err)
 		}
-		got, err := s.SearchMetricNames(nil, []*TagFilters{tfss}, tr, 1e9, noDeadline)
+		got, err := s.SearchMetricNames(noDeadlineContext, nil, []*TagFilters{tfss}, tr, 1e9)
 		if err != nil {
 			t.Fatalf("SearchMetricNames() failed unexpectedly: %v", err)
 		}
@@ -2421,7 +2421,7 @@ func TestStorageSearchMetricNames_TooManyTimeseries(t *testing.T) {
 			tfss = append(tfss, tfs)
 		}
 
-		names, err := s.SearchMetricNames(nil, tfss, opts.tr, opts.maxMetrics, noDeadline)
+		names, err := s.SearchMetricNames(noDeadlineContext, nil, tfss, opts.tr, opts.maxMetrics)
 		gotErr := err != nil
 		if gotErr != opts.wantErr {
 			t.Errorf("SeachMetricNames(%v, %v, %d): unexpected error: got %v, want error to happen %v", []any{
@@ -2612,7 +2612,7 @@ func TestStorageSearchLabelNames_VariousTimeRanges(t *testing.T) {
 		s.AddRows(mrs, defaultPrecisionBits)
 		s.DebugFlush()
 
-		got, err := s.SearchLabelNames(nil, accountID, projectID, nil, tr, 1e9, 1e9, noDeadline)
+		got, err := s.SearchLabelNames(noDeadlineContext, nil, accountID, projectID, nil, tr, 1e9, 1e9)
 		if err != nil {
 			t.Fatalf("SearchLabelNames() failed unexpectedly: %v", err)
 		}
@@ -2669,7 +2669,7 @@ func TestStorageSearchLabelValues_VariousTimeRanges(t *testing.T) {
 		s.AddRows(mrs, defaultPrecisionBits)
 		s.DebugFlush()
 
-		got, err := s.SearchLabelValues(nil, accountID, projectID, "label", nil, tr, 1e9, 1e9, noDeadline)
+		got, err := s.SearchLabelValues(noDeadlineContext, nil, accountID, projectID, "label", nil, tr, 1e9, 1e9)
 		if err != nil {
 			t.Fatalf("SearchLabelValues() failed unexpectedly: %v", err)
 		}
@@ -2719,7 +2719,7 @@ func TestStorageSearchTagValueSuffixes_VariousTimeRanges(t *testing.T) {
 		s.AddRows(mrs, defaultPrecisionBits)
 		s.DebugFlush()
 
-		got, err := s.SearchTagValueSuffixes(nil, accountID, projectID, tr, "", "prefix.", '.', 1e9, noDeadline)
+		got, err := s.SearchTagValueSuffixes(noDeadlineContext, nil, accountID, projectID, tr, "", "prefix.", '.', 1e9)
 		if err != nil {
 			t.Fatalf("SearchTagValueSuffixes() failed unexpectedly: %v", err)
 		}
@@ -2768,7 +2768,7 @@ func TestStorageSearchGraphitePaths_VariousTimeRanges(t *testing.T) {
 		s.AddRows(mrs, defaultPrecisionBits)
 		s.DebugFlush()
 
-		got, err := s.SearchGraphitePaths(nil, accountID, projectID, tr, []byte("*.*"), 1e9, noDeadline)
+		got, err := s.SearchGraphitePaths(noDeadlineContext, nil, accountID, projectID, tr, []byte("*.*"), 1e9)
 		if err != nil {
 			t.Fatalf("SearchTagGraphitePaths() failed unexpectedly: %v", err)
 		}
@@ -2901,7 +2901,7 @@ func TestStorageSearchLabelValues_SingleFilterOnLabelName(t *testing.T) {
 		if err := tfs.Add([]byte(k), []byte(v), isNegative, isRegex); err != nil {
 			t.Fatalf("unexpected error in TagFilters.Add: %v", err)
 		}
-		got, err := s.SearchLabelValues(nil, accountID, projectID, label, []*TagFilters{tfs}, tr, maxLabelValues, maxMetrics, noDeadline)
+		got, err := s.SearchLabelValues(noDeadlineContext, nil, accountID, projectID, label, []*TagFilters{tfs}, tr, maxLabelValues, maxMetrics)
 		if err != nil {
 			t.Fatalf("SearchLabelValues() failed unexpectedly: %v", err)
 		}
@@ -2977,7 +2977,7 @@ func TestStorageSearchLabelValues_EmptyValuesAreNotReturned(t *testing.T) {
 	s.DebugFlush()
 
 	assertSearchLabelValues := func(labelName string, want []string) {
-		got, err := s.SearchLabelValues(nil, accountID, projectID, labelName, nil, tr, 1e9, 1e9, noDeadline)
+		got, err := s.SearchLabelValues(noDeadlineContext, nil, accountID, projectID, labelName, nil, tr, 1e9, 1e9)
 		if err != nil {
 			t.Fatalf("SearchLabelValues() failed unexpectedly: %v", err)
 		}
@@ -3029,7 +3029,7 @@ func TestStorageGetSeriesCount(t *testing.T) {
 		}
 		s.DebugFlush()
 
-		got, err := s.GetSeriesCount(accountID, projectID, noDeadline)
+		got, err := s.GetSeriesCount(noDeadlineContext, accountID, projectID)
 		if err != nil {
 			t.Fatalf("GetSeriesCount() failed unexpectedly: %v", err)
 		}
@@ -3111,7 +3111,7 @@ func TestStorageGetTSDBStatus(t *testing.T) {
 	var got, want *TSDBStatus
 
 	// Check the date on which there is no data.
-	got, err := s.GetTSDBStatus(nil, accountID, projectID, nil, date-1, "", 6, 1e9, noDeadline)
+	got, err := s.GetTSDBStatus(noDeadlineContext, nil, accountID, projectID, nil, date-1, "", 6, 1e9)
 	if err != nil {
 		t.Fatalf("GetTSDBStatus() failed unexpectedly: %v", err)
 	}
@@ -3122,7 +3122,7 @@ func TestStorageGetTSDBStatus(t *testing.T) {
 
 	// With partition index we can no longer support zero date to report stats
 	// for the entire retention period. Expect empty status.
-	got, err = s.GetTSDBStatus(nil, accountID, projectID, nil, globalIndexDate, "", 6, 1e9, noDeadline)
+	got, err = s.GetTSDBStatus(noDeadlineContext, nil, accountID, projectID, nil, globalIndexDate, "", 6, 1e9)
 	if err != nil {
 		t.Fatalf("GetTSDBStatus() failed unexpectedly: %v", err)
 	}
@@ -3132,7 +3132,7 @@ func TestStorageGetTSDBStatus(t *testing.T) {
 	}
 
 	// Check the date on which there is data.
-	got, err = s.GetTSDBStatus(nil, accountID, projectID, nil, date, "label_0000", 6, 1e9, noDeadline)
+	got, err = s.GetTSDBStatus(noDeadlineContext, nil, accountID, projectID, nil, date, "label_0000", 6, 1e9)
 	if err != nil {
 		t.Fatalf("GetTSDBStatus() failed unexpectedly: %v", err)
 	}
@@ -3416,7 +3416,7 @@ func TestStorageGetTSDBStatusWithoutIndex(t *testing.T) {
 		t.Helper()
 
 		date := uint64(tr.MinTimestamp) / msecPerDay
-		gotStatus, err := s.GetTSDBStatus(nil, 0, 0, nil, date, "", 10, 1e6, noDeadline)
+		gotStatus, err := s.GetTSDBStatus(noDeadlineContext, nil, 0, 0, nil, date, "", 10, 1e6)
 		if err != nil {
 			t.Fatalf("GetTSDBStatus(%v) failed unexpectedly", &tr)
 		}
@@ -3475,7 +3475,7 @@ func TestStorageSearchMetricNamesWithoutIndex(t *testing.T) {
 		if err := tfsAll.Add([]byte("__name__"), []byte(".*"), false, true); err != nil {
 			panic(fmt.Sprintf("unexpected error in TagFilters.Add: %v", err))
 		}
-		got, err := s.SearchMetricNames(nil, []*TagFilters{tfsAll}, tr, 1e6, noDeadline)
+		got, err := s.SearchMetricNames(noDeadlineContext, nil, []*TagFilters{tfsAll}, tr, 1e6)
 		if err != nil {
 			t.Fatalf("SearchMetricNames(%v) failed unexpectedly: %v", &tr, err)
 		}
@@ -3539,7 +3539,7 @@ func TestStorageSearchLabelNamesWithoutIndex(t *testing.T) {
 
 	opts.assertSearchResult = func(t *testing.T, s *Storage, tr TimeRange, want any) {
 		t.Helper()
-		got, err := s.SearchLabelNames(nil, accountID, projectID, []*TagFilters{}, tr, 1e6, 1e6, noDeadline)
+		got, err := s.SearchLabelNames(noDeadlineContext, nil, accountID, projectID, []*TagFilters{}, tr, 1e6, 1e6)
 		if err != nil {
 			t.Fatalf("SearchLabelNames(%v) failed unexpectedly: %v", &tr, err)
 		}
@@ -3597,7 +3597,7 @@ func TestStorageSearchLabelValuesWithoutIndex(t *testing.T) {
 
 	opts.assertSearchResult = func(t *testing.T, s *Storage, tr TimeRange, want any) {
 		t.Helper()
-		got, err := s.SearchLabelValues(nil, accountID, projectID, labelName, []*TagFilters{}, tr, 1e6, 1e6, noDeadline)
+		got, err := s.SearchLabelValues(noDeadlineContext, nil, accountID, projectID, labelName, []*TagFilters{}, tr, 1e6, 1e6)
 		if err != nil {
 			t.Fatalf("SearchLabelValues(%v) failed unexpectedly: %v", &tr, err)
 		}
@@ -3651,7 +3651,7 @@ func TestStorageSearchTagValueSuffixesWithoutIndex(t *testing.T) {
 
 	opts.assertSearchResult = func(t *testing.T, s *Storage, tr TimeRange, want any) {
 		t.Helper()
-		got, err := s.SearchTagValueSuffixes(nil, accountID, projectID, tr, "", tagValuePrefix, '.', 1e6, noDeadline)
+		got, err := s.SearchTagValueSuffixes(noDeadlineContext, nil, accountID, projectID, tr, "", tagValuePrefix, '.', 1e6)
 		if err != nil {
 			t.Fatalf("SearchTagValueSuffixes(%v) failed unexpectedly: %v", &tr, err)
 		}
@@ -3705,7 +3705,7 @@ func TestStorageSearchGraphitePathsWithoutIndex(t *testing.T) {
 
 	opts.assertSearchResult = func(t *testing.T, s *Storage, tr TimeRange, want any) {
 		t.Helper()
-		got, err := s.SearchGraphitePaths(nil, accountID, projectID, tr, []byte("*.*"), 1e6, noDeadline)
+		got, err := s.SearchGraphitePaths(noDeadlineContext, nil, accountID, projectID, tr, []byte("*.*"), 1e6)
 		if err != nil {
 			t.Fatalf("SearchGraphitePaths(%v) failed unexpectedly: %v", &tr, err)
 		}
@@ -3841,7 +3841,7 @@ func testStorageAddRowsWithZeroDate(t *testing.T, disablePerDayIndex bool) {
 		if err := tfs.Add(nil, []byte("metric_.*"), false, true); err != nil {
 			t.Fatalf("unexpected error in TagFilters.Add: %v", err)
 		}
-		got, err := s.SearchMetricNames(nil, []*TagFilters{tfs}, tr, 1e9, noDeadline)
+		got, err := s.SearchMetricNames(noDeadlineContext, nil, []*TagFilters{tfs}, tr, 1e9)
 		if err != nil {
 			t.Fatalf("SearchMetricNames(%v, %v) failed unexpectedly: %v", tfs, &tr, err)
 		}
@@ -3864,7 +3864,7 @@ func testStorageAddRowsWithZeroDate(t *testing.T, disablePerDayIndex bool) {
 		if err := tfs.Add(nil, []byte("metric_.*"), false, true); err != nil {
 			t.Fatalf("unexpected error in TagFilters.Add: %v", err)
 		}
-		got, err := s.SearchLabelNames(nil, accountID, projectID, []*TagFilters{tfs}, tr, 1e9, 1e9, noDeadline)
+		got, err := s.SearchLabelNames(noDeadlineContext, nil, accountID, projectID, []*TagFilters{tfs}, tr, 1e9, 1e9)
 		if err != nil {
 			t.Fatalf("SearchLabelNames(%v, %v) failed unexpectedly: %s", tfs, &tr, err)
 		}
@@ -3880,7 +3880,7 @@ func testStorageAddRowsWithZeroDate(t *testing.T, disablePerDayIndex bool) {
 		if err := tfs.Add([]byte("label"), []byte("value_.*"), false, true); err != nil {
 			t.Fatalf("unexpected error in TagFilters.Add: %v", err)
 		}
-		got, err := s.SearchLabelValues(nil, accountID, projectID, "label", []*TagFilters{tfs}, tr, 1e9, 1e9, noDeadline)
+		got, err := s.SearchLabelValues(noDeadlineContext, nil, accountID, projectID, "label", []*TagFilters{tfs}, tr, 1e9, 1e9)
 		if err != nil {
 			t.Fatalf("SearchLabelValues(%v, %v) failed unexpectedly: %s", tfs, tr, err)
 		}
@@ -3971,7 +3971,7 @@ func testStorageAddRowsWithZeroDate(t *testing.T, disablePerDayIndex bool) {
 // tests only.
 func testSearchMetricIDs(s *Storage, tfss []*TagFilters, tr TimeRange, maxMetrics int, deadline uint64) []uint64 {
 	search := func(qt *querytracer.Tracer, idb *indexDB, tr TimeRange) (*uint64set.Set, error) {
-		return idb.searchMetricIDs(qt, tfss, tr, maxMetrics, deadline)
+		return idb.searchMetricIDs(noDeadlineContext, qt, tfss, tr, maxMetrics)
 	}
 	merge := func(data []*uint64set.Set) *uint64set.Set {
 		all := &uint64set.Set{}
@@ -4287,7 +4287,7 @@ func assertCounts(t *testing.T, s *Storage, accountID, projectID uint32, want *c
 
 	for date, wantStatus := range want.dateTSDBStatuses {
 		dt := time.UnixMilli(int64(date) * msecPerDay).UTC()
-		gotStatus, err := s.GetTSDBStatus(nil, accountID, projectID, nil, date, "", 10, 1e6, noDeadline)
+		gotStatus, err := s.GetTSDBStatus(noDeadlineContext, nil, accountID, projectID, nil, date, "", 10, 1e6)
 		if err != nil {
 			t.Fatalf("GetTSDBStatus(%v) failed unexpectedly: %v", dt, err)
 		}
@@ -4455,7 +4455,7 @@ func TestStorageMetricTracker(t *testing.T) {
 
 	var sr Search
 	// check stats for metrics with 0 requests count
-	mus := s.GetMetricNamesStats(nil, nil, 10_000, 0, "")
+	mus := s.GetMetricNamesStats(noDeadlineContext, nil, nil, 10_000, 0, "")
 	if len(mus.Records) != int(numRows) {
 		t.Fatalf("unexpected Stats records count=%d, want %d records", len(mus.Records), numRows)
 	}
@@ -4466,16 +4466,16 @@ func TestStorageMetricTracker(t *testing.T) {
 		t.Fatalf("unexpected error at tfs add: %s", err)
 	}
 
-	sr.Init(nil, s, []*TagFilters{tfs}, tr, 1e5, noDeadline)
-	for sr.NextMetricBlock() {
+	sr.Init(noDeadlineContext, nil, s, []*TagFilters{tfs}, tr, 1e5)
+	for sr.NextMetricBlock(noDeadlineContext) {
 	}
 	sr.MustClose()
 
-	mus = s.GetMetricNamesStats(nil, nil, 10_000, 0, "")
+	mus = s.GetMetricNamesStats(noDeadlineContext, nil, nil, 10_000, 0, "")
 	if len(mus.Records) != 0 {
 		t.Fatalf("unexpected Stats records count=%d; want 0 records", len(mus.Records))
 	}
-	mus = s.GetMetricNamesStats(nil, nil, 10_000, 1, "")
+	mus = s.GetMetricNamesStats(noDeadlineContext, nil, nil, 10_000, 1, "")
 	if len(mus.Records) != int(numRows) {
 		t.Fatalf("unexpected Stats records count=%d, want %d records", len(mus.Records), numRows)
 	}
@@ -4502,7 +4502,7 @@ func TestStorageSearchTagValueSuffixes_maxTagValueSuffixes(t *testing.T) {
 	s.DebugFlush()
 
 	assertSuffixCount := func(maxTagValueSuffixes, want int) {
-		suffixes, err := s.SearchTagValueSuffixes(nil, accountID, projectID, tr, "", "metric.", '.', maxTagValueSuffixes, noDeadline)
+		suffixes, err := s.SearchTagValueSuffixes(noDeadlineContext, nil, accountID, projectID, tr, "", "metric.", '.', maxTagValueSuffixes)
 		if err != nil {
 			t.Fatalf("SearchTagValueSuffixes() failed unexpectedly: %v", err)
 		}
@@ -4599,7 +4599,7 @@ func TestStorageMetrics_IndexDBBlockCaches(t *testing.T) {
 	if err := tfs.Add([]byte("__name__"), []byte(".*"), false, true); err != nil {
 		t.Fatalf("unexpected error in TagFilters.Add: %v", err)
 	}
-	_, err := s.SearchMetricNames(nil, []*TagFilters{tfs}, tr, 1e9, noDeadline)
+	_, err := s.SearchMetricNames(noDeadlineContext, nil, []*TagFilters{tfs}, tr, 1e9)
 	if err != nil {
 		t.Fatalf("SearchMetricNames() failed unexpectedly: %v", err)
 	}
@@ -4660,7 +4660,7 @@ func TestStorage_futureTimestamps(t *testing.T) {
 		if err := tfs.Add([]byte("__name__"), []byte(".*"), false, true); err != nil {
 			t.Fatalf("unexpected error in TagFilters.Add: %v", err)
 		}
-		got, err := s.SearchMetricNames(nil, []*TagFilters{tfs}, tr, 1e9, noDeadline)
+		got, err := s.SearchMetricNames(noDeadlineContext, nil, []*TagFilters{tfs}, tr, 1e9)
 		if err != nil {
 			t.Fatalf("SearchMetricNames() failed unexpectedly: %v", err)
 		}
@@ -4679,7 +4679,7 @@ func TestStorage_futureTimestamps(t *testing.T) {
 	}
 	assertLabelNames := func(t *testing.T, s *Storage, tr TimeRange, want []string) {
 		t.Helper()
-		got, err := s.SearchLabelNames(nil, accountID, projectID, nil, tr, 1e9, 1e9, noDeadline)
+		got, err := s.SearchLabelNames(noDeadlineContext, nil, accountID, projectID, nil, tr, 1e9, 1e9)
 		if err != nil {
 			t.Fatalf("SearchLabelNames() failed unexpectedly: %s", err)
 		}
@@ -4691,7 +4691,7 @@ func TestStorage_futureTimestamps(t *testing.T) {
 	}
 	assertLabelValues := func(t *testing.T, s *Storage, tr TimeRange, want []string) {
 		t.Helper()
-		got, err := s.SearchLabelValues(nil, accountID, projectID, "label", nil, tr, 1e9, 1e9, noDeadline)
+		got, err := s.SearchLabelValues(noDeadlineContext, nil, accountID, projectID, "label", nil, tr, 1e9, 1e9)
 		if err != nil {
 			t.Fatalf("SearchLabelValues() failed unexpectedly: %s", err)
 		}
@@ -4716,7 +4716,7 @@ func TestStorage_futureTimestamps(t *testing.T) {
 		if err := tfs.Add([]byte("__name__"), []byte(".*"), false, true); err != nil {
 			t.Fatalf("unexpected error in TagFilters.Add: %v", err)
 		}
-		if _, err := s.DeleteSeries(nil, []*TagFilters{tfs}, 1e9); err != nil {
+		if _, err := s.DeleteSeries(noDeadlineContext, nil, []*TagFilters{tfs}, 1e9); err != nil {
 			t.Fatalf("DeleteSeries() failed unexpectedly: %s", err)
 		}
 	}
@@ -4871,7 +4871,7 @@ func TestStorageAddFlushSearchMetricNamesConcurrently(t *testing.T) {
 		if err := tfs.Add(nil, []byte(re), false, true); err != nil {
 			return fmt.Errorf("tfs.Add(%q) failed unexpectedly: %w", re, err)
 		}
-		got, err := s.SearchMetricNames(nil, []*TagFilters{tfs}, tr, 1e9, noDeadline)
+		got, err := s.SearchMetricNames(noDeadlineContext, nil, []*TagFilters{tfs}, tr, 1e9)
 		if err != nil {
 			return fmt.Errorf("SearchMetricNames(%v) failed unexpectedly: %w", tfs, err)
 		}

--- a/lib/storage/storage_timing_test.go
+++ b/lib/storage/storage_timing_test.go
@@ -459,7 +459,7 @@ func benchmarkSearch(b *testing.B, dataConfig dataConfig, split splitFunc, searc
 		if err := tfs.Add(nil, []byte(re), false, true); err != nil {
 			b.Fatalf("unexpected error in TagFilters.Add: %v", err)
 		}
-		got, err := s.DeleteSeries(nil, []*TagFilters{tfs}, 1e9)
+		got, err := s.DeleteSeries(noDeadlineContext, nil, []*TagFilters{tfs}, 1e9)
 		if err != nil {
 			b.Fatalf("could not delete series unexpectedly: %v", err)
 		}
@@ -545,7 +545,7 @@ func benchmarkSearchMetricNames(b *testing.B, s *Storage, tr TimeRange, mrs []Me
 		err error
 	)
 	for b.Loop() {
-		got, err = s.SearchMetricNames(nil, []*TagFilters{tfss}, tr, 1e9, noDeadline)
+		got, err = s.SearchMetricNames(noDeadlineContext, nil, []*TagFilters{tfss}, tr, 1e9)
 		if err != nil {
 			b.Fatalf("SearchMetricNames() failed unexpectedly: %v", err)
 		}
@@ -592,7 +592,7 @@ func benchmarkSearchLabelNames(b *testing.B, s *Storage, tr TimeRange, mrs []Met
 		err error
 	)
 	for b.Loop() {
-		got, err = s.SearchLabelNames(nil, accountID, projectID, nil, tr, 1e9, 1e9, noDeadline)
+		got, err = s.SearchLabelNames(noDeadlineContext, nil, accountID, projectID, nil, tr, 1e9, 1e9)
 		if err != nil {
 			b.Fatalf("SearchLabelNames() failed unexpectedly: %v", err)
 		}
@@ -634,7 +634,7 @@ func benchmarkSearchLabelValues(b *testing.B, s *Storage, tr TimeRange, mrs []Me
 		err error
 	)
 	for b.Loop() {
-		got, err = s.SearchLabelValues(nil, accountID, projectID, "label", nil, tr, 1e9, 1e9, noDeadline)
+		got, err = s.SearchLabelValues(noDeadlineContext, nil, accountID, projectID, "label", nil, tr, 1e9, 1e9)
 		if err != nil {
 			b.Fatalf("SearchLabelValues() failed unexpectedly: %v", err)
 		}
@@ -677,7 +677,7 @@ func benchmarkSearchTagValueSuffixes(b *testing.B, s *Storage, tr TimeRange, mrs
 		err    error
 	)
 	for b.Loop() {
-		got, err = s.SearchTagValueSuffixes(nil, accountID, projectID, tr, "", prefix, '.', 1e9, noDeadline)
+		got, err = s.SearchTagValueSuffixes(noDeadlineContext, nil, accountID, projectID, tr, "", prefix, '.', 1e9)
 		if err != nil {
 			b.Fatalf("SearchTagValueSuffixes() failed unexpectedly: %v", err)
 		}
@@ -716,7 +716,7 @@ func benchmarkSearchGraphitePaths(b *testing.B, s *Storage, tr TimeRange, mrs []
 		err error
 	)
 	for b.Loop() {
-		got, err = s.SearchGraphitePaths(nil, accountID, projectID, tr, []byte("*.*"), 1e9, noDeadline)
+		got, err = s.SearchGraphitePaths(noDeadlineContext, nil, accountID, projectID, tr, []byte("*.*"), 1e9)
 		if err != nil {
 			b.Fatalf("SearchGraphitePaths() failed unexpectedly: %v", err)
 		}

--- a/lib/vmselectapi/api.go
+++ b/lib/vmselectapi/api.go
@@ -1,6 +1,8 @@
 package vmselectapi
 
 import (
+	"context"
+
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/querytracer"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/storage"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/storage/metricnamestats"
@@ -12,43 +14,43 @@ type API interface {
 	// InitSearch initialize series search for the given sq.
 	//
 	// The returned BlockIterator must be closed with MustClose to free up resources when it is no longer needed.
-	InitSearch(qt *querytracer.Tracer, sq *storage.SearchQuery, deadline uint64) (BlockIterator, error)
+	InitSearch(ctx context.Context, qt *querytracer.Tracer, sq *storage.SearchQuery) (BlockIterator, error)
 
 	// SearchMetricNames returns metric names matching the given sq.
-	SearchMetricNames(qt *querytracer.Tracer, sq *storage.SearchQuery, deadline uint64) ([]string, error)
+	SearchMetricNames(ctx context.Context, qt *querytracer.Tracer, sq *storage.SearchQuery) ([]string, error)
 
 	// LabelValues returns values for labelName label acorss series matching the given sq.
-	LabelValues(qt *querytracer.Tracer, sq *storage.SearchQuery, labelName string, maxLabelValues int, deadline uint64) ([]string, error)
+	LabelValues(ctx context.Context, qt *querytracer.Tracer, sq *storage.SearchQuery, labelName string, maxLabelValues int) ([]string, error)
 
 	// TagValueSuffixes returns tag value suffixes for the given args.
-	TagValueSuffixes(qt *querytracer.Tracer, accountID, projectID uint32, tr storage.TimeRange, tagKey, tagValuePrefix string, delimiter byte, maxSuffixes int, deadline uint64) ([]string, error)
+	TagValueSuffixes(ctx context.Context, qt *querytracer.Tracer, accountID, projectID uint32, tr storage.TimeRange, tagKey, tagValuePrefix string, delimiter byte, maxSuffixes int) ([]string, error)
 
 	// LabelNames returns lable names for series matching the given sq.
-	LabelNames(qt *querytracer.Tracer, sq *storage.SearchQuery, maxLableNames int, deadline uint64) ([]string, error)
+	LabelNames(ctx context.Context, qt *querytracer.Tracer, sq *storage.SearchQuery, maxLableNames int) ([]string, error)
 
 	// SeriesCount returns the number of series for the given (accountID, projectID).
-	SeriesCount(qt *querytracer.Tracer, accountID, projectID uint32, deadline uint64) (uint64, error)
+	SeriesCount(ctx context.Context, qt *querytracer.Tracer, accountID, projectID uint32) (uint64, error)
 
 	// TSDBStatus returns tsdb status for the given sq.
-	TSDBStatus(qt *querytracer.Tracer, sq *storage.SearchQuery, focusLabel string, topN int, deadline uint64) (*storage.TSDBStatus, error)
+	TSDBStatus(ctx context.Context, qt *querytracer.Tracer, sq *storage.SearchQuery, focusLabel string, topN int) (*storage.TSDBStatus, error)
 
 	// DeleteSeries deletes series matching the given sq.
-	DeleteSeries(qt *querytracer.Tracer, sq *storage.SearchQuery, deadline uint64) (int, error)
+	DeleteSeries(ctx context.Context, qt *querytracer.Tracer, sq *storage.SearchQuery) (int, error)
 
 	// RegisterMetricNames registers the given mrs in the storage.
-	RegisterMetricNames(qt *querytracer.Tracer, mrs []storage.MetricRow, deadline uint64) error
+	RegisterMetricNames(ctx context.Context, qt *querytracer.Tracer, mrs []storage.MetricRow) error
 
 	// Tenants returns list of tenants in the storage on the given tr.
-	Tenants(qt *querytracer.Tracer, tr storage.TimeRange, deadline uint64) ([]string, error)
+	Tenants(ctx context.Context, qt *querytracer.Tracer, tr storage.TimeRange) ([]string, error)
 
 	// GetMetricNamesUsageStats returns statistics for metric names
-	GetMetricNamesUsageStats(qt *querytracer.Tracer, tt *storage.TenantToken, limit, le int, matchPattern string, deadline uint64) (metricnamestats.StatsResult, error)
+	GetMetricNamesUsageStats(ctx context.Context, qt *querytracer.Tracer, tt *storage.TenantToken, limit, le int, matchPattern string) (metricnamestats.StatsResult, error)
 
 	// ResetMetricNamesUsageStats resets internal state of metric names tracker
-	ResetMetricNamesUsageStats(qt *querytracer.Tracer, deadline uint64) error
+	ResetMetricNamesUsageStats(ctx context.Context, qt *querytracer.Tracer) error
 
 	// GetMetadataRecords returns metrics metadata.
-	GetMetadataRecords(qt *querytracer.Tracer, tt *storage.TenantToken, limit int, metricName string, deadline uint64) ([]*metricsmetadata.Row, error)
+	GetMetadataRecords(ctx context.Context, qt *querytracer.Tracer, tt *storage.TenantToken, limit int, metricName string) ([]*metricsmetadata.Row, error)
 }
 
 // BlockIterator must iterate through series blocks found by VMSelect.InitSearch.
@@ -58,7 +60,7 @@ type BlockIterator interface {
 	// NextBlock marshals next storage.MetricBlock into dst.
 	//
 	// It returns true on success, false on error or if no blocks to read.
-	NextBlock(dst []byte) ([]byte, bool)
+	NextBlock(ctx context.Context, dst []byte) ([]byte, bool)
 
 	// MustClose frees up resources allocated by BlockIterator.
 	MustClose()

--- a/lib/vmselectapi/server.go
+++ b/lib/vmselectapi/server.go
@@ -1,6 +1,7 @@
 package vmselectapi
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -247,7 +248,7 @@ func (s *Server) processConn(bc *handshake.BufferedConn) error {
 			if isExpectedError(err) {
 				return nil
 			}
-			if errors.Is(err, storage.ErrDeadlineExceeded) {
+			if errors.Is(err, context.DeadlineExceeded) {
 				return fmt.Errorf("cannot process vmselect request in %d seconds: %w", ctx.timeout, err)
 			}
 			return fmt.Errorf("cannot process vmselect request: %w", err)
@@ -263,7 +264,7 @@ func isExpectedError(err error) bool {
 		// Remote client gracefully closed the connection.
 		return true
 	}
-	if errors.Is(err, net.ErrClosed) {
+	if errors.Is(err, net.ErrClosed) || errors.Is(err, context.Canceled) {
 		return true
 	}
 	errStr := err.Error()
@@ -621,8 +622,11 @@ func (s *Server) processRegisterMetricNames(ctx *vmselectRequestCtx) error {
 	}
 	defer s.endConcurrentRequest()
 
+	rCtx, cm := newRequestContextForConn(ctx.bc, ctx.deadline)
+	defer cm.stop()
+
 	// Register metric names from mrs.
-	if err := s.api.RegisterMetricNames(ctx.qt, mrs, ctx.deadline); err != nil {
+	if err := s.api.RegisterMetricNames(rCtx, ctx.qt, mrs); err != nil {
 		return ctx.writeErrorMessage(err)
 	}
 
@@ -646,8 +650,11 @@ func (s *Server) processDeleteSeries(ctx *vmselectRequestCtx) error {
 	}
 	defer s.endConcurrentRequest()
 
+	rCtx, cm := newRequestContextForConn(ctx.bc, ctx.deadline)
+	defer cm.stop()
+
 	// Execute the request.
-	deletedCount, err := s.api.DeleteSeries(ctx.qt, &ctx.sq, ctx.deadline)
+	deletedCount, err := s.api.DeleteSeries(rCtx, ctx.qt, &ctx.sq)
 	if err != nil {
 		return ctx.writeErrorMessage(err)
 	}
@@ -680,8 +687,11 @@ func (s *Server) processLabelNames(ctx *vmselectRequestCtx) error {
 	}
 	defer s.endConcurrentRequest()
 
+	rCtx, cm := newRequestContextForConn(ctx.bc, ctx.deadline)
+	defer cm.stop()
+
 	// Execute the request
-	labelNames, err := s.api.LabelNames(ctx.qt, &ctx.sq, maxLabelNames, ctx.deadline)
+	labelNames, err := s.api.LabelNames(rCtx, ctx.qt, &ctx.sq, maxLabelNames)
 	if err != nil {
 		return ctx.writeErrorMessage(err)
 	}
@@ -731,8 +741,11 @@ func (s *Server) processLabelValues(ctx *vmselectRequestCtx) error {
 	}
 	defer s.endConcurrentRequest()
 
+	rCtx, cm := newRequestContextForConn(ctx.bc, ctx.deadline)
+	defer cm.stop()
+
 	// Execute the request
-	labelValues, err := s.api.LabelValues(ctx.qt, &ctx.sq, labelName, maxLabelValues, ctx.deadline)
+	labelValues, err := s.api.LabelValues(rCtx, ctx.qt, &ctx.sq, labelName, maxLabelValues)
 	if err != nil {
 		return ctx.writeErrorMessage(err)
 	}
@@ -793,8 +806,11 @@ func (s *Server) processTagValueSuffixes(ctx *vmselectRequestCtx) error {
 	}
 	defer s.endConcurrentRequest()
 
+	rCtx, cm := newRequestContextForConn(ctx.bc, ctx.deadline)
+	defer cm.stop()
+
 	// Execute the request
-	suffixes, err := s.api.TagValueSuffixes(ctx.qt, accountID, projectID, tr, tagKey, tagValuePrefix, delimiter, maxSuffixes, ctx.deadline)
+	suffixes, err := s.api.TagValueSuffixes(rCtx, ctx.qt, accountID, projectID, tr, tagKey, tagValuePrefix, delimiter, maxSuffixes)
 	if err != nil {
 		return ctx.writeErrorMessage(err)
 	}
@@ -831,8 +847,10 @@ func (s *Server) processSeriesCount(ctx *vmselectRequestCtx) error {
 	}
 	defer s.endConcurrentRequest()
 
+	rCtx, cm := newRequestContextForConn(ctx.bc, ctx.deadline)
+	defer cm.stop()
 	// Execute the request
-	n, err := s.api.SeriesCount(ctx.qt, accountID, projectID, ctx.deadline)
+	n, err := s.api.SeriesCount(rCtx, ctx.qt, accountID, projectID)
 	if err != nil {
 		return ctx.writeErrorMessage(err)
 	}
@@ -870,8 +888,11 @@ func (s *Server) processTSDBStatus(ctx *vmselectRequestCtx) error {
 	}
 	defer s.endConcurrentRequest()
 
+	rCtx, cm := newRequestContextForConn(ctx.bc, ctx.deadline)
+	defer cm.stop()
+
 	// Execute the request
-	status, err := s.api.TSDBStatus(ctx.qt, &ctx.sq, focusLabel, int(topN), ctx.deadline)
+	status, err := s.api.TSDBStatus(rCtx, ctx.qt, &ctx.sq, focusLabel, int(topN))
 	if err != nil {
 		return ctx.writeErrorMessage(err)
 	}
@@ -899,8 +920,11 @@ func (s *Server) processTenants(ctx *vmselectRequestCtx) error {
 	}
 	defer s.endConcurrentRequest()
 
+	rCtx, cm := newRequestContextForConn(ctx.bc, ctx.deadline)
+	defer cm.stop()
+
 	// Execute the request
-	tenants, err := s.api.Tenants(ctx.qt, tr, ctx.deadline)
+	tenants, err := s.api.Tenants(rCtx, ctx.qt, tr)
 	if err != nil {
 		return ctx.writeErrorMessage(err)
 	}
@@ -982,8 +1006,11 @@ func (s *Server) processSearchMetricNames(ctx *vmselectRequestCtx) error {
 	}
 	defer s.endConcurrentRequest()
 
+	rCtx, cm := newRequestContextForConn(ctx.bc, ctx.deadline)
+	defer cm.stop()
+
 	// Execute request.
-	metricNames, err := s.api.SearchMetricNames(ctx.qt, &ctx.sq, ctx.deadline)
+	metricNames, err := s.api.SearchMetricNames(rCtx, ctx.qt, &ctx.sq)
 	if err != nil {
 		return ctx.writeErrorMessage(err)
 	}
@@ -1019,8 +1046,11 @@ func (s *Server) processSearch(ctx *vmselectRequestCtx) error {
 	}
 	defer s.endConcurrentRequest()
 
+	rCtx, cm := newRequestContextForConn(ctx.bc, ctx.deadline)
+	defer cm.stop()
+
 	// Initiaialize the search.
-	bi, err := s.api.InitSearch(ctx.qt, &ctx.sq, ctx.deadline)
+	bi, err := s.api.InitSearch(rCtx, ctx.qt, &ctx.sq)
 	if err != nil {
 		return ctx.writeErrorMessage(err)
 	}
@@ -1035,7 +1065,7 @@ func (s *Server) processSearch(ctx *vmselectRequestCtx) error {
 	blocksRead := 0
 	var ok bool
 	for {
-		ctx.dataBuf, ok = bi.NextBlock(ctx.dataBuf[:0])
+		ctx.dataBuf, ok = bi.NextBlock(rCtx, ctx.dataBuf[:0])
 		if !ok {
 			break
 		}
@@ -1097,7 +1127,10 @@ func (s *Server) processMetricNamesUsageStats(ctx *vmselectRequestCtx) error {
 	}
 	defer s.endConcurrentRequest()
 
-	result, err := s.api.GetMetricNamesUsageStats(ctx.qt, at, limit, int(le), matchPattern, ctx.deadline)
+	rCtx, cm := newRequestContextForConn(ctx.bc, ctx.deadline)
+	defer cm.stop()
+
+	result, err := s.api.GetMetricNamesUsageStats(rCtx, ctx.qt, at, limit, int(le), matchPattern)
 	if err != nil {
 		return ctx.writeErrorMessage(err)
 	}
@@ -1149,7 +1182,11 @@ func (s *Server) processResetMetricUsageStats(ctx *vmselectRequestCtx) error {
 		return ctx.writeErrorMessage(err)
 	}
 	defer s.endConcurrentRequest()
-	if err := s.api.ResetMetricNamesUsageStats(ctx.qt, ctx.deadline); err != nil {
+
+	rCtx, cm := newRequestContextForConn(ctx.bc, ctx.deadline)
+	defer cm.stop()
+
+	if err := s.api.ResetMetricNamesUsageStats(rCtx, ctx.qt); err != nil {
 		return fmt.Errorf("cannot reset state of the metric names usage tracker: %w", err)
 	}
 	return nil
@@ -1192,7 +1229,10 @@ func (s *Server) processSearchMetadata(ctx *vmselectRequestCtx) error {
 	}
 	defer s.endConcurrentRequest()
 
-	result, err := s.api.GetMetadataRecords(ctx.qt, at, limit, metricName, ctx.deadline)
+	rCtx, cm := newRequestContextForConn(ctx.bc, ctx.deadline)
+	defer cm.stop()
+
+	result, err := s.api.GetMetadataRecords(rCtx, ctx.qt, at, limit, metricName)
 	if err != nil {
 		return ctx.writeErrorMessage(err)
 	}
@@ -1224,3 +1264,68 @@ func writeMetadataRows(ctx *vmselectRequestCtx, records []*metricsmetadata.Row) 
 
 	return nil
 }
+
+// newRequestContextForConn creates a cancelable context
+// for given BufferedConn and deadline.
+// I starts monitoring whether the client closes or breaks the connection.
+//
+// The caller must stop the returned connMonitor via cm.stop() once request
+// processing is complete.
+func newRequestContextForConn(bc *handshake.BufferedConn, deadline uint64) (context.Context, *connMonitor) {
+	ctx, cancel := context.WithDeadline(context.Background(), time.Unix(int64(deadline), 0))
+	cm := startMonitorConn(cancel, bc)
+	return ctx, cm
+}
+
+// startMonitorConn starts monitoring of given buffered connection for any read operations
+// it's expected that monitoring must be stoped with stop() call,
+// before caller could read anything from it
+func startMonitorConn(cancel func(), bc *handshake.BufferedConn) *connMonitor {
+	cm := &connMonitor{
+		bc:     bc,
+		cancel: cancel,
+	}
+
+	cm.watch()
+	return cm
+}
+
+type connMonitor struct {
+	bc     *handshake.BufferedConn
+	cancel func()
+
+	stopped atomic.Bool
+	wg      sync.WaitGroup
+}
+
+func (cm *connMonitor) watch() {
+	cm.bc.Conn.SetReadDeadline(time.Time{}) //nolint:errcheck
+	cm.wg.Go(func() {
+		// block on conn.Read
+		// it only closes if stop() called or client closes connection
+		var buf [1]byte
+		n, err := cm.bc.Read(buf[:])
+		_ = err
+		if n > 0 {
+			logger.Warnf("unexpected non empty read from remote addr: %s", cm.bc.RemoteAddr())
+		}
+		if cm.stopped.Swap(true) {
+			return
+		}
+		cm.cancel()
+	})
+}
+
+func (cm *connMonitor) stop() {
+	if cm.stopped.Swap(true) {
+		return
+	}
+	cm.cancel()
+	// unblock watcher with read timeout error
+	cm.bc.Conn.SetReadDeadline(timeLongBefore) //nolint:errcheck
+	cm.wg.Wait()
+	// reset connection deadline
+	cm.bc.Conn.SetReadDeadline(time.Time{}) //nolint:errcheck
+}
+
+var timeLongBefore = time.Unix(1, 0)

--- a/lib/vmselectapi/server.go
+++ b/lib/vmselectapi/server.go
@@ -448,7 +448,7 @@ func (ctx *vmselectRequestCtx) writeDataBufBytes() error {
 const maxErrorMessageSize = 64 * 1024
 
 func (ctx *vmselectRequestCtx) writeErrorMessage(err error) error {
-	if errors.Is(err, storage.ErrDeadlineExceeded) {
+	if errors.Is(err, context.DeadlineExceeded) {
 		err = fmt.Errorf("cannot execute request in %d seconds: %w", ctx.timeout, err)
 	}
 	errMsg := err.Error()
@@ -623,13 +623,13 @@ func (s *Server) processRegisterMetricNames(ctx *vmselectRequestCtx) error {
 	defer s.endConcurrentRequest()
 
 	rCtx, cm := newRequestContextForConn(ctx.bc, ctx.deadline)
-	defer cm.stop()
 
 	// Register metric names from mrs.
 	if err := s.api.RegisterMetricNames(rCtx, ctx.qt, mrs); err != nil {
+		cm.stop()
 		return ctx.writeErrorMessage(err)
 	}
-
+	cm.stop()
 	// Send an empty error message to vmselect.
 	if err := ctx.writeString(""); err != nil {
 		return fmt.Errorf("cannot send empty error message: %w", err)
@@ -651,14 +651,14 @@ func (s *Server) processDeleteSeries(ctx *vmselectRequestCtx) error {
 	defer s.endConcurrentRequest()
 
 	rCtx, cm := newRequestContextForConn(ctx.bc, ctx.deadline)
-	defer cm.stop()
 
 	// Execute the request.
 	deletedCount, err := s.api.DeleteSeries(rCtx, ctx.qt, &ctx.sq)
 	if err != nil {
+		cm.stop()
 		return ctx.writeErrorMessage(err)
 	}
-
+	cm.stop()
 	// Send an empty error message to vmselect.
 	if err := ctx.writeString(""); err != nil {
 		return fmt.Errorf("cannot send empty error message: %w", err)
@@ -688,14 +688,14 @@ func (s *Server) processLabelNames(ctx *vmselectRequestCtx) error {
 	defer s.endConcurrentRequest()
 
 	rCtx, cm := newRequestContextForConn(ctx.bc, ctx.deadline)
-	defer cm.stop()
 
 	// Execute the request
 	labelNames, err := s.api.LabelNames(rCtx, ctx.qt, &ctx.sq, maxLabelNames)
 	if err != nil {
+		cm.stop()
 		return ctx.writeErrorMessage(err)
 	}
-
+	cm.stop()
 	// Send an empty error message to vmselect.
 	if err := ctx.writeString(""); err != nil {
 		return fmt.Errorf("cannot send empty error message: %w", err)
@@ -742,14 +742,14 @@ func (s *Server) processLabelValues(ctx *vmselectRequestCtx) error {
 	defer s.endConcurrentRequest()
 
 	rCtx, cm := newRequestContextForConn(ctx.bc, ctx.deadline)
-	defer cm.stop()
 
 	// Execute the request
 	labelValues, err := s.api.LabelValues(rCtx, ctx.qt, &ctx.sq, labelName, maxLabelValues)
 	if err != nil {
+		cm.stop()
 		return ctx.writeErrorMessage(err)
 	}
-
+	cm.stop()
 	// Send an empty error message to vmselect.
 	if err := ctx.writeString(""); err != nil {
 		return fmt.Errorf("cannot send empty error message: %w", err)
@@ -807,14 +807,14 @@ func (s *Server) processTagValueSuffixes(ctx *vmselectRequestCtx) error {
 	defer s.endConcurrentRequest()
 
 	rCtx, cm := newRequestContextForConn(ctx.bc, ctx.deadline)
-	defer cm.stop()
 
 	// Execute the request
 	suffixes, err := s.api.TagValueSuffixes(rCtx, ctx.qt, accountID, projectID, tr, tagKey, tagValuePrefix, delimiter, maxSuffixes)
 	if err != nil {
+		cm.stop()
 		return ctx.writeErrorMessage(err)
 	}
-
+	cm.stop()
 	// Send an empty error message to vmselect.
 	if err := ctx.writeString(""); err != nil {
 		return fmt.Errorf("cannot send empty error message: %w", err)
@@ -848,10 +848,11 @@ func (s *Server) processSeriesCount(ctx *vmselectRequestCtx) error {
 	defer s.endConcurrentRequest()
 
 	rCtx, cm := newRequestContextForConn(ctx.bc, ctx.deadline)
-	defer cm.stop()
+	cm.stop()
 	// Execute the request
 	n, err := s.api.SeriesCount(rCtx, ctx.qt, accountID, projectID)
 	if err != nil {
+		cm.stop()
 		return ctx.writeErrorMessage(err)
 	}
 
@@ -889,14 +890,14 @@ func (s *Server) processTSDBStatus(ctx *vmselectRequestCtx) error {
 	defer s.endConcurrentRequest()
 
 	rCtx, cm := newRequestContextForConn(ctx.bc, ctx.deadline)
-	defer cm.stop()
 
 	// Execute the request
 	status, err := s.api.TSDBStatus(rCtx, ctx.qt, &ctx.sq, focusLabel, int(topN))
 	if err != nil {
+		cm.stop()
 		return ctx.writeErrorMessage(err)
 	}
-
+	cm.stop()
 	// Send an empty error message to vmselect.
 	if err := ctx.writeString(""); err != nil {
 		return fmt.Errorf("cannot send empty error message: %w", err)
@@ -921,14 +922,14 @@ func (s *Server) processTenants(ctx *vmselectRequestCtx) error {
 	defer s.endConcurrentRequest()
 
 	rCtx, cm := newRequestContextForConn(ctx.bc, ctx.deadline)
-	defer cm.stop()
 
 	// Execute the request
 	tenants, err := s.api.Tenants(rCtx, ctx.qt, tr)
 	if err != nil {
+		cm.stop()
 		return ctx.writeErrorMessage(err)
 	}
-
+	cm.stop()
 	// Send an empty error message to vmselect.
 	if err := ctx.writeString(""); err != nil {
 		return fmt.Errorf("cannot send empty error message: %w", err)
@@ -1007,14 +1008,14 @@ func (s *Server) processSearchMetricNames(ctx *vmselectRequestCtx) error {
 	defer s.endConcurrentRequest()
 
 	rCtx, cm := newRequestContextForConn(ctx.bc, ctx.deadline)
-	defer cm.stop()
 
 	// Execute request.
 	metricNames, err := s.api.SearchMetricNames(rCtx, ctx.qt, &ctx.sq)
 	if err != nil {
+		cm.stop()
 		return ctx.writeErrorMessage(err)
 	}
-
+	cm.stop()
 	// Send empty error message to vmselect.
 	if err := ctx.writeString(""); err != nil {
 		return fmt.Errorf("cannot send empty error message: %w", err)
@@ -1048,14 +1049,12 @@ func (s *Server) processSearch(ctx *vmselectRequestCtx) error {
 
 	rCtx, cm := newRequestContextForConn(ctx.bc, ctx.deadline)
 	defer cm.stop()
-
 	// Initiaialize the search.
 	bi, err := s.api.InitSearch(rCtx, ctx.qt, &ctx.sq)
 	if err != nil {
 		return ctx.writeErrorMessage(err)
 	}
 	defer bi.MustClose()
-
 	// Send empty error message to vmselect.
 	if err := ctx.writeString(""); err != nil {
 		return fmt.Errorf("cannot send empty error message: %w", err)
@@ -1080,6 +1079,7 @@ func (s *Server) processSearch(ctx *vmselectRequestCtx) error {
 		return fmt.Errorf("search error: %w", err)
 	}
 	ctx.qt.Printf("sent %d blocks to vmselect", blocksRead)
+	cm.stop()
 
 	// Send 'end of response' marker
 	if err := ctx.writeString(""); err != nil {
@@ -1128,13 +1128,13 @@ func (s *Server) processMetricNamesUsageStats(ctx *vmselectRequestCtx) error {
 	defer s.endConcurrentRequest()
 
 	rCtx, cm := newRequestContextForConn(ctx.bc, ctx.deadline)
-	defer cm.stop()
 
 	result, err := s.api.GetMetricNamesUsageStats(rCtx, ctx.qt, at, limit, int(le), matchPattern)
 	if err != nil {
+		cm.stop()
 		return ctx.writeErrorMessage(err)
 	}
-
+	cm.stop()
 	// Send an empty error message to vmselect.
 	if err := ctx.writeString(""); err != nil {
 		return fmt.Errorf("cannot send empty error message: %w", err)
@@ -1183,10 +1183,9 @@ func (s *Server) processResetMetricUsageStats(ctx *vmselectRequestCtx) error {
 	}
 	defer s.endConcurrentRequest()
 
-	rCtx, cm := newRequestContextForConn(ctx.bc, ctx.deadline)
-	defer cm.stop()
-
-	if err := s.api.ResetMetricNamesUsageStats(rCtx, ctx.qt); err != nil {
+	// there is no need to monitor connection, because this operation is fast and operates
+	// with fire and forget logic
+	if err := s.api.ResetMetricNamesUsageStats(context.Background(), ctx.qt); err != nil {
 		return fmt.Errorf("cannot reset state of the metric names usage tracker: %w", err)
 	}
 	return nil
@@ -1230,13 +1229,13 @@ func (s *Server) processSearchMetadata(ctx *vmselectRequestCtx) error {
 	defer s.endConcurrentRequest()
 
 	rCtx, cm := newRequestContextForConn(ctx.bc, ctx.deadline)
-	defer cm.stop()
 
 	result, err := s.api.GetMetadataRecords(rCtx, ctx.qt, at, limit, metricName)
 	if err != nil {
+		cm.stop()
 		return ctx.writeErrorMessage(err)
 	}
-
+	cm.stop()
 	// Send an empty error message to vmselect.
 	if err := ctx.writeString(""); err != nil {
 		return fmt.Errorf("cannot send empty error message: %w", err)
@@ -1299,7 +1298,7 @@ type connMonitor struct {
 }
 
 func (cm *connMonitor) watch() {
-	cm.bc.Conn.SetReadDeadline(time.Time{}) //nolint:errcheck
+	cm.bc.SetReadDeadline(time.Time{}) //nolint:errcheck
 	cm.wg.Go(func() {
 		// block on conn.Read
 		// it only closes if stop() called or client closes connection
@@ -1309,7 +1308,7 @@ func (cm *connMonitor) watch() {
 		if n > 0 {
 			logger.Warnf("unexpected non empty read from remote addr: %s", cm.bc.RemoteAddr())
 		}
-		if cm.stopped.Swap(true) {
+		if !cm.stopped.CompareAndSwap(false, true) {
 			return
 		}
 		cm.cancel()
@@ -1317,15 +1316,14 @@ func (cm *connMonitor) watch() {
 }
 
 func (cm *connMonitor) stop() {
-	if cm.stopped.Swap(true) {
-		return
+	if cm.stopped.CompareAndSwap(false, true) {
+		cm.cancel()
+		// unblock watcher with read timeout error
+		cm.bc.Conn.SetReadDeadline(timeLongBefore) //nolint:errcheck
 	}
-	cm.cancel()
-	// unblock watcher with read timeout error
-	cm.bc.Conn.SetReadDeadline(timeLongBefore) //nolint:errcheck
 	cm.wg.Wait()
 	// reset connection deadline
-	cm.bc.Conn.SetReadDeadline(time.Time{}) //nolint:errcheck
+	cm.bc.SetReadDeadline(time.Time{}) //nolint:errcheck
 }
 
 var timeLongBefore = time.Unix(1, 0)

--- a/lib/vmselectapi/server.go
+++ b/lib/vmselectapi/server.go
@@ -848,14 +848,13 @@ func (s *Server) processSeriesCount(ctx *vmselectRequestCtx) error {
 	defer s.endConcurrentRequest()
 
 	rCtx, cm := newRequestContextForConn(ctx.bc, ctx.deadline)
-	cm.stop()
 	// Execute the request
 	n, err := s.api.SeriesCount(rCtx, ctx.qt, accountID, projectID)
 	if err != nil {
 		cm.stop()
 		return ctx.writeErrorMessage(err)
 	}
-
+	cm.stop()
 	// Send an empty error message to vmselect.
 	if err := ctx.writeString(""); err != nil {
 		return fmt.Errorf("cannot send empty error message: %w", err)


### PR DESCRIPTION
 This commit replaces deadline timestamp with cancelable request
context. It allows to properly cancel in-flight indexDB requests in cases of:
* client disconnect
* graceful storage shutdown

 Previously, heavy indexDB request may prevent storage from properly
shutdown with-in graceful timeout.

Part of https://github.com/VictoriaMetrics/VictoriaMetrics/issues/11355
