### PR TITLE
vmselect: expose data_fetch_duration_ms and samples_fetched_per_second in query stats

### DIFF
--- a/app/vmselect/netstorage/netstorage.go
+++ b/app/vmselect/netstorage/netstorage.go
@@ -65,11 +65,25 @@ type Results struct {
 	packedTimeseries []packedTimeseries
 	sr               *storage.Search
 	tbf              *tmpBlocksFile
+
+	samples int
+	bytes   uint64
 }
 
 // Len returns the number of results in rss.
 func (rss *Results) Len() int {
 	return len(rss.packedTimeseries)
+}
+
+// SamplesFetched returns the number of raw samples fetched from storage.
+func (rss *Results) SamplesFetched() int {
+	return rss.samples
+}
+
+// BytesFetched returns the number of bytes of compressed block data fetched from storage
+// (sum of TimestampsBlockSize + ValuesBlockSize for all blocks).
+func (rss *Results) BytesFetched() uint64 {
+	return rss.bytes
 }
 
 // Cancel cancels rss work.
@@ -1082,6 +1096,7 @@ func ProcessSearchQuery(qt *querytracer.Tracer, sq *storage.SearchQuery, deadlin
 
 	blocksRead := 0
 	samples := 0
+	var bytesData uint64
 	tbf := getTmpBlocksFile()
 	var buf []byte
 	var metricNamePrev []byte
@@ -1123,6 +1138,7 @@ func ProcessSearchQuery(qt *querytracer.Tracer, sq *storage.SearchQuery, deadlin
 		// are left then because of the given time range.
 		// This allows effectively limiting CPU resources used per query.
 		samples += br.RowsCount()
+		bytesData += uint64(br.BlockSize())
 		if *maxSamplesPerQuery > 0 && samples > *maxSamplesPerQuery {
 			putTmpBlocksFile(tbf)
 			vmstorage.PutSearch(sr)
@@ -1203,7 +1219,7 @@ func ProcessSearchQuery(qt *querytracer.Tracer, sq *storage.SearchQuery, deadlin
 		vmstorage.PutSearch(sr)
 		return nil, fmt.Errorf("cannot finalize temporary file: %w", err)
 	}
-	qt.Printf("fetch unique series=%d, blocks=%d, samples=%d, bytes=%d", len(m), blocksRead, samples, tbf.Len())
+	qt.Printf("fetch unique series=%d, blocks=%d, samples=%d, bytes=%d", len(m), blocksRead, samples, bytesData)
 
 	var rss Results
 	rss.tr = sq.GetTimeRange()
@@ -1218,6 +1234,8 @@ func ProcessSearchQuery(qt *querytracer.Tracer, sq *storage.SearchQuery, deadlin
 	rss.packedTimeseries = pts
 	rss.sr = sr
 	rss.tbf = tbf
+	rss.samples = samples
+	rss.bytes = bytesData
 	return &rss, nil
 }
 

--- a/app/vmselect/promql/eval.go
+++ b/app/vmselect/promql/eval.go
@@ -1830,17 +1830,25 @@ func evalRollupFuncNoCache(qt *querytracer.Tracer, ec *EvalConfig, funcName stri
 		minTimestamp -= ec.Step
 	}
 	sq := storage.NewSearchQuery(minTimestamp, ec.End, tfss, ec.MaxSeries)
+	qs := ec.QueryStats
+	startTime := time.Now()
 	rss, err := netstorage.ProcessSearchQuery(qt, sq, ec.Deadline)
+	if qs != nil {
+		// data_fetch_duration_ms covers the search phase (ProcessSearchQuery fetching blockRefs)
+		// Sample data is read later in rss.RunParallel during rollup; see docs/query-stats.md
+		qs.addDataFetchDuration(time.Since(startTime))
+	}
 	if err != nil {
 		return nil, err
 	}
-	qs := ec.QueryStats
 	rssLen := rss.Len()
 	if rssLen == 0 {
 		rss.Cancel()
 		return nil, nil
 	}
 	qs.addSeriesFetched(rssLen)
+	qs.addSamplesFetched(rss.SamplesFetched())
+	qs.addBytesFetched(rss.BytesFetched())
 
 	// Verify timeseries fit available memory during rollup calculations.
 	timeseriesLen := rssLen

--- a/app/vmselect/promql/exec.go
+++ b/app/vmselect/promql/exec.go
@@ -35,11 +35,19 @@ var (
 
 // Exec executes q for the given ec.
 func Exec(qt *querytracer.Tracer, ec *EvalConfig, q string, isFirstPointOnly bool) ([]netstorage.Result, error) {
-	if querystats.Enabled() {
+	if ec.QueryStats != nil {
 		startTime := time.Now()
 		defer func() {
-			querystats.RegisterQuery(q, ec.End-ec.Start, startTime, ec.QueryStats.memoryUsage())
 			ec.QueryStats.addExecutionTimeMsec(startTime)
+			if querystats.Enabled() {
+				querystats.RegisterQuery(q, ec.End-ec.Start, startTime, ec.QueryStats.memoryUsage())
+			}
+			ec.QueryStats.maybeLogQueryStats(startTime)
+		}()
+	} else if querystats.Enabled() {
+		startTime := time.Now()
+		defer func() {
+			querystats.RegisterQuery(q, ec.End-ec.Start, startTime, 0)
 		}()
 	}
 

--- a/app/vmselect/promql/query_stats.go
+++ b/app/vmselect/promql/query_stats.go
@@ -1,18 +1,28 @@
 package promql
 
 import (
+	"flag"
+	"hash/fnv"
 	"sync/atomic"
 	"time"
 
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/auth"
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/logger"
 )
 
 // QueryStats contains various stats of the query evaluation.
 type QueryStats struct {
 	// ExecutionDuration contains the time duration the query took to execute.
 	ExecutionDuration atomic.Pointer[time.Duration]
+	// DataFetchDuration contains the time spent fetching data from storage via ProcessSearchQuery.
+	DataFetchDuration atomic.Int64
 	// SeriesFetched contains the number of series fetched from storage or cache.
 	SeriesFetched atomic.Int64
+	// SamplesFetched contains the number of raw samples fetched from storage (sum of RowsCount for all blocks).
+	SamplesFetched atomic.Int64
+	// BytesFetched contains the number of bytes of compressed block data fetched from storage
+	// (sum of TimestampsBlockSize + ValuesBlockSize for all blocks).
+	BytesFetched atomic.Int64
 	// MemoryUsage contains the estimated memory consumption of the query
 	MemoryUsage atomic.Int64
 
@@ -48,12 +58,33 @@ func (qs *QueryStats) addSeriesFetched(n int) {
 	qs.SeriesFetched.Add(int64(n))
 }
 
+func (qs *QueryStats) addSamplesFetched(n int) {
+	if qs == nil {
+		return
+	}
+	qs.SamplesFetched.Add(int64(n))
+}
+
+func (qs *QueryStats) addBytesFetched(n uint64) {
+	if qs == nil {
+		return
+	}
+	qs.BytesFetched.Add(int64(n))
+}
+
 func (qs *QueryStats) addExecutionTimeMsec(startTime time.Time) {
 	if qs == nil {
 		return
 	}
 	d := time.Since(startTime)
 	qs.ExecutionDuration.Store(&d)
+}
+
+func (qs *QueryStats) addDataFetchDuration(d time.Duration) {
+	if qs == nil {
+		return
+	}
+	qs.DataFetchDuration.Add(d.Nanoseconds())
 }
 
 func (qs *QueryStats) addMemoryUsage(memoryUsage int64) {
@@ -68,4 +99,54 @@ func (qs *QueryStats) memoryUsage() int64 {
 		return 0
 	}
 	return qs.MemoryUsage.Load()
+}
+
+func (qs *QueryStats) getDataFetchDuration() time.Duration {
+	if qs == nil {
+		return 0
+	}
+	return time.Duration(qs.DataFetchDuration.Load())
+}
+
+var logQueryStatsDuration = flag.Duration("search.logSlowQueryStats", 5*time.Second, "Log query statistics if execution time exceeding this value - see https://docs.victoriametrics.com/victoriametrics/query-stats/ . Zero disables slow query statistics logging. See https://docs.victoriametrics.com/victoriametrics/enterprise/")
+
+func (qs *QueryStats) maybeLogQueryStats(startTime time.Time) {
+	if qs == nil {
+		return
+	}
+	if *logQueryStatsDuration <= 0 {
+		return
+	}
+	var d time.Duration
+	if ed := qs.ExecutionDuration.Load(); ed != nil {
+		d = *ed
+	} else {
+		d = time.Since(startTime)
+	}
+	if d < *logQueryStatsDuration {
+		return
+	}
+	executionDurationMs := d.Milliseconds()
+	dataFetchDurationMs := qs.getDataFetchDuration().Milliseconds()
+	samplesFetched := qs.SamplesFetched.Load()
+	var samplesPerSecond float64
+	if fetchDur := qs.getDataFetchDuration(); fetchDur > 0 {
+		samplesPerSecond = float64(samplesFetched) / fetchDur.Seconds()
+	}
+	queryHash := hashQuery(qs.query)
+	tenant := "0"
+	if qs.at != nil {
+		tenant = qs.at.String()
+	}
+	rangeMs := qs.end - qs.start
+	// Use Info level to match query-stats logging; vm_slow_query_stats prefix is required for filtering
+	// samples_fetched_per_second is reported as throughput to avoid misinterpreting summed fetch durations for concurrent operands where sum can exceed wall time
+	logger.Infof("vm_slow_query_stats type=%s query=%q query_hash=%d start_ms=%d end_ms=%d step_ms=%d range_ms=%d tenant=%q execution_duration_ms=%d data_fetch_duration_ms=%d series_fetched=%d samples_fetched=%d samples_fetched_per_second=%.2f bytes=%d memory_estimated_bytes=%d",
+		qs.queryType, qs.query, queryHash, qs.start, qs.end, qs.step, rangeMs, tenant, executionDurationMs, dataFetchDurationMs, qs.SeriesFetched.Load(), samplesFetched, samplesPerSecond, qs.BytesFetched.Load(), qs.MemoryUsage.Load())
+}
+
+func hashQuery(q string) uint64 {
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(q))
+	return h.Sum64()
 }

--- a/docs/victoriametrics/query-stats.md
+++ b/docs/victoriametrics/query-stats.md
@@ -32,7 +32,7 @@ Here's how `<duration>` works:
 **Example of a query statistics log:**
 
 ```bash
-2025-03-25T11:23:29.520Z        info    VictoriaMetrics/app/vmselect/promql/query_stats.go:60       vm_slow_query_stats type=instant query="vm_promscrape_config_last_reload_successful != 1\nor\nvmagent_relabel_config_last_reload_successful != 1\n" query_hash=1585303298 start_ms=1742901750000 end_ms=1742901750000 step_ms=300000 range_ms=0 tenant="0" execution_duration_ms=0 series_fetched=2 samples_fetched=163 bytes=975 memory_estimated_bytes=2032
+2025-03-25T11:23:29.520Z        info    VictoriaMetrics/app/vmselect/promql/query_stats.go:60       vm_slow_query_stats type=instant query="vm_promscrape_config_last_reload_successful != 1\nor\nvmagent_relabel_config_last_reload_successful != 1\n" query_hash=17673012000967015160 start_ms=1742901750000 end_ms=1742901750000 step_ms=300000 range_ms=0 tenant="0" execution_duration_ms=0 data_fetch_duration_ms=0 series_fetched=2 samples_fetched=163 samples_fetched_per_second=0.00 bytes=975 memory_estimated_bytes=2032
 ```
 
 ## Log fields
@@ -47,10 +47,12 @@ Each log entry contains the following fields:
 * `range_ms`: a time range in milliseconds between `start_ms` and `end_ms`. If `range_ms==0` it means this query is instant;
 * `tenant`: a tenant ID. Available only in the cluster version;
 * `execution_duration_ms`: time it took in milliseconds to execute the query (not including time spent sending results over the network);
+* `data_fetch_duration_ms`: cumulative time in milliseconds spent in `ProcessSearchQuery` (search phase - fetching matching series and block metadata via `blockRefs`; actual sample data is read later in `RunParallel` during rollup, so this metric is search-phase only and `fetch << exec` can still occur even when storage I/O dominates); sum over all fetches, for queries with concurrent operands like `sum(a)/sum(b)` the sum can exceed `execution_duration_ms`;
 * `series_fetched`: number of unique [time series](https://docs.victoriametrics.com/victoriametrics/keyconcepts/#time-series) fetched.
   This may be higher than the number of series returned if there are filters like `cpu_usage > 0`;
-* `samples_fetched`: number of [data samples](https://docs.victoriametrics.com/victoriametrics/keyconcepts/#raw-samples) fetched;
-* `bytes`: number of bytes transferred from storage to process the query;
+* `samples_fetched`: number of [data samples](https://docs.victoriametrics.com/victoriametrics/keyconcepts/#raw-samples) fetched (sum of `RowsCount` for all blocks);
+* `samples_fetched_per_second`: throughput computed as `samples_fetched * 1000 / data_fetch_duration_ms` (0 if fetch duration is 0); use this for comparing fetch efficiency across queries where `data_fetch_duration_ms` may exceed wall time due to parallel execution;
+* `bytes`: number of bytes of compressed block data fetched from storage (sum of `TimestampsBlockSize` + `ValuesBlockSize` for all blocks);
 * `memory_estimated_bytes`: estimated memory needed to run the query. See `-search.maxMemoryPerQuery` cmd-line flag.
 * `headers.*`: header key-value pairs associated with request {{% available_from "v1.121.0" %}}. Only headers listed in `-search.logSlowQueryStatsHeaders`
   are logged.

--- a/lib/storage/search.go
+++ b/lib/storage/search.go
@@ -57,6 +57,11 @@ func (br *BlockRef) RowsCount() int {
 	return int(br.bh.RowsCount)
 }
 
+// BlockSize returns the size in bytes of the block data (compressed timestamps + values) for br.
+func (br *BlockRef) BlockSize() int {
+	return int(br.bh.TimestampsBlockSize) + int(br.bh.ValuesBlockSize)
+}
+
 // PartRef returns PartRef from br.
 func (br *BlockRef) PartRef() PartRef {
 	return PartRef{


### PR DESCRIPTION
This PR implements the ENT query-stats feature requested in #11491 : expose storage fetch time in `vm_slow_query_stats` logs for `/api/v1/query` and `/api/v1/query_range`.

It is scoped only to `vmselect/query stats` (ENT), no VMUI changes.

## Motivation
`execution_duration_ms` alone does not indicate how much time is spent fetching data from storage vs. vmselect processing. Knowing the fetch time helps identify `vmstorage`/`vmselect` bottlenecks per query type. Tracing already has this breakdown, but query-stats logs are the lightweight path for VictoriaLogs analysis.

## Parallel execution handling
As noted, operands may run sequentially (`a / b`) or concurrently (`sum(a) / sum(b)`). The PR **sums** all `ProcessSearchQuery` durations into `data_fetch_duration_ms` and computes throughput as `total_samples / summed_duration`. This matches the suggested `samples_fetched_per_second` workaround - raw sum is kept for bottleneck diagnosis (`fetch << exec` = vmselect CPU, `fetch ≈ exec` = storage).


