### PR TITLE
docs: recommend disabling metadata for MDX targets

### DIFF
--- a/docs/victoriametrics/vmagent.md
+++ b/docs/victoriametrics/vmagent.md
@@ -290,7 +290,7 @@ To enable MDX, set `-remoteWrite.mdx.enable=true` for the target URL and `-remot
   -remoteWrite.disableMetadata=true
 ```
 
-We recommend that you set `-remoteWrite.disableMetadata=true` for each MDX target to save resource usage. Without this setting, `vmagent` sends metadata from all scrape targets to the MDX target.
+> Recommendation: Set `-remoteWrite.disableMetadata=true` for MDX remote writes to save resource usage. Otherwise, `vmagent` sends [metrics metadata](https://docs.victoriametrics.com/victoriametrics/vmagent/#metric-metadata) from all scraped targets to the MDX destination.
 
 When MDX is enabled for a `-remoteWrite.url`, `vmagent` forwards only metrics that:
 - come from the target that exposes the `vm_app_version` metric (emitted by all VictoriaMetrics components)

--- a/docs/victoriametrics/vmagent.md
+++ b/docs/victoriametrics/vmagent.md
@@ -284,9 +284,14 @@ To enable MDX, set `-remoteWrite.mdx.enable=true` for the target URL and `-remot
 ./vmagent \
   -remoteWrite.url=http://service-to-keep-all-metrics:8428/api/v1/write \
   -remoteWrite.mdx.enable=false \
+  -remoteWrite.disableMetadata=false \
   -remoteWrite.url=http://service-to-keep-only-vm-metrics:8428/api/v1/write \
-  -remoteWrite.mdx.enable=true 
+  -remoteWrite.mdx.enable=true \
+  -remoteWrite.disableMetadata=true
 ```
+
+We recommend that you set `-remoteWrite.disableMetadata=true` for each MDX target to save resource usage. Without this setting, `vmagent` sends metadata from all scrape targets to the MDX target.
+
 When MDX is enabled for a `-remoteWrite.url`, `vmagent` forwards only metrics that:
 - come from the target that exposes the `vm_app_version` metric (emitted by all VictoriaMetrics components)
 - contain the `victoriametrics_app=true` label, which will be added automatically to the metrics if the instance was deployed via [VictoriaMetrics Operator](https://docs.victoriametrics.com/operator/).
@@ -299,6 +304,7 @@ When MDX is enabled for a `-remoteWrite.url`, `vmagent` forwards only metrics th
 ./vmagent \
   -remoteWrite.url=http://service-to-keep-only-vm-metrics:8428/api/v1/write \
   -remoteWrite.mdx.enable=true \
+  -remoteWrite.disableMetadata=true \
   -mdx.label="service=victoriametrics"
 ```
 In this configuration, metrics with the label `service=victoriametrics` are preserved even if their scrape targets do not expose `vm_app_version` metric.


### PR DESCRIPTION
MDX filter applies only to time series. It doesn't filter metadata. This causes resource waste because:
1. It sends metadata for metrics that MDX drops.
2. MDX targets usually do not need metadata for retained metrics.

This PR updates the documentation to recommend setting -remoteWrite.disableMetadata=true for each MDX remote write target. This setting reduces resource usage.