### PR TITLE
lib/fs: apply secuential fadvice with prefetch correctly

### DIFF
--- a/lib/fs/fadvise_unix.go
+++ b/lib/fs/fadvise_unix.go
@@ -11,12 +11,13 @@ import (
 
 func fadviseSequentialRead(f *os.File, prefetch bool) error {
 	fd := int(f.Fd())
-	mode := unix.FADV_SEQUENTIAL
-	if prefetch {
-		mode |= unix.FADV_WILLNEED
+	if err := unix.Fadvise(int(fd), 0, 0, unix.FADV_SEQUENTIAL); err != nil {
+		return fmt.Errorf("error returned from unix.Fadvise(%d): %w", unix.FADV_SEQUENTIAL, err)
 	}
-	if err := unix.Fadvise(int(fd), 0, 0, mode); err != nil {
-		return fmt.Errorf("error returned from unix.Fadvise(%d): %w", mode, err)
+	if prefetch {
+		if err := unix.Fadvise(int(fd), 0, 0, unix.FADV_WILLNEED); err != nil {
+			return fmt.Errorf("error returned from unix.Fadvise(%d): %w", unix.FADV_WILLNEED, err)
+		}
 	}
 	return nil
 }

--- a/lib/fs/fadvise_unix.go
+++ b/lib/fs/fadvise_unix.go
@@ -11,11 +11,11 @@ import (
 
 func fadviseSequentialRead(f *os.File, prefetch bool) error {
 	fd := int(f.Fd())
-	if err := unix.Fadvise(int(fd), 0, 0, unix.FADV_SEQUENTIAL); err != nil {
+	if err := unix.Fadvise(fd, 0, 0, unix.FADV_SEQUENTIAL); err != nil {
 		return fmt.Errorf("error returned from unix.Fadvise(%d): %w", unix.FADV_SEQUENTIAL, err)
 	}
 	if prefetch {
-		if err := unix.Fadvise(int(fd), 0, 0, unix.FADV_WILLNEED); err != nil {
+		if err := unix.Fadvise(fd, 0, 0, unix.FADV_WILLNEED); err != nil {
 			return fmt.Errorf("error returned from unix.Fadvise(%d): %w", unix.FADV_WILLNEED, err)
 		}
 	}


### PR DESCRIPTION
This code was saying that was doing something but was doing something completely different. The fadvise Sequencial Hint is suggesting to use the double of read ahead, what is usuful, but if you pass the prefetch was doing a binary or, but the Fadvise mode is not a set of flags, is specific options, in this case we were doing 0x1 | 0x3, what ends up 0x3, what means, we were only advising with will need.

The effect of sequential (double of max read ahead was missing), while the will need is applied.

My understanding is that if for example we have a read_ahead_kb of 512KB, we would read ahead 512KB from the file, and then we read the blocks with the regular readahead policy. and then use the regular readahead approach.

With my changes we apply first sequential, that duplicates that limit, so the first request with the will need, with that same read_ahead_kb setting would read 1MB, and after that it would follow the read ahead pattern with the maximum of 1MB readahead window.
