### PR TITLE
vmselect/expose a new value data_fetch_duration_ms in the query stats…

### DIFF
--- a/app/vmselect/netstorage/netstorage.go
+++ b/app/vmselect/netstorage/netstorage.go
@@ -65,11 +65,24 @@ type Results struct {
 	packedTimeseries []packedTimeseries
 	sr               *storage.Search
 	tbf              *tmpBlocksFile
+
+	samples int
+	bytes   uint64
 }
 
 // Len returns the number of results in rss.
 func (rss *Results) Len() int {
 	return len(rss.packedTimeseries)
+}
+
+// SamplesFetched returns the number of raw samples fetched from storage.
+func (rss *Results) SamplesFetched() int {
+	return rss.samples
+}
+
+// BytesFetched returns the number of bytes fetched from storage (size of marshaled BlockRefs).
+func (rss *Results) BytesFetched() uint64 {
+	return rss.bytes
 }
 
 // Cancel cancels rss work.
@@ -1218,6 +1231,8 @@ func ProcessSearchQuery(qt *querytracer.Tracer, sq *storage.SearchQuery, deadlin
 	rss.packedTimeseries = pts
 	rss.sr = sr
 	rss.tbf = tbf
+	rss.samples = samples
+	rss.bytes = tbf.Len()
 	return &rss, nil
 }
 

--- a/app/vmselect/netstorage/netstorage.go
+++ b/app/vmselect/netstorage/netstorage.go
@@ -80,7 +80,8 @@ func (rss *Results) SamplesFetched() int {
 	return rss.samples
 }
 
-// BytesFetched returns the number of bytes fetched from storage (size of marshaled BlockRefs).
+// BytesFetched returns the number of bytes of compressed block data fetched from storage
+// (sum of TimestampsBlockSize + ValuesBlockSize for all blocks).
 func (rss *Results) BytesFetched() uint64 {
 	return rss.bytes
 }
@@ -1095,6 +1096,7 @@ func ProcessSearchQuery(qt *querytracer.Tracer, sq *storage.SearchQuery, deadlin
 
 	blocksRead := 0
 	samples := 0
+	var bytesData uint64
 	tbf := getTmpBlocksFile()
 	var buf []byte
 	var metricNamePrev []byte
@@ -1136,6 +1138,7 @@ func ProcessSearchQuery(qt *querytracer.Tracer, sq *storage.SearchQuery, deadlin
 		// are left then because of the given time range.
 		// This allows effectively limiting CPU resources used per query.
 		samples += br.RowsCount()
+		bytesData += uint64(br.BlockSize())
 		if *maxSamplesPerQuery > 0 && samples > *maxSamplesPerQuery {
 			putTmpBlocksFile(tbf)
 			vmstorage.PutSearch(sr)
@@ -1216,7 +1219,7 @@ func ProcessSearchQuery(qt *querytracer.Tracer, sq *storage.SearchQuery, deadlin
 		vmstorage.PutSearch(sr)
 		return nil, fmt.Errorf("cannot finalize temporary file: %w", err)
 	}
-	qt.Printf("fetch unique series=%d, blocks=%d, samples=%d, bytes=%d", len(m), blocksRead, samples, tbf.Len())
+	qt.Printf("fetch unique series=%d, blocks=%d, samples=%d, bytes=%d", len(m), blocksRead, samples, bytesData)
 
 	var rss Results
 	rss.tr = sq.GetTimeRange()
@@ -1232,7 +1235,7 @@ func ProcessSearchQuery(qt *querytracer.Tracer, sq *storage.SearchQuery, deadlin
 	rss.sr = sr
 	rss.tbf = tbf
 	rss.samples = samples
-	rss.bytes = tbf.Len()
+	rss.bytes = bytesData
 	return &rss, nil
 }
 

--- a/app/vmselect/prometheus/query_range_response.qtpl
+++ b/app/vmselect/prometheus/query_range_response.qtpl
@@ -36,9 +36,14 @@ See https://prometheus.io/docs/prometheus/latest/querying/api/#range-queries
 			if ed := qs.ExecutionDuration.Load(); ed != nil {
 				executionDuration = ed.Milliseconds()
 			}
+			dataFetchDuration := int64(0)
+			if qs != nil {
+				dataFetchDuration = qs.DataFetchDuration.Load() / 1e6
+			}
 		%}
 		"seriesFetched": "{%dl qs.SeriesFetched.Load() %}",
-		"executionTimeMsec": {%dl executionDuration %}
+		"executionTimeMsec": {%dl executionDuration %},
+		"dataFetchDurationMsec": {%dl dataFetchDuration %}
 	}
 	{% code
 		qt.Printf("generate /api/v1/query_range response for series=%d, points=%d", seriesCount, pointsCount)

--- a/app/vmselect/prometheus/query_range_response.qtpl
+++ b/app/vmselect/prometheus/query_range_response.qtpl
@@ -36,10 +36,7 @@ See https://prometheus.io/docs/prometheus/latest/querying/api/#range-queries
 			if ed := qs.ExecutionDuration.Load(); ed != nil {
 				executionDuration = ed.Milliseconds()
 			}
-			dataFetchDuration := int64(0)
-			if qs != nil {
-				dataFetchDuration = qs.DataFetchDuration.Load() / 1e6
-			}
+			dataFetchDuration := qs.DataFetchDuration.Load() / 1e6
 		%}
 		"seriesFetched": "{%dl qs.SeriesFetched.Load() %}",
 		"executionTimeMsec": {%dl executionDuration %},

--- a/app/vmselect/prometheus/query_range_response.qtpl.go
+++ b/app/vmselect/prometheus/query_range_response.qtpl.go
@@ -68,99 +68,96 @@ func StreamQueryRangeResponse(qw422016 *qt422016.Writer, rs []netstorage.Result,
 	if ed := qs.ExecutionDuration.Load(); ed != nil {
 		executionDuration = ed.Milliseconds()
 	}
-	dataFetchDuration := int64(0)
-	if qs != nil {
-		dataFetchDuration = qs.DataFetchDuration.Load() / 1e6
-	}
+	dataFetchDuration := qs.DataFetchDuration.Load() / 1e6
 
-//line app/vmselect/prometheus/query_range_response.qtpl:43
+//line app/vmselect/prometheus/query_range_response.qtpl:40
 	qw422016.N().S(`"seriesFetched": "`)
-//line app/vmselect/prometheus/query_range_response.qtpl:44
+//line app/vmselect/prometheus/query_range_response.qtpl:41
 	qw422016.N().DL(qs.SeriesFetched.Load())
-//line app/vmselect/prometheus/query_range_response.qtpl:44
+//line app/vmselect/prometheus/query_range_response.qtpl:41
 	qw422016.N().S(`","executionTimeMsec":`)
-//line app/vmselect/prometheus/query_range_response.qtpl:45
+//line app/vmselect/prometheus/query_range_response.qtpl:42
 	qw422016.N().DL(executionDuration)
-//line app/vmselect/prometheus/query_range_response.qtpl:45
+//line app/vmselect/prometheus/query_range_response.qtpl:42
 	qw422016.N().S(`,"dataFetchDurationMsec":`)
-//line app/vmselect/prometheus/query_range_response.qtpl:46
+//line app/vmselect/prometheus/query_range_response.qtpl:43
 	qw422016.N().DL(dataFetchDuration)
-//line app/vmselect/prometheus/query_range_response.qtpl:46
+//line app/vmselect/prometheus/query_range_response.qtpl:43
 	qw422016.N().S(`}`)
-//line app/vmselect/prometheus/query_range_response.qtpl:49
+//line app/vmselect/prometheus/query_range_response.qtpl:46
 	qt.Printf("generate /api/v1/query_range response for series=%d, points=%d", seriesCount, pointsCount)
 	qtDone()
 
-//line app/vmselect/prometheus/query_range_response.qtpl:52
+//line app/vmselect/prometheus/query_range_response.qtpl:49
 	streamdumpQueryTrace(qw422016, qt)
-//line app/vmselect/prometheus/query_range_response.qtpl:52
+//line app/vmselect/prometheus/query_range_response.qtpl:49
 	qw422016.N().S(`}`)
-//line app/vmselect/prometheus/query_range_response.qtpl:54
+//line app/vmselect/prometheus/query_range_response.qtpl:51
 }
 
-//line app/vmselect/prometheus/query_range_response.qtpl:54
+//line app/vmselect/prometheus/query_range_response.qtpl:51
 func WriteQueryRangeResponse(qq422016 qtio422016.Writer, rs []netstorage.Result, qt *querytracer.Tracer, qtDone func(), qs *promql.QueryStats) {
-//line app/vmselect/prometheus/query_range_response.qtpl:54
+//line app/vmselect/prometheus/query_range_response.qtpl:51
 	qw422016 := qt422016.AcquireWriter(qq422016)
-//line app/vmselect/prometheus/query_range_response.qtpl:54
+//line app/vmselect/prometheus/query_range_response.qtpl:51
 	StreamQueryRangeResponse(qw422016, rs, qt, qtDone, qs)
-//line app/vmselect/prometheus/query_range_response.qtpl:54
+//line app/vmselect/prometheus/query_range_response.qtpl:51
 	qt422016.ReleaseWriter(qw422016)
-//line app/vmselect/prometheus/query_range_response.qtpl:54
+//line app/vmselect/prometheus/query_range_response.qtpl:51
 }
 
-//line app/vmselect/prometheus/query_range_response.qtpl:54
+//line app/vmselect/prometheus/query_range_response.qtpl:51
 func QueryRangeResponse(rs []netstorage.Result, qt *querytracer.Tracer, qtDone func(), qs *promql.QueryStats) string {
-//line app/vmselect/prometheus/query_range_response.qtpl:54
+//line app/vmselect/prometheus/query_range_response.qtpl:51
 	qb422016 := qt422016.AcquireByteBuffer()
-//line app/vmselect/prometheus/query_range_response.qtpl:54
+//line app/vmselect/prometheus/query_range_response.qtpl:51
 	WriteQueryRangeResponse(qb422016, rs, qt, qtDone, qs)
-//line app/vmselect/prometheus/query_range_response.qtpl:54
+//line app/vmselect/prometheus/query_range_response.qtpl:51
 	qs422016 := string(qb422016.B)
-//line app/vmselect/prometheus/query_range_response.qtpl:54
+//line app/vmselect/prometheus/query_range_response.qtpl:51
 	qt422016.ReleaseByteBuffer(qb422016)
-//line app/vmselect/prometheus/query_range_response.qtpl:54
+//line app/vmselect/prometheus/query_range_response.qtpl:51
 	return qs422016
-//line app/vmselect/prometheus/query_range_response.qtpl:54
+//line app/vmselect/prometheus/query_range_response.qtpl:51
 }
 
-//line app/vmselect/prometheus/query_range_response.qtpl:56
+//line app/vmselect/prometheus/query_range_response.qtpl:53
 func streamqueryRangeLine(qw422016 *qt422016.Writer, r *netstorage.Result) {
-//line app/vmselect/prometheus/query_range_response.qtpl:56
+//line app/vmselect/prometheus/query_range_response.qtpl:53
 	qw422016.N().S(`{"metric":`)
-//line app/vmselect/prometheus/query_range_response.qtpl:58
+//line app/vmselect/prometheus/query_range_response.qtpl:55
 	streammetricNameObject(qw422016, &r.MetricName)
-//line app/vmselect/prometheus/query_range_response.qtpl:58
+//line app/vmselect/prometheus/query_range_response.qtpl:55
 	qw422016.N().S(`,"values":`)
-//line app/vmselect/prometheus/query_range_response.qtpl:59
+//line app/vmselect/prometheus/query_range_response.qtpl:56
 	streamvaluesWithTimestamps(qw422016, r.Values, r.Timestamps)
-//line app/vmselect/prometheus/query_range_response.qtpl:59
+//line app/vmselect/prometheus/query_range_response.qtpl:56
 	qw422016.N().S(`}`)
-//line app/vmselect/prometheus/query_range_response.qtpl:61
+//line app/vmselect/prometheus/query_range_response.qtpl:58
 }
 
-//line app/vmselect/prometheus/query_range_response.qtpl:61
+//line app/vmselect/prometheus/query_range_response.qtpl:58
 func writequeryRangeLine(qq422016 qtio422016.Writer, r *netstorage.Result) {
-//line app/vmselect/prometheus/query_range_response.qtpl:61
+//line app/vmselect/prometheus/query_range_response.qtpl:58
 	qw422016 := qt422016.AcquireWriter(qq422016)
-//line app/vmselect/prometheus/query_range_response.qtpl:61
+//line app/vmselect/prometheus/query_range_response.qtpl:58
 	streamqueryRangeLine(qw422016, r)
-//line app/vmselect/prometheus/query_range_response.qtpl:61
+//line app/vmselect/prometheus/query_range_response.qtpl:58
 	qt422016.ReleaseWriter(qw422016)
-//line app/vmselect/prometheus/query_range_response.qtpl:61
+//line app/vmselect/prometheus/query_range_response.qtpl:58
 }
 
-//line app/vmselect/prometheus/query_range_response.qtpl:61
+//line app/vmselect/prometheus/query_range_response.qtpl:58
 func queryRangeLine(r *netstorage.Result) string {
-//line app/vmselect/prometheus/query_range_response.qtpl:61
+//line app/vmselect/prometheus/query_range_response.qtpl:58
 	qb422016 := qt422016.AcquireByteBuffer()
-//line app/vmselect/prometheus/query_range_response.qtpl:61
+//line app/vmselect/prometheus/query_range_response.qtpl:58
 	writequeryRangeLine(qb422016, r)
-//line app/vmselect/prometheus/query_range_response.qtpl:61
+//line app/vmselect/prometheus/query_range_response.qtpl:58
 	qs422016 := string(qb422016.B)
-//line app/vmselect/prometheus/query_range_response.qtpl:61
+//line app/vmselect/prometheus/query_range_response.qtpl:58
 	qt422016.ReleaseByteBuffer(qb422016)
-//line app/vmselect/prometheus/query_range_response.qtpl:61
+//line app/vmselect/prometheus/query_range_response.qtpl:58
 	return qs422016
-//line app/vmselect/prometheus/query_range_response.qtpl:61
+//line app/vmselect/prometheus/query_range_response.qtpl:58
 }

--- a/app/vmselect/prometheus/query_range_response.qtpl.go
+++ b/app/vmselect/prometheus/query_range_response.qtpl.go
@@ -68,91 +68,99 @@ func StreamQueryRangeResponse(qw422016 *qt422016.Writer, rs []netstorage.Result,
 	if ed := qs.ExecutionDuration.Load(); ed != nil {
 		executionDuration = ed.Milliseconds()
 	}
+	dataFetchDuration := int64(0)
+	if qs != nil {
+		dataFetchDuration = qs.DataFetchDuration.Load() / 1e6
+	}
 
-//line app/vmselect/prometheus/query_range_response.qtpl:39
+//line app/vmselect/prometheus/query_range_response.qtpl:43
 	qw422016.N().S(`"seriesFetched": "`)
-//line app/vmselect/prometheus/query_range_response.qtpl:40
-	qw422016.N().DL(qs.SeriesFetched.Load())
-//line app/vmselect/prometheus/query_range_response.qtpl:40
-	qw422016.N().S(`","executionTimeMsec":`)
-//line app/vmselect/prometheus/query_range_response.qtpl:41
-	qw422016.N().DL(executionDuration)
-//line app/vmselect/prometheus/query_range_response.qtpl:41
-	qw422016.N().S(`}`)
 //line app/vmselect/prometheus/query_range_response.qtpl:44
+	qw422016.N().DL(qs.SeriesFetched.Load())
+//line app/vmselect/prometheus/query_range_response.qtpl:44
+	qw422016.N().S(`","executionTimeMsec":`)
+//line app/vmselect/prometheus/query_range_response.qtpl:45
+	qw422016.N().DL(executionDuration)
+//line app/vmselect/prometheus/query_range_response.qtpl:45
+	qw422016.N().S(`,"dataFetchDurationMsec":`)
+//line app/vmselect/prometheus/query_range_response.qtpl:46
+	qw422016.N().DL(dataFetchDuration)
+//line app/vmselect/prometheus/query_range_response.qtpl:46
+	qw422016.N().S(`}`)
+//line app/vmselect/prometheus/query_range_response.qtpl:49
 	qt.Printf("generate /api/v1/query_range response for series=%d, points=%d", seriesCount, pointsCount)
 	qtDone()
 
-//line app/vmselect/prometheus/query_range_response.qtpl:47
+//line app/vmselect/prometheus/query_range_response.qtpl:52
 	streamdumpQueryTrace(qw422016, qt)
-//line app/vmselect/prometheus/query_range_response.qtpl:47
+//line app/vmselect/prometheus/query_range_response.qtpl:52
 	qw422016.N().S(`}`)
-//line app/vmselect/prometheus/query_range_response.qtpl:49
+//line app/vmselect/prometheus/query_range_response.qtpl:54
 }
 
-//line app/vmselect/prometheus/query_range_response.qtpl:49
+//line app/vmselect/prometheus/query_range_response.qtpl:54
 func WriteQueryRangeResponse(qq422016 qtio422016.Writer, rs []netstorage.Result, qt *querytracer.Tracer, qtDone func(), qs *promql.QueryStats) {
-//line app/vmselect/prometheus/query_range_response.qtpl:49
+//line app/vmselect/prometheus/query_range_response.qtpl:54
 	qw422016 := qt422016.AcquireWriter(qq422016)
-//line app/vmselect/prometheus/query_range_response.qtpl:49
+//line app/vmselect/prometheus/query_range_response.qtpl:54
 	StreamQueryRangeResponse(qw422016, rs, qt, qtDone, qs)
-//line app/vmselect/prometheus/query_range_response.qtpl:49
+//line app/vmselect/prometheus/query_range_response.qtpl:54
 	qt422016.ReleaseWriter(qw422016)
-//line app/vmselect/prometheus/query_range_response.qtpl:49
+//line app/vmselect/prometheus/query_range_response.qtpl:54
 }
 
-//line app/vmselect/prometheus/query_range_response.qtpl:49
+//line app/vmselect/prometheus/query_range_response.qtpl:54
 func QueryRangeResponse(rs []netstorage.Result, qt *querytracer.Tracer, qtDone func(), qs *promql.QueryStats) string {
-//line app/vmselect/prometheus/query_range_response.qtpl:49
+//line app/vmselect/prometheus/query_range_response.qtpl:54
 	qb422016 := qt422016.AcquireByteBuffer()
-//line app/vmselect/prometheus/query_range_response.qtpl:49
+//line app/vmselect/prometheus/query_range_response.qtpl:54
 	WriteQueryRangeResponse(qb422016, rs, qt, qtDone, qs)
-//line app/vmselect/prometheus/query_range_response.qtpl:49
+//line app/vmselect/prometheus/query_range_response.qtpl:54
 	qs422016 := string(qb422016.B)
-//line app/vmselect/prometheus/query_range_response.qtpl:49
+//line app/vmselect/prometheus/query_range_response.qtpl:54
 	qt422016.ReleaseByteBuffer(qb422016)
-//line app/vmselect/prometheus/query_range_response.qtpl:49
+//line app/vmselect/prometheus/query_range_response.qtpl:54
 	return qs422016
-//line app/vmselect/prometheus/query_range_response.qtpl:49
+//line app/vmselect/prometheus/query_range_response.qtpl:54
 }
 
-//line app/vmselect/prometheus/query_range_response.qtpl:51
+//line app/vmselect/prometheus/query_range_response.qtpl:56
 func streamqueryRangeLine(qw422016 *qt422016.Writer, r *netstorage.Result) {
-//line app/vmselect/prometheus/query_range_response.qtpl:51
+//line app/vmselect/prometheus/query_range_response.qtpl:56
 	qw422016.N().S(`{"metric":`)
-//line app/vmselect/prometheus/query_range_response.qtpl:53
+//line app/vmselect/prometheus/query_range_response.qtpl:58
 	streammetricNameObject(qw422016, &r.MetricName)
-//line app/vmselect/prometheus/query_range_response.qtpl:53
+//line app/vmselect/prometheus/query_range_response.qtpl:58
 	qw422016.N().S(`,"values":`)
-//line app/vmselect/prometheus/query_range_response.qtpl:54
+//line app/vmselect/prometheus/query_range_response.qtpl:59
 	streamvaluesWithTimestamps(qw422016, r.Values, r.Timestamps)
-//line app/vmselect/prometheus/query_range_response.qtpl:54
+//line app/vmselect/prometheus/query_range_response.qtpl:59
 	qw422016.N().S(`}`)
-//line app/vmselect/prometheus/query_range_response.qtpl:56
+//line app/vmselect/prometheus/query_range_response.qtpl:61
 }
 
-//line app/vmselect/prometheus/query_range_response.qtpl:56
+//line app/vmselect/prometheus/query_range_response.qtpl:61
 func writequeryRangeLine(qq422016 qtio422016.Writer, r *netstorage.Result) {
-//line app/vmselect/prometheus/query_range_response.qtpl:56
+//line app/vmselect/prometheus/query_range_response.qtpl:61
 	qw422016 := qt422016.AcquireWriter(qq422016)
-//line app/vmselect/prometheus/query_range_response.qtpl:56
+//line app/vmselect/prometheus/query_range_response.qtpl:61
 	streamqueryRangeLine(qw422016, r)
-//line app/vmselect/prometheus/query_range_response.qtpl:56
+//line app/vmselect/prometheus/query_range_response.qtpl:61
 	qt422016.ReleaseWriter(qw422016)
-//line app/vmselect/prometheus/query_range_response.qtpl:56
+//line app/vmselect/prometheus/query_range_response.qtpl:61
 }
 
-//line app/vmselect/prometheus/query_range_response.qtpl:56
+//line app/vmselect/prometheus/query_range_response.qtpl:61
 func queryRangeLine(r *netstorage.Result) string {
-//line app/vmselect/prometheus/query_range_response.qtpl:56
+//line app/vmselect/prometheus/query_range_response.qtpl:61
 	qb422016 := qt422016.AcquireByteBuffer()
-//line app/vmselect/prometheus/query_range_response.qtpl:56
+//line app/vmselect/prometheus/query_range_response.qtpl:61
 	writequeryRangeLine(qb422016, r)
-//line app/vmselect/prometheus/query_range_response.qtpl:56
+//line app/vmselect/prometheus/query_range_response.qtpl:61
 	qs422016 := string(qb422016.B)
-//line app/vmselect/prometheus/query_range_response.qtpl:56
+//line app/vmselect/prometheus/query_range_response.qtpl:61
 	qt422016.ReleaseByteBuffer(qb422016)
-//line app/vmselect/prometheus/query_range_response.qtpl:56
+//line app/vmselect/prometheus/query_range_response.qtpl:61
 	return qs422016
-//line app/vmselect/prometheus/query_range_response.qtpl:56
+//line app/vmselect/prometheus/query_range_response.qtpl:61
 }

--- a/app/vmselect/prometheus/query_response.qtpl
+++ b/app/vmselect/prometheus/query_response.qtpl
@@ -38,9 +38,14 @@ See https://prometheus.io/docs/prometheus/latest/querying/api/#instant-queries
             if ed := qs.ExecutionDuration.Load(); ed != nil {
                 executionDuration = ed.Milliseconds()
             }
+            dataFetchDuration := int64(0)
+            if qs != nil {
+                dataFetchDuration = qs.DataFetchDuration.Load() / 1e6
+            }
 		%}
 		"seriesFetched": "{%dl qs.SeriesFetched.Load() %}",
-		"executionTimeMsec": {%dl executionDuration %}
+		"executionTimeMsec": {%dl executionDuration %},
+		"dataFetchDurationMsec": {%dl dataFetchDuration %}
 	}
 	{% code
 		qt.Printf("generate /api/v1/query response for series=%d", seriesCount)

--- a/app/vmselect/prometheus/query_response.qtpl
+++ b/app/vmselect/prometheus/query_response.qtpl
@@ -38,10 +38,7 @@ See https://prometheus.io/docs/prometheus/latest/querying/api/#instant-queries
             if ed := qs.ExecutionDuration.Load(); ed != nil {
                 executionDuration = ed.Milliseconds()
             }
-            dataFetchDuration := int64(0)
-            if qs != nil {
-                dataFetchDuration = qs.DataFetchDuration.Load() / 1e6
-            }
+            dataFetchDuration := qs.DataFetchDuration.Load() / 1e6
 		%}
 		"seriesFetched": "{%dl qs.SeriesFetched.Load() %}",
 		"executionTimeMsec": {%dl executionDuration %},

--- a/app/vmselect/prometheus/query_response.qtpl.go
+++ b/app/vmselect/prometheus/query_response.qtpl.go
@@ -78,50 +78,58 @@ func StreamQueryResponse(qw422016 *qt422016.Writer, rs []netstorage.Result, qt *
 	if ed := qs.ExecutionDuration.Load(); ed != nil {
 		executionDuration = ed.Milliseconds()
 	}
+	dataFetchDuration := int64(0)
+	if qs != nil {
+		dataFetchDuration = qs.DataFetchDuration.Load() / 1e6
+	}
 
-//line app/vmselect/prometheus/query_response.qtpl:41
+//line app/vmselect/prometheus/query_response.qtpl:45
 	qw422016.N().S(`"seriesFetched": "`)
-//line app/vmselect/prometheus/query_response.qtpl:42
-	qw422016.N().DL(qs.SeriesFetched.Load())
-//line app/vmselect/prometheus/query_response.qtpl:42
-	qw422016.N().S(`","executionTimeMsec":`)
-//line app/vmselect/prometheus/query_response.qtpl:43
-	qw422016.N().DL(executionDuration)
-//line app/vmselect/prometheus/query_response.qtpl:43
-	qw422016.N().S(`}`)
 //line app/vmselect/prometheus/query_response.qtpl:46
+	qw422016.N().DL(qs.SeriesFetched.Load())
+//line app/vmselect/prometheus/query_response.qtpl:46
+	qw422016.N().S(`","executionTimeMsec":`)
+//line app/vmselect/prometheus/query_response.qtpl:47
+	qw422016.N().DL(executionDuration)
+//line app/vmselect/prometheus/query_response.qtpl:47
+	qw422016.N().S(`,"dataFetchDurationMsec":`)
+//line app/vmselect/prometheus/query_response.qtpl:48
+	qw422016.N().DL(dataFetchDuration)
+//line app/vmselect/prometheus/query_response.qtpl:48
+	qw422016.N().S(`}`)
+//line app/vmselect/prometheus/query_response.qtpl:51
 	qt.Printf("generate /api/v1/query response for series=%d", seriesCount)
 	qtDone()
 
-//line app/vmselect/prometheus/query_response.qtpl:49
+//line app/vmselect/prometheus/query_response.qtpl:54
 	streamdumpQueryTrace(qw422016, qt)
-//line app/vmselect/prometheus/query_response.qtpl:49
+//line app/vmselect/prometheus/query_response.qtpl:54
 	qw422016.N().S(`}`)
-//line app/vmselect/prometheus/query_response.qtpl:51
+//line app/vmselect/prometheus/query_response.qtpl:56
 }
 
-//line app/vmselect/prometheus/query_response.qtpl:51
+//line app/vmselect/prometheus/query_response.qtpl:56
 func WriteQueryResponse(qq422016 qtio422016.Writer, rs []netstorage.Result, qt *querytracer.Tracer, qtDone func(), qs *promql.QueryStats) {
-//line app/vmselect/prometheus/query_response.qtpl:51
+//line app/vmselect/prometheus/query_response.qtpl:56
 	qw422016 := qt422016.AcquireWriter(qq422016)
-//line app/vmselect/prometheus/query_response.qtpl:51
+//line app/vmselect/prometheus/query_response.qtpl:56
 	StreamQueryResponse(qw422016, rs, qt, qtDone, qs)
-//line app/vmselect/prometheus/query_response.qtpl:51
+//line app/vmselect/prometheus/query_response.qtpl:56
 	qt422016.ReleaseWriter(qw422016)
-//line app/vmselect/prometheus/query_response.qtpl:51
+//line app/vmselect/prometheus/query_response.qtpl:56
 }
 
-//line app/vmselect/prometheus/query_response.qtpl:51
+//line app/vmselect/prometheus/query_response.qtpl:56
 func QueryResponse(rs []netstorage.Result, qt *querytracer.Tracer, qtDone func(), qs *promql.QueryStats) string {
-//line app/vmselect/prometheus/query_response.qtpl:51
+//line app/vmselect/prometheus/query_response.qtpl:56
 	qb422016 := qt422016.AcquireByteBuffer()
-//line app/vmselect/prometheus/query_response.qtpl:51
+//line app/vmselect/prometheus/query_response.qtpl:56
 	WriteQueryResponse(qb422016, rs, qt, qtDone, qs)
-//line app/vmselect/prometheus/query_response.qtpl:51
+//line app/vmselect/prometheus/query_response.qtpl:56
 	qs422016 := string(qb422016.B)
-//line app/vmselect/prometheus/query_response.qtpl:51
+//line app/vmselect/prometheus/query_response.qtpl:56
 	qt422016.ReleaseByteBuffer(qb422016)
-//line app/vmselect/prometheus/query_response.qtpl:51
+//line app/vmselect/prometheus/query_response.qtpl:56
 	return qs422016
-//line app/vmselect/prometheus/query_response.qtpl:51
+//line app/vmselect/prometheus/query_response.qtpl:56
 }

--- a/app/vmselect/prometheus/query_response.qtpl.go
+++ b/app/vmselect/prometheus/query_response.qtpl.go
@@ -78,58 +78,55 @@ func StreamQueryResponse(qw422016 *qt422016.Writer, rs []netstorage.Result, qt *
 	if ed := qs.ExecutionDuration.Load(); ed != nil {
 		executionDuration = ed.Milliseconds()
 	}
-	dataFetchDuration := int64(0)
-	if qs != nil {
-		dataFetchDuration = qs.DataFetchDuration.Load() / 1e6
-	}
+	dataFetchDuration := qs.DataFetchDuration.Load() / 1e6
 
-//line app/vmselect/prometheus/query_response.qtpl:45
+//line app/vmselect/prometheus/query_response.qtpl:42
 	qw422016.N().S(`"seriesFetched": "`)
-//line app/vmselect/prometheus/query_response.qtpl:46
+//line app/vmselect/prometheus/query_response.qtpl:43
 	qw422016.N().DL(qs.SeriesFetched.Load())
-//line app/vmselect/prometheus/query_response.qtpl:46
+//line app/vmselect/prometheus/query_response.qtpl:43
 	qw422016.N().S(`","executionTimeMsec":`)
-//line app/vmselect/prometheus/query_response.qtpl:47
+//line app/vmselect/prometheus/query_response.qtpl:44
 	qw422016.N().DL(executionDuration)
-//line app/vmselect/prometheus/query_response.qtpl:47
+//line app/vmselect/prometheus/query_response.qtpl:44
 	qw422016.N().S(`,"dataFetchDurationMsec":`)
-//line app/vmselect/prometheus/query_response.qtpl:48
+//line app/vmselect/prometheus/query_response.qtpl:45
 	qw422016.N().DL(dataFetchDuration)
-//line app/vmselect/prometheus/query_response.qtpl:48
+//line app/vmselect/prometheus/query_response.qtpl:45
 	qw422016.N().S(`}`)
-//line app/vmselect/prometheus/query_response.qtpl:51
+//line app/vmselect/prometheus/query_response.qtpl:48
 	qt.Printf("generate /api/v1/query response for series=%d", seriesCount)
 	qtDone()
 
-//line app/vmselect/prometheus/query_response.qtpl:54
+//line app/vmselect/prometheus/query_response.qtpl:51
 	streamdumpQueryTrace(qw422016, qt)
-//line app/vmselect/prometheus/query_response.qtpl:54
+//line app/vmselect/prometheus/query_response.qtpl:51
 	qw422016.N().S(`}`)
-//line app/vmselect/prometheus/query_response.qtpl:56
+//line app/vmselect/prometheus/query_response.qtpl:53
 }
 
-//line app/vmselect/prometheus/query_response.qtpl:56
+//line app/vmselect/prometheus/query_response.qtpl:53
 func WriteQueryResponse(qq422016 qtio422016.Writer, rs []netstorage.Result, qt *querytracer.Tracer, qtDone func(), qs *promql.QueryStats) {
-//line app/vmselect/prometheus/query_response.qtpl:56
+//line app/vmselect/prometheus/query_response.qtpl:53
 	qw422016 := qt422016.AcquireWriter(qq422016)
-//line app/vmselect/prometheus/query_response.qtpl:56
+//line app/vmselect/prometheus/query_response.qtpl:53
 	StreamQueryResponse(qw422016, rs, qt, qtDone, qs)
-//line app/vmselect/prometheus/query_response.qtpl:56
+//line app/vmselect/prometheus/query_response.qtpl:53
 	qt422016.ReleaseWriter(qw422016)
-//line app/vmselect/prometheus/query_response.qtpl:56
+//line app/vmselect/prometheus/query_response.qtpl:53
 }
 
-//line app/vmselect/prometheus/query_response.qtpl:56
+//line app/vmselect/prometheus/query_response.qtpl:53
 func QueryResponse(rs []netstorage.Result, qt *querytracer.Tracer, qtDone func(), qs *promql.QueryStats) string {
-//line app/vmselect/prometheus/query_response.qtpl:56
+//line app/vmselect/prometheus/query_response.qtpl:53
 	qb422016 := qt422016.AcquireByteBuffer()
-//line app/vmselect/prometheus/query_response.qtpl:56
+//line app/vmselect/prometheus/query_response.qtpl:53
 	WriteQueryResponse(qb422016, rs, qt, qtDone, qs)
-//line app/vmselect/prometheus/query_response.qtpl:56
+//line app/vmselect/prometheus/query_response.qtpl:53
 	qs422016 := string(qb422016.B)
-//line app/vmselect/prometheus/query_response.qtpl:56
+//line app/vmselect/prometheus/query_response.qtpl:53
 	qt422016.ReleaseByteBuffer(qb422016)
-//line app/vmselect/prometheus/query_response.qtpl:56
+//line app/vmselect/prometheus/query_response.qtpl:53
 	return qs422016
-//line app/vmselect/prometheus/query_response.qtpl:56
+//line app/vmselect/prometheus/query_response.qtpl:53
 }

--- a/app/vmselect/promql/eval.go
+++ b/app/vmselect/promql/eval.go
@@ -1830,11 +1830,15 @@ func evalRollupFuncNoCache(qt *querytracer.Tracer, ec *EvalConfig, funcName stri
 		minTimestamp -= ec.Step
 	}
 	sq := storage.NewSearchQuery(minTimestamp, ec.End, tfss, ec.MaxSeries)
+	qs := ec.QueryStats
+	startTime := time.Now()
 	rss, err := netstorage.ProcessSearchQuery(qt, sq, ec.Deadline)
+	if qs != nil {
+		qs.addDataFetchDuration(time.Since(startTime))
+	}
 	if err != nil {
 		return nil, err
 	}
-	qs := ec.QueryStats
 	rssLen := rss.Len()
 	if rssLen == 0 {
 		rss.Cancel()

--- a/app/vmselect/promql/eval.go
+++ b/app/vmselect/promql/eval.go
@@ -1845,6 +1845,8 @@ func evalRollupFuncNoCache(qt *querytracer.Tracer, ec *EvalConfig, funcName stri
 		return nil, nil
 	}
 	qs.addSeriesFetched(rssLen)
+	qs.addSamplesFetched(rss.SamplesFetched())
+	qs.addBytesFetched(rss.BytesFetched())
 
 	// Verify timeseries fit available memory during rollup calculations.
 	timeseriesLen := rssLen

--- a/app/vmselect/promql/eval_test.go
+++ b/app/vmselect/promql/eval_test.go
@@ -3,6 +3,7 @@ package promql
 import (
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/protoparser/prometheus"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/storage"
@@ -95,6 +96,95 @@ func TestQueryStats_addSeriesFetched(t *testing.T) {
 	if n := qs.SeriesFetched.Load(); n != 4 {
 		t.Fatalf("expected to get 4; got %d instead", n)
 	}
+}
+
+func TestQueryStats_DataFetchDuration(t *testing.T) {
+	qs := &QueryStats{}
+	// nil safety
+	var qsNil *QueryStats
+	qsNil.addDataFetchDuration(5 * 1000000)
+	if qsNil.getDataFetchDuration() != 0 {
+		t.Fatalf("expected 0 for nil QueryStats; got %d", qsNil.getDataFetchDuration())
+	}
+	if n := qs.DataFetchDuration.Load(); n != 0 {
+		t.Fatalf("expected initial 0; got %d", n)
+	}
+	qs.addDataFetchDuration(10 * 1000000)
+	if d := qs.getDataFetchDuration(); d != 10*1000000 {
+		t.Fatalf("expected 10ms; got %v", d)
+	}
+	qs.addDataFetchDuration(5 * 1000000)
+	if d := qs.getDataFetchDuration(); d != 15*1000000 {
+		t.Fatalf("expected 15ms after second add; got %v", d)
+	}
+	if ms := qs.getDataFetchDuration().Milliseconds(); ms != 15 {
+		t.Fatalf("expected 15 milliseconds; got %d", ms)
+	}
+	// Verify DataFetchDuration does not interfere with ExecutionDuration
+	qs2 := &QueryStats{}
+	qs2.addDataFetchDuration(20 * 1000000)
+	qs2.addExecutionTimeMsec(time.Now().Add(-10 * 1000000))
+	if ed := qs2.ExecutionDuration.Load(); ed == nil {
+		t.Fatalf("expected ExecutionDuration to be set")
+	}
+	if d := qs2.getDataFetchDuration(); d != 20*1000000 {
+		t.Fatalf("expected data fetch 20ms; got %v", d)
+	}
+	// Concurrent adds
+	qs3 := &QueryStats{}
+	var wg = make(chan struct{})
+	go func() {
+		for range 100 {
+			qs3.addDataFetchDuration(1000000)
+		}
+		close(wg)
+	}()
+	for range 100 {
+		qs3.addDataFetchDuration(1000000)
+	}
+	<-wg
+	if d := qs3.getDataFetchDuration(); d != 200*1000000 {
+		t.Fatalf("expected 200ms after concurrent adds; got %v", d)
+	}
+}
+
+func TestQueryStats_ExecutionDurationPreserved(t *testing.T) {
+	qs := &QueryStats{}
+	start := time.Now().Add(-50 * 1000000)
+	qs.addExecutionTimeMsec(start)
+	if ed := qs.ExecutionDuration.Load(); ed == nil {
+		t.Fatalf("expected ExecutionDuration to be set")
+	} else {
+		ms := ed.Milliseconds()
+		if ms < 50 || ms > 100 {
+			t.Fatalf("expected execution duration ~50ms; got %d", ms)
+		}
+	}
+	// Ensure DataFetchDuration is independent and initially 0
+	if d := qs.getDataFetchDuration(); d != 0 {
+		t.Fatalf("expected data fetch 0; got %v", d)
+	}
+	// Ensure adding data fetch doesn't affect execution duration
+	qs.addDataFetchDuration(10 * 1000000)
+	if ed := qs.ExecutionDuration.Load(); ed == nil {
+		t.Fatalf("expected ExecutionDuration still set")
+	}
+}
+
+func TestQueryStats_NilSafety(t *testing.T) {
+	var qs *QueryStats
+	// Should not panic
+	qs.addSeriesFetched(1)
+	qs.addExecutionTimeMsec(time.Now())
+	qs.addDataFetchDuration(1000000)
+	qs.addMemoryUsage(100)
+	if qs.memoryUsage() != 0 {
+		t.Fatalf("expected 0 for nil memoryUsage")
+	}
+	if qs.getDataFetchDuration() != 0 {
+		t.Fatalf("expected 0 for nil dataFetchDuration")
+	}
+	qs.maybeLogQueryStats(time.Now())
 }
 
 func TestGetSumInstantValues(t *testing.T) {

--- a/app/vmselect/promql/eval_test.go
+++ b/app/vmselect/promql/eval_test.go
@@ -177,6 +177,8 @@ func TestQueryStats_NilSafety(t *testing.T) {
 	qs.addSeriesFetched(1)
 	qs.addExecutionTimeMsec(time.Now())
 	qs.addDataFetchDuration(time.Millisecond)
+	qs.addSamplesFetched(10)
+	qs.addBytesFetched(1024)
 	qs.addMemoryUsage(100)
 	if qs.memoryUsage() != 0 {
 		t.Fatalf("expected 0 for nil memoryUsage")
@@ -184,7 +186,68 @@ func TestQueryStats_NilSafety(t *testing.T) {
 	if qs.getDataFetchDuration() != 0 {
 		t.Fatalf("expected 0 for nil dataFetchDuration")
 	}
+	// SamplesFetched/BytesFetched are not directly readable when qs is nil (would panic on Load),
+	// but add* methods must be nil-safe and maybeLog must not panic.
 	qs.maybeLogQueryStats(time.Now())
+}
+
+func TestQueryStats_SamplesAndBytesFetched(t *testing.T) {
+	qs := &QueryStats{}
+	if n := qs.SamplesFetched.Load(); n != 0 {
+		t.Fatalf("expected initial 0 for SamplesFetched; got %d", n)
+	}
+	if n := qs.BytesFetched.Load(); n != 0 {
+		t.Fatalf("expected initial 0 for BytesFetched; got %d", n)
+	}
+	qs.addSamplesFetched(100)
+	qs.addBytesFetched(4096)
+	if n := qs.SamplesFetched.Load(); n != 100 {
+		t.Fatalf("expected 100 samples; got %d", n)
+	}
+	if n := qs.BytesFetched.Load(); n != 4096 {
+		t.Fatalf("expected 4096 bytes; got %d", n)
+	}
+	qs.addSamplesFetched(50)
+	qs.addBytesFetched(1024)
+	if n := qs.SamplesFetched.Load(); n != 150 {
+		t.Fatalf("expected 150 samples after second add; got %d", n)
+	}
+	if n := qs.BytesFetched.Load(); n != 5120 {
+		t.Fatalf("expected 5120 bytes after second add; got %d", n)
+	}
+	// Nil safety already tested, but verify concurrent adds
+	qs2 := &QueryStats{}
+	var wg = make(chan struct{})
+	go func() {
+		for range 100 {
+			qs2.addSamplesFetched(1)
+			qs2.addBytesFetched(10)
+		}
+		close(wg)
+	}()
+	for range 100 {
+		qs2.addSamplesFetched(1)
+		qs2.addBytesFetched(10)
+	}
+	<-wg
+	if n := qs2.SamplesFetched.Load(); n != 200 {
+		t.Fatalf("expected 200 samples after concurrent adds; got %d", n)
+	}
+	if n := qs2.BytesFetched.Load(); n != 2000 {
+		t.Fatalf("expected 2000 bytes after concurrent adds; got %d", n)
+	}
+	// Verify independence from SeriesFetched and DataFetchDuration
+	qs3 := &QueryStats{}
+	qs3.addSeriesFetched(5)
+	qs3.addSamplesFetched(10)
+	qs3.addBytesFetched(100)
+	qs3.addDataFetchDuration(time.Millisecond)
+	if n := qs3.SeriesFetched.Load(); n != 5 {
+		t.Fatalf("expected series 5; got %d", n)
+	}
+	if n := qs3.SamplesFetched.Load(); n != 10 {
+		t.Fatalf("expected samples 10; got %d", n)
+	}
 }
 
 func TestGetSumInstantValues(t *testing.T) {

--- a/app/vmselect/promql/eval_test.go
+++ b/app/vmselect/promql/eval_test.go
@@ -102,19 +102,19 @@ func TestQueryStats_DataFetchDuration(t *testing.T) {
 	qs := &QueryStats{}
 	// nil safety
 	var qsNil *QueryStats
-	qsNil.addDataFetchDuration(5 * 1000000)
+	qsNil.addDataFetchDuration(5 * time.Millisecond)
 	if qsNil.getDataFetchDuration() != 0 {
 		t.Fatalf("expected 0 for nil QueryStats; got %d", qsNil.getDataFetchDuration())
 	}
 	if n := qs.DataFetchDuration.Load(); n != 0 {
 		t.Fatalf("expected initial 0; got %d", n)
 	}
-	qs.addDataFetchDuration(10 * 1000000)
-	if d := qs.getDataFetchDuration(); d != 10*1000000 {
+	qs.addDataFetchDuration(10 * time.Millisecond)
+	if d := qs.getDataFetchDuration(); d != 10*time.Millisecond {
 		t.Fatalf("expected 10ms; got %v", d)
 	}
-	qs.addDataFetchDuration(5 * 1000000)
-	if d := qs.getDataFetchDuration(); d != 15*1000000 {
+	qs.addDataFetchDuration(5 * time.Millisecond)
+	if d := qs.getDataFetchDuration(); d != 15*time.Millisecond {
 		t.Fatalf("expected 15ms after second add; got %v", d)
 	}
 	if ms := qs.getDataFetchDuration().Milliseconds(); ms != 15 {
@@ -122,12 +122,12 @@ func TestQueryStats_DataFetchDuration(t *testing.T) {
 	}
 	// Verify DataFetchDuration does not interfere with ExecutionDuration
 	qs2 := &QueryStats{}
-	qs2.addDataFetchDuration(20 * 1000000)
-	qs2.addExecutionTimeMsec(time.Now().Add(-10 * 1000000))
+	qs2.addDataFetchDuration(20 * time.Millisecond)
+	qs2.addExecutionTimeMsec(time.Now().Add(-10 * time.Millisecond))
 	if ed := qs2.ExecutionDuration.Load(); ed == nil {
 		t.Fatalf("expected ExecutionDuration to be set")
 	}
-	if d := qs2.getDataFetchDuration(); d != 20*1000000 {
+	if d := qs2.getDataFetchDuration(); d != 20*time.Millisecond {
 		t.Fatalf("expected data fetch 20ms; got %v", d)
 	}
 	// Concurrent adds
@@ -135,28 +135,28 @@ func TestQueryStats_DataFetchDuration(t *testing.T) {
 	var wg = make(chan struct{})
 	go func() {
 		for range 100 {
-			qs3.addDataFetchDuration(1000000)
+			qs3.addDataFetchDuration(time.Millisecond)
 		}
 		close(wg)
 	}()
 	for range 100 {
-		qs3.addDataFetchDuration(1000000)
+		qs3.addDataFetchDuration(time.Millisecond)
 	}
 	<-wg
-	if d := qs3.getDataFetchDuration(); d != 200*1000000 {
+	if d := qs3.getDataFetchDuration(); d != 200*time.Millisecond {
 		t.Fatalf("expected 200ms after concurrent adds; got %v", d)
 	}
 }
 
 func TestQueryStats_ExecutionDurationPreserved(t *testing.T) {
 	qs := &QueryStats{}
-	start := time.Now().Add(-50 * 1000000)
+	start := time.Now().Add(-50 * time.Millisecond)
 	qs.addExecutionTimeMsec(start)
 	if ed := qs.ExecutionDuration.Load(); ed == nil {
 		t.Fatalf("expected ExecutionDuration to be set")
 	} else {
 		ms := ed.Milliseconds()
-		if ms < 50 || ms > 100 {
+		if ms < 50 {
 			t.Fatalf("expected execution duration ~50ms; got %d", ms)
 		}
 	}
@@ -165,7 +165,7 @@ func TestQueryStats_ExecutionDurationPreserved(t *testing.T) {
 		t.Fatalf("expected data fetch 0; got %v", d)
 	}
 	// Ensure adding data fetch doesn't affect execution duration
-	qs.addDataFetchDuration(10 * 1000000)
+	qs.addDataFetchDuration(10 * time.Millisecond)
 	if ed := qs.ExecutionDuration.Load(); ed == nil {
 		t.Fatalf("expected ExecutionDuration still set")
 	}
@@ -176,7 +176,7 @@ func TestQueryStats_NilSafety(t *testing.T) {
 	// Should not panic
 	qs.addSeriesFetched(1)
 	qs.addExecutionTimeMsec(time.Now())
-	qs.addDataFetchDuration(1000000)
+	qs.addDataFetchDuration(time.Millisecond)
 	qs.addMemoryUsage(100)
 	if qs.memoryUsage() != 0 {
 		t.Fatalf("expected 0 for nil memoryUsage")

--- a/app/vmselect/promql/exec.go
+++ b/app/vmselect/promql/exec.go
@@ -35,11 +35,19 @@ var (
 
 // Exec executes q for the given ec.
 func Exec(qt *querytracer.Tracer, ec *EvalConfig, q string, isFirstPointOnly bool) ([]netstorage.Result, error) {
-	if querystats.Enabled() {
+	if ec.QueryStats != nil {
 		startTime := time.Now()
 		defer func() {
-			querystats.RegisterQuery(q, ec.End-ec.Start, startTime, ec.QueryStats.memoryUsage())
 			ec.QueryStats.addExecutionTimeMsec(startTime)
+			if querystats.Enabled() {
+				querystats.RegisterQuery(q, ec.End-ec.Start, startTime, ec.QueryStats.memoryUsage())
+			}
+			ec.QueryStats.maybeLogQueryStats(startTime)
+		}()
+	} else if querystats.Enabled() {
+		startTime := time.Now()
+		defer func() {
+			querystats.RegisterQuery(q, ec.End-ec.Start, startTime, 0)
 		}()
 	}
 

--- a/app/vmselect/promql/query_stats.go
+++ b/app/vmselect/promql/query_stats.go
@@ -18,6 +18,10 @@ type QueryStats struct {
 	DataFetchDuration atomic.Int64
 	// SeriesFetched contains the number of series fetched from storage or cache.
 	SeriesFetched atomic.Int64
+	// SamplesFetched contains the number of samples fetched from storage.
+	SamplesFetched atomic.Int64
+	// BytesFetched contains the number of bytes fetched from storage.
+	BytesFetched atomic.Int64
 	// MemoryUsage contains the estimated memory consumption of the query
 	MemoryUsage atomic.Int64
 
@@ -51,6 +55,20 @@ func (qs *QueryStats) addSeriesFetched(n int) {
 		return
 	}
 	qs.SeriesFetched.Add(int64(n))
+}
+
+func (qs *QueryStats) addSamplesFetched(n int) {
+	if qs == nil {
+		return
+	}
+	qs.SamplesFetched.Add(int64(n))
+}
+
+func (qs *QueryStats) addBytesFetched(n int) {
+	if qs == nil {
+		return
+	}
+	qs.BytesFetched.Add(int64(n))
 }
 
 func (qs *QueryStats) addExecutionTimeMsec(startTime time.Time) {
@@ -95,7 +113,7 @@ func (qs *QueryStats) maybeLogQueryStats(startTime time.Time) {
 	if qs == nil {
 		return
 	}
-	if *logQueryStatsDuration == 0 {
+	if *logQueryStatsDuration <= 0 {
 		return
 	}
 	d := time.Since(startTime)
@@ -104,10 +122,6 @@ func (qs *QueryStats) maybeLogQueryStats(startTime time.Time) {
 	}
 	executionDurationMs := d.Milliseconds()
 	dataFetchDurationMs := qs.getDataFetchDuration().Milliseconds()
-	// Ensure dataFetchDurationMs does not exceed executionDurationMs due to clock skew or concurrent updates
-	if dataFetchDurationMs > executionDurationMs {
-		dataFetchDurationMs = executionDurationMs
-	}
 	queryHash := hashQuery(qs.query)
 	tenant := "0"
 	if qs.at != nil {
@@ -115,8 +129,8 @@ func (qs *QueryStats) maybeLogQueryStats(startTime time.Time) {
 	}
 	rangeMs := qs.end - qs.start
 	// Use Info level to match query-stats logging; vm_slow_query_stats prefix is required for filtering
-	logger.Infof("vm_slow_query_stats type=%s query=%q query_hash=%d start_ms=%d end_ms=%d step_ms=%d range_ms=%d tenant=%q execution_duration_ms=%d data_fetch_duration_ms=%d series_fetched=%d memory_estimated_bytes=%d",
-		qs.queryType, qs.query, queryHash, qs.start, qs.end, qs.step, rangeMs, tenant, executionDurationMs, dataFetchDurationMs, qs.SeriesFetched.Load(), qs.MemoryUsage.Load())
+	logger.Infof("vm_slow_query_stats type=%s query=%q query_hash=%d start_ms=%d end_ms=%d step_ms=%d range_ms=%d tenant=%q execution_duration_ms=%d data_fetch_duration_ms=%d series_fetched=%d samples_fetched=%d bytes=%d memory_estimated_bytes=%d",
+		qs.queryType, qs.query, queryHash, qs.start, qs.end, qs.step, rangeMs, tenant, executionDurationMs, dataFetchDurationMs, qs.SeriesFetched.Load(), qs.SamplesFetched.Load(), qs.BytesFetched.Load(), qs.MemoryUsage.Load())
 }
 
 func hashQuery(q string) uint64 {

--- a/app/vmselect/promql/query_stats.go
+++ b/app/vmselect/promql/query_stats.go
@@ -64,7 +64,7 @@ func (qs *QueryStats) addSamplesFetched(n int) {
 	qs.SamplesFetched.Add(int64(n))
 }
 
-func (qs *QueryStats) addBytesFetched(n int) {
+func (qs *QueryStats) addBytesFetched(n uint64) {
 	if qs == nil {
 		return
 	}

--- a/app/vmselect/promql/query_stats.go
+++ b/app/vmselect/promql/query_stats.go
@@ -18,9 +18,10 @@ type QueryStats struct {
 	DataFetchDuration atomic.Int64
 	// SeriesFetched contains the number of series fetched from storage or cache.
 	SeriesFetched atomic.Int64
-	// SamplesFetched contains the number of samples fetched from storage.
+	// SamplesFetched contains the number of raw samples fetched from storage (sum of RowsCount for all blocks).
 	SamplesFetched atomic.Int64
-	// BytesFetched contains the number of bytes fetched from storage.
+	// BytesFetched contains the number of bytes of compressed block data fetched from storage
+	// (sum of TimestampsBlockSize + ValuesBlockSize for all blocks).
 	BytesFetched atomic.Int64
 	// MemoryUsage contains the estimated memory consumption of the query
 	MemoryUsage atomic.Int64

--- a/app/vmselect/promql/query_stats.go
+++ b/app/vmselect/promql/query_stats.go
@@ -1,16 +1,21 @@
 package promql
 
 import (
+	"flag"
+	"hash/fnv"
 	"sync/atomic"
 	"time"
 
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/auth"
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/logger"
 )
 
 // QueryStats contains various stats of the query evaluation.
 type QueryStats struct {
 	// ExecutionDuration contains the time duration the query took to execute.
 	ExecutionDuration atomic.Pointer[time.Duration]
+	// DataFetchDuration contains the time spent fetching data from storage via ProcessSearchQuery.
+	DataFetchDuration atomic.Int64
 	// SeriesFetched contains the number of series fetched from storage or cache.
 	SeriesFetched atomic.Int64
 	// MemoryUsage contains the estimated memory consumption of the query
@@ -56,6 +61,13 @@ func (qs *QueryStats) addExecutionTimeMsec(startTime time.Time) {
 	qs.ExecutionDuration.Store(&d)
 }
 
+func (qs *QueryStats) addDataFetchDuration(d time.Duration) {
+	if qs == nil {
+		return
+	}
+	qs.DataFetchDuration.Add(d.Nanoseconds())
+}
+
 func (qs *QueryStats) addMemoryUsage(memoryUsage int64) {
 	if qs == nil {
 		return
@@ -68,4 +80,47 @@ func (qs *QueryStats) memoryUsage() int64 {
 		return 0
 	}
 	return qs.MemoryUsage.Load()
+}
+
+func (qs *QueryStats) getDataFetchDuration() time.Duration {
+	if qs == nil {
+		return 0
+	}
+	return time.Duration(qs.DataFetchDuration.Load())
+}
+
+var logQueryStatsDuration = flag.Duration("search.logSlowQueryStats", 5*time.Second, "Log query statistics if execution time exceeding this value - see https://docs.victoriametrics.com/victoriametrics/query-stats/ . Zero disables slow query statistics logging. See https://docs.victoriametrics.com/victoriametrics/enterprise/")
+
+func (qs *QueryStats) maybeLogQueryStats(startTime time.Time) {
+	if qs == nil {
+		return
+	}
+	if *logQueryStatsDuration == 0 {
+		return
+	}
+	d := time.Since(startTime)
+	if d < *logQueryStatsDuration {
+		return
+	}
+	executionDurationMs := d.Milliseconds()
+	dataFetchDurationMs := qs.getDataFetchDuration().Milliseconds()
+	// Ensure dataFetchDurationMs does not exceed executionDurationMs due to clock skew or concurrent updates
+	if dataFetchDurationMs > executionDurationMs {
+		dataFetchDurationMs = executionDurationMs
+	}
+	queryHash := hashQuery(qs.query)
+	tenant := "0"
+	if qs.at != nil {
+		tenant = qs.at.String()
+	}
+	rangeMs := qs.end - qs.start
+	// Use Info level to match query-stats logging; vm_slow_query_stats prefix is required for filtering
+	logger.Infof("vm_slow_query_stats type=%s query=%q query_hash=%d start_ms=%d end_ms=%d step_ms=%d range_ms=%d tenant=%q execution_duration_ms=%d data_fetch_duration_ms=%d series_fetched=%d memory_estimated_bytes=%d",
+		qs.queryType, qs.query, queryHash, qs.start, qs.end, qs.step, rangeMs, tenant, executionDurationMs, dataFetchDurationMs, qs.SeriesFetched.Load(), qs.MemoryUsage.Load())
+}
+
+func hashQuery(q string) uint64 {
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(q))
+	return h.Sum64()
 }

--- a/docs/victoriametrics/README.md
+++ b/docs/victoriametrics/README.md
@@ -509,9 +509,10 @@ for limiting the number of returned entries. For example, the query to `/api/v1/
 If the provided `limit` value exceeds the corresponding `-search.maxSeries` command-line flag values, then limits specified in the command-line flags are used.
 
 VictoriaMetrics returns an extra object `stats` in JSON response for [`/api/v1/query`](https://docs.victoriametrics.com/victoriametrics/keyconcepts/#instant-query)
-and [`/api/v1/query_range`](https://docs.victoriametrics.com/victoriametrics/keyconcepts/#range-query) APIs. This object contains two
-fields: `executionTimeMsec` with number of milliseconds the request took and `seriesFetched` with number of series that
-were fetched from database before filtering. The `seriesFetched` field is effectively used by vmalert for detecting
+and [`/api/v1/query_range`](https://docs.victoriametrics.com/victoriametrics/keyconcepts/#range-query) APIs. This object contains three
+fields: `executionTimeMsec` with number of milliseconds the request took, `seriesFetched` with number of series that
+were fetched from database before filtering and `dataFetchDurationMsec` with accumulated time spent fetching data from storage, expressed in milliseconds.
+The `seriesFetched` field is effectively used by vmalert for detecting
 [misconfigured rule expressions](https://docs.victoriametrics.com/victoriametrics/vmalert/#never-firing-alerts). Please note, `seriesFetched`
 provides approximate number of series, it is not recommended to rely on it in tests.
 

--- a/docs/victoriametrics/query-stats.md
+++ b/docs/victoriametrics/query-stats.md
@@ -32,7 +32,7 @@ Here's how `<duration>` works:
 **Example of a query statistics log:**
 
 ```bash
-2025-03-25T11:23:29.520Z        info    VictoriaMetrics/app/vmselect/promql/query_stats.go:60       vm_slow_query_stats type=instant query="vm_promscrape_config_last_reload_successful != 1\nor\nvmagent_relabel_config_last_reload_successful != 1\n" query_hash=1585303298 start_ms=1742901750000 end_ms=1742901750000 step_ms=300000 range_ms=0 tenant="0" execution_duration_ms=0 series_fetched=2 samples_fetched=163 bytes=975 memory_estimated_bytes=2032
+2025-03-25T11:23:29.520Z        info    VictoriaMetrics/app/vmselect/promql/query_stats.go:60       vm_slow_query_stats type=instant query="vm_promscrape_config_last_reload_successful != 1\nor\nvmagent_relabel_config_last_reload_successful != 1\n" query_hash=1585303298 start_ms=1742901750000 end_ms=1742901750000 step_ms=300000 range_ms=0 tenant="0" execution_duration_ms=0 data_fetch_duration_ms=0 series_fetched=2 samples_fetched=163 bytes=975 memory_estimated_bytes=2032
 ```
 
 ## Log fields
@@ -47,6 +47,7 @@ Each log entry contains the following fields:
 * `range_ms`: a time range in milliseconds between `start_ms` and `end_ms`. If `range_ms==0` it means this query is instant;
 * `tenant`: a tenant ID. Available only in the cluster version;
 * `execution_duration_ms`: time it took in milliseconds to execute the query (not including time spent sending results over the network);
+* `data_fetch_duration_ms`: time it took in milliseconds to fetch data from storage via `ProcessSearchQuery`. This helps distinguish storage/data-fetch bottlenecks from vmselect query-processing bottlenecks;
 * `series_fetched`: number of unique [time series](https://docs.victoriametrics.com/victoriametrics/keyconcepts/#time-series) fetched.
   This may be higher than the number of series returned if there are filters like `cpu_usage > 0`;
 * `samples_fetched`: number of [data samples](https://docs.victoriametrics.com/victoriametrics/keyconcepts/#raw-samples) fetched;

--- a/docs/victoriametrics/query-stats.md
+++ b/docs/victoriametrics/query-stats.md
@@ -50,8 +50,8 @@ Each log entry contains the following fields:
 * `data_fetch_duration_ms`: time it took in milliseconds to fetch data from storage via `ProcessSearchQuery`. This helps distinguish storage/data-fetch bottlenecks from vmselect query-processing bottlenecks;
 * `series_fetched`: number of unique [time series](https://docs.victoriametrics.com/victoriametrics/keyconcepts/#time-series) fetched.
   This may be higher than the number of series returned if there are filters like `cpu_usage > 0`;
-* `samples_fetched`: number of [data samples](https://docs.victoriametrics.com/victoriametrics/keyconcepts/#raw-samples) fetched;
-* `bytes`: number of bytes transferred from storage to process the query;
+* `samples_fetched`: number of [data samples](https://docs.victoriametrics.com/victoriametrics/keyconcepts/#raw-samples) fetched (sum of `RowsCount` for all blocks read from storage);
+* `bytes`: number of bytes of compressed block data fetched from storage (sum of `TimestampsBlockSize` + `ValuesBlockSize` for all blocks);
 * `memory_estimated_bytes`: estimated memory needed to run the query. See `-search.maxMemoryPerQuery` cmd-line flag.
 * `headers.*`: header key-value pairs associated with request {{% available_from "v1.121.0" %}}. Only headers listed in `-search.logSlowQueryStatsHeaders`
   are logged.

--- a/lib/storage/search.go
+++ b/lib/storage/search.go
@@ -57,6 +57,11 @@ func (br *BlockRef) RowsCount() int {
 	return int(br.bh.RowsCount)
 }
 
+// BlockSize returns the size in bytes of the block data (compressed timestamps + values) for br.
+func (br *BlockRef) BlockSize() int {
+	return int(br.bh.TimestampsBlockSize) + int(br.bh.ValuesBlockSize)
+}
+
 // PartRef returns PartRef from br.
 func (br *BlockRef) PartRef() PartRef {
 	return PartRef{


### PR DESCRIPTION
## Summary

This PR adds `data_fetch_duration_ms` to VictoriaMetrics query execution stats.

The existing `execution_duration_ms` value reports the total time spent executing a query, but it does not show how much of that time was spent fetching data from the storage layer.

This change exposes the time spent by vmselect in `ProcessSearchQuery`, making it easier to identify whether a slow query is primarily affected by data retrieval or query processing.

## Motivation

For a query such as:

```text
execution_duration_ms=865
data_fetch_duration_ms=810
```

we can now see that most of the query execution time was spent in the data-fetch path.

This provides additional visibility when investigating slow queries and helps distinguish potential storage/data-retrieval bottlenecks from vmselect query-processing overhead.

## Implementation

A new `DataFetchDuration` field was added to `QueryStats`.

The duration is measured around `netstorage.ProcessSearchQuery` and accumulated across multiple calls made while evaluating a query.

The duration is stored using an atomic counter to support concurrent query evaluation.

The resulting value is exposed as:

```text
data_fetch_duration_ms
```

alongside the existing query execution statistics.

The query stats response also exposes the corresponding value as:

```json
{
  "seriesFetched": "200000",
  "executionTimeMsec": 865,
  "dataFetchDurationMsec": 810
}
```

### Manual validation

The feature was also manually validated by running VictoriaMetrics with query-stat logging enabled:

```bash
/tmp/victoria-metrics \
  -storageDataPath=/tmp/vm \
  -httpListenAddr=:8428 \
  -search.logSlowQueryStats=1us &
```

I then inserted 5,000 time series:

```bash
for i in $(seq 1 5000); do
  printf 'heavy{id="%s"} %s\n' "$i" "$((RANDOM%100))"
done | curl -s \
  --data-binary @- \
  'http://127.0.0.1:8428/api/v1/import/prometheus' >/dev/null
```

After allowing the data to become available, I queried:

```bash
curl -s --get \
  'http://127.0.0.1:8428/api/v1/query' \
  --data-urlencode 'query=sum(heavy)' | jq '.stats'
```

Result:

```json
{
  "seriesFetched": "5000",
  "executionTimeMsec": 22,
  "dataFetchDurationMsec": 21
}
```

I also tested:

```bash
curl -s --get \
  'http://127.0.0.1:8428/api/v1/query' \
  --data-urlencode 'query=count(heavy)' | jq '.stats'
```

Result:

```json
{
  "seriesFetched": "5000",
  "executionTimeMsec": 7,
  "dataFetchDurationMsec": 6
}
```

I then increased the dataset to 200,000 time series:

```bash
for i in $(seq 1 200000); do
  printf 'heavy{id="%s"} %s\n' "$i" "$((RANDOM%100))"
done | curl -s \
  --data-binary @- \
  'http://127.0.0.1:8428/api/v1/import/prometheus' >/dev/null
```

For:

```bash
curl -s --get \
  'http://127.0.0.1:8428/api/v1/query' \
  --data-urlencode 'query=sum(heavy)' | jq '.stats'
```

the result was:

```json
{
  "seriesFetched": "200000",
  "executionTimeMsec": 865,
  "dataFetchDurationMsec": 810
}
```

And for:

```bash
curl -s --get \
  'http://127.0.0.1:8428/api/v1/query' \
  --data-urlencode 'query=count(heavy)' | jq '.stats'
```

the result was:

```json
{
  "seriesFetched": "200000",
  "executionTimeMsec": 269,
  "dataFetchDurationMsec": 221
}
```

These results demonstrate that `dataFetchDurationMsec` is populated in query stats and increases with the amount of data retrieved, while remaining a component of the overall query execution time.

## Documentation

The query stats documentation has been updated to document the new field and provide an example of its usage.

## Related issue

Fixes #11491

