### PR TITLE
lib/storage: avoid copying contiguous rows into partition buckets

### DIFF
--- a/lib/storage/storage_timing_test.go
+++ b/lib/storage/storage_timing_test.go
@@ -16,6 +16,42 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
+// BenchmarkStorageAddRowsExistingMonths includes the full synchronous ingestion
+// path and normal background flush/merge work, with existing series and partitions.
+func BenchmarkStorageAddRowsExistingMonths(b *testing.B) {
+	for _, layout := range []string{"grouped", "alternating"} {
+		b.Run(layout, func(b *testing.B) {
+			s := MustOpenStorage(b.TempDir(), OpenOptions{Retention: retentionMax, MaxBackfillAge: retentionMax})
+			defer s.MustClose()
+			mrs := make([]MetricRow, 8000)
+			now := time.Now().UTC()
+			month := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC)
+			mn := MetricName{MetricGroup: []byte("existing_months")}
+			name := mn.marshalRaw(nil)
+			for i := range mrs {
+				p := i / 4000
+				if layout == "alternating" {
+					p = i % 2
+				}
+				mrs[i] = MetricRow{MetricNameRaw: name, Timestamp: month.AddDate(0, -p, 0).UnixMilli() + int64(i), Value: float64(i)}
+			}
+			s.AddRows(mrs, defaultPrecisionBits)
+			s.DebugFlush()
+			var m Metrics
+			s.UpdateMetrics(&m)
+			if got := m.TableMetrics.TotalRowsCount(); got != uint64(len(mrs)) {
+				b.Fatalf("warmup retained %d rows; want %d", got, len(mrs))
+			}
+			b.ReportAllocs()
+			b.ResetTimer()
+			for range b.N {
+				s.AddRows(mrs, defaultPrecisionBits)
+			}
+			b.StopTimer()
+		})
+	}
+}
+
 func BenchmarkStorageAddRows(b *testing.B) {
 	defer fs.MustRemoveDir(b.Name())
 

--- a/lib/storage/table.go
+++ b/lib/storage/table.go
@@ -340,14 +340,31 @@ func (tb *table) MustAddRows(rows []rawRow) {
 	}
 
 	// Slower path - split rows into per-partition buckets.
-	ptBuckets := make(map[*partitionWrapper][]rawRow)
+	type rowBucket struct {
+		rows []rawRow
+		end  int // Exclusive end in the input; -1 after copying a discontiguous bucket.
+	}
+	ptBuckets := make(map[*partitionWrapper]*rowBucket)
 	var missingRows []rawRow
 	for i := range rows {
 		r := &rows[i]
 		ptFound := false
 		for _, ptw := range ptws {
 			if ptw.pt.HasTimestamp(r.Timestamp) {
-				ptBuckets[ptw] = append(ptBuckets[ptw], *r)
+				bucket := ptBuckets[ptw]
+				switch {
+				case bucket == nil:
+					bucket = &rowBucket{rows: rows[i : i+1 : i+1], end: i + 1}
+					ptBuckets[ptw] = bucket
+				case bucket.end == i:
+					bucket.rows = rows[i-len(bucket.rows) : i+1 : i+1]
+					bucket.end = i + 1
+				default:
+					// The borrowed slice has no spare capacity, so the first
+					// append copies it. AddRows also copies before returning.
+					bucket.rows = append(bucket.rows, *r)
+					bucket.end = -1
+				}
 				ptFound = true
 				break
 			}
@@ -357,8 +374,8 @@ func (tb *table) MustAddRows(rows []rawRow) {
 		}
 	}
 
-	for ptw, ptRows := range ptBuckets {
-		ptw.pt.AddRows(ptRows)
+	for ptw, bucket := range ptBuckets {
+		ptw.pt.AddRows(bucket.rows)
 	}
 	tb.PutPartitions(ptws)
 	if len(missingRows) == 0 {

--- a/lib/storage/table_test.go
+++ b/lib/storage/table_test.go
@@ -1,12 +1,123 @@
 package storage
 
 import (
+	"slices"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/fs"
 )
+
+// newBucketTestTable uses real partitions and shard writes without background workers.
+func newBucketTestTable(partitions, capacity int) *table {
+	tb := &table{}
+	for i := range partitions {
+		start := time.Date(2025, time.Month(i+1), 1, 0, 0, 0, 0, time.UTC)
+		pt := &partition{tr: TimeRange{MinTimestamp: start.UnixMilli(), MaxTimestamp: start.AddDate(0, 1, 0).UnixMilli() - 1}}
+		pt.rawRows.shards = make([]rawRowsShard, 1)
+		pt.rawRows.shards[0].rows = make([]rawRow, 0, capacity)
+		tb.addPartitionLocked(pt)
+	}
+	return tb
+}
+
+func TestTableMustAddRowsBuckets(t *testing.T) {
+	for _, indices := range [][]int{{}, {0, 0}, {0, 0, 1, 1}, {0, 1, 0, 1, 0}, {0, 0, 1, 1, 0, 0, 2, 0}} {
+		tb := newBucketTestTable(3, 100)
+		backing := make([]rawRow, len(indices)+8)
+		for i := range backing {
+			backing[i] = rawRow{Timestamp: -999, Value: -123, PrecisionBits: defaultPrecisionBits}
+		}
+		rows := backing[:len(indices)]
+		want := make([][]rawRow, 3)
+		for i, idx := range indices {
+			pt := tb.ptws[idx].pt
+			ts := pt.tr.MinTimestamp
+			if i%2 == 0 {
+				ts = pt.tr.MaxTimestamp
+			}
+			rows[i] = rawRow{TSID: TSID{MetricID: uint64(i + 1)}, Timestamp: ts, Value: float64(i + 1), PrecisionBits: defaultPrecisionBits}
+			want[idx] = append(want[idx], rows[i])
+		}
+		original := slices.Clone(backing)
+		partitions := slices.Clone(tb.ptws)
+		tb.MustAddRows(rows)
+		if !slices.Equal(backing, original) {
+			t.Fatalf("input or spare capacity modified for %v", indices)
+		}
+		clear(backing)
+		for i, ptw := range partitions {
+			got := ptw.pt.rawRows.shards[0].rows
+			if !slices.Equal(got, want[i]) {
+				t.Fatalf("partition %d for %v: got %+v; want %+v", i, indices, got, want[i])
+			}
+			calls := uint32(0)
+			if len(want[i]) > 0 {
+				calls = 1
+			}
+			if got := ptw.pt.rawRows.shardIdx.Load(); got != calls {
+				t.Fatalf("partition %d: got %d shard writes; want %d", i, got, calls)
+			}
+		}
+	}
+}
+
+func TestTableMustAddRowsMissingMonth(t *testing.T) {
+	s := newTestStorage()
+	defer stopTestStorage(s)
+	tb := mustOpenTable(t.TempDir(), s)
+	defer tb.MustClose()
+	now := time.Now().UTC()
+	boundary := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC).UnixMilli()
+	ptw := tb.MustGetPartition(boundary - 1)
+	tb.PutPartition(ptw)
+	rows := []rawRow{
+		{Timestamp: boundary - 1, Value: 1, PrecisionBits: defaultPrecisionBits},
+		{Timestamp: boundary, Value: 2, PrecisionBits: defaultPrecisionBits},
+		{Timestamp: boundary - 2, Value: 3, PrecisionBits: defaultPrecisionBits},
+		{Timestamp: boundary + 1, Value: 4, PrecisionBits: defaultPrecisionBits},
+	}
+	want := slices.Clone(rows)
+	tb.MustAddRows(rows)
+	if !slices.Equal(rows, want) {
+		t.Fatal("input modified")
+	}
+	clear(rows)
+	tb.DebugFlush()
+	for _, ts := range []int64{boundary - 1, boundary} {
+		ptw := tb.GetPartition(ts)
+		if ptw == nil {
+			t.Fatalf("missing partition for %d", ts)
+		}
+		tr := ptw.pt.tr
+		tb.PutPartition(ptw)
+		var search tableSearch
+		search.Init(tb, []TSID{{}}, tr)
+		var got []rawRow
+		for search.NextBlock() {
+			var block Block
+			search.BlockRef.MustReadBlock(&block)
+			rb := newTestRawBlock(&block, tr)
+			for i, timestamp := range rb.Timestamps {
+				got = append(got, rawRow{TSID: rb.TSID, Timestamp: timestamp, Value: rb.Values[i], PrecisionBits: defaultPrecisionBits})
+			}
+		}
+		err := search.Error()
+		search.MustClose()
+		if err != nil {
+			t.Fatal(err)
+		}
+		slices.SortFunc(got, func(a, b rawRow) int { return int(a.Value - b.Value) })
+		expected := []rawRow{want[0], want[2]}
+		if ts == boundary {
+			expected = []rawRow{want[1], want[3]}
+		}
+		if !slices.Equal(got, expected) {
+			t.Fatalf("timestamp %d: got %+v; want %+v", ts, got, expected)
+		}
+	}
+}
 
 func TestTableOpenClose(t *testing.T) {
 	const path = "TestTableOpenClose"

--- a/lib/storage/table_timing_test.go
+++ b/lib/storage/table_timing_test.go
@@ -5,10 +5,46 @@ import (
 	"math/rand"
 	"testing"
 	"time"
+	"unsafe"
 
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/cgroup"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/fs"
 )
+
+// BenchmarkTableMustAddRowsBuckets measures routing and synchronous shard writes.
+// Preallocated shards are drained after each batch to exclude asynchronous merges.
+func BenchmarkTableMustAddRowsBuckets(b *testing.B) {
+	b.Logf("rawRow size: %d bytes", unsafe.Sizeof(rawRow{}))
+	for _, r := range []int{100, 8000} {
+		for _, p := range []int{2, 12} {
+			for _, layout := range []string{"grouped", "alternating", "single"} {
+				b.Run(fmt.Sprintf("R=%d/P=%d/%s", r, p, layout), func(b *testing.B) {
+					tb := newBucketTestTable(p, r)
+					rows := make([]rawRow, r)
+					for i := range rows {
+						idx := 0
+						switch layout {
+						case "grouped":
+							idx = i * p / r
+						case "alternating":
+							idx = i % p
+						}
+						rows[i] = rawRow{Timestamp: tb.ptws[idx].pt.tr.MinTimestamp, Value: float64(i), PrecisionBits: defaultPrecisionBits}
+					}
+					b.ReportAllocs()
+					b.ResetTimer()
+					for range b.N {
+						tb.MustAddRows(rows)
+						for _, ptw := range tb.ptws {
+							shard := &ptw.pt.rawRows.shards[0]
+							shard.rows = shard.rows[:0]
+						}
+					}
+				})
+			}
+		}
+	}
+}
 
 func BenchmarkTableAddRows(b *testing.B) {
 	for _, tsidsCount := range []int{1e0, 1e1, 1e2, 1e3, 1e4} {


### PR DESCRIPTION
### Motivation

`table.MustAddRows` currently copies each row into a temporary per-partition slice. `partition.AddRows` subsequently copies the rows into its own shard buffers. 

### Change

A bucket initially borrows a capacity-limited slice of the input. Consecutive rows for that partition extend the borrowed range. If that partition reappears after a gap, appending to the capacity-limited slice allocates an independent buffer; subsequent rows use that buffer.

`partition.AddRows` synchronously copies its input before returning, so the caller can still reuse its input after `MustAddRows` returns. 

Limiting capacity prevents a later append from overwriting another partition's rows. Each existing partition still receives at most one `AddRows` call per batch, and the single-partition fast path is preserved.


### Performance evidence

Baseline: `0e16465c1`. Candidate: this patch.
Environment: Go 1.27.1, darwin/arm64, Apple M4, `GOMAXPROCS=4`.
Six alternating baseline/candidate rounds, `-benchtime=500ms`, compared with `benchstat`.

Representative results (one operation is one batch):

| Benchmark | Before | After | Change |
| --- | ---: | ---: | ---: |
| Table, 8000 rows, 2 partitions, grouped | 141.77 us | 51.89 us | -63.40%, p=0.002 |
| Table, 8000 rows, 12 partitions, grouped | 173.79 us | 85.76 us | -50.65%, p=0.002 |
| Table, 8000 rows, 2 partitions, alternating | 145.8 us | 127.0 us | -12.95%, p=0.009 |
| Storage, 8000 rows, 2 months, grouped | 515.6 us | 393.0 us | -23.77%, p=0.002 |
| Storage, 8000 rows, 2 months, alternating | 944.5 us | 957.5 us | no significant difference, p=0.937 |

Table grouped input improved across the measured 100/8000-row and 2/12-partition combinations. All measured single-partition controls had no statistically significant timing change. The 100-row, 12-partition alternating case also had no significant timing change. These results do not prove the absence of regressions outside the measured cases.

For the 8000-row, two-partition grouped table case, allocated bytes fell from approximately 1,654,712 B/op to 64 B/op, and allocations from 32 to 2. For the grouped Storage benchmark, bytes fell from 2020.8 KiB/op to 385.8 KiB/op (-80.91%), and allocations from 35 to 4.

No production traffic replay or production profile is available for this change. The local synthetic evidence supports the optimization, but production impact remains unverified

To reproduce the benchmarks on each version with the same benchmark code:

```sh
GOTOOLCHAIN=auto GOSUMDB=sum.golang.org go test -c -o /tmp/storage-bench.test ./lib/storage
GOMAXPROCS=4 /tmp/storage-bench.test \
  -test.run='^$' \
  -test.bench='^(BenchmarkTableMustAddRowsBuckets|BenchmarkStorageAddRowsExistingMonths)$' \
  -test.benchmem -test.benchtime=500ms -test.count=1
```

Run the two binaries alternately six times, save their complete output separately, and compare the benchmark records with `benchstat`. The accompanying evidence contains the complete result matrix, raw output, binaries, profiles, and commands.


### Validation

- `make check-all`: passed 
- `make test-full`: passed
- Targeted `go test ./lib/storage -run 'Test(Table|GetPartition)' -count=1`: passed.
- Targeted `go test -race ./lib/storage -run 'Test(Table|GetPartition)' -count=1`: passed.
- `git diff --check`: passed.
- `make apptest`: passed, including race-enabled component builds and the target's default application tests (cluster/mixed/legacy suites are excluded by the Makefile).
- My change adheres https://docs.victoriametrics.com/victoriametrics/contributing/