### PR TITLE
deployment: fix TooManyErrorLogs alert

### DIFF
--- a/deployment/docker/rules/alerts-health.yml
+++ b/deployment/docker/rules/alerts-health.yml
@@ -100,7 +100,7 @@ groups:
             - Use `source_code_url` annotation to check the source code that produced the log message.
 
             NOTE: The metric `vm_log_messages_total` tracks all log messages including those suppressed by `-loggerLevel`. Check the `is_printed` label to see whether the log was actually printed.
-          source_code_url: '{{ with printf "last_over_time(vm_log_messages_total{job=%q,instance=%q,location=%q}[6m])" $labels.job $labels.instance $labels.location | query }}https://l2s.victoriametrics.com/?app_version={{ (index . 0).Labels.app_version }}&location={{ $labels.location | urlquery }}{{ end }}'
+          source_code_url: '{{ with printf "last_over_time(vm_log_messages_total{job=%q,instance=%q,location=%q}[6m])" $labels.job $labels.instance $labels.location | query }}{{ with index . 0 }}https://l2s.victoriametrics.com/?app_version={{ .Labels.app_version }}&location={{ $labels.location | urlquery }}{{ end }}{{ end }}'
 
       - alert: TooManyLogs
         expr: sum(increase(vm_log_messages_total{level="warn"}[5m])) without (app_version, location, is_printed) > 0

--- a/deployment/docker/rules/alerts-health.yml
+++ b/deployment/docker/rules/alerts-health.yml
@@ -100,7 +100,7 @@ groups:
             - Use `source_code_url` annotation to check the source code that produced the log message.
 
             NOTE: The metric `vm_log_messages_total` tracks all log messages including those suppressed by `-loggerLevel`. Check the `is_printed` label to see whether the log was actually printed.
-          source_code_url: '{{ with printf "vm_log_messages_total{job=%q,instance=%q,location=%q}" $labels.job $labels.instance $labels.location | query | first }}https://l2s.victoriametrics.com/?app_version={{ .Labels.app_version }}&location={{ $labels.location | urlquery }}{{ end }}'
+          source_code_url: '{{ with printf "last_over_time(vm_log_messages_total{job=%q,instance=%q,location=%q}[6m])" $labels.job $labels.instance $labels.location | query }}https://l2s.victoriametrics.com/?app_version={{ (index . 0).Labels.app_version }}&location={{ $labels.location | urlquery }}{{ end }}'
 
       - alert: TooManyLogs
         expr: sum(increase(vm_log_messages_total{level="warn"}[5m])) without (app_version, location, is_printed) > 0


### PR DESCRIPTION
Follow-up on https://github.com/VictoriaMetrics/VictoriaMetrics/pull/11417

I spotted an issue in our sandbox. The query used to fetch `app_version` returned no series. In this case, `first() called on vector with no elements`, so the alert annotation template fails to render.

Changes:
- Use `{{ with index . 0 }}` instead of `| first` so the link is generated only when the query returns at least one series.
- Use `last_over_time(...[6m])` to query a slightly longer time range than the alert's `for: 5m`.

<details>
<summary>The log</summary>
```
{"ts":"2026-09-11T12:49:15.138Z","level":"error","caller":"VictoriaMetrics/app/vmalert/rule/alerting.go:521","msg":"got templating error in rule TooManyErrorLogs: \"failed to expand annotation templates: errors(1): \\n(key: \\\"source_code_url\\\", value: \\\"{{ with printf
\\\\\\\"vm_log_messages_total{job=%q,instance=%q,location=%q}\\\\\\\" $labels.job
$labels.instance $labels.location | query | first
}}https://l2s.victoriametrics.com/?app_version={{ .Labels.app_version }}&location={{ $labels.location | urlquery }}{{ end }}\\\"): error evaluating template: template: :1:443: executing \\\"\\\" at <first>: error calling first: first() called on vector with no elements\""} {"ts":"2026-09-11T12:49:45.129Z","level":"error","caller":"VictoriaMetrics/app/vmalert/rule/alerting.go:521","msg":"got templating error in rule TooManyErrorLogs: \"failed to expand annotation templates: errors(1): \\n(key: \\\"source_code_url\\\", value: \\\"{{ with printf
\\\\\\\"vm_log_messages_total{job=%q,instance=%q,location=%q}\\\\\\\" $labels.job
$labels.instance $labels.location | query | first
}}https://l2s.victoriametrics.com/?app_version={{ .Labels.app_version }}&location={{ $labels.location | urlquery }}{{ end }}\\\"): error evaluating template: template: :1:443: executing \\\"\\\" at <first>: error calling first: first() called on vector with no elements\""}
```
</details>