### PR TITLE
lib/vmselectapi: gracefully complete in-flight RPC requests on storage shutdown

### DIFF
--- a/lib/ingestserver/conns_map.go
+++ b/lib/ingestserver/conns_map.go
@@ -43,6 +43,19 @@ func (cm *ConnsMap) Delete(c net.Conn) {
 	cm.mu.Unlock()
 }
 
+// CloseReads sets read deadline to now on all connections in cm and marks cm as closed.
+// No new connections can be added.
+// In-flight requests could finish and write results. They will exit while trying to read next rpc request.
+func (cm *ConnsMap) CloseReads() {
+	cm.mu.Lock()
+	cm.isClosed = true
+	now := time.Now()
+	for c := range cm.m {
+		_ = c.SetReadDeadline(now)
+	}
+	cm.mu.Unlock()
+}
+
 // CloseAll gradually closes all the cm conns with during the given shutdownDuration.
 //
 // If shutdownDuration <= 0, then all the connections are closed simultaneously.

--- a/lib/vmselectapi/server.go
+++ b/lib/vmselectapi/server.go
@@ -50,6 +50,9 @@ type Server struct {
 	// wg is used for waiting for worker goroutines to stop when MustStop() is called.
 	wg sync.WaitGroup
 
+	// shutdownDuration is the maximum time to wait for in-flight RPC requests to finish during graceful shutdown.
+	shutdownDuration time.Duration
+
 	// stopFlag is set to true when the server needs to stop.
 	stopFlag atomic.Bool
 
@@ -110,6 +113,7 @@ func NewServer(addr string, api API, limits Limits, disableResponseCompression b
 		api:                        api,
 		limits:                     limits,
 		disableResponseCompression: disableResponseCompression,
+		shutdownDuration:           time.Second * 10, // TODO: add flag
 		ln:                         ln,
 
 		concurrencyLimitCh: concurrencyLimitCh,
@@ -180,7 +184,7 @@ func (s *Server) run() {
 			bc, err := handshake.VMSelectServer(c, compressionLevel)
 			if err != nil {
 				if s.isStopping() {
-					// c is closed inside Server.MustStop
+					_ = c.Close()
 					return
 				}
 				if handshake.IsTimeoutNetworkError(err) {
@@ -213,7 +217,7 @@ func (s *Server) run() {
 
 // MustStop gracefully stops s, so it no longer touches s.api after returning.
 func (s *Server) MustStop() {
-	// Mark the server as stoping.
+	// Mark the server as stopping.
 	s.setIsStopping()
 
 	// Stop accepting new connections from vmselect.
@@ -221,12 +225,24 @@ func (s *Server) MustStop() {
 		logger.Panicf("FATAL: cannot close vmselect listener: %s", err)
 	}
 
-	// Close existing connections from vmselect, so the goroutines
-	// processing these connections are finished.
-	s.connsMap.CloseAll(0)
+	// Interrupt connections that are idle (blocked waiting for the next RPC name).
+	// Active connections finish their in-flight request and exit via the isStopping()
+	// check in processConn.
+	s.connsMap.CloseReads()
 
-	// Wait until all the goroutines processing vmselect conns are finished.
-	s.wg.Wait()
+	done := make(chan struct{})
+	go func() {
+		s.wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+		return
+	case <-time.After(s.shutdownDuration):
+		logger.Warnf("not all vmselect connections were closed within %s; force-closing the remaining ones", s.shutdownDuration)
+		s.connsMap.CloseAll(0)
+		s.wg.Wait()
+	}
 }
 
 func (s *Server) setIsStopping() {
@@ -243,6 +259,9 @@ func (s *Server) processConn(bc *handshake.BufferedConn) error {
 		sizeBuf: make([]byte, 8),
 	}
 	for {
+		if s.isStopping() {
+			return nil
+		}
 		if err := s.processRequest(ctx); err != nil {
 			if isExpectedError(err) {
 				return nil


### PR DESCRIPTION
Previously, all vmselect connections were force-closed on shutdown, causing in-flight queries to fail with errors visible to users.

With this change, vmstorage waits up to 10s for active queries to complete before closing connections. Idle connections (waiting for the next RPC request) are interrupted immediately by setting their read deadline to now.

If the deadline is reached, remaining connections are force-closed.

JUST A CONCEPT. I've not tested it yet. 