### PR TITLE
app/vmselect: apply metric stats le filter after merging

### DIFF
--- a/app/vmselect/netstorage/netstorage.go
+++ b/app/vmselect/netstorage/netstorage.go
@@ -3453,9 +3453,13 @@ func GetMetricNamesStats(qt *querytracer.Tracer, tt *storage.TenantToken, limit,
 		err  error
 	}
 	sns := getStorageNodes()
+	nodeLimit := limit
+	if le >= 0 {
+		nodeLimit = math.MaxInt32
+	}
 	snr := startStorageNodesRequest(qt, sns, true, func(qt *querytracer.Tracer, _ uint, sn *storageNode) any {
-		// Request unfiltered stats, so le can be applied to counters aggregated across all the vmstorage nodes.
-		resp, err := sn.processGetMetricNamesStats(qt, tt, limit, -1, matchPattern, deadline)
+		// Request unfiltered stats, so le and limit can be applied to counters aggregated across all the vmstorage nodes.
+		resp, err := sn.processGetMetricNamesStats(qt, tt, nodeLimit, -1, matchPattern, deadline)
 		return nodeResult{resp: resp, err: err}
 	})
 	var mu sync.Mutex
@@ -3472,11 +3476,11 @@ func GetMetricNamesStats(qt *querytracer.Tracer, tt *storage.TenantToken, limit,
 	}); err != nil {
 		return mnuss, err
 	}
-	finalizeMetricNamesStats(&mnuss, le)
+	finalizeMetricNamesStats(&mnuss, limit, le)
 	return mnuss, nil
 }
 
-func finalizeMetricNamesStats(mnuss *metricnamestats.StatsResult, le int) {
+func finalizeMetricNamesStats(mnuss *metricnamestats.StatsResult, limit, le int) {
 	if le >= 0 {
 		records := mnuss.Records[:0]
 		for _, record := range mnuss.Records {
@@ -3487,6 +3491,12 @@ func finalizeMetricNamesStats(mnuss *metricnamestats.StatsResult, le int) {
 		mnuss.Records = records
 	}
 	mnuss.Sort()
+	if limit < 0 {
+		limit = 0
+	}
+	if len(mnuss.Records) > limit {
+		mnuss.Records = mnuss.Records[:limit]
+	}
 }
 
 func (sn *storageNode) processGetMetricNamesStats(qt *querytracer.Tracer, tt *storage.TenantToken, limit, le int, matchPattern string, deadline searchutil.Deadline) (metricnamestats.StatsResult, error) {

--- a/app/vmselect/netstorage/netstorage.go
+++ b/app/vmselect/netstorage/netstorage.go
@@ -3455,10 +3455,11 @@ func GetMetricNamesStats(qt *querytracer.Tracer, tt *storage.TenantToken, limit,
 	sns := getStorageNodes()
 	nodeLimit := limit
 	if le >= 0 {
+		// Request unfiltered stats, so le and limit can be applied to counters aggregated across all the vmstorage nodes.
 		nodeLimit = math.MaxInt32
+		qt.Printf("`le` request param is set to non-default value: %d, raising per node limit from %d to %d", le, limit, nodeLimit)
 	}
 	snr := startStorageNodesRequest(qt, sns, true, func(qt *querytracer.Tracer, _ uint, sn *storageNode) any {
-		// Request unfiltered stats, so le and limit can be applied to counters aggregated across all the vmstorage nodes.
 		resp, err := sn.processGetMetricNamesStats(qt, tt, nodeLimit, -1, matchPattern, deadline)
 		return nodeResult{resp: resp, err: err}
 	})
@@ -3476,27 +3477,7 @@ func GetMetricNamesStats(qt *querytracer.Tracer, tt *storage.TenantToken, limit,
 	}); err != nil {
 		return mnuss, err
 	}
-	finalizeMetricNamesStats(&mnuss, limit, le)
 	return mnuss, nil
-}
-
-func finalizeMetricNamesStats(mnuss *metricnamestats.StatsResult, limit, le int) {
-	if le >= 0 {
-		records := mnuss.Records[:0]
-		for _, record := range mnuss.Records {
-			if record.RequestsCount <= uint64(le) {
-				records = append(records, record)
-			}
-		}
-		mnuss.Records = records
-	}
-	mnuss.Sort()
-	if limit < 0 {
-		limit = 0
-	}
-	if len(mnuss.Records) > limit {
-		mnuss.Records = mnuss.Records[:limit]
-	}
 }
 
 func (sn *storageNode) processGetMetricNamesStats(qt *querytracer.Tracer, tt *storage.TenantToken, limit, le int, matchPattern string, deadline searchutil.Deadline) (metricnamestats.StatsResult, error) {

--- a/app/vmselect/netstorage/netstorage.go
+++ b/app/vmselect/netstorage/netstorage.go
@@ -3454,7 +3454,8 @@ func GetMetricNamesStats(qt *querytracer.Tracer, tt *storage.TenantToken, limit,
 	}
 	sns := getStorageNodes()
 	snr := startStorageNodesRequest(qt, sns, true, func(qt *querytracer.Tracer, _ uint, sn *storageNode) any {
-		resp, err := sn.processGetMetricNamesStats(qt, tt, limit, le, matchPattern, deadline)
+		// Request unfiltered stats, so le can be applied to counters aggregated across all the vmstorage nodes.
+		resp, err := sn.processGetMetricNamesStats(qt, tt, limit, -1, matchPattern, deadline)
 		return nodeResult{resp: resp, err: err}
 	})
 	var mu sync.Mutex
@@ -3471,8 +3472,21 @@ func GetMetricNamesStats(qt *querytracer.Tracer, tt *storage.TenantToken, limit,
 	}); err != nil {
 		return mnuss, err
 	}
-	mnuss.Sort()
+	finalizeMetricNamesStats(&mnuss, le)
 	return mnuss, nil
+}
+
+func finalizeMetricNamesStats(mnuss *metricnamestats.StatsResult, le int) {
+	if le >= 0 {
+		records := mnuss.Records[:0]
+		for _, record := range mnuss.Records {
+			if record.RequestsCount <= uint64(le) {
+				records = append(records, record)
+			}
+		}
+		mnuss.Records = records
+	}
+	mnuss.Sort()
 }
 
 func (sn *storageNode) processGetMetricNamesStats(qt *querytracer.Tracer, tt *storage.TenantToken, limit, le int, matchPattern string, deadline searchutil.Deadline) (metricnamestats.StatsResult, error) {

--- a/app/vmselect/netstorage/netstorage_test.go
+++ b/app/vmselect/netstorage/netstorage_test.go
@@ -8,52 +8,7 @@ import (
 	"testing"
 
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/decimal"
-	"github.com/VictoriaMetrics/VictoriaMetrics/lib/storage/metricnamestats"
 )
-
-func TestFinalizeMetricNamesStatsAppliesLeAfterMerge(t *testing.T) {
-	result := metricnamestats.StatsResult{
-		Records: []metricnamestats.StatRecord{
-			{MetricName: "active_metric", RequestsCount: 3},
-			{MetricName: "unused_metric"},
-		},
-	}
-	otherNodeResult := metricnamestats.StatsResult{
-		Records: []metricnamestats.StatRecord{
-			{MetricName: "active_metric"},
-			{MetricName: "unused_metric"},
-		},
-	}
-	result.Merge(&otherNodeResult)
-
-	finalizeMetricNamesStats(&result, len(result.Records), 0)
-
-	want := []metricnamestats.StatRecord{
-		{MetricName: "unused_metric"},
-	}
-	if !reflect.DeepEqual(result.Records, want) {
-		t.Fatalf("unexpected records; got %v; want %v", result.Records, want)
-	}
-}
-
-func TestFinalizeMetricNamesStatsAppliesLimitAfterLe(t *testing.T) {
-	result := metricnamestats.StatsResult{
-		Records: []metricnamestats.StatRecord{
-			{MetricName: "active_metric", RequestsCount: 3},
-			{MetricName: "unused_metric_2"},
-			{MetricName: "unused_metric_1"},
-		},
-	}
-
-	finalizeMetricNamesStats(&result, 1, 0)
-
-	want := []metricnamestats.StatRecord{
-		{MetricName: "unused_metric_1"},
-	}
-	if !reflect.DeepEqual(result.Records, want) {
-		t.Fatalf("unexpected records; got %v; want %v", result.Records, want)
-	}
-}
 
 func TestInitStopNodes(t *testing.T) {
 	if err := flag.Set("vmstorageDialTimeout", "1ms"); err != nil {

--- a/app/vmselect/netstorage/netstorage_test.go
+++ b/app/vmselect/netstorage/netstorage_test.go
@@ -26,10 +26,29 @@ func TestFinalizeMetricNamesStatsAppliesLeAfterMerge(t *testing.T) {
 	}
 	result.Merge(&otherNodeResult)
 
-	finalizeMetricNamesStats(&result, 0)
+	finalizeMetricNamesStats(&result, len(result.Records), 0)
 
 	want := []metricnamestats.StatRecord{
 		{MetricName: "unused_metric"},
+	}
+	if !reflect.DeepEqual(result.Records, want) {
+		t.Fatalf("unexpected records; got %v; want %v", result.Records, want)
+	}
+}
+
+func TestFinalizeMetricNamesStatsAppliesLimitAfterLe(t *testing.T) {
+	result := metricnamestats.StatsResult{
+		Records: []metricnamestats.StatRecord{
+			{MetricName: "active_metric", RequestsCount: 3},
+			{MetricName: "unused_metric_2"},
+			{MetricName: "unused_metric_1"},
+		},
+	}
+
+	finalizeMetricNamesStats(&result, 1, 0)
+
+	want := []metricnamestats.StatRecord{
+		{MetricName: "unused_metric_1"},
 	}
 	if !reflect.DeepEqual(result.Records, want) {
 		t.Fatalf("unexpected records; got %v; want %v", result.Records, want)

--- a/app/vmselect/netstorage/netstorage_test.go
+++ b/app/vmselect/netstorage/netstorage_test.go
@@ -8,7 +8,33 @@ import (
 	"testing"
 
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/decimal"
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/storage/metricnamestats"
 )
+
+func TestFinalizeMetricNamesStatsAppliesLeAfterMerge(t *testing.T) {
+	result := metricnamestats.StatsResult{
+		Records: []metricnamestats.StatRecord{
+			{MetricName: "active_metric", RequestsCount: 3},
+			{MetricName: "unused_metric"},
+		},
+	}
+	otherNodeResult := metricnamestats.StatsResult{
+		Records: []metricnamestats.StatRecord{
+			{MetricName: "active_metric"},
+			{MetricName: "unused_metric"},
+		},
+	}
+	result.Merge(&otherNodeResult)
+
+	finalizeMetricNamesStats(&result, 0)
+
+	want := []metricnamestats.StatRecord{
+		{MetricName: "unused_metric"},
+	}
+	if !reflect.DeepEqual(result.Records, want) {
+		t.Fatalf("unexpected records; got %v; want %v", result.Records, want)
+	}
+}
 
 func TestInitStopNodes(t *testing.T) {
 	if err := flag.Set("vmstorageDialTimeout", "1ms"); err != nil {

--- a/app/vmselect/stats/stats.go
+++ b/app/vmselect/stats/stats.go
@@ -12,6 +12,7 @@ import (
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/auth"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/querytracer"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/storage"
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/storage/metricnamestats"
 )
 
 // MetricNamesStatsHandler returns timeseries metric names usage statistics
@@ -56,6 +57,7 @@ func MetricNamesStatsHandler(startTime time.Time, at *auth.Token, qt *querytrace
 	if err != nil {
 		return err
 	}
+	finalizeMetricNamesStats(&stats, limit, le)
 	WriteMetricNamesStatsResponse(w, &stats, qt)
 	return nil
 }
@@ -67,4 +69,23 @@ func ResetMetricNamesStatsHandler(startTime time.Time, qt *querytracer.Tracer, r
 		return err
 	}
 	return nil
+}
+
+func finalizeMetricNamesStats(mnuss *metricnamestats.StatsResult, limit, le int) {
+	if le >= 0 {
+		tmp := mnuss.Records[:0]
+		for _, record := range mnuss.Records {
+			if record.RequestsCount <= uint64(le) {
+				tmp = append(tmp, record)
+			}
+		}
+		mnuss.Records = tmp
+	}
+	mnuss.Sort()
+	if limit < 0 {
+		limit = 0
+	}
+	if len(mnuss.Records) > limit {
+		mnuss.Records = mnuss.Records[:limit]
+	}
 }

--- a/apptest/tests/metric_names_stats_test.go
+++ b/apptest/tests/metric_names_stats_test.go
@@ -271,7 +271,7 @@ func TestClusterMetricNamesStats(t *testing.T) {
 	}
 }
 
-func TestClusterMetricNamesStatsLeAfterMerge(t *testing.T) {
+func TestClusterMetricNamesStatsWithParams(t *testing.T) {
 	fs.MustRemoveDir(t.Name())
 
 	tc := apptest.NewTestCase(t)
@@ -279,46 +279,119 @@ func TestClusterMetricNamesStatsLeAfterMerge(t *testing.T) {
 	vmstorage1 := tc.MustStartVmstorage("vmstorage-1", []string{
 		"-storageDataPath=" + tc.Dir() + "/vmstorage-1",
 		"-retentionPeriod=100y",
-		"-storage.trackMetricNamesStats",
 	})
 	vmstorage2 := tc.MustStartVmstorage("vmstorage-2", []string{
 		"-storageDataPath=" + tc.Dir() + "/vmstorage-2",
 		"-retentionPeriod=100y",
-		"-storage.trackMetricNamesStats",
 	})
 
-	vminsert := tc.MustStartVminsert("vminsert", []string{
-		fmt.Sprintf("-storageNode=%s,%s", vmstorage1.VminsertAddr(), vmstorage2.VminsertAddr()),
+	vminsert1 := tc.MustStartVminsert("vminsert-1", []string{
+		fmt.Sprintf("-storageNode=%s", vmstorage1.VminsertAddr()),
 	})
-	vmselect := tc.MustStartVmselect("vmselect", []string{
-		fmt.Sprintf("-storageNode=%s,%s", vmstorage1.VmselectAddr(), vmstorage2.VmselectAddr()),
+	vminsert2 := tc.MustStartVminsert("vminsert-2", []string{
+		fmt.Sprintf("-storageNode=%s", vmstorage2.VminsertAddr()),
+	})
+	vmselect1 := tc.MustStartVmselect("vmselect-1", []string{
+		fmt.Sprintf("-storageNode=%s", vmstorage1.VmselectAddr()),
+	})
+	vmselect2 := tc.MustStartVmselect("vmselect-2", []string{
+		fmt.Sprintf("-storageNode=%s", vmstorage2.VmselectAddr()),
+	})
+	vmselectGlobal := tc.MustStartVmselect("vmselect-global", []string{
+		fmt.Sprintf("-storageNode=%s,%s", vmselect1.ClusternativeListenAddr(), vmselect2.ClusternativeListenAddr()),
 	})
 
-	dataSet := make([]string, 100)
-	for i := range dataSet {
-		dataSet[i] = fmt.Sprintf(`metric_name{instance="%d"} %d 1707123456700`, i, i)
+	const ingestDateTime = `2024-02-05T08:57:36.700Z`
+	const ingestTimestamp = ` 1707123456700`
+	const date = `2024-02-05`
+	dataSet := []string{
+		`metric_name_1{label="foo"} 10`,
+		`metric_name_1{label="bar"} 10`,
+		`metric_name_2{label="baz"} 20`,
+		`metric_name_1{label="baz"} 10`,
+		`metric_name_3{label="baz"} 30`,
 	}
-	vminsert.PrometheusAPIV1ImportPrometheus(t, dataSet, apptest.QueryOpts{Tenant: "1:1"})
+	for idx := range dataSet {
+		dataSet[idx] += ingestTimestamp
+	}
+
+	tenantID := "1:1"
+
+	// verify empty stats
+	resp := vmselectGlobal.PrometheusAPIV1StatusMetricNamesStats(t, "", "", "", apptest.QueryOpts{Tenant: tenantID})
+	if len(resp.Records) != 0 {
+		t.Fatalf("unexpected resp Records: %d, want: %d", len(resp.Records), 0)
+	}
+
+	vminsert1.PrometheusAPIV1ImportPrometheus(t, dataSet, apptest.QueryOpts{Tenant: tenantID})
+
+	// ingest extra metric to the second cluster
+	dataSet = append(dataSet, fmt.Sprintf(`metric_name_0{label="baz"} 30 %s`, ingestTimestamp))
+	vminsert2.PrometheusAPIV1ImportPrometheus(t, dataSet, apptest.QueryOpts{Tenant: tenantID})
+
 	vmstorage1.ForceFlush(t)
 	vmstorage2.ForceFlush(t)
 
-	vmselect.PrometheusAPIV1Query(t, `metric_name{instance="0"}`, apptest.QueryOpts{
-		Tenant: "1:1",
-		Time:   "2024-02-05T08:57:36.700Z",
-	})
-
-	want := apptest.MetricNamesStatsResponse{
+	// verify ingested dataset correctly registered
+	expected := apptest.MetricNamesStatsResponse{
 		Records: []apptest.MetricNamesStatsRecord{
-			{MetricName: "metric_name", QueryRequestsCount: 1},
+			{MetricName: "metric_name_1"},
+			{MetricName: "metric_name_2"},
+			{MetricName: "metric_name_3"},
 		},
 	}
-	got := vmselect.PrometheusAPIV1StatusMetricNamesStats(t, "", "", `^metric_name$`, apptest.QueryOpts{Tenant: "1:1"})
-	if diff := cmp.Diff(want, got); diff != "" {
-		t.Fatalf("unexpected unfiltered response (-want, +got):\n%s", diff)
+	gotStats := vmselect1.PrometheusAPIV1StatusMetricNamesStats(t, "", "", "", apptest.QueryOpts{Tenant: tenantID})
+	if diff := cmp.Diff(expected, gotStats); diff != "" {
+		t.Errorf("unexpected response (-want, +got):\n%s", diff)
+	}
+	// and for second cluster
+	expected = apptest.MetricNamesStatsResponse{
+		Records: []apptest.MetricNamesStatsRecord{
+			{MetricName: "metric_name_0"},
+			{MetricName: "metric_name_1"},
+			{MetricName: "metric_name_2"},
+			{MetricName: "metric_name_3"},
+		},
+	}
+	gotStats = vmselect2.PrometheusAPIV1StatusMetricNamesStats(t, "", "", "", apptest.QueryOpts{Tenant: tenantID})
+	if diff := cmp.Diff(expected, gotStats); diff != "" {
+		t.Errorf("unexpected response (-want, +got):\n%s", diff)
 	}
 
-	got = vmselect.PrometheusAPIV1StatusMetricNamesStats(t, "", "0", `^metric_name$`, apptest.QueryOpts{Tenant: "1:1"})
-	if len(got.Records) != 0 {
-		t.Fatalf("unexpected records for le=0: %v", got.Records)
+	// query metrics for 1 cluster and check stats
+	vmselect1.PrometheusAPIV1Query(t, `{__name__!=""}`, apptest.QueryOpts{
+		Tenant: tenantID, Time: ingestDateTime,
+	})
+
+	expected = apptest.MetricNamesStatsResponse{
+		Records: []apptest.MetricNamesStatsRecord{
+			{MetricName: "metric_name_2", QueryRequestsCount: 1},
+			{MetricName: "metric_name_3", QueryRequestsCount: 1},
+			{MetricName: "metric_name_1", QueryRequestsCount: 3},
+		},
+	}
+	gotStats = vmselect1.PrometheusAPIV1StatusMetricNamesStats(t, "", "", "", apptest.QueryOpts{Tenant: tenantID})
+	if diff := cmp.Diff(expected, gotStats); diff != "" {
+		t.Errorf("unexpected response (-want, +got):\n%s", diff)
+	}
+
+	// check global stats with query params
+	expected = apptest.MetricNamesStatsResponse{
+		Records: []apptest.MetricNamesStatsRecord{
+			{MetricName: "metric_name_0", QueryRequestsCount: 0},
+		},
+	}
+	gotStats = vmselectGlobal.PrometheusAPIV1StatusMetricNamesStats(t, "", "0", "", apptest.QueryOpts{Tenant: tenantID})
+	if diff := cmp.Diff(expected, gotStats); diff != "" {
+		t.Errorf("unexpected response (-want, +got):\n%s", diff)
+	}
+	expected = apptest.MetricNamesStatsResponse{
+		Records: []apptest.MetricNamesStatsRecord{
+			{MetricName: "metric_name_0", QueryRequestsCount: 0},
+		},
+	}
+	gotStats = vmselectGlobal.PrometheusAPIV1StatusMetricNamesStats(t, "2", "0", "", apptest.QueryOpts{Tenant: tenantID})
+	if diff := cmp.Diff(expected, gotStats); diff != "" {
+		t.Errorf("unexpected response (-want, +got):\n%s", diff)
 	}
 }

--- a/apptest/tests/metric_names_stats_test.go
+++ b/apptest/tests/metric_names_stats_test.go
@@ -270,3 +270,55 @@ func TestClusterMetricNamesStats(t *testing.T) {
 		t.Fatalf("want 0 records, got: %d", len(resp.Records))
 	}
 }
+
+func TestClusterMetricNamesStatsLeAfterMerge(t *testing.T) {
+	fs.MustRemoveDir(t.Name())
+
+	tc := apptest.NewTestCase(t)
+	defer tc.Stop()
+	vmstorage1 := tc.MustStartVmstorage("vmstorage-1", []string{
+		"-storageDataPath=" + tc.Dir() + "/vmstorage-1",
+		"-retentionPeriod=100y",
+		"-storage.trackMetricNamesStats",
+	})
+	vmstorage2 := tc.MustStartVmstorage("vmstorage-2", []string{
+		"-storageDataPath=" + tc.Dir() + "/vmstorage-2",
+		"-retentionPeriod=100y",
+		"-storage.trackMetricNamesStats",
+	})
+
+	vminsert := tc.MustStartVminsert("vminsert", []string{
+		fmt.Sprintf("-storageNode=%s,%s", vmstorage1.VminsertAddr(), vmstorage2.VminsertAddr()),
+	})
+	vmselect := tc.MustStartVmselect("vmselect", []string{
+		fmt.Sprintf("-storageNode=%s,%s", vmstorage1.VmselectAddr(), vmstorage2.VmselectAddr()),
+	})
+
+	dataSet := make([]string, 100)
+	for i := range dataSet {
+		dataSet[i] = fmt.Sprintf(`metric_name{instance="%d"} %d 1707123456700`, i, i)
+	}
+	vminsert.PrometheusAPIV1ImportPrometheus(t, dataSet, apptest.QueryOpts{Tenant: "1:1"})
+	vmstorage1.ForceFlush(t)
+	vmstorage2.ForceFlush(t)
+
+	vmselect.PrometheusAPIV1Query(t, `metric_name{instance="0"}`, apptest.QueryOpts{
+		Tenant: "1:1",
+		Time:   "2024-02-05T08:57:36.700Z",
+	})
+
+	want := apptest.MetricNamesStatsResponse{
+		Records: []apptest.MetricNamesStatsRecord{
+			{MetricName: "metric_name", QueryRequestsCount: 1},
+		},
+	}
+	got := vmselect.PrometheusAPIV1StatusMetricNamesStats(t, "", "", `^metric_name$`, apptest.QueryOpts{Tenant: "1:1"})
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("unexpected unfiltered response (-want, +got):\n%s", diff)
+	}
+
+	got = vmselect.PrometheusAPIV1StatusMetricNamesStats(t, "", "0", `^metric_name$`, apptest.QueryOpts{Tenant: "1:1"})
+	if len(got.Records) != 0 {
+		t.Fatalf("unexpected records for le=0: %v", got.Records)
+	}
+}

--- a/apptest/tests/metric_names_stats_test.go
+++ b/apptest/tests/metric_names_stats_test.go
@@ -303,7 +303,6 @@ func TestClusterMetricNamesStatsWithParams(t *testing.T) {
 
 	const ingestDateTime = `2024-02-05T08:57:36.700Z`
 	const ingestTimestamp = ` 1707123456700`
-	const date = `2024-02-05`
 	dataSet := []string{
 		`metric_name_1{label="foo"} 10`,
 		`metric_name_1{label="bar"} 10`,

--- a/docs/victoriametrics/changelog/CHANGELOG.md
+++ b/docs/victoriametrics/changelog/CHANGELOG.md
@@ -29,8 +29,7 @@ See also [LTS releases](https://docs.victoriametrics.com/victoriametrics/lts-rel
 * SECURITY: upgrade Go builder from Go1.26.6 to Go1.27.1. See [Go 1.27 release notes](https://go.dev/doc/go1.27).
 
 * BUGFIX: [vmsingle](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/), [vmagent](https://docs.victoriametrics.com/victoriametrics/vmagent/) and `vminsert` in [VictoriaMetrics cluster](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/): fix insert requests getting stuck after another insert request times out, causing clients to time out while waiting for a response. See [VictoriaLogs#1743](https://github.com/VictoriaMetrics/VictoriaLogs/issues/1743).
-* BUGFIX: `vmselect` in [VictoriaMetrics cluster](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/): apply the `le` filter at `/api/v1/status/metric_names_stats` after merging request counters from all `vmstorage` nodes. Previously, the endpoint could report actively queried metrics as unused when the local request counter was zero on one of the nodes. See [#11473](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/11473).
-
+* BUGFIX: `vmselect` in [VictoriaMetrics cluster](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/): apply the `le` filter at `/api/v1/status/metric_names_stats` after merging request counters from all `vmstorage` nodes. Previously, the endpoint could report actively queried metrics as unused when the local request counter was zero on one of the nodes. See [#11473](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/11473). Thanks to @missusk for contribution.
 
 ## [v1.151.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.151.0)
 

--- a/docs/victoriametrics/changelog/CHANGELOG.md
+++ b/docs/victoriametrics/changelog/CHANGELOG.md
@@ -29,6 +29,8 @@ See also [LTS releases](https://docs.victoriametrics.com/victoriametrics/lts-rel
 * SECURITY: upgrade Go builder from Go1.26.6 to Go1.27.1. See [Go 1.27 release notes](https://go.dev/doc/go1.27).
 
 * BUGFIX: [vmsingle](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/), [vmagent](https://docs.victoriametrics.com/victoriametrics/vmagent/) and `vminsert` in [VictoriaMetrics cluster](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/): fix insert requests getting stuck after another insert request times out, causing clients to time out while waiting for a response. See [VictoriaLogs#1743](https://github.com/VictoriaMetrics/VictoriaLogs/issues/1743).
+* BUGFIX: `vmselect` in [VictoriaMetrics cluster](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/): apply the `le` filter at `/api/v1/status/metric_names_stats` after merging request counters from all `vmstorage` nodes. Previously, the endpoint could report actively queried metrics as unused when the local request counter was zero on one of the nodes. See [#11473](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/11473).
+
 
 ## [v1.151.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.151.0)
 


### PR DESCRIPTION
The `le` filter was applied by each `vmstorage` before `vmselect` merged request counters. For a metric stored on multiple nodes, the node with a non-zero counter could remove it while a zero-count record from another node remained. This made `le=0` report an actively queried metric as unused.

This change requests unfiltered metric-name stats from every `vmstorage` and applies `le` after `vmselect` merges the counters. The regression coverage includes the merge order and a two-`vmstorage` app test.

Concurrent work:

- #11482 was opened during final validation for this change. This version also adds an end-to-end two-`vmstorage` regression and keeps `RequestsCount` as `uint64` during the `le` comparison.

Before:

```text
--- FAIL: TestFinalizeMetricNamesStatsAppliesLeAfterMerge
unexpected records; got [{unused_metric 0 0} {active_metric 3 0}]; want [{unused_metric 0 0}]
```

After:

- `go test ./app/vmselect/netstorage -run '^TestFinalizeMetricNamesStatsAppliesLeAfterMerge$' -count=1`
- `go test ./app/vmselect/netstorage -count=1`
- `go test ./apptest/tests -run '^TestClusterMetricNamesStatsLeAfterMerge$' -count=1 -v`
- `make check-all`

Fixes https://github.com/VictoriaMetrics/VictoriaMetrics/issues/11473
