### PR TITLE
lib/promscrape: fix http_sd => file_sd switching bug

### DIFF
--- a/lib/promscrape/config.go
+++ b/lib/promscrape/config.go
@@ -863,17 +863,20 @@ func (cfg *Config) getScrapeWorkGeneric(visitConfigs func(sc *ScrapeConfig, visi
 		//
 		// If no successful response is received (i.e., hasSuccess is false), fall back to the result from the previous round.
 		hasSuccess := false
+		visited := 0
 		visitConfigs(sc, func(sdc targetLabelsGetter) {
+			visited++
 			targetLabels, err := sdc.GetLabels(cfg.baseDir)
 			if err != nil {
 				logger.Errorf("skipping some %s targets for job_name=%s because of error: %s", discoveryType, sc.swc.jobName, err)
-				hasSuccess = hasSuccess || false
 				return
 			}
 			hasSuccess = true
 			dst = appendScrapeWorkForTargetLabels(dst, sc.swc, targetLabels, discoveryType)
 		})
-		if !hasSuccess {
+		// Fall back to the previous round only when the job still has SD configs of this type and all of them failed.
+		// A job with no SD configs of this type (e.g. http_sd_configs removed on reload) must yield no such targets.
+		if visited > 0 && !hasSuccess {
 			dst = sc.appendPrevTargets(dst[:dstLen], swsPrevByJob, discoveryType)
 		}
 	}

--- a/lib/promscrape/config_sdfallback_test.go
+++ b/lib/promscrape/config_sdfallback_test.go
@@ -1,0 +1,100 @@
+package promscrape
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/promutil"
+)
+
+// fakeSDConfig is a targetLabelsGetter that returns fixed labels or a fixed error.
+type fakeSDConfig struct {
+	labels []*promutil.Labels
+	err    error
+}
+
+func (f *fakeSDConfig) GetLabels(_ string) ([]*promutil.Labels, error) {
+	return f.labels, f.err
+}
+
+func mustParseConfig(t *testing.T, data string) *Config {
+	t.Helper()
+	var cfg Config
+	if err := cfg.parseData([]byte(data), "test.yml"); err != nil {
+		t.Fatalf("cannot parse config: %s", err)
+	}
+	return &cfg
+}
+
+// TestGetScrapeWorkGenericDropsTargetsWhenSDConfigsRemoved verifies that a job which no longer
+// has any service-discovery config of a given type (e.g. http_sd_configs was removed from the job
+// on config reload) does NOT keep the targets discovered by the removed config.
+//
+// The fallback in getScrapeWorkGeneric that preserves the previous round's targets exists for
+// the case "every SD config of the job failed this round" (temporary discovery error). A job with
+// zero SD configs of that type is not a discovery error: it must yield zero targets of that type,
+// otherwise removing http_sd_configs from a job (or switching a job from http_sd to file_sd) keeps
+// the old http_sd targets being scraped until the process is restarted.
+func TestGetScrapeWorkGenericDropsTargetsWhenSDConfigsRemoved(t *testing.T) {
+	labels := []*promutil.Labels{
+		promutil.NewLabelsFromMap(map[string]string{"__address__": "host1:9100"}),
+		promutil.NewLabelsFromMap(map[string]string{"__address__": "host2:9100"}),
+	}
+
+	// Round 1: job "foo" has one http_sd config which discovers two targets.
+	cfgWithSD := mustParseConfig(t, `
+scrape_configs:
+- job_name: foo
+  http_sd_configs:
+  - url: http://sd.example.invalid/targets
+`)
+	visitOne := func(sc *ScrapeConfig, visitor func(sdc targetLabelsGetter)) {
+		visitor(&fakeSDConfig{labels: labels})
+	}
+	prev := cfgWithSD.getScrapeWorkGeneric(visitOne, "http_sd_config", nil)
+	if len(prev) != 2 {
+		t.Fatalf("round 1: expected 2 scrape works, got %d", len(prev))
+	}
+
+	// Round 2 (the bug): the same job still exists but its http_sd_configs were removed
+	// (it now uses file_sd_configs). The real http_sd visitor finds nothing to visit.
+	cfgWithoutSD := mustParseConfig(t, `
+scrape_configs:
+- job_name: foo
+  file_sd_configs:
+  - files: [testdata/file_sd.json]
+`)
+	sws := cfgWithoutSD.getHTTPDScrapeWork(prev)
+	if len(sws) != 0 {
+		t.Fatalf("job without http_sd_configs must yield 0 http_sd scrape works, got %d (previous round's targets were preserved): %v",
+			len(sws), scrapeURLs(sws))
+	}
+
+	// Control 1: the job was removed entirely -> nothing is preserved (this already works).
+	cfgNoJob := mustParseConfig(t, `
+scrape_configs:
+- job_name: bar
+  static_configs:
+  - targets: [host3:9100]
+`)
+	if sws := cfgNoJob.getHTTPDScrapeWork(prev); len(sws) != 0 {
+		t.Fatalf("removed job must yield 0 scrape works, got %d", len(sws))
+	}
+
+	// Control 2: the job still has its http_sd config but discovery FAILS this round ->
+	// the previous targets must be preserved (the intended purpose of the fallback).
+	visitFailing := func(sc *ScrapeConfig, visitor func(sdc targetLabelsGetter)) {
+		visitor(&fakeSDConfig{err: errors.New("temporary discovery error")})
+	}
+	if sws := cfgWithSD.getScrapeWorkGeneric(visitFailing, "http_sd_config", prev); len(sws) != 2 {
+		t.Fatalf("failed discovery must preserve the previous 2 scrape works, got %d", len(sws))
+	}
+}
+
+func scrapeURLs(sws []*ScrapeWork) []string {
+	urls := make([]string, 0, len(sws))
+	for _, sw := range sws {
+		urls = append(urls, sw.ScrapeURL)
+	}
+	return urls
+}


### PR DESCRIPTION
Fix bug when switching from http_sd => file_sd where a full vmagent restart is required to drop the old http_sd targets.

This surfaced in the following scenario:
1. We want to gradually (using a feature flag) switch from using static file discovery (file_sd) to more dynamic http_sd.
2. We switched (using feature flag) from file_sd => http_sd. This went seamlessly (did not require a vmagent restart)
3. We discovered a bug and flipped the feature flag off, reverting vmagent scrape config back to file_sd.
4. We continued to see http_sd scrapes until a full restart of vmagent.

Bug background:

getScrapeWorkGeneric() falls back to the previous round's targets when a job's service discovery "has no success" this round. Since e8975e560 the success flag starts false and is only set when an SD config of that type returns successfully, so a job that still exists but no longer has any SD config of that type (for example http_sd_configs removed from the job on config reload, or the job switched from http_sd to file_sd) never sets it. Every round the job is treated as a temporary discovery error, its old targets are re-added, and the scrapers for them are never stopped. The stale targets keep being scraped until the process is restarted, and the log fills with "preserving the previous http_sd_config targets for job_name=... because of temporary discovery error".

Only fall back when the job still has at least one SD config of that type and all of them failed. A job with none yields no targets of that type.

Affects every SD type served by getScrapeWorkGeneric (http_sd, consul, dns, ec2, azure, ...). Regression introduced in v1.130.0 and the v1.122.x LTS backport of e8975e560.

The new test reproduces the removed-config case through the real http_sd path and keeps the two intended behaviours covered: a removed job yields nothing, and a job whose discovery fails keeps its previous targets.

**PLEASE REMOVE LINE BELOW BEFORE SUBMITTING**

Before creating the PR, make sure you have read and followed the [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
